### PR TITLE
Handle dnsmasq "extra" logging

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -138,7 +138,7 @@ typedef struct {
 	bool valid;
 	bool db;
 	// the ID is a (signed) in dnsmasq, so no need for a long int here
-	unsigned int id;
+	int id;
 	bool complete;
 } queriesDataStruct;
 

--- a/FTL.h
+++ b/FTL.h
@@ -110,6 +110,10 @@ typedef struct {
 	int SRV;
 	int wildcarddomains;
 	int forwardedqueries;
+	int reply_NODATA;
+	int reply_NXDOMAIN;
+	int reply_CNAME;
+	int reply_IP;
 } countersStruct;
 
 typedef struct {

--- a/FTL.h
+++ b/FTL.h
@@ -137,9 +137,10 @@ typedef struct {
 	int forwardID;
 	bool valid;
 	bool db;
-	// the ID is a (signed) in dnsmasq, so no need for a long int here
+	// the ID is a (signed) int in dnsmasq, so no need for a long int here
 	int id;
 	bool complete;
+	unsigned char reply;
 	int generation;
 } queriesDataStruct;
 

--- a/FTL.h
+++ b/FTL.h
@@ -137,6 +137,9 @@ typedef struct {
 	int forwardID;
 	bool valid;
 	bool db;
+	// the ID is a (signed) in dnsmasq, so no need for a long int here
+	unsigned int id;
+	bool complete;
 } queriesDataStruct;
 
 typedef struct {

--- a/FTL.h
+++ b/FTL.h
@@ -140,6 +140,7 @@ typedef struct {
 	// the ID is a (signed) in dnsmasq, so no need for a long int here
 	int id;
 	bool complete;
+	int generation;
 } queriesDataStruct;
 
 typedef struct {

--- a/database.c
+++ b/database.c
@@ -312,12 +312,9 @@ void save_to_DB(void)
 	for(i = lastdbindex; i < counters.queries; i++)
 	{
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);
-		if(queries[i].timestamp <= lasttimestamp || queries[i].db == true)
-		{
-			// Already in database
-			// logg("Skipping %i",i);
+		if(queries[i].timestamp <= lasttimestamp || queries[i].db || !queries[i].complete)
+			// Already in database or not yet complete
 			continue;
-		}
 
 		// Memory checks
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);

--- a/database.c
+++ b/database.c
@@ -309,12 +309,20 @@ void save_to_DB(void)
 		return;
 	}
 
+	int currenttimestamp = time(NULL);
 	for(i = lastdbindex; i < counters.queries; i++)
 	{
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);
-		if(queries[i].timestamp <= lasttimestamp || queries[i].db || !queries[i].complete)
+		if(queries[i].timestamp <= lasttimestamp || queries[i].db)
 			// Already in database or not yet complete
 			continue;
+
+		if(!queries[i].complete && queries[i].timestamp > currenttimestamp-2)
+		{
+			// Break if a brand new query (age < 2 seconds) is not yet completed
+			// giving it a chance to be stored next time
+			break;
+		}
 
 		// Memory checks
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);

--- a/gc.c
+++ b/gc.c
@@ -69,6 +69,28 @@ void *GC_thread(void *val)
 					counters.forwardedqueries--;
 					validate_access("forwarded", queries[i].forwardID, true, __LINE__, __FUNCTION__, __FILE__);
 					forwarded[queries[i].forwardID].count--;
+					// Maybe we have to adjust total counters depending on the reply type
+					switch(queries[i].reply)
+					{
+						case 1: // NODATA(-IPv6)
+						counters.reply_NODATA--;
+						break;
+
+						case 2: // NXDOMAIN
+						counters.reply_NXDOMAIN--;
+						break;
+
+						case 3: // <CNAME>
+						counters.reply_CNAME--;
+						break;
+
+						case 4: // valid IP
+						counters.reply_IP--;
+						break;
+
+						default: // Incomplete query, do nothing
+						break;
+					}
 					break;
 				case 3:
 					// Answered from local cache _or_ local config

