### PR TITLE
Remove need for empty obj directory in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
-# Generated binary file
+# Generated binary files
+/obj/
 pihole-FTL
 
 # Versioning files
 version*
+
+# CMake files
+/CMakeLists.txt
+/cmake-build-debug/
+
+# IDE files
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GIT_DATE := $(shell git --no-pager show --date=short --format="%ai" --name-only 
 GIT_TAG := $(shell git describe --tags --abbrev=0)
 
 # -fstack-protector: The program will be resistant to having its stack overflowed
-# -D_FORTIFY_SOURCE=2 and -O1 or higher: This causes certain unsafe glibc functions zo be replaced with their safer counterparts
+# -D_FORTIFY_SOURCE=2 and -O1 or higher: This causes certain unsafe glibc functions to be replaced with their safer counterparts
 # -Wl,-z,relro: reduces the possible areas of memory in a program that can be used by an attacker that performs a successful memory corruption exploit
 # -Wl,-z,now: When combined with RELRO above, this further reduces the regions of memory available to memory corruption attacks
 # -pie -fPIE: For ASLR
@@ -40,8 +40,13 @@ _DEPS = $(patsubst %,$(IDIR)/%,$(DEPS))
 
 _OBJ = $(patsubst %,$(ODIR)/%,$(OBJ))
 
-$(ODIR)/%.o: %.c $(_DEPS)
+all: pihole-FTL
+
+$(ODIR)/%.o: %.c $(_DEPS) | $(ODIR)
 	$(CC) -c -o $@ $< $(CCFLAGS)
+
+$(ODIR):
+	mkdir -p $(ODIR)
 
 pihole-FTL: $(_OBJ)
 	$(CC) -v $(CCFLAGS) -o $@ $^ $(LIBS)

--- a/obj/.gitignore
+++ b/obj/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 7

---

This adds a step in the Makefile to create the `obj` directory before making the object files. The empty `obj` directory currently in the repo is now not needed.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
