### PR TITLE
Update README to include command modifiers in telnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ PTR: 12
 SRV: 0
 ```
 
-- `>getallqueries` : get all queries that FTL has in its database
+- `>getallqueries X` : get all queries that FTL has in its database if used with X being the number of queries you would like to limit to ie: `getallqueries 10` will show the last 10 logged queries
  ```
 1483964292 IPv4 apis.google.com 1.2.3.4 3
 1483964293 IPv4 clients5.google.com 1.2.3.4 2
@@ -166,7 +166,7 @@ SRV: 0
 1483964333 IPv4 www.linguee.de 2.3.4.5 2
 ```
 
-- `>recentBlocked` : get most recently pi-holed domain name
+- `>recentBlocked (X)` : get most recently pi-holed domain name when used with X returns the number of blocked queries specified by X
  ```
 www.googleadservices.com
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please see `LICENSE` file for your rights under this license.
 | VirtualBox | Ubuntu 16.10 | amd64 | `linux-x86_64` | [@DL6ER](https://github.com/dl6er) |
 | Raspberry Pi Zero | Raspbian Jessie | armv6 | `arm-linux-gnueabi` | [@DanSchaper](https://github.com/dschaper) |
 | Raspberry Pi 1 | Raspbian Jessie | armv6 | `arm-linux-gnueabi` | [@DL6ER](https://github.com/dl6er) |
-| Raspberry Pi 2 | Raspbian Jessie | ? | ? | ? |
+| Raspberry Pi 2 | Raspbian Jessie | armv7l | `arm-linux-gnueabihf` | [@TechnicalPyro](https://github.com/technicalpyro) |
 | Raspberry Pi 3 | Raspbian Jessie | armv7l | `arm-linux-gnuabi` and `arm-linux-gnueabihf` | [@DL6ER](https://github.com/dl6er) |
 | NanoPi NEO | armbian Ubuntu 16.04 | armv7l | `arm-linux-gnueabihf` | [@DL6ER](https://github.com/dl6er) |
 | Odroid-C2 | Ubuntu 16.04 | aarch64 | `aarch64-linux-gnu` | [@DanSchaper](https://github.com/dschaper) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please see `LICENSE` file for your rights under this license.
 | VirtualBox | Ubuntu 16.10 | amd64 | `linux-x86_64` | [@DL6ER](https://github.com/dl6er) |
 | Raspberry Pi Zero | Raspbian Jessie | armv6 | `arm-linux-gnueabi` | [@DanSchaper](https://github.com/dschaper) |
 | Raspberry Pi 1 | Raspbian Jessie | armv6 | `arm-linux-gnueabi` | [@DL6ER](https://github.com/dl6er) |
-| Raspberry Pi 2 | Raspbian Jessie | armv7l | `arm-linux-gnueabihf`and `arm-linux-gnuabi` | [@TechnicalPyro](https://github.com/technicalpyro) |
+| Raspberry Pi 2 | Raspbian Jessie | armv7l | `arm-linux-gnueabihf` and `arm-linux-gnuabi` | [@TechnicalPyro](https://github.com/technicalpyro) |
 | Raspberry Pi 3 | Raspbian Jessie | armv7l | `arm-linux-gnuabi` and `arm-linux-gnueabihf` | [@DL6ER](https://github.com/dl6er) |
 | NanoPi NEO | armbian Ubuntu 16.04 | armv7l | `arm-linux-gnueabihf` | [@DL6ER](https://github.com/dl6er) |
 | Odroid-C2 | Ubuntu 16.04 | aarch64 | `aarch64-linux-gnu` | [@DanSchaper](https://github.com/dschaper) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please see `LICENSE` file for your rights under this license.
 | VirtualBox | Ubuntu 16.10 | amd64 | `linux-x86_64` | [@DL6ER](https://github.com/dl6er) |
 | Raspberry Pi Zero | Raspbian Jessie | armv6 | `arm-linux-gnueabi` | [@DanSchaper](https://github.com/dschaper) |
 | Raspberry Pi 1 | Raspbian Jessie | armv6 | `arm-linux-gnueabi` | [@DL6ER](https://github.com/dl6er) |
-| Raspberry Pi 2 | Raspbian Jessie | armv7l | `arm-linux-gnueabihf` | [@TechnicalPyro](https://github.com/technicalpyro) |
+| Raspberry Pi 2 | Raspbian Jessie | armv7l | `arm-linux-gnueabihf`and `arm-linux-gnuabi` | [@TechnicalPyro](https://github.com/technicalpyro) |
 | Raspberry Pi 3 | Raspbian Jessie | armv7l | `arm-linux-gnuabi` and `arm-linux-gnueabihf` | [@DL6ER](https://github.com/dl6er) |
 | NanoPi NEO | armbian Ubuntu 16.04 | armv7l | `arm-linux-gnueabihf` | [@DL6ER](https://github.com/dl6er) |
 | Odroid-C2 | Ubuntu 16.04 | aarch64 | `aarch64-linux-gnu` | [@DanSchaper](https://github.com/dschaper) |


### PR DESCRIPTION
updated the README to include the modifiers usable within the telnet.

unfortunately it shows as 5 commits still understanding how this works but might be due to updating my fork today not one hundred percent sure 