### PR TITLE
Detect pihole blocking status

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -86,6 +86,7 @@ typedef struct {
 	const char* setupVars;
 	const char* wildcards;
 	const char* auditlist;
+	const char* dnsmasqconfig;
 } logFileNamesStruct;
 
 typedef struct {
@@ -209,6 +210,7 @@ bool debugGC;
 bool debugDB;
 bool threadwritelock;
 bool threadreadlock;
+unsigned char blockingstatus;
 
 char ** wildcarddomains;
 

--- a/grep.c
+++ b/grep.c
@@ -49,6 +49,9 @@ void read_gravity_files(void)
 	{
 		logg("No wildcard blocking list present");
 	}
+
+	// Get blocking status
+	check_blocking_status();
 }
 
 int countlines(const char* fname)
@@ -200,4 +203,19 @@ int countlineswith(const char* str, const char* fname)
 	fclose(fp);
 
 	return found;
+}
+
+void check_blocking_status(void)
+{
+	int disabled = countlineswith("#addn-hosts=/etc/pihole/gravity.list",files.dnsmasqconfig);
+
+	if(disabled < 0)
+		// Failed to open file -> unknown status
+		blockingstatus = 2;
+	else if(disabled > 0)
+		// Disabled
+		blockingstatus = 0;
+	else
+		// Enabled
+		blockingstatus = 1;
 }

--- a/request.c
+++ b/request.c
@@ -229,8 +229,20 @@ void getStats(int *sock)
 	{
 		percentage = 1e2*blocked/total;
 	}
-	sprintf(server_message,"domains_being_blocked %i\ndns_queries_today %i\nads_blocked_today %i\nads_percentage_today %f\n", \
-	        counters.gravity,total,blocked,percentage);
+
+	switch(blockingstatus)
+	{
+		case 0: // Blocking disabled
+			sprintf(server_message,"domains_being_blocked N/A\n");
+			swrite(server_message, *sock);
+			break;
+		default: // Either unknown or enabled
+			sprintf(server_message,"domains_being_blocked %i\n",counters.gravity);
+			swrite(server_message, *sock);
+			break;
+	}
+	sprintf(server_message,"dns_queries_today %i\nads_blocked_today %i\nads_percentage_today %f\n", \
+	        total,blocked,percentage);
 	swrite(server_message, *sock);
 	sprintf(server_message,"unique_domains %i\nqueries_forwarded %i\nqueries_cached %i\n", \
 	        counters.domains,counters.forwardedqueries,counters.cached);
@@ -252,6 +264,22 @@ void getStats(int *sock)
 	sprintf(server_message,"unique_clients %i\n", \
 	        activeclients);
 	swrite(server_message, *sock);
+
+	switch(blockingstatus)
+	{
+		case 0: // Blocking disabled
+			sprintf(server_message,"status disabled\n");
+			swrite(server_message, *sock);
+			break;
+		case 1: // Blocking Enabled
+			sprintf(server_message,"status enabled\n");
+			swrite(server_message, *sock);
+			break;
+		default: // Unknown status
+			sprintf(server_message,"status unknown\n");
+			swrite(server_message, *sock);
+			break;
+	}
 
 	if(debugclients)
 		logg("Sent stats data to client, ID: %i", *sock);

--- a/routines.h
+++ b/routines.h
@@ -49,6 +49,7 @@ void formatNumber(bool raw, int n, char* buffer);
 void read_gravity_files(void);
 int countlines(const char* fname);
 int countlineswith(const char* str, const char* fname);
+void check_blocking_status(void);
 
 void check_setupVarsconf(void);
 char * read_setupVarsconf(const char * key);

--- a/structs.c
+++ b/structs.c
@@ -26,7 +26,8 @@ logFileNamesStruct files = {
 	"/etc/pihole/blacklist.txt",
 	"/etc/pihole/setupVars.conf",
 	"/etc/dnsmasq.d/03-pihole-wildcard.conf",
-	"/etc/pihole/auditlog.list"
+	"/etc/pihole/auditlog.list",
+	"/etc/dnsmasq.d/01-pihole.conf"
 };
 
 countersStruct counters = { 0 };

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -27,7 +27,8 @@ load 'libs/bats-support/load'
   [[ ${lines[7]} =~ "queries_cached 2" ]]
   [[ ${lines[8]} == "clients_ever_seen 3" ]]
   [[ ${lines[9]} == "unique_clients 3" ]]
-  [[ ${lines[10]} == "---EOM---" ]]
+  [[ ${lines[10]} == "status unknown" ]]
+  [[ ${lines[11]} == "---EOM---" ]]
 }
 
 @test "Top Clients" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Detect Pi-hole blocking status and return this on API request:

Enabled:
<pre>
echo ">stats" | nc pi.hole 4711
<b>domains_being_blocked 113207</b>
dns_queries_today 13248
ads_blocked_today 302
ads_percentage_today 2.279589
unique_domains 584
queries_forwarded 4725
queries_cached 8221
clients_ever_seen 6
unique_clients 6
<b>status enabled</b>
---EOM---
</pre>

Disabled:
<pre>
echo ">stats" | nc pi.hole 4711
<b>domains_being_blocked N/A</b>
dns_queries_today 13248
ads_blocked_today 302
ads_percentage_today 2.279589
unique_domains 584
queries_forwarded 4725
queries_cached 8221
clients_ever_seen 6
unique_clients 6
<b>status disabled</b>
---EOM---
</pre>


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
