### PR TITLE
Improve IP search; check end character

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -685,10 +685,12 @@ int findDomain(char *domain)
 int findClient(char *client)
 {
 	int i;
+	int client_last_pos = strlen(client) - 1;
 	for(i=0; i < counters.clients; i++)
 	{
-		// Quick test: Does the clients IP start with the same character?
-		if(clients[i].ip[0] != client[0])
+		int clients_last_pos = strlen(clients[i].ip) - 1;
+		// Quick test: Does the clients IP end with the same character?
+		if(clients[i].ip[clients_last_pos] != client[client_last_pos])
 			continue;
 
 		// If so, compare the full domain using strcmp


### PR DESCRIPTION
In a LAN with clients 192.x.x.1-255, comparing first character (1) will perform **strcmp** 254 times for say 192.x.x.14.  By checking last character, it would do **strcmp** 26 times. In the black-hole, less is more : )
Please feel free to change anything and everything - I'm a newbie.