### PR TITLE
Final fix for Travis versioning and all the cosmetic issues we have seen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
 - mkdir -p "${DEST_DIR}"
 - make clean
 script:
-- make CC="${BUILD_CC}" CFLAGS="${CFLAGS}"
+- make CC="${BUILD_CC}" CFLAGS="${CFLAGS}" GIT_BRANCH="${TRAVIS_BRANCH}" GIT_TAG="${TRAVIS_TAG}" GIT_HASH="${TRAVIS_COMMIT}"
 - file pihole-FTL
 - if [[ "${BIN_NAME}" == "pihole-FTL-linux-x86_64" ]]; then test/run.sh; fi
 - mv pihole-FTL "${DEST_DIR}/${BIN_NAME}"

--- a/args.c
+++ b/args.c
@@ -78,9 +78,9 @@ void parse_args(int argc, char* argv[])
 			}
 			else
 			{
-				char hash[7];
-				// Extract first 6 characters of the hash
-				strncpy(hash, commit, 6); hash[6] = 0;
+				char hash[8];
+				// Extract first 7 characters of the hash
+				strncpy(hash, commit, 7); hash[7] = 0;
 				printf("vDev-%s\n", hash);
 			}
 			exit(EXIT_SUCCESS);

--- a/args.c
+++ b/args.c
@@ -70,13 +70,19 @@ void parse_args(int argc, char* argv[])
 		if(strcmp(argv[i], "-v") == 0 ||
 		   strcmp(argv[i], "version") == 0)
 		{
-			const char * version = GIT_VERSION;
-			// Check if version is of format vX.YY
-			// '.' can never be part of a commit hash
-			if(strstr(version, ".") != NULL)
+			const char * commit = GIT_HASH;
+			const char * tag = GIT_TAG;
+			if(strlen(tag) > 1)
+			{
 				printf("%s\n",GIT_VERSION);
+			}
 			else
-				printf("vDev-%s\n",GIT_HASH);
+			{
+				char hash[7];
+				// Extract first 6 characters of the hash
+				strncpy(hash, commit, 6); hash[6] = 0;
+				printf("vDev-%s\n", hash);
+			}
 			exit(EXIT_SUCCESS);
 		}
 
@@ -91,13 +97,6 @@ void parse_args(int argc, char* argv[])
 		   strcmp(argv[i], "branch") == 0)
 		{
 			const char * branch = GIT_BRANCH;
-			const char * version = GIT_VERSION;
-			// Travis CI pulls on a tag basis, not by branch.
-			// Hence, it may happen that the master binary isn't aware of its branch.
-			// We check if this is the case and if there is a "vX.YY" like tag on the
-			// binary are print out branch "master" if we find that this is the case
-			if(strstr(branch, "(no branch)") != NULL && strstr(version, ".") != NULL)
-				branch = "master";
 			printf("%s\n",branch);
 			exit(EXIT_SUCCESS);
 		}

--- a/args.c
+++ b/args.c
@@ -96,8 +96,7 @@ void parse_args(int argc, char* argv[])
 		if(strcmp(argv[i], "-b") == 0 ||
 		   strcmp(argv[i], "branch") == 0)
 		{
-			const char * branch = GIT_BRANCH;
-			printf("%s\n",branch);
+			printf("%s\n",GIT_BRANCH);
 			exit(EXIT_SUCCESS);
 		}
 

--- a/log.c
+++ b/log.c
@@ -147,8 +147,8 @@ void log_counter_info(void)
 void log_FTL_version(void)
 {
 	logg("FTL branch: %s", GIT_BRANCH);
-	logg("FTL version: %s", GIT_VERSION);
-	logg("FTL tag: %s", GIT_TAG);
+	logg("FTL version: %s", GIT_TAG);
+	logg("FTL commit: %s", GIT_HASH);
 	logg("FTL date: %s", GIT_DATE);
 	logg("FTL user: %s", username);
 }

