### PR TITLE
Detect and skip queries older than the ones before in the same log file

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -284,6 +284,17 @@ void process_pihole_log(int file)
 				}
 			}
 
+			// Detect time travel events
+			if(timeidx < 0)
+			{
+				// This query is older than the first one in the log, hence the clock
+				// on this machine was at least slightly off for a while. We will skip
+				// this query as we cannot attribute it correctly to anything.
+				validate_access("overTime", 0, false, __LINE__, __FUNCTION__, __FILE__);
+				logg("Warning: Skipping log entry with incorrect timestamp (%i/%i)", overTimetimestamp, overTime[0].timestamp);
+				continue;
+			}
+
 			// Get domain
 			// domainstart = pointer to | in "query[AAAA] |host.name from ww.xx.yy.zz\n"
 			const char *domainstart = strstr(readbuffer, "] ");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Assume non-contiguous entries in `pihole.log(.1)` (however they are created) like:
<pre>
Oct  3 00:00:05 dnsmasq[27516]: query[A] api.nixstats.com from 127.0.0.1
Oct  3 00:00:13 dnsmasq[27516]: query[A] checkip.dyndns.org from 127.0.0.1
<b>Oct  2 19:00:05</b> dnsmasq[27516]: query[AAAA] api.nixstats.com from 127.0.0.1
Oct  3 00:00:19 dnsmasq[27516]: query[A] checkip.dyndns.org from 127.0.0.1
</pre>

This may lead to a crash of `FTL` which assumes that time can only go in a forward direction:
```
[2017-10-03 14:08:12.467] FATAL ERROR: Trying to access overTime[-1], but maximum is 100
[2017-10-03 14:08:12.467]              found in process_pihole_log() (line 370) in parser.c

Program received signal SIGSEGV, Segmentation fault.
```

This PR fixes this crash and allows `FTL` to handle time as a continuum with only a slight preference for the forward direction (explicitly supporting also the backwards direction). However, backward time travel makes little sense on computers and point to problems with the system clock. Hence, these entries will be skipped during the log analysis. The user will get informed about this via a warning message in `FTL`'s log file:
```
[2017-10-03 13:59:08.839] Warning: Skipping log entry with incorrect timestamp (1506963900/1506981900)
```

This PR fixes #139 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
