### PR TITLE
Save queries to long-term database on exit

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -203,8 +203,8 @@ typedef struct {
 } memoryStruct;
 
 // Prepare timers, used mainly for debugging purposes
-#define NUMTIMERS 1
-enum { DATABASE_WRITE_TIMER };
+#define NUMTIMERS 2
+enum { DATABASE_WRITE_TIMER, EXIT_TIMER };
 
 enum { QUERIES, FORWARDED, CLIENTS, DOMAINS, OVERTIME, WILDCARD };
 enum { SOCKET };

--- a/main.c
+++ b/main.c
@@ -176,9 +176,12 @@ int main (int argc, char* argv[]) {
 	pthread_cancel(socket_listenthread);
 
 	// Save new queries to database
-	save_to_DB();
-	logg("Finished final database update");
-
+	if(database)
+	{
+		save_to_DB();
+		logg("Finished final database update");
+	}
+	
 	// Close sockets
 	close_telnet_socket();
 	close_unix_socket();

--- a/main.c
+++ b/main.c
@@ -168,12 +168,22 @@ int main (int argc, char* argv[]) {
 	}
 
 	logg("Shutting down...");
+
+	// Cancel active threads as we don't need them any more
 	pthread_cancel(piholelogthread);
 	pthread_cancel(telnet_listenthreadv4);
 	if(telnet_ipv6) pthread_cancel(telnet_listenthreadv6);
 	pthread_cancel(socket_listenthread);
+
+	// Save new queries to database
+	save_to_DB();
+	logg("Finished final database update");
+
+	// Close sockets
 	close_telnet_socket();
 	close_unix_socket();
+
+	//Remove PID file
 	removepid();
 	logg("########## FTL terminated! ##########");
 	return 1;

--- a/main.c
+++ b/main.c
@@ -185,6 +185,6 @@ int main (int argc, char* argv[]) {
 
 	//Remove PID file
 	removepid();
-	logg("########## FTL terminated! ##########");
+	logg("########## FTL terminated after %.1f ms! ##########", timer_elapsed_msec(EXIT_TIMER));
 	return 1;
 }

--- a/routines.h
+++ b/routines.h
@@ -82,3 +82,4 @@ void *GC_thread(void *val);
 void db_init(void);
 void *DB_thread(void *val);
 int get_number_of_queries_in_DB(void);
+void save_to_DB(void);

--- a/signals.c
+++ b/signals.c
@@ -16,7 +16,8 @@ bool rereadgravity = false;
 
 static void SIGTERM_handler(int sig, siginfo_t *si, void *unused)
 {
-	logg("FATAL: FTL received SIGTERM from PID/UID %i/%i, scheduled to exit gracefully", (int)si->si_pid, (int)si->si_uid);
+	logg("FATAL: FTL received SIGTERM from PID/UID %i/%i, exiting gracefully", (int)si->si_pid, (int)si->si_uid);
+	timer_start(EXIT_TIMER);
 	killed = 1;
 }
 
@@ -24,6 +25,7 @@ static void SIGINT_handler(int sig, siginfo_t *si, void *unused)
 {
 	// Should probably not use printf in signal handler, but this will anyhow exit immediately
 	logg("FATAL: FTL received SIGINT (Ctrl + C, PID/UID %i/%i), exiting immediately!", (int)si->si_pid, (int)si->si_uid);
+	logg("       There may be queries that have not been saved in the long-term data base");
 	exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Save remaining queries to the long-term database on graceful shutdown (after receiving `SIGTERM`). Experiments revealed that storing even thousands of queries does not take longer than half a second on real Raspberry Pi hardware so it can be considered safe to delay shutdown by a few millisecond. The benefit is that the long-term database will be up-to-date and there will be no missing queries that have not yet been stored in the database due to the finite database update intervals.

Exemplary output:
```
[2018-01-15 23:04:28.789] FATAL: FTL received SIGTERM (PID/UID 0/0), exiting gracefully
[2018-01-15 23:04:28.789] Shutting down...
[2018-01-15 23:04:29.119] Finished final database update
[2018-01-15 23:04:29.119] ########## FTL terminated after 329.9 ms! ##########
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
