### PR TITLE
Revert "Fix SQLite3 function that is crashing"

### DIFF
--- a/database.c
+++ b/database.c
@@ -360,6 +360,13 @@ void delete_old_queries_in_DB(void)
 		return;
 	}
 
+	// Get how many rows have been affected (deleted)
+	int affected = sqlite3_changes(db);
+
+	// Print final message only if there is a difference
+	if(debug || affected)
+		logg("Notice: Database size is %.2f MB, deleted %i rows", get_db_filesize(), affected);
+
 	// Close database
 	dbclose();
 


### PR DESCRIPTION
Reverts pi-hole/FTL#95

With new method that ensures that DB cleaning and DB insertion cannot run at the same time, this function should be safe, again.

However, it will require more extensive testing.