### PR TITLE
Fix Travis test suite (work around a Travis bug)

### DIFF
--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -168,3 +168,9 @@ load 'libs/bats-support/load'
   [[ "${lines[@]}" == *"CREATE TABLE ftl ( id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL );"* ]]
   [[ "${lines[@]}" == *"INSERT INTO \"ftl\" VALUES(0,1);"* ]]
 }
+
+@test "Final part of the tests: Killing pihole-FTL process" {
+  run bash -c 'echo ">kill" | nc -v 127.0.0.1 4711'
+  echo "output: ${lines[@]}"
+  [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

According to https://github.com/travis-ci/travis-ci/issues/8082, there is a subsential bug on Travis CI since at least four days that has not been resolved, so far. Tests fail despite that everything is green when **all** those three points are met:
- The job runs on EC2 (we have no influence on that)
- The job contains secrets (we have them for deployment of binaries)
- The job invokes a process that goes into the background (`pihole-FTL` does that during testing)

We explicitly kill FTL at the end of the test suite to mitigate the Travis bug by solving the third point of the list mentioned above.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