--- a/log.c
+++ b/log.c
@@ -135,7 +135,9 @@ void log_counter_info(void)
 {
 	logg(" -> Total DNS queries: %i", counters.queries);
 	logg(" -> Cached DNS queries: %i", counters.cached);
-	logg(" -> Blocked DNS queries: %i", counters.blocked);
+	logg(" -> Forwarded DNS queries: %i", counters.forwarded);
+	logg(" -> Exactly blocked DNS queries: %i", counters.blocked);
+	logg(" -> Wildcard blocked DNS queries: %i", counters.wildcardblocked);
 	logg(" -> Unknown DNS queries: %i", counters.unknown);
 	logg(" -> Unique domains: %i", counters.domains);
 	logg(" -> Unique clients: %i", counters.clients);

--- a/log.c
+++ b/log.c
@@ -135,12 +135,13 @@ void log_counter_info(void)
 {
 	logg(" -> Total DNS queries: %i", counters.queries);
 	logg(" -> Cached DNS queries: %i", counters.cached);
-	logg(" -> Forwarded DNS queries: %i", counters.forwarded);
+	logg(" -> Forwarded DNS queries: %i", counters.forwardedqueries);
 	logg(" -> Exactly blocked DNS queries: %i", counters.blocked);
 	logg(" -> Wildcard blocked DNS queries: %i", counters.wildcardblocked);
 	logg(" -> Unknown DNS queries: %i", counters.unknown);
 	logg(" -> Unique domains: %i", counters.domains);
 	logg(" -> Unique clients: %i", counters.clients);
+	logg(" -> Known forward destinations: %i", counters.forwarded);
 }
 
 void log_FTL_version(void)

--- a/main.c
+++ b/main.c
@@ -150,7 +150,6 @@ int main (int argc, char* argv[]) {
 		}
 	}
 
-
 	logg("Shutting down...");
 	pthread_cancel(piholelogthread);
 	pthread_cancel(socket_listenthread);

--- a/main.c
+++ b/main.c
@@ -145,6 +145,7 @@ int main (int argc, char* argv[]) {
 			// Have to re-read gravity files
 			rereadgravity = false;
 			read_gravity_files();
+			log_counter_info();
 			disable_thread_lock("pihole_main_thread");
 		}
 	}

--- a/parser.c
+++ b/parser.c
@@ -519,11 +519,10 @@ void process_pihole_log(int file)
 			queries[queryID].magic = MAGICBYTE;
 			queries[queryID].timestamp = querytimestamp;
 			queries[queryID].type = type;
-			// queries[queryID].status = status;
+			queries[queryID].status = 0;
 			queries[queryID].domainID = domainID;
 			queries[queryID].clientID = clientID;
 			queries[queryID].timeidx = timeidx;
-			// queries[queryID].forwardID = forwardID;
 			queries[queryID].valid = true;
 			queries[queryID].db = false;
 			queries[queryID].id = dnsmasqID;

--- a/parser.c
+++ b/parser.c
@@ -676,9 +676,10 @@ void process_pihole_log(int file)
 				// Reallocate more space for forwarddata
 				overTime[timeidx].forwarddata = realloc(overTime[timeidx].forwarddata, (forwardID+1)*sizeof(*overTime[timeidx].forwarddata));
 				// Initialize new data fields with zeroes
-				for(i = overTime[timeidx].forwardnum; i <= forwardID; i++)
+				int j;
+				for(j = overTime[timeidx].forwardnum; j <= forwardID; j++)
 				{
-					overTime[timeidx].forwarddata[i] = 0;
+					overTime[timeidx].forwarddata[j] = 0;
 					memory.forwarddata++;
 				}
 				// Update counter

--- a/parser.c
+++ b/parser.c
@@ -356,6 +356,9 @@ void process_pihole_log(int file)
 
 			// Get dnsmasq's ID for this transaction
 			int dnsmasqID = getID(readbuffer);
+			// Skip invalid lines
+			if(dnsmasqID < 0)
+				continue;
 
 			// Get domain
 			// domainstart = pointer to | in "query[AAAA] |host.name from ww.xx.yy.zz\n"
