### PR TITLE
Always send EOM at end of transmission

### DIFF
--- a/request.c
+++ b/request.c
@@ -134,7 +134,7 @@ void process_request(char *client_message, int *sock)
 
 	if(!processed)
 	{
-		sprintf(server_message,"unknown command: %s\n",client_message);
+		sprintf(server_message,"unknown command: %s",client_message);
 		swrite(server_message, *sock);
 	}
 

--- a/request.c
+++ b/request.c
@@ -114,13 +114,6 @@ void process_request(char *client_message, int *sock)
 		getDBstats(sock);
 	}
 
-	// End of queryable commands
-	if(processed)
-	{
-		// Send EOM
-		seom(server_message, *sock);
-	}
-
 	// Test only at the end if we want to quit or kill
 	// so things can be processed before
 	if(command(client_message, ">quit") || command(client_message, EOT))
@@ -143,6 +136,13 @@ void process_request(char *client_message, int *sock)
 	{
 		sprintf(server_message,"unknown command: %s\n",client_message);
 		swrite(server_message, *sock);
+	}
+
+	// End of queryable commands
+	if(*sock != 0)
+	{
+		// Send EOM
+		seom(server_message, *sock);
 	}
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Always send `EOM` at end of transmission (if connection is still alive).

I found that when we implement new features on the web interface (e.g. the Clients over time graph) but don't have the according functionality already in the background (i.e. `FTL` running on a matching branch), then the `PHP API` will hang. The reason is that it continues to wait for additional data as long as it didn't see the end of transmission (`EOM`) indicator. However - so far - the return for an unknown command
```
unknown command: abcd
```
did not send an `EOM` telegram so the API was always assuming that additional information may be on its way and git stuck in an infinity loop there.

Proposed solution: Always send `EOM` as it doesn't hurt and actually makes the telnet output more consistent.
```
unknown command: abcd
---EOM---
```

Note that this specific "bug" is very unlikely to ever affect users that are using it in production machines as they will always have a version of `FTL` that is in sync with the other branches (as `FTL` is either released at the same time or even a bit before the other branches). Nevertheless, this change eases development as we don't have to care about if the branches are in the correct causal connection.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
