### PR TITLE
Re-resolve client host names in regular intervals

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -148,6 +148,10 @@ void *GC_thread(void *val)
 		logg("Notice: GC removed %i queries", invalidated);
 	}
 
+	// Run reresolveHostnames at the end of GC to account for
+	// formally unknown and/or changed host names on the network
+	reresolveHostnames();
+
 	// Release thread lock
 	disable_thread_lock("GC_thread");
 

--- a/main.c
+++ b/main.c
@@ -90,6 +90,7 @@ int main (int argc, char* argv[]) {
 			runDBthread = true;
 
 		// Garbadge collect in regular interval, but don't do it if the threadlocks is set
+		// This will also run reresolveHostnames()
 		if(runGCthread || needGC)
 		{
 			// Wait until we are allowed to work on the data

--- a/parser.c
+++ b/parser.c
@@ -1032,6 +1032,7 @@ void reresolveHostnames(void)
 			// Delete possibly already existing hostname pointer before storing new data
 			if(clients[clientID].name != NULL)
 			{
+				memory.clientnames -= (strlen(clients[clientID].name) + 1) * sizeof(char);
 				free(clients[clientID].name);
 				clients[clientID].name = NULL;
 			}

--- a/parser.c
+++ b/parser.c
@@ -1015,3 +1015,31 @@ void validate_access_oTfd(int timeidx, int pos, int line, const char * function,
 		logg("             found in %s() (line %i) in %s", function, line, file);
 	}
 }
+
+void reresolveHostnames(void)
+{
+	int clientID;
+	for(clientID = 0; clientID < counters.clients_MAX; clientID++)
+	{
+		// Process this client only if it has at least one active query in the log
+		if(clients[clientID].count < 1)
+			continue;
+
+		// Get client hostname
+		char *hostname = resolveHostname(clients[clientID].ip);
+		if(strlen(hostname) > 0)
+		{
+			// Delete possibly already existing hostname pointer before storing new data
+			if(clients[clientID].name != NULL)
+			{
+				free(clients[clientID].name);
+				clients[clientID].name = NULL;
+			}
+
+			// Store client hostname
+			clients[clientID].name = strdup(hostname);
+			memory.clientnames += (strlen(hostname) + 1) * sizeof(char);
+		}
+		free(hostname);
+	}
+}

--- a/parser.c
+++ b/parser.c
@@ -1019,8 +1019,11 @@ void validate_access_oTfd(int timeidx, int pos, int line, const char * function,
 void reresolveHostnames(void)
 {
 	int clientID;
-	for(clientID = 0; clientID < counters.clients_MAX; clientID++)
+	for(clientID = 0; clientID < counters.clients; clientID++)
 	{
+		// Memory validation
+		validate_access("clients", clientID, true, __LINE__, __FUNCTION__, __FILE__);
+
 		// Process this client only if it has at least one active query in the log
 		if(clients[clientID].count < 1)
 			continue;

--- a/routines.h
+++ b/routines.h
@@ -31,6 +31,7 @@ void process_pihole_log(int file);
 void *pihole_log_thread(void *val);
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file);
 void validate_access_oTfd(int timeidx, int pos, int line, const char * function, const char * file);
+void reresolveHostnames(void);
 
 void pihole_log_flushed(bool message);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

With this modification, `FTL` tries to re-resolve the client's host names after each GC run (each full hour).
This tackles two issues:

- Host names that couldn't be (for whatever reason) resolved when `FTL` first encountered a new client (see https://github.com/pi-hole/pi-hole/issues/1507 )
- Host names that changed during the run time of `FTL`

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
