### PR TITLE
Check pointer values to avoid double-free issues

### DIFF
--- a/setupVars.c
+++ b/setupVars.c
@@ -80,8 +80,13 @@ char * read_setupVarsconf(const char * key)
 
 	// Key not found -> return NULL
 	fclose(setupVarsfp);
+
+	// setting unused pointers to NULL
+	// protecting against dangling pointer bugs
 	free(keystr);
+	keystr = NULL;
 	free(linebuffer);
+	linebuffer = NULL;
 	return NULL;
 }
 
@@ -112,12 +117,19 @@ void getSetupVarsArray(char * input)
 void clearSetupVarsArray(void)
 {
 	setupVarsElements = 0;
-	free(setupVarsArray);
-	free(linebuffer);
 	// setting unused pointers to NULL
 	// protecting against dangling pointer bugs
-	setupVarsArray = NULL;
-	linebuffer = NULL;
+	// free only if not already NULL
+	if(setupVarsArray != NULL)
+	{
+		free(setupVarsArray);
+		setupVarsArray = NULL;
+	}
+	if(linebuffer != NULL)
+	{
+		free(linebuffer);
+		linebuffer = NULL;
+	}
 }
 
 /* Example


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Avoid double-`free` issues by first checking if a pointer can actually be `free`d. To be able to do this, we set all pointers to `NULL` after they have been `free`d to avoid dangling behavior. Although this is the general strategy throughout the code, it was missing here in this rather old part of the entire project.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
