### PR TITLE
Convert forward destinations, clients and domains to lower case

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -38,6 +38,8 @@
 #include <syslog.h>
 // SQLite
 #include "sqlite3.h"
+// tolower()
+#include <ctype.h>
 
 #include "routines.h"
 

--- a/parser.c
+++ b/parser.c
@@ -91,6 +91,13 @@ void get_file_permissions(const char *path)
 	logg("Reading from %s (%s)", path, permissions);
 }
 
+// converts upper to lower case, and leaves other characters unchanged
+void strtolower(char *str)
+{
+	int i = 0;
+	while(str[i]){ str[i] = tolower(str[i]); i++; }
+}
+
 void *pihole_log_thread(void *val)
 {
 	prctl(PR_SET_NAME,"loganalyzer",0,0,0);
@@ -329,6 +336,8 @@ void process_pihole_log(int file)
 			char *domainwithspaces = calloc(domainlen+3,sizeof(char));
 			// strncat() NULL-terminates the copied string (strncpy() doesn't!)
 			strncat(domain,domainstart+2,domainlen);
+			// Convert domain to lower case
+			strtolower(domain);
 			sprintf(domainwithspaces," %s ",domain);
 
 			if(strcmp(domain, "pi.hole") == 0)
@@ -366,6 +375,8 @@ void process_pihole_log(int file)
 			char *client = calloc(clientlen+1,sizeof(char));
 			// strncat() NULL-terminates the copied string (strncpy() doesn't!)
 			strncat(client,domainend+6,clientlen);
+			// Convert client to lower case
+			strtolower(client);
 
 			// Get type
 			unsigned char type = 0;
@@ -514,7 +525,11 @@ void process_pihole_log(int file)
 				char *hostname = resolveHostname(client);
 				// Debug output
 				if(strlen(hostname) > 0)
+				{
+					// Convert hostname to lower case
+					strtolower(hostname);
 					logg("New client: %s %s (%i/%i)", client, hostname, clientID, counters.clients_MAX);
+				}
 				else
 					logg("New client: %s (%i/%i)", client, clientID, counters.clients_MAX);
 
@@ -932,6 +947,8 @@ int getforwardID(const char * str, bool count)
 	char *forward = calloc(forwardlen+1,sizeof(char));
 	// strncat() NULL-terminates the copied string (strncpy() doesn't!)
 	strncat(forward,forwardstart+4,forwardlen);
+	// Convert forward to lower case
+	strtolower(forward);
 
 	bool processed = false;
 	int i, forwardID = -1;
@@ -958,7 +975,11 @@ int getforwardID(const char * str, bool count)
 		// Get forward destination host name
 		char *hostname = resolveHostname(forward);
 		if(strlen(hostname) > 0)
+		{
+			// Convert hostname to lower case
+			strtolower(hostname);
 			logg("New forward server: %s %s (%i/%i)", forward, hostname, forwardID, counters.forwarded_MAX);
+		}
 		else
 			logg("New forward server: %s (%i/%u)", forward, forwardID, counters.forwarded_MAX);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR is the logical continuation of #162 

For consistency, we convert all domains, clients, and forward destinations to lower case before we use and analyze them. Before this PR, e.g., `Domain.com` was handled differently than `domain.com`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
