### PR TITLE
Fix concurrent client threads accessing the same memory

### DIFF
--- a/setupVars.c
+++ b/setupVars.c
@@ -43,6 +43,7 @@ char* find_equals(const char* s)
 // actually point to memory addresses
 // which we allocate for this buffer.
 char * linebuffer = NULL;
+size_t linebuffersize = 0;
 
 char * read_setupVarsconf(const char * key)
 {
@@ -63,9 +64,8 @@ char * read_setupVarsconf(const char * key)
 	}
 	sprintf(keystr, "%s=", key);
 
-	size_t size;
 	errno = 0;
-	while(getline(&linebuffer, &size, setupVarsfp) != -1)
+	while(getline(&linebuffer, &linebuffersize, setupVarsfp) != -1)
 	{
 		// Strip (possible) newline
 		linebuffer[strcspn(linebuffer, "\n")] = '\0';
@@ -97,6 +97,7 @@ char * read_setupVarsconf(const char * key)
 	if(linebuffer != NULL)
 	{
 		free(linebuffer);
+		linebuffersize = 0;
 		linebuffer = NULL;
 	}
 
@@ -141,6 +142,7 @@ void clearSetupVarsArray(void)
 	if(linebuffer != NULL)
 	{
 		free(linebuffer);
+		linebuffersize = 0;
 		linebuffer = NULL;
 	}
 }

--- a/socket.c
+++ b/socket.c
@@ -208,13 +208,13 @@ void *connection_handler_thread(void *socket_desc)
 
 			// Lock FTL data structure, since it is likely that it will be changed here
 			// Requests should not be processed/answered when data is about to change
-			enable_read_lock(threadname);
+			enable_read_write_lock(threadname);
 
 			process_request(message, &sock);
 			free(message);
 
 			// Release thread lock
-			disable_thread_locks("connection_handler_thread");
+			disable_thread_locks(threadname);
 
 			if(sock == 0)
 			{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10
---

Multiple client threads at the same time might want to access/modify the same memory at the same time. This leads to undefined behavior and can result in crashs with mysterious messages.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
