### PR TITLE
Specify fixed age of queries until they get deleted

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -119,7 +119,7 @@ typedef struct {
 	bool rolling_24h;
 	bool query_display;
 	bool analyze_AAAA;
-	int maxDBfilesize;
+	int maxDBdays;
 } ConfigStruct;
 
 // Dynamic structs

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Possible settings (**the option shown first is the default**):
 - `TIMEFRAME=rolling24h|yesterday|today` (Rolling data window, up to 48h (today + yesterday), or up to 24h (only today, as in Pi-hole `v2.x` ))
 - `QUERY_DISPLAY=yes|no` (Display all queries? Set to `no` to hide query display)
 - `AAAA_QUERY_ANALYSIS=yes|no` (Allow `FTL` to analyze AAAA queries from pihole.log?)
-- `MAXDBFILESIZE=100` (How large do we want the FTL database to grow at max (given in MB), setting this to `0` disables the database altogether)
+- `MAXDBDAYS=365` (How long should queries be stored in the database? Setting this to `0` disables the database altogether)
 
 ### Implemented keywords (starting with `>`, subject to change):
 

--- a/config.c
+++ b/config.c
@@ -95,21 +95,21 @@ void read_FTLconf(void)
 	else
 		logg("   AAAA_QUERY_ANALYSIS: Hide AAAA queries");
 
-	// MAXDBFILESIZE
-	// defaults to: 100 MB
-	config.maxDBfilesize = 100;
-	buffer = parse_FTLconf(fp, "MAXDBFILESIZE");
+	// MAXDBDAYS
+	// defaults to: 365 days
+	config.maxDBdays = 365;
+	buffer = parse_FTLconf(fp, "MAXDBDAYS");
 	if(buffer != NULL)
 	{
 		int value = 0;
 		if(sscanf(buffer, "%i", &value))
 			if(value >= 0)
-				config.maxDBfilesize = value;
+				config.maxDBdays = value;
 	}
-	if(config.maxDBfilesize == 0)
-		logg("   MAXDBFILESIZE: --- (DB disabled)", config.maxDBfilesize);
+	if(config.maxDBdays == 0)
+		logg("   MAXDBDAYS: --- (DB disabled)", config.maxDBdays);
 	else
-		logg("   MAXDBFILESIZE: %i MB", config.maxDBfilesize);
+		logg("   MAXDBDAYS: max age for stored queries is %i days", config.maxDBdays);
 
 	logg("Finished config file parsing");
 

--- a/main.c
+++ b/main.c
@@ -13,7 +13,6 @@
 
 char * username;
 bool needGC = false;
-bool needDBGC = false;
 
 int main (int argc, char* argv[]) {
 	username = getUserName();
@@ -49,7 +48,7 @@ int main (int argc, char* argv[]) {
 
 	read_gravity_files();
 
-	if(config.maxDBfilesize != 0)
+	if(config.maxDBdays != 0)
 		db_init();
 
 	logg("Starting initial log file parsing");
@@ -84,27 +83,16 @@ int main (int argc, char* argv[]) {
 	{
 		sleepms(100);
 
-		bool runGCthread = false, runDBthread = false, runDBGCthread = false;
+		bool runGCthread = false, runDBthread = false;
 
 		if(((time(NULL) - GCdelay)%GCinterval) == 0)
 			runGCthread = true;
 
-		if(database)
-		{
-			// DBGC_time == 0 at five minutes after each full even hour
-			int DBGC_time = time(NULL) % 7200;
-			if(DBGC_time == 300 || needDBGC)
-			{
-				needDBGC = false;
-				runDBGCthread = true;
-			}
-
-			else if(((time(NULL)%DBinterval) == 0) && !runDBGCthread)
-				runDBthread = true;
-		}
+		if(database && ((time(NULL)%DBinterval) == 0))
+			runDBthread = true;
 
 		// Garbadge collect in regular interval, but don't do it if the threadlocks is set
-		if(config.rolling_24h && (runGCthread || needGC))
+		if(runGCthread || needGC)
 		{
 			// Wait until we are allowed to work on the data
 			while(threadwritelock || threadreadlock)
@@ -113,11 +101,30 @@ int main (int argc, char* argv[]) {
 			needGC = false;
 			runGCthread = false;
 
-			pthread_t GCthread;
-			if(pthread_create( &GCthread, &attr, GC_thread, NULL ) != 0)
+			if(config.rolling_24h)
 			{
-				logg("Unable to open GC thread. Exiting...");
-				killed = 1;
+				pthread_t GCthread;
+				if(pthread_create( &GCthread, &attr, GC_thread, NULL ) != 0)
+				{
+					logg("Unable to open GC thread. Exiting...");
+					killed = 1;
+				}
+			}
+
+			if(database)
+			{
+				// Disable any other DB accesses while doing this and wait one second
+				// so that currently running transactions can still finish
+				database = false;
+				sleepms(1000);
+
+				// Launch DB GC thread
+				pthread_t DBGCthread;
+				if(pthread_create( &DBGCthread, &attr, DB_GC_thread, NULL ) != 0)
+				{
+					logg("Unable to open DB GC thread. Exiting...");
+					killed = 1;
+				}
 			}
 
 			// Avoid immediate re-run of GC thread
@@ -143,24 +150,6 @@ int main (int argc, char* argv[]) {
 			// Avoid immediate re-run of DB thread
 			while(((time(NULL)%DBinterval) == 0))
 				sleepms(100);
-		}
-
-		// Clean database in regular interval
-		if(runDBGCthread)
-		{
-			runDBGCthread = false;
-
-			// Avoid any further DB activities outside of the DB_GC thread
-			database = false;
-
-			if(debug)
-				logg("Launching DB GC...");
-
-			pthread_t DBGCthread;
-			if(pthread_create( &DBGCthread, &attr, DB_GC_thread, NULL ) != 0)
-			{
-				logg("WARN: Unable to open DB GC thread.");
-			}
 		}
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

## 10

---

Instead of limiting the database by its file size, we allow setting a maximum age of the stored queries.

This limit defaults to 365 days and can be changed in the `FTL` config file (see `README` for further details).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
