### PR TITLE
Limit maximum number of logged errors

### DIFF
--- a/database.c
+++ b/database.c
@@ -329,7 +329,15 @@ void save_to_DB(void)
 		if( rc != SQLITE_DONE ){
 			logg("save_to_DB() - SQL error (%i): %s", rc, sqlite3_errmsg(db));
 			saved_error++;
-			continue;
+			if(saved_error < 3)
+			{
+				continue;
+			}
+			else
+			{
+				logg("save_to_DB() - exiting due to too many errors");
+				break;
+			}
 		}
 
 		saved++;
@@ -359,10 +367,9 @@ void save_to_DB(void)
 
 	if(debug)
 	{
-		if(saved > 0)
-			logg("Notice: Queries stored in DB: %u", saved);
+		logg("Notice: Queries stored in DB: %u", saved);
 		if(saved_error > 0)
-			logg("        Queries NOT stored in DB: %u (due to an error)", saved_error);
+			logg("        There are queries that have not been saved", saved_error);
 	}
 }
 

--- a/database.c
+++ b/database.c
@@ -369,7 +369,7 @@ void save_to_DB(void)
 	{
 		logg("Notice: Queries stored in DB: %u", saved);
 		if(saved_error > 0)
-			logg("        There are queries that have not been saved", saved_error);
+			logg("        There are queries that have not been saved");
 	}
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Currently, we log the error for each failed database transaction to `pihole.FTL.log`. This can, however, lead to extraordinary log growth as see e.g. [here](https://discourse.pi-hole.net/t/pihole-ftl-log-sql-error-attempt-to-write-a-readonly-database/3761).

Assume permissions are wrong (e.g. `pihole-FTL.db` is owned by `root` with no `w` permissions for `a`):
```
[2017-08-02 17:36:00.104] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[ ... some thousands of similar messages in addition ... ]
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
```

This PR fixes the maximum number of logged errors to three. If a fourth error in encountered, the database algorithm will stop trying and terminates.
```
[2017-08-02 17:36:00.104] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - SQL error (8): attempt to write a readonly database
[2017-08-02 17:36:00.105] save_to_DB() - exiting due to too many errors
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
