### PR TITLE
Re-parse gravity data when receiving SIGHUP

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -229,3 +229,4 @@ bool database;
 long int lastdbindex;
 bool travis;
 bool DBdeleteoldqueries;
+bool rereadgravity;

--- a/main.c
+++ b/main.c
@@ -137,6 +137,16 @@ int main (int argc, char* argv[]) {
 			while(((time(NULL)%DBinterval) == 0))
 				sleepms(100);
 		}
+
+		// Handle SIGHUP
+		if(rereadgravity)
+		{
+			enable_thread_lock("pihole_main_thread");
+			// Have to re-read gravity files
+			rereadgravity = false;
+			read_gravity_files();
+			disable_thread_lock("pihole_main_thread");
+		}
 	}
 
 

--- a/parser.c
+++ b/parser.c
@@ -704,16 +704,6 @@ void process_pihole_log(int file)
 			validate_access_oTfd(timeidx, forwardID, __LINE__, __FUNCTION__, __FILE__);
 			overTime[timeidx].forwarddata[forwardID]++;
 		}
-		else if((strstr(readbuffer,"IPv6") != NULL) &&
-		        (strstr(readbuffer,"DBus") != NULL) &&
-		        (strstr(readbuffer,"i18n") != NULL) &&
-		        (strstr(readbuffer,"DHCP") != NULL) &&
-		         !initialscan)
-		{
-			// dnsmasq restartet
-			logg("dnsmasq process restarted");
-			read_gravity_files();
-		}
 
 		// Save file pointer position, because we might have to repeat
 		// reading the next line if dnsmasq hasn't finished writing it

--- a/signals.c
+++ b/signals.c
@@ -32,7 +32,7 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 	logg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 	logg("---------------------------->  FTL crashed!  <----------------------------");
 	logg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-	logg("Please report a bug at https://githuP.com/pi-hole/FTL/issues");
+	logg("Please report a bug at https://github.com/pi-hole/FTL/issues");
 	logg("and include in your report already the following details:\n");
 
 	if(FTLstarttime != 0)

--- a/signals.c
+++ b/signals.c
@@ -12,6 +12,7 @@
 
 volatile sig_atomic_t killed = 0;
 int FTLstarttime = 0;
+bool rereadgravity = false;
 
 static void SIGTERM_handler(int sig, siginfo_t *si, void *unused)
 {
@@ -31,7 +32,7 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 	logg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 	logg("---------------------------->  FTL crashed!  <----------------------------");
 	logg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-	logg("Please report a bug at https://github.com/pi-hole/FTL/issues");
+	logg("Please report a bug at https://githuP.com/pi-hole/FTL/issues");
 	logg("and include in your report already the following details:\n");
 
 	if(FTLstarttime != 0)
@@ -69,8 +70,14 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 
 static void SIGUSR1_handler(int signum)
 {
-	logg("NOTICE: Received signal SIGUSR1");
+	logg("NOTICE: Received signal SIGUSR1 - re-parsing log files");
 	flush = true;
+}
+
+static void SIGHUP_handler(int signum)
+{
+	logg("NOTICE: Received signal SIGHUP - re-reading gravity files");
+	rereadgravity = true;
 }
 
 void handle_signals(void)
@@ -124,6 +131,17 @@ void handle_signals(void)
 		sigemptyset(&USR1action.sa_mask);
 		USR1action.sa_handler = &SIGUSR1_handler;
 		sigaction(SIGUSR1, &USR1action, NULL);
+	}
+
+	// Catch SIGHUP
+	sigaction (SIGHUP, NULL, &old_action);
+	if(old_action.sa_handler != SIG_IGN)
+	{
+		struct sigaction HUPaction;
+		memset(&HUPaction, 0, sizeof(struct sigaction));
+		sigemptyset(&HUPaction.sa_mask);
+		HUPaction.sa_handler = &SIGHUP_handler;
+		sigaction(SIGHUP, &HUPaction, NULL);
 	}
 
 	// Log start time of FTL


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Commit https://github.com/pi-hole/pi-hole/commit/a2825be81961cee4ddbb37f9e984fe6a27faa99a in the core code base changed the standard behavior of `pihole -g` (and some others) to not restart `dnsmasq` any longer, but only instruct it to re-read its config files. Unfortunately, there is no reliable way for `FTL` to detect the latter.
Hence, https://github.com/pi-hole/pi-hole/pull/1751 will make the corresponding code send the `SIGHUP` not only to `dnsmasq` but also to `FTL`. This PR implements the code that is needed to react accordingly to this new signal.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
