### PR TITLE
Improve sorting and displaying algorithms for top-clients and top-domains

### DIFF
--- a/request.c
+++ b/request.c
@@ -207,8 +207,8 @@ bool command(char *client_message, const char* cmd)
 // 	}
 // }
 
-/* qsort comparision function (count field), sort DESC */
-int cmpdesc(const void *a, const void *b)
+/* qsort comparision function (count field), sort ASC */
+int cmpasc(const void *a, const void *b)
 {
 	int *elem1 = (int*)a;
 	int *elem2 = (int*)b;
@@ -221,8 +221,8 @@ int cmpdesc(const void *a, const void *b)
 		return 0;
 }
 
-// qsort subroutine, sort ASC
-int cmpasc(const void *a, const void *b)
+// qsort subroutine, sort DESC
+int cmpdesc(const void *a, const void *b)
 {
 	int *elem1 = (int*)a;
 	int *elem2 = (int*)b;
@@ -411,7 +411,7 @@ void getTopDomains(char *client_message, int *sock)
 	for(i=0; i < counters.domains; i++)
 	{
 		// Get sorted indices
-		int j = temparray[counters.domains-i-1][0];
+		int j = temparray[i][0];
 		validate_access("domains", j, true, __LINE__, __FUNCTION__, __FILE__);
 
 		// Skip this domain if there is a filter on it
@@ -506,7 +506,7 @@ void getTopClients(char *client_message, int *sock)
 	for(i=0; i < counters.clients; i++)
 	{
 		// Get sorted indices
-		int j = temparray[counters.clients-i-1][0];
+		int j = temparray[i][0];
 		validate_access("clients", j, true, __LINE__, __FUNCTION__, __FILE__);
 
 		// Skip this client if there is a filter on it

--- a/request.c
+++ b/request.c
@@ -207,8 +207,8 @@ bool command(char *client_message, const char* cmd)
 // 	}
 // }
 
-/* qsort comparision function (count field), sort ASC */
-int cmpasc(const void *a, const void *b)
+/* qsort comparision function (count field), sort DESC */
+int cmpdesc(const void *a, const void *b)
 {
 	int *elem1 = (int*)a;
 	int *elem2 = (int*)b;
@@ -221,8 +221,8 @@ int cmpasc(const void *a, const void *b)
 		return 0;
 }
 
-// qsort subroutine, sort DESC
-int cmpdesc(const void *a, const void *b)
+// qsort subroutine, sort ASC
+int cmpasc(const void *a, const void *b)
 {
 	int *elem1 = (int*)a;
 	int *elem2 = (int*)b;
@@ -329,11 +329,12 @@ void getTopDomains(char *client_message, int *sock)
 {
 	char server_message[SOCKETBUFFERLEN];
 	int i, temparray[counters.domains][2], count=10, num;
-	bool blocked = command(client_message, ">top-ads"), audit = false, desc = false;
+	bool blocked = command(client_message, ">top-ads"), audit = false, asc = false;
 
 	// Exit before processing any data if requested via config setting
 	if(!config.query_display)
 		return;
+
 
 	// Match both top-domains and top-ads
 	if(sscanf(client_message, ">%*[^(](%i)", &num) > 0)
@@ -349,9 +350,9 @@ void getTopDomains(char *client_message, int *sock)
 	}
 
 	// Sort in descending order?
-	if(command(client_message, " desc"))
+	if(command(client_message, " asc"))
 	{
-		desc = true;
+		asc = true;
 	}
 
 	for(i=0; i < counters.domains; i++)
@@ -366,10 +367,10 @@ void getTopDomains(char *client_message, int *sock)
 	}
 
 	// Sort temporary array
-	if(desc)
-		qsort(temparray, counters.domains, sizeof(int[2]), cmpdesc);
-	else
+	if(asc)
 		qsort(temparray, counters.domains, sizeof(int[2]), cmpasc);
+	else
+		qsort(temparray, counters.domains, sizeof(int[2]), cmpdesc);
 
 
 	// Get filter
@@ -479,18 +480,18 @@ void getTopClients(char *client_message, int *sock)
 		temparray[i][1] = clients[i].count;
 	}
 
-	// Sort in descending order?
-	bool desc = false;
-	if(command(client_message, " desc"))
+	// Sort in ascending order?
+	bool asc = false;
+	if(command(client_message, " asc"))
 	{
-		desc = true;
+		asc = true;
 	}
 
 	// Sort temporary array
-	if(desc)
-		qsort(temparray, counters.clients, sizeof(int[2]), cmpdesc);
-	else
+	if(asc)
 		qsort(temparray, counters.clients, sizeof(int[2]), cmpasc);
+	else
+		qsort(temparray, counters.clients, sizeof(int[2]), cmpdesc);
 
 	// Get clients which the user doesn't want to see
 	char * excludeclients = read_setupVarsconf("API_EXCLUDE_CLIENTS");

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -86,8 +86,8 @@ load 'libs/bats-support/load'
   run bash -c 'echo ">top-ads asc" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} == "0 1 addomain.com" ]]
-  [[ ${lines[2]} == "1 1 blacklisted.com" ]]
+  [[ ${lines[1]} == "0 1 blacklisted.com" ]]
+  [[ ${lines[2]} == "1 1 addomain.com" ]]
   [[ ${lines[3]} == "---EOM---" ]]
 }
 

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -31,7 +31,7 @@ load 'libs/bats-support/load'
   [[ ${lines[11]} == "---EOM---" ]]
 }
 
