### PR TITLE
SQLite3: Have to finalize statements before closing database handle

### DIFF
--- a/database.c
+++ b/database.c
@@ -397,9 +397,9 @@ void save_to_DB(void)
 	}
 
 	// Finish prepared statement
-	dbquery("END TRANSACTION");
-	ret = sqlite3_finalize(stmt);
-	if(ret != SQLITE_OK){ dbclose(); return; }
+	ret = dbquery("END TRANSACTION");
+	int ret2 = sqlite3_finalize(stmt);
+	if(!ret || ret2 != SQLITE_OK){ dbclose(); return; }
 
 	// Store index for next loop interation round and update last time stamp
 	// in the database only if all queries have been saved successfully

--- a/database.c
+++ b/database.c
@@ -36,7 +36,12 @@ void check_database(int rc)
 
 void dbclose(void)
 {
-	sqlite3_close(db);
+	int rc = sqlite3_close(db);
+	// Report any error
+	if( rc )
+		logg("dbclose() - SQL error (%i): %s", rc, sqlite3_errmsg(db));
+
+	// Unlock mutex on the database
 	pthread_mutex_unlock(&dblock);
 }
 
@@ -392,9 +397,9 @@ void save_to_DB(void)
 	}
 
 	// Finish prepared statement
-	ret = dbquery("END TRANSACTION");
-	if(!ret){ dbclose(); return; }
-	sqlite3_finalize(stmt);
+	dbquery("END TRANSACTION");
+	ret = sqlite3_finalize(stmt);
+	if(ret != SQLITE_OK){ dbclose(); return; }
 
 	// Store index for next loop interation round and update last time stamp
 	// in the database only if all queries have been saved successfully


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Imagine the following situation: A user queries some extensive data on the log term dashboard. This will cause the database to be locked for maybe up to 30 seconds. If `FTL` wants to write in this time window to the database, it is actually allowed to open and use it as `PHP` is explicitly requesting only read-only access to the database. We can even prepare all queries we want to add to the database in a `TRANSACTION`, however, at the end of the transaction, we won't be able to save them as the database is locked against any writes.

Problem: Since the statement that was supposed to write queries to the database is not yet finalized, `sqlite3_close()` actually **fails** and `FTL` keeps the database handle open forever (in an undefined status) as we haven't even considered that `close` can fail due to locked (I though closing will be just fine and unlock, but that is not guaranteed to be the case!).

Solution: We finalize all statements before calling `sqlite3_close()` after an error, that may or not be caused by a database lock. In addition, we now also check the return value of `sqlite3_close()` and print some error message in the future if closing the database failed (although we don't expect this to happen anymore).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
