### PR TITLE
Some tweaks for stats and top-clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ domains_being_blocked 19977
 dns_queries_today 104749
 ads_blocked_today 279
 ads_percentage_today 1.396606
+unique_domains 6
+queries_forwarded 3
+queries_cached 2
+clients_ever_seen 3
+unique_clients 3
 ```
 
 - `>overTime` : over time data (10 min intervals)
@@ -156,13 +161,15 @@ ads_percentage_today 1.396606
 ```
  Variant: `>top-ads (14)` to show (up to) 14 entries
 
-- `top-clients` : get top clients (IP addresses + host names (if available))
+- `top-clients` : get recently active top clients (IP addresses + host names (if available))
  ```
 0 9373 192.168.2.1 router
 1 484 192.168.2.2 work-machine
 2 8 127.0.0.1 localhost
 ```
  Variant: `>top-clients (9)` to show (up to) 9 client entries
+
+ Variant: `>top-clients withzero (15)` to show (up to) 15 clients even if they have not been active recently (see PR #124 for further details)
 
 - `>forward-dest` : get forward destinations (IP addresses + host names (if available))
  ```

--- a/request.c
+++ b/request.c
@@ -234,10 +234,13 @@ void getStats(int *sock)
 	sprintf(server_message,"unique_domains %i\nqueries_forwarded %i\nqueries_cached %i\n", \
 	        counters.domains,counters.forwardedqueries,counters.cached);
 	swrite(server_message, *sock);
+
+	// clients_ever_seen: all clients ever seen by FTL
 	sprintf(server_message,"clients_ever_seen %i\n", \
 	        counters.clients);
 	swrite(server_message, *sock);
 
+	// unique_clients: count only clients that have been active within the most recent 24 hours
 	int i, activeclients = 0;
 	for(i=0; i < counters.clients; i++)
 	{
@@ -416,7 +419,9 @@ void getTopClients(char *client_message, int *sock)
 		count = num;
 	}
 
-	// Apply Audit Log filtering?
+	// Show also clients which have not been active recently?
+	// This option can be combined with existing options,
+	// i.e. both >top-clients withzero" and ">top-clients withzero (123)" are valid
 	bool includezeroclients = false;
 	if(command(client_message, " withzero"))
 	{
@@ -459,7 +464,9 @@ void getTopClients(char *client_message, int *sock)
 				continue;
 			}
 		}
-
+		// Return this client if either
+		// - "withzero" option is set, and/or
+		// - the client made at least one query within the most recent 24 hours
 		if(includezeroclients || clients[j].count > 0)
 		{
 			sprintf(server_message,"%i %i %s %s\n",i,clients[j].count,clients[j].ip,clients[j].name);

--- a/request.c
+++ b/request.c
@@ -404,6 +404,13 @@ void getTopClients(char *client_message, int *sock)
 		count = num;
 	}
 
+	// Apply Audit Log filtering?
+	bool includezeroclients = false;
+	if(command(client_message, " withzero"))
+	{
+		includezeroclients = true;
+	}
+
 	for(i=0; i < counters.clients; i++)
 	{
 		validate_access("clients", i, true, __LINE__, __FUNCTION__, __FILE__);
@@ -441,7 +448,7 @@ void getTopClients(char *client_message, int *sock)
 			}
 		}
 
-		if(clients[j].count > 0)
+		if(includezeroclients || clients[j].count > 0)
 		{
 			sprintf(server_message,"%i %i %s %s\n",i,clients[j].count,clients[j].ip,clients[j].name);
 			swrite(server_message, *sock);

--- a/request.c
+++ b/request.c
@@ -234,9 +234,21 @@ void getStats(int *sock)
 	sprintf(server_message,"unique_domains %i\nqueries_forwarded %i\nqueries_cached %i\n", \
 	        counters.domains,counters.forwardedqueries,counters.cached);
 	swrite(server_message, *sock);
-	sprintf(server_message,"unique_clients %i\n", \
+	sprintf(server_message,"clients_ever_seen %i\n", \
 	        counters.clients);
 	swrite(server_message, *sock);
+
+	int i, activeclients = 0;
+	for(i=0; i < counters.clients; i++)
+	{
+		validate_access("clients", i, true, __LINE__, __FUNCTION__, __FILE__);
+		if(clients[i].count > 0)
+			activeclients++;
+	}
+	sprintf(server_message,"unique_clients %i\n", \
+	        activeclients);
+	swrite(server_message, *sock);
+
 	if(debugclients)
 		logg("Sent stats data to client, ID: %i", *sock);
 }

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -25,8 +25,9 @@ load 'libs/bats-support/load'
   [[ ${lines[5]} =~ "unique_domains 6" ]]
   [[ ${lines[6]} =~ "queries_forwarded 3" ]]
   [[ ${lines[7]} =~ "queries_cached 2" ]]
-  [[ ${lines[8]} == "unique_clients 3" ]]
-  [[ ${lines[9]} == "---EOM---" ]]
+  [[ ${lines[8]} == "clients_ever_seen 3" ]]
+  [[ ${lines[9]} == "unique_clients 3" ]]
+  [[ ${lines[10]} == "---EOM---" ]]
 }
 
 @test "Top Clients" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Currently, `unique_clients` (in the output of `>stats`) returns the number of clients that `FTL` has *ever* seen in its runtime. However, this is inconsistent with the data returned by `>top-clients` which only contains clients that are active, i.e. have made *at least* one query in the most recent 24 hours.

This PR makes the behavior more consistent:

- `>stats` will return `unique_clients` that is consistent with the `>top-lists` output (count only active clients). We add a new property `clients_ever_seen` to preserve the information of how many unique clients FTL has seen in its runtime (whether or not they have been active recently) to not loose the availability of this data.

- We add `withzero` as an option to `>top-clients` (e.g. `>top-clients withzero (15)`). With this flag enabled, the top clients result will contain *all* clients that are know to `FTL`, i.e. also those which haven't been active recently.

- Update `README.md`

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