-@test "Top Clients" {
+@test "Top Clients (descending, default)" {
   run bash -c 'echo ">top-clients" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
@@ -41,19 +41,49 @@ load 'libs/bats-support/load'
   [[ ${lines[4]} == "---EOM---" ]]
 }
 
-@test "Top Domains" {
+@test "Top Clients (ascending)" {
+  run bash -c 'echo ">top-clients asc" | nc -v 127.0.0.1 4711'
+  echo "output: ${lines[@]}"
+  [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
+  [[ ${lines[1]} =~ "0 1 10.8.0.2" ]]
+  [[ ${lines[2]} =~ "1 2 127.0.0.1" ]]
+  [[ ${lines[3]} =~ "2 4 192.168.2.208" ]]
+  [[ ${lines[4]} == "---EOM---" ]]
+}
+
+@test "Top Domains (descending, default)" {
   run bash -c 'echo ">top-domains" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
   [[ ${lines[1]} == "0 2 play.google.com" ]]
-  [[ ${lines[2]} == "1 1 example.com" ]]
+  [[ ${lines[2]} == "1 1 raspberrypi" ]]
   [[ ${lines[3]} == "2 1 checkip.dyndns.org" ]]
-  [[ ${lines[4]} == "3 1 raspberrypi" ]]
+  [[ ${lines[4]} == "3 1 example.com" ]]
   [[ ${lines[5]} == "---EOM---" ]]
 }
 
-@test "Top Ads" {
+@test "Top Domains (ascending)" {
+  run bash -c 'echo ">top-domains asc" | nc -v 127.0.0.1 4711'
+  echo "output: ${lines[@]}"
+  [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
+  [[ ${lines[1]} == "0 1 raspberrypi" ]]
+  [[ ${lines[2]} == "1 1 checkip.dyndns.org" ]]
+  [[ ${lines[3]} == "2 1 example.com" ]]
+  [[ ${lines[4]} == "3 2 play.google.com" ]]
+  [[ ${lines[5]} == "---EOM---" ]]
+}
+
+@test "Top Ads (descending, default)" {
   run bash -c 'echo ">top-ads" | nc -v 127.0.0.1 4711'
+  echo "output: ${lines[@]}"
+  [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
+  [[ ${lines[1]} == "0 1 blacklisted.com" ]]
+  [[ ${lines[2]} == "1 1 addomain.com" ]]
+  [[ ${lines[3]} == "---EOM---" ]]
+}
+
+@test "Top Ads (ascending)" {
+  run bash -c 'echo ">top-ads asc" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"
   [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
   [[ ${lines[1]} == "0 1 addomain.com" ]]


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

-  Implement improved algorithm in `getTopDomains()`. Instead of assuming how many lines of data we have sent, we can also explicitly count them.
- Implement improved algorithm in `getTopClients()`. As a by-product this also adds the optional `desc` feature to the top clients requests where it wasn't available before.

Note that I completely removed the `skip` variable as it is not important how many lines we have already skipped when now directly count the number of returned datasets.

The new code has been tested against two possible failures:
- Requested more data than is available, and
- Requested data when no data is available.

Both tests returned the expected results.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
