### PR TITLE
Add dual-stack socket support for FTL

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -42,6 +42,9 @@
 #include <ctype.h>
 // Unix socket
 #include <sys/un.h>
+// Interfaces
+#include <ifaddrs.h>
+#include <net/if.h>
 
 
 #include "routines.h"

--- a/FTL.h
+++ b/FTL.h
@@ -131,6 +131,7 @@ typedef struct {
 	bool resolveIPv6;
 	bool resolveIPv4;
 	int DBinterval;
+	int port;
 } ConfigStruct;
 
 // Dynamic structs

--- a/config.c
+++ b/config.c
@@ -173,6 +173,16 @@ void read_FTLconf(void)
 	else
 		logg("   DBFILE: Not using database due to empty filename");
 
+	// FTLPORT
+	// On which port should FTL be listening?
+	// defaults to: 4711
+	config.port = 4711;
+	buffer = parse_FTLconf(fp, "FTLPORT");
+
+	value = 0;
+	if(buffer != NULL && sscanf(buffer, "%i", &value))
+		if(value > 0 && value <= 65535)
+			config.port = value;
 
 	logg("Finished config file parsing");
 

--- a/main.c
+++ b/main.c
@@ -70,10 +70,17 @@ int main (int argc, char* argv[]) {
 		killed = 1;
 	}
 
-	pthread_t telnet_listenthread;
-	if(pthread_create( &telnet_listenthread, &attr, telnet_listening_thread, NULL ) != 0)
+	pthread_t telnet_listenthreadv4;
+	if(pthread_create( &telnet_listenthreadv4, &attr, telnet_listening_thread_IPv4, NULL ) != 0)
 	{
-		logg("Unable to open telnet listening thread. Exiting...");
+		logg("Unable to open IPv4 telnet listening thread. Exiting...");
+		killed = 1;
+	}
+
+	pthread_t telnet_listenthreadv6;
+	if(pthread_create( &telnet_listenthreadv6, &attr, telnet_listening_thread_IPv6, NULL ) != 0)
+	{
+		logg("Unable to open IPv6 telnet listening thread. Exiting...");
 		killed = 1;
 	}
 
@@ -159,7 +166,8 @@ int main (int argc, char* argv[]) {
 
 	logg("Shutting down...");
 	pthread_cancel(piholelogthread);
-	pthread_cancel(telnet_listenthread);
+	pthread_cancel(telnet_listenthreadv4);
+	pthread_cancel(telnet_listenthreadv6);
 	pthread_cancel(socket_listenthread);
 	close_telnet_socket();
 	close_unix_socket();

--- a/routines.h
+++ b/routines.h
@@ -42,7 +42,8 @@ void close_telnet_socket(void);
 void close_unix_socket(void);
 void seom(char server_message[], int sock);
 void swrite(char server_message[], int sock);
-void *telnet_listening_thread(void *args);
+void *telnet_listening_thread_IPv4(void *args);
+void *telnet_listening_thread_IPv6(void *args);
 void *socket_listening_thread(void *args);
 bool ipv6_available(void);
 

--- a/routines.h
+++ b/routines.h
@@ -44,6 +44,7 @@ void seom(char server_message[], int sock);
 void swrite(char server_message[], int sock);
 void *telnet_listening_thread(void *args);
 void *socket_listening_thread(void *args);
+bool ipv6_available(void);
 
 void process_request(char *client_message, int *sock);
 bool command(char *client_message, const char* cmd);

--- a/socket.c
+++ b/socket.c
@@ -151,7 +151,7 @@ void bind_to_telnet_port(char type, int *socketdescriptor)
 		exit(EXIT_FAILURE);
 	}
 
-	logg("Listening on port %i for incoming %s connections", port, dualstack == true ? "IPv4 + IPv6" : "IPv4");
+	logg("Listening on port %i for incoming %s connections", port, dualstack ? "IPv4 + IPv6" : "IPv4");
 }
 
 

