### PR TITLE
Ensure that host names are always lower case

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -504,8 +504,6 @@ void process_pihole_log(int file)
 				// Debug output
 				if(strlen(hostname) > 0)
 				{
-					// Convert hostname to lower case
-					strtolower(hostname);
 					logg("New client: %s %s (%i: %i/%i)", client, hostname, dnsmasqID, clientID, counters.clients_MAX);
 				}
 				else
@@ -1081,6 +1079,8 @@ char *resolveHostname(const char *addr)
 	{
 		// Return hostname copied to new memory location
 		hostname = strdup(he->h_name);
+		// Convert hostname to lower case
+		strtolower(hostname);
 	}
 
 	return hostname;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Ensure that host name returned by `char *resolveHostname(const char *addr)` is always lower case. This is an issue as we currently convert the host name to lower case on the initial reading of the log (when a client is newly added) but we didn't do it again later when we ran `void reresolveHostnames(void)` which is periodically called to recognize updated host names.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