--- a/request.c
+++ b/request.c
@@ -1044,20 +1044,18 @@ void getVersion(int *sock)
 {
 	char server_message[SOCKETBUFFERLEN];
 
-	const char * version = GIT_VERSION;
-	const char * branch = GIT_BRANCH;
 	const char * commit = GIT_HASH;
 	const char * tag = GIT_TAG;
 	if(strlen(tag) > 1)
 	{
-		sprintf(server_message,"version %s\ntag %s\nbranch %s\ndate %s\n", version, tag, branch, GIT_DATE);
+		sprintf(server_message,"version %s\ntag %s\nbranch %s\ndate %s\n", GIT_VERSION, tag, GIT_BRANCH, GIT_DATE);
 	}
 	else
 	{
 		char hash[8];
 		// Extract first 7 characters of the hash
 		strncpy(hash, commit, 7); hash[7] = 0;
-		sprintf(server_message,"version vDev-%s\ntag %s\nbranch %s\ndate %s\n", hash, tag, branch, GIT_DATE);
+		sprintf(server_message,"version vDev-%s\ntag %s\nbranch %s\ndate %s\n", hash, tag, GIT_BRANCH, GIT_DATE);
 	}
 
 	swrite(server_message, *sock);

--- a/request.c
+++ b/request.c
@@ -1046,17 +1046,20 @@ void getVersion(int *sock)
 
 	const char * version = GIT_VERSION;
 	const char * branch = GIT_BRANCH;
-	// Travis CI pulls on a tag basis, not by branch.
-	// Hence, it may happen that the master binary isn't aware of its branch.
-	// We check if this is the case and if there is a "vX.YY" like tag on the
-	// binary are print out branch "master" if we find that this is the case
-	if(strstr(branch, "(no branch)") != NULL && strstr(version, ".") != NULL)
-		branch = "master";
-
-	if(strstr(version, ".") != NULL)
-		sprintf(server_message,"version %s\ntag %s\nbranch %s\ndate %s\n", version, GIT_TAG, branch, GIT_DATE);
+	const char * commit = GIT_HASH;
+	const char * tag = GIT_TAG;
+	if(strlen(tag) > 1)
+	{
+		sprintf(server_message,"version %s\ntag %s\nbranch %s\ndate %s\n", version, tag, branch, GIT_DATE);
+	}
 	else
-		sprintf(server_message,"version vDev-%s\ntag %s\nbranch %s\ndate %s\n", GIT_HASH, GIT_TAG, branch, GIT_DATE);
+	{
+		char hash[7];
+		// Extract first 6 characters of the hash
+		strncpy(hash, commit, 6); hash[6] = 0;
+		sprintf(server_message,"version vDev-%s\ntag %s\nbranch %s\ndate %s\n", hash, tag, branch, GIT_DATE);
+	}
+
 	swrite(server_message, *sock);
 
 	if(debugclients)

--- a/request.c
+++ b/request.c
@@ -1054,9 +1054,9 @@ void getVersion(int *sock)
 	}
 	else
 	{
-		char hash[7];
-		// Extract first 6 characters of the hash
-		strncpy(hash, commit, 6); hash[6] = 0;
+		char hash[8];
+		// Extract first 7 characters of the hash
+		strncpy(hash, commit, 7); hash[7] = 0;
 		sprintf(server_message,"version vDev-%s\ntag %s\nbranch %s\ndate %s\n", hash, tag, branch, GIT_DATE);
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This pull request fixes the issues with versioning once and for all. Instead of using a hacky solution like detecting `(no branch)` and crossing our fingers that it means we are currently building a tagged release, we use the proper Travis environment variables and show `vDev-...` as version for **all** builds except tagged releases.

This has been tested on a private fork.

Output on branch `fix_versioning`
```
./pihole-FTL tag: 
./pihole-FTL version: vDev-4cf31d
./pihole-FTL branch: fix/TravisVersioning
```

Output on branch `master`, untagged
```
./pihole-FTL tag: 
./pihole-FTL version: vDev-7801f9
./pihole-FTL branch: master
```

Output on branch `master`, tagged `v5.0` (this is what is triggered when we release officially)
```
./pihole-FTL tag: v5.0
./pihole-FTL version: v5.0
./pihole-FTL branch: v5.0
```



_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
