### PR TITLE
Try again to open pihole.log if necessary

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -53,11 +53,16 @@ void open_pihole_log(void)
 {
 	FILE * fp;
 	if((fp = fopen(files.log, "r")) == NULL) {
-		logg("FATAL: Opening of %s failed!", files.log);
-		logg("       Make sure it exists and is readable by user %s", username);
-		syslog(LOG_ERR, "Opening of pihole.log failed!");
-		// Return failure in exit status
-		exit(EXIT_FAILURE);
+		logg("WARN:  Opening of %s failed!", files.log);
+		logg("       Make sure it exists and is readable by user %s\n       Will try again in 15 seconds.", username);
+
+		sleepms(15000);
+		if((fp = fopen(files.log, "r")) == NULL) {
+			logg("FATAL: Opening of %s failed permanently!", files.log);
+			syslog(LOG_ERR, "Opening of pihole.log failed!");
+			// Return failure in exit status
+			exit(EXIT_FAILURE);
+		}
 	}
 	fclose(fp);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Assume a user has configured his `/var/log` using `ramfs` or some other mechanism that results in an *empty* log folder on startup.

If, by chance, `FTL` is getting started before `dnsmasq` has created its log file, `FTL` will exit with status `FAILURE`.

With these proposed changes, we pause for 15 seconds if we cannot find `pihole.log` and then test again. If the log file is there, `FTL` will continue as usual. If the file can still not be opened in the second attempt, it will exit only then.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