--- a/socket.c
+++ b/socket.c
@@ -40,7 +40,7 @@ void saveport(int port)
 
 void bind_to_port(char type, int *socketdescriptor)
 {
-	*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
+	*socketdescriptor = socket(AF_INET6, SOCK_STREAM, 0);
 
 	if(*socketdescriptor < 0)
 	{
@@ -57,15 +57,15 @@ void bind_to_port(char type, int *socketdescriptor)
 	// the TIME_WAIT state for 30-120 seconds, so you fall into case 1 above.
 	setsockopt(*socketdescriptor, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int));
 
-	struct sockaddr_in serv_addr;
+	struct sockaddr_in6 serv_addr;
 	// set all values in the buffer to zero
 	memset(&serv_addr, 0, sizeof(serv_addr));
-	serv_addr.sin_family = AF_INET;
+	serv_addr.sin6_family = AF_INET6;
 
 	if(config.socket_listenlocal && type == SOCKET)
-		serv_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+		serv_addr.sin6_addr = in6addr_loopback;
 	else
-		serv_addr.sin_addr.s_addr = INADDR_ANY;
+		serv_addr.sin6_addr = in6addr_any;
 
 	// The bind() system call binds a socket to an address,
 	// in this case the address of the current host and
@@ -89,7 +89,7 @@ void bind_to_port(char type, int *socketdescriptor)
 	bool bound = false;
 	for(port = port_init; port <= (port_init + 20); port++)
 	{
-		serv_addr.sin_port = htons(port);
+		serv_addr.sin6_port = htons(port);
 		if(bind(*socketdescriptor, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0)
 		{
 			logg("Error on binding on port %i", port);

--- a/socket.c
+++ b/socket.c
@@ -42,7 +42,6 @@ void saveport(void)
 char bind_to_telnet_port_IPv4(char type, int *socketdescriptor)
 {
 	// IPv4 socket
-	// see the comments further up for details
 	*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
 
 	if(*socketdescriptor < 0)

--- a/socket.c
+++ b/socket.c
@@ -22,6 +22,7 @@
 
 // File descriptors
 int socketfd;
+bool dualstack = false;
 
 void saveport(int port)
 {
@@ -86,7 +87,7 @@ void bind_to_port(char type, int *socketdescriptor)
 			break;
 	}
 
-	bool bound = false, dualstack = false;
+	bool bound = false;
 	// Try dual-stack socket
 	for(port = port_init; port <= (port_init + 20); port++)
 	{
@@ -180,6 +181,7 @@ void swrite(char server_message[SOCKETBUFFERLEN], int sock)
 int listener(int sockfd)
 {
 	struct sockaddr_in6 cli_addr;
+	struct sockaddr_in cli_addr4;
 	// set all values in the buffer to zero
 	memset(&cli_addr, 0, sizeof(cli_addr));
 	socklen_t clilen = sizeof(cli_addr);
@@ -187,16 +189,29 @@ int listener(int sockfd)
 
 	if(clientsocket > 0)
 	{
-		// Determine the client address.  Note that if the client is
-		// an IPv4 client, the address will be shown as an IPv4 Mapped
-		// IPv6 address, like "::ffff:127.0.0.1"
-		getpeername(clientsocket, (struct sockaddr *)&cli_addr, &clilen);
 		char str[INET6_ADDRSTRLEN];
-		if(inet_ntop(AF_INET6, &cli_addr.sin6_addr, str, sizeof(str)))
+		if(dualstack)
 		{
-			int port = ntohs(cli_addr.sin6_port);
-			if(debugclients)
-				logg("Client connected: %s:%d, ID: %i", str, port, clientsocket);
+			// Determine the client address.  Note that if we bound to a dual-stack
+			// socket and the client is an IPv4 client, the address will be shown
+			// as an IPv4 Mapped IPv6 address, like "::ffff:127.0.0.1"
+			getpeername(clientsocket, (struct sockaddr *)&cli_addr, &clilen);
+			if(inet_ntop(AF_INET6, &cli_addr.sin6_addr, str, sizeof(str)))
+			{
+				int port = ntohs(cli_addr.sin6_port);
+				if(debugclients)
+					logg("Client connected: %s:%d, ID: %i", str, port, clientsocket);
+			}
+		}
+		else
+		{
+			getpeername(clientsocket, (struct sockaddr *)&cli_addr4, &clilen);
+			if(inet_ntop(AF_INET, &cli_addr4.sin_addr, str, sizeof(str)))
+			{
+				int port = ntohs(cli_addr4.sin_port);
+				if(debugclients)
+					logg("Client connected: %s:%d, ID: %i", str, port, clientsocket);
+			}
 		}
 	}
 	return clientsocket;

--- a/socket.c
+++ b/socket.c
@@ -21,10 +21,10 @@
 #define BACKLOG 5
 
 // File descriptors
-int telnetfd, socketfd;
+int socketfd, telnetfd4 = 0, telnetfd6 = 0;
 bool dualstack = false;
 
-void saveport(int port)
+void saveport(void)
 {
 	FILE *f;
 	if((f = fopen(FTLfiles.port, "w+")) == NULL)
@@ -34,117 +34,122 @@ void saveport(int port)
 	}
 	else
 	{
-		fprintf(f, "%i", port);
+		fprintf(f, "%i", config.port);
 		fclose(f);
 	}
 }
 
-void bind_to_telnet_port(char type, int *socketdescriptor)
+char bind_to_telnet_port_IPv4(char type, int *socketdescriptor)
 {
-	int port, port_init = 4711;
+	// Try IPv4 only socket
+	// see the comments further up for details
+	*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
 
-	if(ipv6_available())
+	if(*socketdescriptor < 0)
 	{
-		*socketdescriptor = socket(AF_INET6, SOCK_STREAM, 0);
-
-		if(*socketdescriptor < 0)
-		{
-			logg("Error opening telnet socket");
-			exit(EXIT_FAILURE);
-		}
-
-		// Set SO_REUSEADDR to allow re-binding to the port that has been used
-		// previously by FTL. A common pattern is that you change FTL's
-		// configuration file and need to restart that server to make it reload
-		// its configuration. Without SO_REUSEADDR, the bind() call in the restarted
-		// new instance will fail if there were connections open to the previous
-		// instance when you killed it. Those connections will hold the TCP port in
-		// the TIME_WAIT state for 30-120 seconds, so you fall into case 1 above.
-		setsockopt(*socketdescriptor, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int));
-
-		struct sockaddr_in6 serv_addr;
-		// set all values in the buffer to zero
-		memset(&serv_addr, 0, sizeof(serv_addr));
-		serv_addr.sin6_family = AF_INET6;
-
-		if(config.socket_listenlocal && type == SOCKET)
-			serv_addr.sin6_addr = in6addr_loopback;
-		else
-			serv_addr.sin6_addr = in6addr_any;
-
-		// The bind() system call binds a socket to an address,
-		// in this case the address of the current host and
-		// port number on which the server will run.
-		// convert this to network byte order using the function htons()
-		// which converts a port number in host byte order to a port number
-		// in network byte order
-
-		bool bound = false;
-		// Bind to dual-stack socket
-		for(port = port_init; port <= (port_init + 20); port++)
-		{
-			serv_addr.sin6_port = htons(port);
-			if(bind(*socketdescriptor, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) >= 0)
-			{
-				bound = true;
-				dualstack = true;
-				break;
-			}
-		}
-
-		if(!bound)
-		{
-			logg("Error listening on any IPv4 + IPv6 port");
-			exit(EXIT_FAILURE);
-		}
-
+		logg("Error opening IPv4 telnet socket: %s (%i)", strerror(errno), errno);
+		exit(EXIT_FAILURE);
 	}
+
+	// Set SO_REUSEADDR to allow re-binding to the port that has been used
+	// previously by FTL. A common pattern is that you change FTL's
+	// configuration file and need to restart that server to make it reload
+	// its configuration. Without SO_REUSEADDR, the bind() call in the restarted
+	// new instance will fail if there were connections open to the previous
+	// instance when you killed it. Those connections will hold the TCP port in
+	// the TIME_WAIT state for 30-120 seconds, so you fall into case 1 above.
+	setsockopt(*socketdescriptor, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int));
+
+	struct sockaddr_in serv_addr4;
+	// set all values in the buffer to zero
+	memset(&serv_addr4, 0, sizeof(serv_addr4));
+	serv_addr4.sin_family = AF_INET;
+
+	if(config.socket_listenlocal && type == SOCKET)
+		serv_addr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	else
+		serv_addr4.sin_addr.s_addr = INADDR_ANY;
+
+	// Bind to IPv4 port
+	serv_addr4.sin_port = htons(config.port);
+	if(bind(*socketdescriptor, (struct sockaddr *) &serv_addr4, sizeof(serv_addr4)) < 0)
 	{
-		// Try IPv4 only socket
-		// see the comments further up for details
-		*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
-
-		struct sockaddr_in serv_addr4;
-		memset(&serv_addr4, 0, sizeof(serv_addr4));
-		serv_addr4.sin_family = AF_INET;
-
-		if(config.socket_listenlocal && type == SOCKET)
-			serv_addr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-		else
-			serv_addr4.sin_addr.s_addr = INADDR_ANY;
-
-		bool bound = false;
-		// Bind to IPv4 port
-		for(port = port_init; port <= (port_init + 20); port++)
-		{
-			serv_addr4.sin_port = htons(port);
-			if(bind(*socketdescriptor, (struct sockaddr *) &serv_addr4, sizeof(serv_addr4)) >= 0)
-			{
-				bound = true;
-				break;
-			}
-		}
-
-		if(!bound)
-		{
-			logg("Error listening on any IPv4 port");
-			exit(EXIT_FAILURE);
-		}
+		logg("Error listening on IPv4 port %i: %s (%i)", config.port, strerror(errno), errno);
+		return 0;
 	}
-
-	saveport(port);
 
 	// The listen system call allows the process to listen on the socket for connections
 	if(listen(*socketdescriptor, BACKLOG) == -1)
 	{
-		logg("Error on listening");
+		logg("Error listening on IPv4 socket: %s (%i)", strerror(errno), errno);
+		return 0;
+	}
+
+	logg("Listening on port %i for incoming IPv4 connections", config.port);
+	return 1;
+}
+
+char bind_to_telnet_port_IPv6(char type, int *socketdescriptor)
+{
+	// Try IPv6 only socket
+	*socketdescriptor = socket(AF_INET6, SOCK_STREAM, 0);
+
+	if(*socketdescriptor < 0)
+	{
+		logg("Error opening IPv6 telnet socket: %s (%i)", strerror(errno), errno);
 		exit(EXIT_FAILURE);
 	}
 
-	logg("Listening on port %i for incoming %s connections", port, dualstack ? "IPv4 + IPv6" : "IPv4");
-}
+	// If this flag is set to true (nonzero), then the  socket  is  re‐
+	// stricted  to  sending  and receiving IPv6 packets only.  In this
+	// case, an IPv4 and an IPv6 application can bind to a single  port
+	// at the same time.
+	setsockopt(*socketdescriptor, IPPROTO_IPV6, IPV6_V6ONLY, &(int){ 1 }, sizeof(int));
 
+	// Set SO_REUSEADDR to allow re-binding to the port that has been used
+	// previously by FTL. A common pattern is that you change FTL's
+	// configuration file and need to restart that server to make it reload
+	// its configuration. Without SO_REUSEADDR, the bind() call in the restarted
+	// new instance will fail if there were connections open to the previous
+	// instance when you killed it. Those connections will hold the TCP port in
+	// the TIME_WAIT state for 30-120 seconds, so you fall into case 1 above.
+	setsockopt(*socketdescriptor, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int));
+
+	struct sockaddr_in6 serv_addr;
+	// set all values in the buffer to zero
+	memset(&serv_addr, 0, sizeof(serv_addr));
+	serv_addr.sin6_family = AF_INET6;
+
+	if(config.socket_listenlocal && type == SOCKET)
+		serv_addr.sin6_addr = in6addr_loopback;
+	else
+		serv_addr.sin6_addr = in6addr_any;
+
+	// The bind() system call binds a socket to an address,
+	// in this case the address of the current host and
+	// port number on which the server will run.
+	// convert this to network byte order using the function htons()
+	// which converts a port number in host byte order to a port number
+	// in network byte order
+
+	// Bind to IPv6 socket
+	serv_addr.sin6_port = htons(config.port);
+	if(bind(*socketdescriptor, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0)
+	{
+		logg("Error listening on IPv6 port %i: %s (%i)", config.port, strerror(errno), errno);
+		return 0;
+	}
+
+	// The listen system call allows the process to listen on the socket for connections
+	if(listen(*socketdescriptor, BACKLOG) == -1)
+	{
+		logg("Error listening on IPv6 socket: %s (%i)", strerror(errno), errno);
+		return 0;
+	}
+
+	logg("Listening on port %i for incoming IPv6 connections", config.port);
+	return 1;
+}
 
 void bind_to_unix_socket(int *socketdescriptor)
 {
@@ -165,22 +170,21 @@ void bind_to_unix_socket(int *socketdescriptor)
 
 	// Bild to Unix socket handle
 	errno = 0;
-	if(bind(*socketdescriptor, (struct sockaddr *) &address, sizeof (address)) != 0) {
-		logg("Error on binding on unix socket %s", FTLfiles.socketfile);
-		logg("Reason: %s (%i)", strerror(errno), errno);
+	if(bind(*socketdescriptor, (struct sockaddr *) &address, sizeof (address)) != 0)
+	{
+		logg("Error on binding on unix socket %s: %s (%i)", FTLfiles.socketfile, strerror(errno), errno);
 		exit(EXIT_FAILURE);
 	}
 
 	// The listen system call allows the process to listen on the Unix socket for connections
 	if(listen(*socketdescriptor, BACKLOG) == -1)
 	{
-		logg("Error on listening");
+		logg("Error listening on Unix socket: %s (%i)", strerror(errno), errno);
 		exit(EXIT_FAILURE);
 	}
 
 	logg("Listening on Unix socket");
 }
-
 
 // Called from main() at graceful shutdown
 void removeport(void)
@@ -206,50 +210,44 @@ void swrite(char server_message[SOCKETBUFFERLEN], int sock)
 		logg("WARNING: Socket write returned error code %i", errno);
 }
 
-int listener(int sockfd)
+int listener(int sockfd, char type)
 {
-	struct sockaddr_in6 cli_addr;
-	struct sockaddr_in cli_addr4;
-	// set all values in the buffer to zero
-	memset(&cli_addr, 0, sizeof(cli_addr));
-	socklen_t clilen = sizeof(cli_addr);
-	int clientsocket = accept(sockfd, (struct sockaddr *) &cli_addr, &clilen);
+	struct sockaddr_un un_addr;
+	struct sockaddr_in in4_addr;
+	struct sockaddr_in6 in6_addr;
+	socklen_t socklen = 0;
 
-	if(clientsocket > 0)
+	switch(type)
 	{
-		char str[INET6_ADDRSTRLEN];
-		if(dualstack)
-		{
-			// Determine the client address.  Note that if we bound to a dual-stack
-			// socket and the client is an IPv4 client, the address will be shown
-			// as an IPv4 Mapped IPv6 address, like "::ffff:127.0.0.1"
-			getpeername(clientsocket, (struct sockaddr *)&cli_addr, &clilen);
-			if(inet_ntop(AF_INET6, &cli_addr.sin6_addr, str, sizeof(str)))
-			{
-				int port = ntohs(cli_addr.sin6_port);
-				if(debugclients)
-					logg("Client connected: %s:%d, ID: %i", str, port, clientsocket);
-			}
-		}
-		else
-		{
-			getpeername(clientsocket, (struct sockaddr *)&cli_addr4, &clilen);
-			if(inet_ntop(AF_INET, &cli_addr4.sin_addr, str, sizeof(str)))
-			{
-				int port = ntohs(cli_addr4.sin_port);
-				if(debugclients)
-					logg("Client connected: %s:%d, ID: %i", str, port, clientsocket);
-			}
-		}
+		case 0: // Unix socket
+		memset(&un_addr, 0, sizeof(un_addr));
+		socklen = sizeof(un_addr);
+		return accept(sockfd, (struct sockaddr *) &un_addr, &socklen);
+
+		case 4: // Internet socket (IPv4)
+		memset(&in4_addr, 0, sizeof(in4_addr));
+		socklen = sizeof(un_addr);
+		return accept(sockfd, (struct sockaddr *) &in4_addr, &socklen);
+
+		case 6: // Internet socket (IPv6)
+		memset(&in6_addr, 0, sizeof(in6_addr));
+		socklen = sizeof(un_addr);
+		return accept(sockfd, (struct sockaddr *) &in6_addr, &socklen);
+
+		default: // Should not happen
+		logg("Cannot listen on type %i connection, code error!", type);
+		exit(EXIT_FAILURE);
 	}
-	return clientsocket;
 }
 
 void close_telnet_socket(void)
 {
 	removeport();
 	// Using global variable here
-	close(telnetfd);
+	if(telnetfd4)
+		close(telnetfd4);
+	if(telnetfd6)
+		close(telnetfd6);
 }
 
 void close_unix_socket(void)
@@ -374,7 +372,7 @@ void *socket_connection_handler_thread(void *socket_desc)
 	return 0;
 }
 
-void *telnet_listening_thread(void *args)
+void *telnet_listening_thread_IPv4(void *args)
 {
 	// We will use the attributes object later to start all threads in detached mode
 	pthread_attr_t attr;
@@ -385,16 +383,69 @@ void *telnet_listening_thread(void *args)
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
 	// Set thread name
-	prctl(PR_SET_NAME,"telnet listener",0,0,0);
+	prctl(PR_SET_NAME,"telnet-v4",0,0,0);
 
 	// Initialize sockets only after initial log parsing in listenting_thread
-	bind_to_telnet_port(SOCKET, &telnetfd);
+	bind_to_telnet_port_IPv4(SOCKET, &telnetfd4);
+
+	saveport();
 
 	// Listen as long as FTL is not killed
 	while(!killed)
 	{
 		// Look for new clients that want to connect
-		int csck = listener(telnetfd);
+		int csck = listener(telnetfd4, 4);
+		if(csck == -1)
+		{
+			logg("IPv4 telnet error: %s (%i)", strerror(errno), errno);
+			continue;
+		}
+
+		// Allocate memory used to transport client socket ID to client listening thread
+		int *newsock;
+		newsock = calloc(1,sizeof(int));
+		*newsock = csck;
+
+		pthread_t telnet_connection_thread;
+		// Create a new thread
+		if(pthread_create( &telnet_connection_thread, &attr, telnet_connection_handler_thread, (void*) newsock ) != 0)
+		{
+			// Log the error code description
+			logg("WARNING: Unable to open telnet processing thread, error: %s", strerror(errno));
+		}
+	}
+	return 0;
+}
+
+void *telnet_listening_thread_IPv6(void *args)
+{
+	// We will use the attributes object later to start all threads in detached mode
+	pthread_attr_t attr;
+	// Initialize thread attributes object with default attribute values
+	pthread_attr_init(&attr);
+	// When a detached thread terminates, its resources are automatically released back to
+	// the system without the need for another thread to join with the terminated thread
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+	// Set thread name
+	prctl(PR_SET_NAME,"telnet-v6",0,0,0);
+
+	// Initialize sockets only after initial log parsing in listenting_thread
+	if(ipv6_available())
+		bind_to_telnet_port_IPv6(SOCKET, &telnetfd6);
+	else
+		return 0;
+
+	// Listen as long as FTL is not killed
+	while(!killed)
+	{
+		// Look for new clients that want to connect
+		int csck = listener(telnetfd6, 6);
+		if(csck == -1)
+		{
+			logg("IPv6 telnet error: %s (%i)", strerror(errno), errno);
+			continue;
+		}
 
 		// Allocate memory used to transport client socket ID to client listening thread
 		int *newsock;
@@ -432,7 +483,7 @@ void *socket_listening_thread(void *args)
 	while(!killed)
 	{
 		// Look for new clients that want to connect
-		int csck = listener(socketfd);
+		int csck = listener(socketfd, 0);
 
 		// Allocate memory used to transport client socket ID to client listening thread
 		int *newsock;

--- a/socket.c
+++ b/socket.c
@@ -179,15 +179,26 @@ void swrite(char server_message[SOCKETBUFFERLEN], int sock)
 
 int listener(int sockfd)
 {
-	struct sockaddr_in cli_addr;
+	struct sockaddr_in6 cli_addr;
 	// set all values in the buffer to zero
 	memset(&cli_addr, 0, sizeof(cli_addr));
 	socklen_t clilen = sizeof(cli_addr);
 	int clientsocket = accept(sockfd, (struct sockaddr *) &cli_addr, &clilen);
 
-	if(debugclients)
-		logg("Client connected: %s, ID: %i", inet_ntoa (cli_addr.sin_addr), clientsocket);
-
+	if(clientsocket > 0)
+	{
+		// Determine the client address.  Note that if the client is
+		// an IPv4 client, the address will be shown as an IPv4 Mapped
+		// IPv6 address, like "::ffff:127.0.0.1"
+		getpeername(clientsocket, (struct sockaddr *)&cli_addr, &clilen);
+		char str[INET6_ADDRSTRLEN];
+		if(inet_ntop(AF_INET6, &cli_addr.sin6_addr, str, sizeof(str)))
+		{
+			int port = ntohs(cli_addr.sin6_port);
+			if(debugclients)
+				logg("Client connected: %s:%d, ID: %i", str, port, clientsocket);
+		}
+	}
 	return clientsocket;
 }
 

--- a/socket.c
+++ b/socket.c
@@ -103,7 +103,6 @@ void bind_to_telnet_port(char type, int *socketdescriptor)
 	{
 		// Try IPv4 only socket
 		// see the comments further up for details
-		logg("Error listening on any IPv4 + IPv6 port, trying IPv4-only binding");
 		*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
 
 		struct sockaddr_in serv_addr4;
@@ -471,9 +470,8 @@ bool ipv6_available(void)
 			{
 				iface[addr->sa_family == AF_INET6 ? 1 : 0]++;
 
-				// Debug statement that is only executed on TravisCI
-				if(travis)
-					logg("Interface %s is %s", interface->ifa_name, addr->sa_family == AF_INET6 ? "IPv6" : "IPv4");
+				// For now unused debug statement
+				// logg("Interface %s is %s", interface->ifa_name, addr->sa_family == AF_INET6 ? "IPv6" : "IPv4");
 			}
 		}
 		freeifaddrs(allInterfaces);

--- a/socket.c
+++ b/socket.c
@@ -41,7 +41,7 @@ void saveport(void)
 
 char bind_to_telnet_port_IPv4(char type, int *socketdescriptor)
 {
-	// Try IPv4 only socket
+	// IPv4 socket
 	// see the comments further up for details
 	*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -91,7 +91,7 @@ char bind_to_telnet_port_IPv4(char type, int *socketdescriptor)
 
 char bind_to_telnet_port_IPv6(char type, int *socketdescriptor)
 {
-	// Try IPv6 only socket
+	// IPv6 socket
 	*socketdescriptor = socket(AF_INET6, SOCK_STREAM, 0);
 
 	if(*socketdescriptor < 0)
@@ -157,7 +157,7 @@ void bind_to_unix_socket(int *socketdescriptor)
 
 	if(*socketdescriptor < 0)
 	{
-		logg("Error opening unix socket");
+		logg("Error opening Unix socket");
 		exit(EXIT_FAILURE);
 	}
 
@@ -172,7 +172,7 @@ void bind_to_unix_socket(int *socketdescriptor)
 	errno = 0;
 	if(bind(*socketdescriptor, (struct sockaddr *) &address, sizeof (address)) != 0)
 	{
-		logg("Error on binding on unix socket %s: %s (%i)", FTLfiles.socketfile, strerror(errno), errno);
+		logg("Error on binding on Unix socket %s: %s (%i)", FTLfiles.socketfile, strerror(errno), errno);
 		exit(EXIT_FAILURE);
 	}
 
@@ -383,7 +383,7 @@ void *telnet_listening_thread_IPv4(void *args)
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
 	// Set thread name
-	prctl(PR_SET_NAME,"telnet-v4",0,0,0);
+	prctl(PR_SET_NAME,"telnet-IPv4",0,0,0);
 
 	// Initialize sockets only after initial log parsing in listenting_thread
 	bind_to_telnet_port_IPv4(SOCKET, &telnetfd4);
@@ -428,7 +428,7 @@ void *telnet_listening_thread_IPv6(void *args)
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
 	// Set thread name
-	prctl(PR_SET_NAME,"telnet-v6",0,0,0);
+	prctl(PR_SET_NAME,"telnet-IPv6",0,0,0);
 
 	// Initialize sockets only after initial log parsing in listenting_thread
 	if(ipv6_available())

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -175,13 +175,13 @@ load 'libs/bats-support/load'
   [[ ${lines[2]} == "---EOM---" ]]
 }
 
-@test "IPv6 socket connection" {
-  run bash -c 'echo ">recentBlocked" | nc -v ::1 4711'
-  echo "output: ${lines[@]}"
-  [[ ${lines[0]} == "Connection to ::1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} == "addomain.com" ]]
-  [[ ${lines[2]} == "---EOM---" ]]
-}
+# @test "IPv6 socket connection" {
+#   run bash -c 'echo ">recentBlocked" | nc -v ::1 4711'
+#   echo "output: ${lines[@]}"
+#   [[ ${lines[0]} == "Connection to ::1 4711 port [tcp/*] succeeded!" ]]
+#   [[ ${lines[1]} == "addomain.com" ]]
+#   [[ ${lines[2]} == "---EOM---" ]]
+# }
 
 @test "DB test: Tables created and populated?" {
   run bash -c 'sqlite3 pihole-FTL.db .dump'

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -175,6 +175,14 @@ load 'libs/bats-support/load'
   [[ ${lines[2]} == "---EOM---" ]]
 }
 
+@test "IPv6 socket connection" {
+  run bash -c 'echo ">recentBlocked" | nc -v ::1 4711'
+  echo "output: ${lines[@]}"
+  [[ ${lines[0]} == "Connection to ::1 4711 port [tcp/*] succeeded!" ]]
+  [[ ${lines[1]} == "addomain.com" ]]
+  [[ ${lines[2]} == "---EOM---" ]]
+}
+
 @test "DB test: Tables created and populated?" {
   run bash -c 'sqlite3 pihole-FTL.db .dump'
   echo "output: ${lines[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This pull request adds full dual-stack support for `FTL`'s `telnet`-like socket. Previously, we bound only to an IPv4 port, now we bind to both the IPv4 and IPv6 port spaces.

In case no IPv6 interface is available (e.g. in `docker`), `FTL` will bind only to the IPv4 port - just as it did before.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

  