@@ -582,6 +585,9 @@ void process_pihole_log(int file)
 
 			// Get dnsmasq's ID for this transaction
 			int dnsmasqID = getID(readbuffer);
+			// Skip invalid lines
+			if(dnsmasqID < 0)
+				continue;
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
@@ -636,6 +642,9 @@ void process_pihole_log(int file)
 
 			// Get dnsmasq's ID for this transaction
 			int dnsmasqID = getID(readbuffer);
+			// Skip invalid lines
+			if(dnsmasqID < 0)
+				continue;
 
 			// Get ID of forward destination, create new forward destination record
 			// if not found in current data structure
@@ -723,6 +732,9 @@ void process_pihole_log(int file)
 
 			// Get dnsmasq's ID for this transaction
 			int dnsmasqID = getID(readbuffer);
+			// Skip invalid lines
+			if(dnsmasqID < 0)
+				continue;
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
@@ -775,6 +787,9 @@ void process_pihole_log(int file)
 
 			// Get dnsmasq's ID for this transaction
 			int dnsmasqID = getID(readbuffer);
+			// Skip invalid lines
+			if(dnsmasqID < 0)
+				continue;
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
@@ -845,6 +860,9 @@ void process_pihole_log(int file)
 
 			// Get dnsmasq's ID for this transaction
 			int dnsmasqID = getID(readbuffer);
+			// Skip invalid lines
+			if(dnsmasqID < 0)
+				continue;
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;

--- a/parser.c
+++ b/parser.c
@@ -911,8 +911,32 @@ void process_pihole_log(int file)
 				continue;
 			}
 
-			// Do something here
-
+			// Iterate through possible values
+			if(strstr(readbuffer," is NODATA") != NULL)
+			{
+				// NODATA(-IPv6)
+				queries[i].reply = 1;
+			}
+			else if(strstr(readbuffer," is NXDOMAIN") != NULL)
+			{
+				// NXDOMAIN
+				queries[i].reply = 2;
+			}
+			else if(strstr(readbuffer," is <CNAME>") != NULL)
+			{
+				// <CNAME>
+				queries[i].reply = 3;
+			}
+			else
+			{
+				// Valid IP
+				queries[i].reply = 4;
+				// const char * dest = strstr(readbuffer," is ");
+				// char * result;
+				// sscanf(dest, " is %ms", &result);
+				// printf("reply is IP: %s\n",result);
+				// free(result);
+			}
 		}
 
 		// Save file pointer position, because we might have to repeat

--- a/parser.c
+++ b/parser.c
@@ -589,7 +589,7 @@ void process_pihole_log(int file)
 			if(dnsmasqID < 0)
 				continue;
 
-			// Save forwardID in corresponding query indentified by dnsmasq's ID
+			// Save status in corresponding query indentified by dnsmasq's ID
 			bool found = false;
 			for(i=0; i<counters.queries; i++)
 			{
@@ -647,7 +647,7 @@ void process_pihole_log(int file)
 				continue;
 			}
 
