### PR TITLE
New year's issue

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -844,8 +844,21 @@ void extracttimestamp(const char *readbuffer, int *querytimestamp, int *overTime
 	// %M = Minute (00-59)
 	// %S = Second (00-59)
 	strptime(timestamp, "%b %e %H:%M:%S", &querytime);
-	// Year is missing in dnsmasq's output - add the current year
-	querytime.tm_year = (*timeinfo).tm_year;
+
+	// Year is missing in dnsmasq's output so we have to take care of it
+	if(querytime.tm_mon == 11 && (*timeinfo).tm_mon == 0)
+	{
+		// Special case: read timestamp in December (e.g. 2017), but current
+		// month is already January (e.g. 2018) -> use (year-1) for this timestamp
+		// Note that months are counted from January on, i.e.
+		// January == 0, December == 11
+		querytime.tm_year = (*timeinfo).tm_year - 1;
+	}
+	else
+	{
+		// In all other cases: Use current year
+		querytime.tm_year = (*timeinfo).tm_year;
+	}
 
 	// DST - according to ISO/IEC 9899:TC3
 	// > A negative value causes mktime to attempt to determine whether


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Currently, `FTL` will fail to interpret dates when restarted on Jan 01.
The problem is that `dnsmasq`'s log lacks the year which is probably being done as a filesize reduction measure. That is irrelevant most of the year. However, every year we come to the point where a year ends and a new year starts. Here, the lack of the year *can* become problematic as we have to assume a year when converting dates into times tamps. Before this commit, `FTL` always assumed the current year to be the correct choice. That is true in all cases except one: `FTL` is restarted on Jan 01. It would then interpret the Dec 31 data if finds during log parsing with this (instead of last) year which would be wrong. This misbehavior is fixed by this PR in the following way: We test if we are currently in January (local time), but the query we found was in December.

If so: Use `year_of_query = current_year - 1`
If not: Use `year_of_query = current_year`

Note that this bug fix fixes a bug before it could even show up (so there's also no issue report for this).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
