### PR TITLE
Disable FTL's DB functionality on errors

### DIFF
--- a/database.c
+++ b/database.c
@@ -25,8 +25,13 @@ void check_database(int rc)
 	// However, we won't retry if any other error happened
 	// and - instead - disable the database functionality
 	// altogether in FTL (setting database to false)
-	if(rc != SQLITE_OK && rc != SQLITE_BUSY)
+	if(rc != SQLITE_OK &&
+	   rc != SQLITE_DONE &&
+	   rc != SQLITE_ROW &&
+	   rc != SQLITE_BUSY)
+	{
 		database = false;
+	}
 }
 
 void dbclose(void)
@@ -357,8 +362,9 @@ void save_to_DB(void)
 				logg("save_to_DB() - exiting due to too many errors");
 				break;
 			}
+			// Check this error message
+			check_database(rc);
 		}
-		check_database(rc);
 
 		saved++;
 		// Mark this query as saved in the database only if successful


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Disable FTL's database functionality on all errors except `SQLITE_BUSY`. I'm not sure if other [errors](https://sqlite.org/c3ref/c_abort.html) should be (temporarily) allowed as well, but I don't think so.

> "Error codes" are a subset of "result codes" that indicate that something has gone wrong. There are only a few non-error result codes: `SQLITE_OK`, `SQLITE_ROW`, and `SQLITE_DONE`. The term "error code" means any result code other than these three.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
