### PR TITLE
Add RESOLVEIPV6 config flag

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -120,6 +120,7 @@ typedef struct {
 	bool query_display;
 	bool analyze_AAAA;
 	int maxDBdays;
+	bool resolveIPv6;
 } ConfigStruct;
 
 // Dynamic structs

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Possible settings (**the option shown first is the default**):
 - `QUERY_DISPLAY=yes|no` (Display all queries? Set to `no` to hide query display)
 - `AAAA_QUERY_ANALYSIS=yes|no` (Allow `FTL` to analyze AAAA queries from pihole.log?)
 - `MAXDBDAYS=365` (How long should queries be stored in the database? Setting this to `0` disables the database altogether)
-- `RESOLVEIPV6=yes|no` (Should `FTL` try to resolve IPv6 addresses to host names?)
+- `RESOLVE_IPV6=yes|no` (Should `FTL` try to resolve IPv6 addresses to host names?)
 
 ### Implemented keywords (starting with `>`, subject to change):
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Possible settings (**the option shown first is the default**):
 - `QUERY_DISPLAY=yes|no` (Display all queries? Set to `no` to hide query display)
 - `AAAA_QUERY_ANALYSIS=yes|no` (Allow `FTL` to analyze AAAA queries from pihole.log?)
 - `MAXDBDAYS=365` (How long should queries be stored in the database? Setting this to `0` disables the database altogether)
+- `RESOLVEIPV6=yes|no` (Should `FTL` try to resolve IPv6 addresses to host names?)
 
 ### Implemented keywords (starting with `>`, subject to change):
 

--- a/config.c
+++ b/config.c
@@ -111,6 +111,20 @@ void read_FTLconf(void)
 	else
 		logg("   MAXDBDAYS: max age for stored queries is %i days", config.maxDBdays);
 
+	// RESOLVEIPV6
+	// defaults to: Yes
+	config.resolveIPv6 = true;
+	buffer = parse_FTLconf(fp, "RESOLVEIPV6");
+	if(buffer != NULL)
+	{
+		if(strcmp(buffer, "no") == 0)
+			config.resolveIPv6 = false;
+	}
+	if(config.resolveIPv6)
+		logg("   RESOLVEIPV6: Resolve IPv6 addresses");
+	else
+		logg("   RESOLVEIPV6: Don\'t resolve IPv6 addresses");
+
 	logg("Finished config file parsing");
 
 	if(conflinebuffer != NULL)

--- a/config.c
+++ b/config.c
@@ -111,19 +111,19 @@ void read_FTLconf(void)
 	else
 		logg("   MAXDBDAYS: max age for stored queries is %i days", config.maxDBdays);
 
-	// RESOLVEIPV6
+	// RESOLVE_IPV6
 	// defaults to: Yes
 	config.resolveIPv6 = true;
-	buffer = parse_FTLconf(fp, "RESOLVEIPV6");
+	buffer = parse_FTLconf(fp, "RESOLVE_IPV6");
 	if(buffer != NULL)
 	{
 		if(strcmp(buffer, "no") == 0)
 			config.resolveIPv6 = false;
 	}
 	if(config.resolveIPv6)
-		logg("   RESOLVEIPV6: Resolve IPv6 addresses");
+		logg("   RESOLVE_IPV6: Resolve IPv6 addresses");
 	else
-		logg("   RESOLVEIPV6: Don\'t resolve IPv6 addresses");
+		logg("   RESOLVE_IPV6: Don\'t resolve IPv6 addresses");
 
 	logg("Finished config file parsing");
 

--- a/parser.c
+++ b/parser.c
@@ -718,15 +718,23 @@ void process_pihole_log(int file)
 char *resolveHostname(const char *addr)
 {
 	// Get host name
-	struct hostent *he;
+	struct hostent *he = NULL;
 	char *hostname;
+	bool IPv6 = false;
+
+	// Test if we want to resolve an IPv6 address
 	if(strstr(addr,":") != NULL)
+	{
+		IPv6 = true;
+	}
+
+	if(IPv6 && config.resolveIPv6) // Resolve IPv6 address only if requested
 	{
 		struct in6_addr ipaddr;
 		inet_pton(AF_INET6, addr, &ipaddr);
 		he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET6);
 	}
-	else
+	else if(!IPv6) // Always resolve IPv4 addresses
 	{
 		struct in_addr ipaddr;
 		inet_pton(AF_INET, addr, &ipaddr);
@@ -735,11 +743,13 @@ char *resolveHostname(const char *addr)
 
 	if(he == NULL)
 	{
+		// No hostname found
 		hostname = calloc(1,sizeof(char));
 		hostname[0] = '\0';
 	}
 	else
 	{
+		// Return hostname copied to new memory location
 		hostname = strdup(he->h_name);
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add config flag `RESOLVEIPV6=yes|no` to specify whether `FTL` should try to resolve IPv6 addresses to host names or not. Several users (like @WaLLy3K ) have seen issues with IPv6 addresses being resolved to extremely cumbersome generic ISP host names.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
