### PR TITLE
Use case insensitive string comparison for wildcards

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -817,7 +817,7 @@ int detectStatus(const char *domain)
 		while(sscanf(part,"%*[^.].%s", partbuffer) > 0)
 		{
 			// Test for a match
-			if(strcmp(wildcarddomains[i], partbuffer) == 0)
+			if(strcasecmp(wildcarddomains[i], partbuffer) == 0)
 			{
 				// Free allocated memory before return'ing
 				free(part);

--- a/parser.c
+++ b/parser.c
@@ -789,7 +789,7 @@ int detectStatus(const char *domain)
 	for(i=0; i < counters.wildcarddomains; i++)
 	{
 		validate_access("wildcarddomains", i, false, __LINE__, __FUNCTION__, __FILE__);
-		if(strcmp(wildcarddomains[i], domain) == 0)
+		if(strcasecmp(wildcarddomains[i], domain) == 0)
 		{
 			// Exact match with wildcard domain
 			// if(debug)

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -36,7 +36,7 @@ load 'libs/bats-support/load'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
   [[ ${lines[1]} =~ "0 4 192.168.2.208" ]]
-  [[ ${lines[2]} == "1 2 127.0.0.1 localhost" ]]
+  [[ ${lines[2]} =~ "1 2 127.0.0.1"]]
   [[ ${lines[3]} =~ "2 1 10.8.0.2" ]]
   [[ ${lines[4]} == "---EOM---" ]]
 }
@@ -106,8 +106,8 @@ load 'libs/bats-support/load'
   run bash -c 'echo ">getallqueries" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} =~ "IPv6 raspberrypi localhost 3" ]]
-  [[ ${lines[2]} =~ "IPv4 checkip.dyndns.org localhost 2" ]]
+  [[ ${lines[1]} =~ "IPv6 raspberrypi" ]]
+  [[ ${lines[2]} =~ "IPv4 checkip.dyndns.org" ]]
   [[ ${lines[3]} =~ "IPv4 example.com" ]]
   [[ ${lines[4]} =~ "IPv4 play.google.com" ]]
   [[ ${lines[5]} =~ "IPv6 play.google.com" ]]
@@ -134,19 +134,19 @@ load 'libs/bats-support/load'
 }
 
 @test "Get all queries (client filtered)" {
-  run bash -c 'echo ">getallqueries-client localhost" | nc -v 127.0.0.1 4711'
+  run bash -c 'echo ">getallqueries-client 127.0.0.1" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} =~ "IPv6 raspberrypi localhost 3" ]]
-  [[ ${lines[2]} =~ "IPv4 checkip.dyndns.org localhost 2" ]]
+  [[ ${lines[1]} =~ "IPv6 raspberrypi" ]]
+  [[ ${lines[2]} =~ "IPv4 checkip.dyndns.org" ]]
   [[ ${lines[3]} == "---EOM---" ]]
 }
 
 @test "Get all queries (client + number filtered)" {
-  run bash -c 'echo ">getallqueries-client localhost (6)" | nc -v 127.0.0.1 4711'
+  run bash -c 'echo ">getallqueries-client 127.0.0.1 (6)" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} =~ "IPv4 checkip.dyndns.org localhost 2" ]]
+  [[ ${lines[1]} =~ "IPv4 checkip.dyndns.org" ]]
   [[ ${lines[2]} == "---EOM---" ]]
 }
 

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -36,7 +36,7 @@ load 'libs/bats-support/load'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
   [[ ${lines[1]} =~ "0 4 192.168.2.208" ]]
-  [[ ${lines[2]} =~ "1 2 127.0.0.1"]]
+  [[ ${lines[2]} =~ "1 2 127.0.0.1" ]]
   [[ ${lines[3]} =~ "2 1 10.8.0.2" ]]
   [[ ${lines[4]} == "---EOM---" ]]
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This fixes an issue reported on [Discourse](https://discourse.pi-hole.net/t/pi-hole-dns-server-should-be-case-insensitive-but-it-isnt/5583).

Replace `strcmp` by `strcasecmp`, see e.g.
https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_72/rtref/strcasecmp.htm


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
