### PR TITLE
only compare the ends of two domains instead of entire domain string

### DIFF
--- a/setupVars.c
+++ b/setupVars.c
@@ -183,7 +183,16 @@ bool insetupVarsArray(char * str)
 		}
 		else
 		{
-			if(strcmp(setupVarsArray[i], str) == 0)
+			// Return true only when the ends of the two domains match
+			// This allows an exclusion of 'nflxso.net' to not display:
+			// occ-2-990-987.1.nflxso.net, occ-0-990-987.1.nflxso.net, etc.
+			size_t candidate = strlen(str);
+			size_t excluded = strlen(setupVarsArray[i]);
+			if (excluded > candidate)
+				continue;
+
+			size_t end_pos = candidate - excluded;
+			if(strcmp(str + end_pos, setupVarsArray[i]) == 0)
 				return true;
 		}
 


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 3

---

**Problem**
On the Top Domains portion of the dashboard, multiple host names appear for the same domain name which can make one domain name dominate the results.  For example, three of the top 10 domains for my system include something1.nflxso.net, something2.nflxso.net, and something3.nflxso.net.  

**Proposal**
Instead of having to individually add each host name to the Settings -> Top Lists -> Excludes, only add the domain (in this case  nflxso.net).  The code for insetupVarsArray() currently checks for an identical strings via strcmp().  I have written a patch that only returns true when the end of the two strings are identical.  Thus, and entry of nflxso.net will return true for anything ending in nflxso.net.  By doing this, a more varied list of Top Domains will be displayed on the dashboard.


