### PR TITLE
Use low-level mutual exclusive locks

### DIFF
--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@ int main (int argc, char* argv[]) {
 	logg("FTL hash: %s", GIT_VERSION);
 	logg("FTL date: %s", GIT_DATE);
 	logg("FTL user: %s", username);
+	init_thread_lock();
 
 	// pihole-FTL should really be run as user "pihole" to not mess up with the file permissions
 	// still allow this if "debug" flag is set

--- a/routines.h
+++ b/routines.h
@@ -61,6 +61,7 @@ char* find_equals(const char* s);
 
 void enable_thread_lock(const char *message);
 void disable_thread_lock(const char *message);
+void init_thread_lock(void);
 
 void read_FTLconf(void);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Use low-level mutual exclusive (`mutex`) locks to ensure FTLs main datastructure can only be accessed by one thread at a time. In contrast to what we use now we pass the responsibility to the scheduler of the operating system to be sure that two threads cannot run at the same time by coincidence. 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