-			// Save forwardID in corresponding query indentified by dnsmasq's ID
+			// Save status and forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
 			for(i=0; i<counters.queries; i++)
 			{
@@ -720,7 +720,7 @@ void process_pihole_log(int file)
 			if(dnsmasqID < 0)
 				continue;
 
-			// Save forwardID in corresponding query indentified by dnsmasq's ID
+			// Save status in corresponding query indentified by dnsmasq's ID
 			bool found = false;
 			for(i=0; i<counters.queries; i++)
 			{
@@ -758,7 +758,7 @@ void process_pihole_log(int file)
 		else if(strstr(readbuffer," config ") != NULL && strstr(readbuffer," is ") != NULL)
 		{
 			// Check query for invalid characters
-			if(!checkQuery(readbuffer, "gravity.list"))
+			if(!checkQuery(readbuffer, "config"))
 				continue;
 
 			// Get dnsmasq's ID for this transaction
@@ -767,7 +767,7 @@ void process_pihole_log(int file)
 			if(dnsmasqID < 0)
 				continue;
 
-			// Save forwardID in corresponding query indentified by dnsmasq's ID
+			// Save status in corresponding query indentified by dnsmasq's ID
 			bool found = false;
 			for(i=0; i<counters.queries; i++)
 			{
@@ -832,7 +832,7 @@ void process_pihole_log(int file)
 			if(dnsmasqID < 0)
 				continue;
 
-			// Save forwardID in corresponding query indentified by dnsmasq's ID
+			// Save status in corresponding query indentified by dnsmasq's ID
 			bool found = false;
 			for(i=0; i<counters.queries; i++)
 			{

--- a/parser.c
+++ b/parser.c
@@ -585,7 +585,7 @@ void process_pihole_log(int file)
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
-			for(i=0;i<counters.queries;i++)
+			for(i=0; i<counters.queries; i++)
 			{
 				if(queries[i].id == dnsmasqID)
 				{
@@ -648,7 +648,7 @@ void process_pihole_log(int file)
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
-			for(i=0;i<counters.queries;i++)
+			for(i=0; i<counters.queries; i++)
 			{
 				if(queries[i].id == dnsmasqID)
 				{
@@ -725,7 +725,7 @@ void process_pihole_log(int file)
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
-			for(i=0;i<counters.queries;i++)
+			for(i=0; i<counters.queries; i++)
 			{
 				if(queries[i].id == dnsmasqID)
 				{
@@ -777,7 +777,7 @@ void process_pihole_log(int file)
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
-			for(i=0;i<counters.queries;i++)
+			for(i=0; i<counters.queries; i++)
 			{
 				if(queries[i].id == dnsmasqID)
 				{
@@ -795,7 +795,7 @@ void process_pihole_log(int file)
 
 			if(!queries[i].complete)
 			{
-				// This query is no longer unknown ...
+				// This query is no longer unknown
 				counters.unknown--;
 				// Hereby, this query is now fully determined
 				queries[i].complete = true;
@@ -847,7 +847,7 @@ void process_pihole_log(int file)
 
 			// Save forwardID in corresponding query indentified by dnsmasq's ID
 			bool found = false;
-			for(i=0;i<counters.queries;i++)
+			for(i=0; i<counters.queries; i++)
 			{
 				if(queries[i].id == dnsmasqID)
 				{

--- a/parser.c
+++ b/parser.c
@@ -565,7 +565,7 @@ void process_pihole_log(int file)
 			free(domainwithspaces);
 		}
 		// is this a "gravity.list" line?
-		else if(strstr(readbuffer," gravity.list ") != NULL && strstr(readbuffer," is ") != NULL)
+		else if(strstr(readbuffer,"/gravity.list ") != NULL && strstr(readbuffer," is ") != NULL)
 		{
 			// Check if this domain names contains only printable characters
 			// if not: skip analysis of this log line
@@ -599,7 +599,6 @@ void process_pihole_log(int file)
 				// as we ignore them altogether
 				continue;
 			}
-			if(debug) logg("Gravity: %i \"%s\"",dnsmasqID, readbuffer);
 
 			if(!queries[i].complete)
 			{
@@ -700,8 +699,8 @@ void process_pihole_log(int file)
 		}
 		// is this a "cached" line?
 		else if((strstr(readbuffer," cached ") != NULL || \
-			     strstr(readbuffer," local.list ") != NULL || \
-			     strstr(readbuffer," hostname.list ") != NULL || \
+			     strstr(readbuffer,"/local.list ") != NULL || \
+			     strstr(readbuffer,"/hostname.list ") != NULL || \
 			     strstr(readbuffer," DHCP ") != NULL || \
 			     strstr(readbuffer," /etc/hosts ") != NULL) \
 			  && strstr(readbuffer," is ") != NULL)
@@ -738,7 +737,6 @@ void process_pihole_log(int file)
 				// as we ignore them altogether
 				continue;
 			}
-			if(debug) logg("Cached: %i \"%s\"",dnsmasqID, readbuffer);
 
 			if(!queries[i].complete)
 			{

--- a/parser.c
+++ b/parser.c
@@ -200,7 +200,7 @@ void process_pihole_log(int file)
 		}
 
 		// Test if the read line is a query line
-		if(strstr(readbuffer,"]: query[A") != NULL)
+		if(strstr(readbuffer," query[A") != NULL)
 		{
 			// Check if this domain names contains only printable characters
 			// if not: skip analysis of this log line
@@ -216,7 +216,7 @@ void process_pihole_log(int file)
 				continue;
 			}
 
-			if(!config.analyze_AAAA && strstr(readbuffer,"]: query[AAAA]") != NULL)
+			if(!config.analyze_AAAA && strstr(readbuffer," query[AAAA]") != NULL)
 			{
 				if(debug) logg("Not analyzing AAAA query");
 				continue;
@@ -301,6 +301,15 @@ void process_pihole_log(int file)
 				// this query as we cannot attribute it correctly to anything.
 				validate_access("overTime", 0, false, __LINE__, __FUNCTION__, __FILE__);
 				logg("Warning: Skipping log entry with incorrect timestamp (%i/%i)", overTimetimestamp, overTime[0].timestamp);
+				continue;
+			}
+
+			// Get query ID
+			// "Dec 20 21:16:22 dnsmasq[19372]: 4 10.8.0.2/34596 query[A] pi.hole from 10.8.0.2
+			unsigned int dnsmasqID = 0;
+			if(!sscanf(readbuffer, "%*[^]]]: %u", &dnsmasqID))
+			{
+				if(debug) logg("Error getting ID for query \"%s\" %u", readbuffer, dnsmasqID);
 				continue;
 			}
 

--- a/parser.c
+++ b/parser.c
@@ -564,6 +564,60 @@ void process_pihole_log(int file)
 			free(domain);
 			free(domainwithspaces);
 		}
+		// is this a "gravity.list" line?
+		else if(strstr(readbuffer," gravity.list ") != NULL && strstr(readbuffer," is ") != NULL)
+		{
+			// Check if this domain names contains only printable characters
+			// if not: skip analysis of this log line
+			if(strstr(readbuffer,"<name unprintable>") != NULL)
+			{
+				if(debug) logg("Ignoring <name unprintable> domain (cached)");
+				continue;
+			}
+
+			// Check if this is a PTR query
+			// if so: skip analysis of this log line
+			if(strstr(readbuffer,"in-addr.arpa") != NULL)
+				continue;
+
+			// Get dnsmasq's ID for this transaction
+			int dnsmasqID = getID(readbuffer);
+
+			// Save forwardID in corresponding query indentified by dnsmasq's ID
+			bool found = false;
+			for(i=0;i<counters.queries;i++)
+			{
+				if(queries[i].id == dnsmasqID)
+				{
+					queries[i].status = 1;
+					found = true;
+				}
+			}
+			if(!found)
+			{
+				// This may happen e.g. if the original query was a PTR query or "pi.hole"
+				// as we ignore them altogether
+				continue;
+			}
+			if(debug) logg("Gravity: %i \"%s\"",dnsmasqID, readbuffer);
+
+			if(!queries[i].complete)
+			{
+				// This query is no longer unknown
+				counters.unknown--;
+				// ... but got blocked
+				counters.blocked++;
+				// Hereby, this query is now fully determined
+				queries[i].complete = true;
+
+				// Get time index
+				int timeidx = getTimeIndex(readbuffer);
+				validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
+				overTime[timeidx].blocked++;
+				validate_access("domains", queries[i].domainID, true, __LINE__, __FUNCTION__, __FILE__);
+				domains[queries[i].domainID].blockedcount++;
+			}
+		}
 		// is this a "forwarded" line?
 		else if(strstr(readbuffer," forwarded ") != NULL && strstr(readbuffer," to ") != NULL)
 		{
@@ -694,12 +748,13 @@ void process_pihole_log(int file)
 				counters.cached++;
 				// Hereby, this query is now fully determined
 				queries[i].complete = true;
+
+				// Get time index
+				int timeidx = getTimeIndex(readbuffer);
+				validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
+				overTime[timeidx].cached++;
 			}
 
-			// Get time index
-			int timeidx = getTimeIndex(readbuffer);
-			validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
-			overTime[timeidx].cached++;
 		}
 
 		// Save file pointer position, because we might have to repeat

--- a/parser.c
+++ b/parser.c
@@ -591,6 +591,7 @@ void process_pihole_log(int file)
 				{
 					queries[i].status = 1;
 					found = true;
+					break;
 				}
 			}
 			if(!found)
@@ -654,6 +655,7 @@ void process_pihole_log(int file)
 					queries[i].status = 2;
 					queries[i].forwardID = forwardID;
 					found = true;
+					break;
 				}
 			}
 			if(!found)
@@ -729,6 +731,7 @@ void process_pihole_log(int file)
 				{
 					queries[i].status = 3;
 					found = true;
+					break;
 				}
 			}
 			if(!found)
@@ -780,6 +783,7 @@ void process_pihole_log(int file)
 				{
 					queries[i].status = detectStatus(domains[queries[i].domainID].domain);
 					found = true;
+					break;
 				}
 			}
 			if(!found)
@@ -796,14 +800,16 @@ void process_pihole_log(int file)
 				// Hereby, this query is now fully determined
 				queries[i].complete = true;
 
+
 				// Get time index
 				int timeidx = getTimeIndex(readbuffer);
 
 				// Decide what to do depening on the result of detectStatus()
-				if(queries[i].id == 4)
+				if(queries[i].status == 4)
 				{
 					// Blocked due to a matching wildcard rule
 					counters.wildcardblocked++;
+
 					validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 					overTime[timeidx].blocked++;
 					validate_access("domains", queries[i].domainID, true, __LINE__, __FUNCTION__, __FILE__);
@@ -815,8 +821,6 @@ void process_pihole_log(int file)
 					// Answered from a custom (user provided) cache file
 					counters.cached++;
 
-					// Get time index
-					int timeidx = getTimeIndex(readbuffer);
 					validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 					overTime[timeidx].cached++;
 				}
@@ -850,6 +854,7 @@ void process_pihole_log(int file)
 				{
 					queries[i].status = 5;
 					found = true;
+					break;
 				}
 			}
 			if(!found)

--- a/parser.c
+++ b/parser.c
@@ -916,21 +916,25 @@ void process_pihole_log(int file)
 			{
 				// NODATA(-IPv6)
 				queries[i].reply = 1;
+				counters.reply_NODATA++;
 			}
 			else if(strstr(readbuffer," is NXDOMAIN") != NULL)
 			{
 				// NXDOMAIN
 				queries[i].reply = 2;
+				counters.reply_NXDOMAIN++;
 			}
 			else if(strstr(readbuffer," is <CNAME>") != NULL)
 			{
 				// <CNAME>
 				queries[i].reply = 3;
+				counters.reply_CNAME++;
 			}
 			else
 			{
 				// Valid IP
 				queries[i].reply = 4;
+				counters.reply_IP++;
 				// const char * dest = strstr(readbuffer," is ");
 				// char * result;
 				// sscanf(dest, " is %ms", &result);

--- a/parser.c
+++ b/parser.c
@@ -800,7 +800,6 @@ void process_pihole_log(int file)
 				// Hereby, this query is now fully determined
 				queries[i].complete = true;
 
-
 				// Get time index
 				int timeidx = getTimeIndex(readbuffer);
 

--- a/request.c
+++ b/request.c
@@ -1207,7 +1207,7 @@ void getUnknownQueries(int *sock)
 	{
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);
 		// Check if this query has been removed due to garbage collection
-		if(queries[i].status != 0) continue;
+		if(queries[i].status != 0 && queries[i].complete) continue;
 
 		char type[5];
 		if(queries[i].type == 1)
@@ -1223,9 +1223,9 @@ void getUnknownQueries(int *sock)
 		validate_access("clients", queries[i].clientID, true, __LINE__, __FUNCTION__, __FILE__);
 
 		if(strlen(clients[queries[i].clientID].name) > 0)
-			sprintf(server_message,"%i %s %s %s %i\n",queries[i].timestamp,type,domains[queries[i].domainID].domain,clients[queries[i].clientID].name,queries[i].status);
+			sprintf(server_message,"%i %i %i %s %s %s %i %s\n",queries[i].timestamp,i,queries[i].id,type,domains[queries[i].domainID].domain,clients[queries[i].clientID].name,queries[i].status,queries[i].complete ?"true":"false");
 		else
-			sprintf(server_message,"%i %s %s %s %i\n",queries[i].timestamp,type,domains[queries[i].domainID].domain,clients[queries[i].clientID].ip,queries[i].status);
+			sprintf(server_message,"%i %i %i %s %s %s %i %s\n",queries[i].timestamp,i,queries[i].id,type,domains[queries[i].domainID].domain,clients[queries[i].clientID].ip,queries[i].status,queries[i].complete?"true":"false");
 		swrite(server_message, *sock);
 	}
 

--- a/request.c
+++ b/request.c
@@ -1195,13 +1195,6 @@ void getUnknownQueries(int *sock)
 {
 	char server_message[SOCKETBUFFERLEN];
 
-	if(!debug)
-	{
-		sprintf(server_message,"For safety reasons, the command is only available in debugging mode!\n");
-		swrite(server_message, *sock);
-		return;
-	}
-
 	int i;
 	for(i=0; i < counters.queries; i++)
 	{

--- a/test/run.sh
+++ b/test/run.sh
@@ -8,39 +8,39 @@ dnsmasq_pre() {
 # Prepare FTL's files
 ts="$(dnsmasq_pre)"
 cat <<EOT >> pihole.log
-${ts} query[AAAA] raspberrypi from 127.0.0.1
-${ts} /etc/pihole/local.list raspberrypi is fda2:2001:5647:0:ba27:ebff:fe37:4205
-${ts} query[A] ChEcKiP.DyNdNs.OrG from 127.0.0.1
-${ts} forwarded ChEcKiP.DyNdNs.OrG to 2001:1608:10:25::9249:d69b
-${ts} forwarded ChEcKiP.DyNdNs.OrG to 2001:1608:10:25::1c04:b12f
-${ts} forwarded ChEcKiP.DyNdNs.OrG to 2620:0:ccd::2
-${ts} forwarded ChEcKiP.DyNdNs.OrG to 2620:0:ccc::2
-${ts} reply ChEcKiP.DyNdNs.OrG is <CNAME>
-${ts} reply checkip.dyndns.com is 216.146.38.70
-${ts} reply checkip.dyndns.com is 216.146.43.71
-${ts} reply checkip.dyndns.com is 91.198.22.70
-${ts} reply checkip.dyndns.com is 216.146.43.70
-${ts} query[A] pi.hole from 10.8.0.2
-${ts} /etc/pihole/local.list pi.hole is 192.168.2.10
-${ts} query[A] example.com from 10.8.0.2
-${ts} /etc/pihole/local.list example.com is 192.168.2.10
-${ts} query[A] play.google.com from 192.168.2.208
-${ts} forwarded play.google.com to 2001:1608:10:25::9249:d69b
-${ts} forwarded play.google.com to 2001:1608:10:25::1c04:b12f
-${ts} forwarded play.google.com to 2620:0:ccd::2
-${ts} forwarded play.google.com to 2620:0:ccc::2
-${ts} reply play.google.com is <CNAME>
-${ts} reply play.l.google.com is 216.58.208.110
-${ts} reply play.l.google.com is 216.58.208.110
-${ts} reply play.l.google.com is 216.58.208.110
-${ts} reply play.google.com is <CNAME>
-${ts} query[AAAA] play.google.com from 192.168.2.208
-${ts} forwarded play.google.com to 2620:0:ccd::2
-${ts} reply play.l.google.com is 2a00:1450:4017:802::200e
-${ts} query[A] blacklisted.com from 192.168.2.208
-${ts} /etc/pihole/black.list blacklisted.com is 1.2.3.4
-${ts} query[A] addomain.com from 192.168.2.208
-${ts} /etc/pihole/gravity.list addomain.com is 1.2.3.4
+${ts} 1 1270.0.01/1234 query[AAAA] raspberrypi from 127.0.0.1
+${ts} 1 1270.0.01/1234 /etc/pihole/local.list raspberrypi is fda2:2001:5647:0:ba27:ebff:fe37:4205
+${ts} 2 1270.0.01/1234 query[A] ChEcKiP.DyNdNs.OrG from 127.0.0.1
+${ts} 2 1270.0.01/1234 forwarded ChEcKiP.DyNdNs.OrG to 2001:1608:10:25::9249:d69b
+${ts} 2 1270.0.01/1234 forwarded ChEcKiP.DyNdNs.OrG to 2001:1608:10:25::1c04:b12f
+${ts} 2 1270.0.01/1234 forwarded ChEcKiP.DyNdNs.OrG to 2620:0:ccd::2
+${ts} 2 1270.0.01/1234 forwarded ChEcKiP.DyNdNs.OrG to 2620:0:ccc::2
+${ts} 2 1270.0.01/1234 reply ChEcKiP.DyNdNs.OrG is <CNAME>
+${ts} 2 1270.0.01/1234 reply ChEcKiP.DyNdNs.OrG is 216.146.38.70
+${ts} 2 1270.0.01/1234 reply ChEcKiP.DyNdNs.OrG is 216.146.43.71
+${ts} 2 1270.0.01/1234 reply ChEcKiP.DyNdNs.OrG is 91.198.22.70
+${ts} 2 1270.0.01/1234 reply ChEcKiP.DyNdNs.OrG is 216.146.43.70
+${ts} 3 1270.0.01/1234 query[A] pi.hole from 10.8.0.2
+${ts} 3 1270.0.01/1234 /etc/pihole/local.list pi.hole is 192.168.2.10
+${ts} 4 1270.0.01/1234 query[A] example.com from 10.8.0.2
+${ts} 4 1270.0.01/1234 /etc/pihole/local.list example.com is 192.168.2.10
+${ts} 5 1270.0.01/1234 query[A] play.google.com from 192.168.2.208
+${ts} 5 1270.0.01/1234 forwarded play.google.com to 2001:1608:10:25::9249:d69b
+${ts} 5 1270.0.01/1234 forwarded play.google.com to 2001:1608:10:25::1c04:b12f
+${ts} 5 1270.0.01/1234 forwarded play.google.com to 2620:0:ccd::2
+${ts} 5 1270.0.01/1234 forwarded play.google.com to 2620:0:ccc::2
+${ts} 5 1270.0.01/1234 reply play.google.com is <CNAME>
+${ts} 5 1270.0.01/1234 reply play.l.google.com is 216.58.208.110
+${ts} 5 1270.0.01/1234 reply play.l.google.com is 216.58.208.110
+${ts} 5 1270.0.01/1234 reply play.l.google.com is 216.58.208.110
+${ts} 5 1270.0.01/1234 reply play.google.com is <CNAME>
+${ts} 6 1270.0.01/1234 query[AAAA] play.google.com from 192.168.2.208
+${ts} 6 1270.0.01/1234 forwarded play.google.com to 2620:0:ccd::2
+${ts} 6 1270.0.01/1234 reply play.l.google.com is 2a00:1450:4017:802::200e
+${ts} 7 1270.0.01/1234 query[A] blacklisted.com from 192.168.2.208
+${ts} 7 1270.0.01/1234 /etc/pihole/black.list blacklisted.com is 1.2.3.4
+${ts} 8 1270.0.01/1234 query[A] addomain.com from 192.168.2.208
+${ts} 8 1270.0.01/1234 /etc/pihole/gravity.list addomain.com is 1.2.3.4
 EOT
 touch "pihole-FTL.log"
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Complete re-write of `FTL` log file parser to use `dnsmasq`'s UUIDs present in the log if option `log-queries=extra` is set. This will ensure 100% correctness of the interpreted log files.

One particular difficulty with `dnsmasq`'s `extra` logging is that it resets the UUID counter to 0 when being restarted. This poisons the whole idea of having UUIDs. A proper failsafe condition (using the idea of UUID generations) has been implemented in the new parser.

Note that this is a **breaking change** as the "old" log format cannot be read anymore and as such will bump `FTL`'s version to `v3.0`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
