### PR TITLE
Bugfix: Compute properly normalized percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ unique_clients 3
 
  Variant: `>top-clients withzero (15)` to show (up to) 15 clients even if they have not been active recently (see PR #124 for further details)
 
-- `>forward-dest` : get forward destinations (IP addresses + host names (if available))
+- `>forward-dest` : get forward destinations (IP addresses + host names (if available)) along with the percentage
  ```
-0 12940 1.2.3.4 some.dns.de
-1 629 5.6.7.8 some.other.dns.com
+0 80.0 ::1 local
+1 10.0 1.2.3.4 some.dns.de
+2 10.0 5.6.7.8 some.other.dns.com
 ```
 
 - `>querytypes` : get collected query types

--- a/README.md
+++ b/README.md
@@ -180,12 +180,10 @@ unique_clients 3
  Variant: `>forward-dest unsorted` to show forward destinations in unsorted order (equivalent to using `>forward-names`)
 ```
 
-- `>querytypes` : get collected query types
+- `>querytypes` : get collected query types share
  ```
-A (IPv4): 7729
-AAAA (IPv6): 5880
-PTR: 12
-SRV: 0
+A (IPv4): 60.5
+AAAA (IPv6): 39.5
 ```
 
 - `>getallqueries` : get all queries that FTL has in its database

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ unique_clients 3
  Variant: `>forward-dest unsorted` to show forward destinations in unsorted order (equivalent to using `>forward-names`)
 ```
 
-- `>querytypes` : get collected query types share
+- `>querytypes` : get collected query types percentage
  ```
 A (IPv4): 60.5
 AAAA (IPv6): 39.5

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ unique_clients 3
 1 10.0 1.2.3.4 some.dns.de
 2 10.0 5.6.7.8 some.other.dns.com
 ```
+ Variant: `>forward-dest unsorted` to show forward destinations in unsorted order (equivalent to using `>forward-names`)
+```
 
 - `>querytypes` : get collected query types
  ```

--- a/request.c
+++ b/request.c
@@ -559,7 +559,7 @@ void getForwardDestinations(char *client_message, int *sock)
 			// To get the total percentage of a specific query on the total number of queries,
 			// we simply have to scale b by a which is what we do in the following.
 			if(forwardedsum > 0 && counters.queries > 0)
-				percentage = 1e2 * (forwarded[j].count / forwardedsum) * (counters.forwardedqueries / counters.queries);
+				percentage = 1e2 * forwarded[j].count / forwardedsum * counters.forwardedqueries / counters.queries;
 			else
 				percentage = 0.0;
 			allocated = false;
@@ -918,7 +918,7 @@ void getForwardDestinationsOverTime(int *sock)
 					//
 					// To get the total percentage of a specific forward destination on the total
 					// number of queries, we simply have to multiply a and b as done below:
-					percentage = 1e2 * (thisforward / forwardedsum) * (overTime[i].total - (overTime[i].cached + overTime[i].blocked)) / overTime[i].total;
+					percentage = 1e2 * thisforward / forwardedsum * (overTime[i].total - (overTime[i].cached + overTime[i].blocked)) / overTime[i].total;
 				}
 				else
 				{
@@ -930,7 +930,7 @@ void getForwardDestinationsOverTime(int *sock)
 
 			// Avoid floating point exceptions
 			if(overTime[i].total > 0)
-				// Forward count for destination "local" is cached + blocked normalized by total:
+				// Forward count for destinatio "local" is cached + blocked normalized by total:
 				percentage = 1e2 * (overTime[i].cached + overTime[i].blocked) / overTime[i].total;
 			else
 				percentage = 0.0;

--- a/request.c
+++ b/request.c
@@ -856,7 +856,6 @@ void getForwardDestinationsOverTime(int *sock)
 {
 	char server_message[SOCKETBUFFERLEN];
 	int i, sendit = -1;
-	double percentage;
 
 	for(i = 0; i < counters.overTime; i++)
 	{
@@ -871,6 +870,8 @@ void getForwardDestinationsOverTime(int *sock)
 	{
 		for(i = sendit; i < counters.overTime; i++)
 		{
+			double percentage;
+
 			validate_access("overTime", i, true, __LINE__, __FUNCTION__, __FILE__);
 			sprintf(server_message, "%i", overTime[i].timestamp);
 
@@ -885,7 +886,7 @@ void getForwardDestinationsOverTime(int *sock)
 			// Loop over forward destinations to generate output to be sent to the client
 			for(j = 0; j < counters.forwarded; j++)
 			{
-				int k, forwarded;
+				int k;
 
 				if(j < overTime[i].forwardnum)
 				{
@@ -903,8 +904,7 @@ void getForwardDestinationsOverTime(int *sock)
 				// Avoid floating point exceptions
 				if(forwardedsum > 0 && overTime[i].total > 0)
 				{
-					forwarded = overTime[i].total - (overTime[i].cached + overTime[i].blocked);
-					percentage = 1e2*k/forwardedsum*forwarded/overTime[i].total;
+					percentage = 1e2*k/forwardedsum*(overTime[i].total - (overTime[i].cached + overTime[i].blocked))/overTime[i].total;
 				}
 				else
 				{

--- a/request.c
+++ b/request.c
@@ -585,8 +585,17 @@ void getForwardDestinations(char *client_message, int *sock)
 void getQueryTypes(int *sock)
 {
 	char server_message[SOCKETBUFFERLEN];
+	int total = counters.IPv4 + counters.IPv6;
+	double percentageIPv4 = 0.0, percentageIPv6 = 0.0;
 
-	sprintf(server_message,"A (IPv4): %i\nAAAA (IPv6): %i\n",counters.IPv4,counters.IPv6);
+	// Prevent floating point exceptions by checking if the divisor is != 0
+	if(total > 0)
+	{
+		percentageIPv4 = 1e2*counters.IPv4/total;
+		percentageIPv6 = 1e2*counters.IPv6/total;
+	}
+
+	sprintf(server_message,"A (IPv4): %.2f\nAAAA (IPv6): %.2f\n", percentageIPv4, percentageIPv6);
 	swrite(server_message, *sock);
 	if(debugclients)
 		logg("Sent query type data to client, ID: %i", *sock);

--- a/request.c
+++ b/request.c
@@ -954,7 +954,14 @@ void getQueryTypesOverTime(int *sock)
 		for(i = sendit; i < counters.overTime; i++)
 		{
 			validate_access("overTime", i, true, __LINE__, __FUNCTION__, __FILE__);
-			sprintf(server_message, "%i %i %i\n", overTime[i].timestamp,overTime[i].querytypedata[0],overTime[i].querytypedata[1]);
+			double percentageIPv4 = 0.0, percentageIPv6 = 0.0;
+			int sum = overTime[i].querytypedata[0] + overTime[i].querytypedata[1];
+			if(sum > 0)
+			{
+				percentageIPv4 = 1e2*overTime[i].querytypedata[0] / sum;
+				percentageIPv6 = 1e2*overTime[i].querytypedata[1] / sum;
+			}
+			sprintf(server_message, "%i %.2f %.2f\n", overTime[i].timestamp, percentageIPv4, percentageIPv6);
 			swrite(server_message, *sock);
 		}
 	}

--- a/request.c
+++ b/request.c
@@ -559,7 +559,7 @@ void getForwardDestinations(char *client_message, int *sock)
 			// To get the total percentage of a specific query on the total number of queries,
 			// we simply have to scale b by a which is what we do in the following.
 			if(forwardedsum > 0 && counters.queries > 0)
-				percentage = 1e2 * forwarded[j].count / forwardedsum * counters.forwardedqueries / counters.queries;
+				percentage = 1e2 * (forwarded[j].count / forwardedsum) * (counters.forwardedqueries / counters.queries);
 			else
 				percentage = 0.0;
 			allocated = false;
@@ -918,7 +918,7 @@ void getForwardDestinationsOverTime(int *sock)
 					//
 					// To get the total percentage of a specific forward destination on the total
 					// number of queries, we simply have to multiply a and b as done below:
-					percentage = 1e2 * thisforward / forwardedsum * (overTime[i].total - (overTime[i].cached + overTime[i].blocked)) / overTime[i].total;
+					percentage = 1e2 * (thisforward / forwardedsum) * (overTime[i].total - (overTime[i].cached + overTime[i].blocked)) / overTime[i].total;
 				}
 				else
 				{
@@ -930,7 +930,7 @@ void getForwardDestinationsOverTime(int *sock)
 
 			// Avoid floating point exceptions
 			if(overTime[i].total > 0)
-				// Forward count for destinatio "local" is cached + blocked normalized by total:
+				// Forward count for destination "local" is cached + blocked normalized by total:
 				percentage = 1e2 * (overTime[i].cached + overTime[i].blocked) / overTime[i].total;
 			else
 				percentage = 0.0;

--- a/request.c
+++ b/request.c
@@ -930,7 +930,7 @@ void getForwardDestinationsOverTime(int *sock)
 
 			// Avoid floating point exceptions
 			if(overTime[i].total > 0)
-				// Forward count for destinatio "local" is cached + blocked normalized by total:
+				// Forward count for destination "local" is cached + blocked normalized by total:
 				percentage = 1e2 * (overTime[i].cached + overTime[i].blocked) / overTime[i].total;
 			else
 				percentage = 0.0;

--- a/request.c
+++ b/request.c
@@ -535,7 +535,10 @@ void getForwardDestinations(char *client_message, int *sock)
 			strcpy(ip, "::1");
 			name = calloc(6,1);
 			strcpy(name, "local");
-			percentage = 1e2*(counters.cached + counters.blocked)/counters.queries;
+			if(counters.queries > 0)
+				percentage = 1e2*(counters.cached + counters.blocked)/counters.queries;
+			else
+				percentage = 0.0;
 			allocated = true;
 		}
 		else
@@ -557,7 +560,7 @@ void getForwardDestinations(char *client_message, int *sock)
 			//
 			// To get the total percentage of a specific query on the total number of queries,
 			// we simply have to scale b by a which is what we do in the following.
-			if(forwardedsum > 0)
+			if(forwardedsum > 0 && counters.queries > 0)
 				percentage = 1e2*forwarded[j].count/forwardedsum*counters.forwardedqueries/counters.queries;
 			else
 				percentage = 0.0;

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -72,11 +72,11 @@ load 'libs/bats-support/load'
   run bash -c 'echo ">forward-dest" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} =~ "0 4 ::1 local" ]]
-  [[ ${lines[2]} =~ "1 3 2620:0:ccd::2 resolver2.ipv6-sandbox.opendns.com" ]]
-  [[ ${lines[3]} =~ "2 2 2001:1608:10:25::9249:d69b" ]]
-  [[ ${lines[4]} =~ "3 2 2001:1608:10:25::1c04:b12f" ]]
-  [[ ${lines[5]} =~ "4 2 2620:0:ccc::2 resolver1.ipv6-sandbox.opendns.com" ]]
+  [[ ${lines[1]} =~ "0 57.14 ::1 local" ]]
+  [[ ${lines[2]} =~ "1 14.29 2620:0:ccd::2 resolver2.ipv6-sandbox.opendns.com" ]]
+  [[ ${lines[3]} =~ "2 9.52 2001:1608:10:25::9249:d69b" ]]
+  [[ ${lines[4]} =~ "3 9.52 2001:1608:10:25::1c04:b12f" ]]
+  [[ ${lines[5]} =~ "4 9.52 2620:0:ccc::2 resolver1.ipv6-sandbox.opendns.com" ]]
   [[ ${lines[6]} == "---EOM---" ]]
 }
 
@@ -84,11 +84,11 @@ load 'libs/bats-support/load'
   run bash -c 'echo ">forward-dest unsorted" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} =~ "0 2 2001:1608:10:25::9249:d69b" ]]
-  [[ ${lines[2]} =~ "1 2 2001:1608:10:25::1c04:b12f" ]]
-  [[ ${lines[3]} =~ "2 3 2620:0:ccd::2 resolver2.ipv6-sandbox.opendns.com" ]]
-  [[ ${lines[4]} =~ "3 2 2620:0:ccc::2 resolver1.ipv6-sandbox.opendns.com" ]]
-  [[ ${lines[5]} =~ "4 4 ::1 local" ]]
+  [[ ${lines[1]} =~ "0 9.52 2001:1608:10:25::9249:d69b" ]]
+  [[ ${lines[2]} =~ "1 9.52 2001:1608:10:25::1c04:b12f" ]]
+  [[ ${lines[3]} =~ "2 14.29 2620:0:ccd::2 resolver2.ipv6-sandbox.opendns.com" ]]
+  [[ ${lines[4]} =~ "3 9.52 2620:0:ccc::2 resolver1.ipv6-sandbox.opendns.com" ]]
+  [[ ${lines[5]} =~ "4 57.14 ::1 local" ]]
   [[ ${lines[6]} == "---EOM---" ]]
 }
 
@@ -96,8 +96,8 @@ load 'libs/bats-support/load'
   run bash -c 'echo ">querytypes" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} == "A (IPv4): 5" ]]
-  [[ ${lines[2]} == "AAAA (IPv6): 2" ]]
+  [[ ${lines[1]} == "A (IPv4): 71.43" ]]
+  [[ ${lines[2]} == "AAAA (IPv6): 28.57" ]]
   [[ ${lines[3]} == "---EOM---" ]]
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Properly normalize the percentages computed from the raw statistics. This is a bug fix PR.
Very briefly summarized what went wrong: When `dnsmasq` receives a query that cannot be answered from cache, it may be forwarded to more than one forward destination. Int his case we would count e.g. four forwarded queries although we only made one request to `dnsmasq`. Hence, the count of forwarded requests has to be normalized by the number of queries that required a forwarding. The wrong computation is fixed by this PR. Most notable is that the `local` destination should be more prominent for most users as the previous situation was quite "adverse" for this "destination".

Previously
![screenshot at 2017-09-20 17-13-00](https://user-images.githubusercontent.com/16748619/30651956-6176a362-9e27-11e7-82a8-0abebe84f42b.png)

Corrected
![screenshot at 2017-09-20 17-12-24](https://user-images.githubusercontent.com/16748619/30651961-6321aab8-9e27-11e7-9169-d7ecf39b336b.png)

This PR changes also the output of the query types from absolute (counts) to relative (percentage) outputs for consistency. However, the displayed statistics do not actually change as no normalization is required here.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
