### PR TITLE
Make DB interval adjustable

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -66,10 +66,6 @@
 // Default -60 (one minute before a full hour)
 #define GCdelay (-60)
 
-// How often do we dump into FTL's database?
-// Default: 60 (once per minute)
-#define DBinterval 60
-
 // Static structs
 typedef struct {
 	const char* conf;
@@ -125,6 +121,7 @@ typedef struct {
 	int maxDBdays;
 	bool resolveIPv6;
 	bool resolveIPv4;
+	int DBinterval;
 } ConfigStruct;
 
 // Dynamic structs

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Possible settings (**the option shown first is the default**):
 - `MAXDBDAYS=365` (How long should queries be stored in the database? Setting this to `0` disables the database altogether)
 - `RESOLVE_IPV6=yes|no` (Should `FTL` try to resolve IPv6 addresses to host names?)
 - `RESOLVE_IPV4=yes|no` (Should `FTL` try to resolve IPv4 addresses to host names?)
+- `DBINTERVAL=1.0` (How often do we store queries in FTL's database [minutes]?)
 
 ### Implemented keywords (starting with `>`, subject to change):
 

--- a/config.c
+++ b/config.c
@@ -141,8 +141,8 @@ void read_FTLconf(void)
 	if(buffer != NULL && sscanf(buffer, "%f", &fvalue))
 		// check if the read value is
 		// - larger than 0.1min (6sec), and
-		// - smaller than 43200 (once a month)
-		if(fvalue >= 0.1 && fvalue <= 43200.0)
+		// - smaller than 1440.0min (once a day)
+		if(fvalue >= 0.1 && fvalue <= 1440.0)
 			config.DBinterval = (int)(60.*fvalue);
 
 	if(config.DBinterval == 60)

--- a/config.c
+++ b/config.c
@@ -130,6 +130,26 @@ void read_FTLconf(void)
 	else
 		logg("   RESOLVE_IPV4: Don\'t resolve IPv4 addresses");
 
+	// DBINTERVAL
+	// How often do we store queries in FTL's database [minutes]?
+	// this value can be a floating point number, e.g. "DBINTERVAL=0.5"
+	// defaults to: 1 (once per minute)
+	config.DBinterval = 1;
+	buffer = parse_FTLconf(fp, "DBINTERVAL");
+
+	float fvalue = 0;
+	if(buffer != NULL && sscanf(buffer, "%f", &fvalue))
+		// check if the read value is
+		// - larger than 0.1min (6sec), and
+		// - smaller than 43200 (once a month)
+		if(fvalue >= 0.1 && fvalue <= 43200.0)
+			config.DBinterval = (int)(60.*fvalue);
+
+	if(config.DBinterval == 60)
+		logg("   DBINTERVAL: saving to DB file every minute");
+	else
+		logg("   DBINTERVAL: saving to DB file every %i seconds", config.DBinterval);
+
 	logg("Finished config file parsing");
 
 	if(conflinebuffer != NULL)

--- a/config.c
+++ b/config.c
@@ -133,8 +133,8 @@ void read_FTLconf(void)
 	// DBINTERVAL
 	// How often do we store queries in FTL's database [minutes]?
 	// this value can be a floating point number, e.g. "DBINTERVAL=0.5"
-	// defaults to: 1 (once per minute)
-	config.DBinterval = 1;
+	// defaults to: once per minute
+	config.DBinterval = 60;
 	buffer = parse_FTLconf(fp, "DBINTERVAL");
 
 	float fvalue = 0;

--- a/database.c
+++ b/database.c
@@ -445,18 +445,17 @@ void *DB_thread(void *val)
 	// Set thread name
 	prctl(PR_SET_NAME,"DB",0,0,0);
 
-	if(!DBdeleteoldqueries)
-	{
-		// Lock FTL's data structure, since it is likely that it will be changed here
-		enable_thread_lock("DB_thread");
+	// Lock FTL's data structure, since it is likely that it will be changed here
+	enable_thread_lock("DB_thread");
 
-		// Save data to database
-		save_to_DB();
+	// Save data to database
+	save_to_DB();
 
-		// Release thread lock
-		disable_thread_lock("DB_thread");
-	}
-	else
+	// Release thread lock
+	disable_thread_lock("DB_thread");
+
+	// Check if GC should be done on the database
+	if(DBdeleteoldqueries)
 	{
 		// No thread locks needed
 		delete_old_queries_in_DB();

--- a/main.c
+++ b/main.c
@@ -86,7 +86,7 @@ int main (int argc, char* argv[]) {
 		if(((time(NULL) - GCdelay)%GCinterval) == 0)
 			runGCthread = true;
 
-		if(database && ((time(NULL)%DBinterval) == 0))
+		if(database && ((time(NULL)%config.DBinterval) == 0))
 			runDBthread = true;
 
 		// Garbadge collect in regular interval, but don't do it if the threadlocks is set
@@ -134,7 +134,7 @@ int main (int argc, char* argv[]) {
 			}
 
 			// Avoid immediate re-run of DB thread
-			while(((time(NULL)%DBinterval) == 0))
+			while(((time(NULL)%config.DBinterval) == 0))
 				sleepms(100);
 		}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Make interval in which FTL stores queries in the long term database easily adjustable via the config file. 

It defaults to `1.0` (once per minute).
It cannot be lower than `0.1` (every six seconds).
It cannot be larger than `1440.0` (once a day).

Related to https://github.com/pi-hole/pi-hole/issues/1839

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
