### PR TITLE
Don't read pihole.log.1

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -122,8 +122,6 @@ typedef struct {
 
 typedef struct {
 	bool socket_listenlocal;
-	bool include_yesterday;
-	bool rolling_24h;
 	bool query_display;
 	bool analyze_AAAA;
 	int maxDBdays;

--- a/FTL.h
+++ b/FTL.h
@@ -84,7 +84,6 @@ typedef struct {
 
 typedef struct {
 	const char* log;
-	const char* log1;
 	const char* gravity;
 	const char* whitelist;
 	const char* blacklist;

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ You can create a file `/etc/pihole/pihole-FTL.conf` that will be read by `FTL` o
 Possible settings (**the option shown first is the default**):
 
 - `SOCKET_LISTENING=localonly|all` (Listen only for local socket connections or permit all connections)
-- `TIMEFRAME=rolling24h|yesterday|today` (Rolling data window, up to 48h (today + yesterday), or up to 24h (only today, as in Pi-hole `v2.x` ))
 - `QUERY_DISPLAY=yes|no` (Display all queries? Set to `no` to hide query display)
 - `AAAA_QUERY_ANALYSIS=yes|no` (Allow `FTL` to analyze AAAA queries from pihole.log?)
 - `MAXDBDAYS=365` (How long should queries be stored in the database? Setting this to `0` disables the database altogether)

--- a/config.c
+++ b/config.c
@@ -43,28 +43,6 @@ void read_FTLconf(void)
 	else
 		logg("   SOCKET_LISTENING: all destinations");
 
-	// TIMEFRAME
-	// defaults to: ROLLING
-	config.rolling_24h = true;
-	config.include_yesterday = true;
-	buffer = parse_FTLconf(fp, "TIMEFRAME");
-
-	if(buffer != NULL && strcmp(buffer, "yesterday") == 0)
-	{
-		config.include_yesterday = true;
-		config.rolling_24h = false;
-		logg("   TIMEFRAME: Yesterday + Today");
-	}
-	else if(buffer != NULL && strcmp(buffer, "today") == 0)
-	{
-		config.include_yesterday = false;
-		config.rolling_24h = false;
-		logg("   TIMEFRAME: Today");
-	}
-
-	if(config.rolling_24h)
-		logg("   TIMEFRAME: Rolling 24h");
-
 	// QUERY_DISPLAY
 	// defaults to: Yes
 	config.query_display = true;

--- a/main.c
+++ b/main.c
@@ -121,14 +121,11 @@ int main (int argc, char* argv[]) {
 			needGC = false;
 			runGCthread = false;
 
-			if(config.rolling_24h)
+			pthread_t GCthread;
+			if(pthread_create( &GCthread, &attr, GC_thread, NULL ) != 0)
 			{
-				pthread_t GCthread;
-				if(pthread_create( &GCthread, &attr, GC_thread, NULL ) != 0)
-				{
-					logg("Unable to open GC thread. Exiting...");
-					killed = 1;
-				}
+				logg("Unable to open GC thread. Exiting...");
+				killed = 1;
 			}
 
 			if(database)

--- a/parser.c
+++ b/parser.c
@@ -259,6 +259,12 @@ void process_pihole_log(void)
 		// Check if this query has already been imported from the database
 		if(querytimestamp < lastDBimportedtimestamp) continue;
 
+		// Skip parsing of log entries that are too old
+		// Get minimum time stamp to analyze
+		int differencetofullhour = time(NULL) % GCinterval;
+		int mintime = (time(NULL) - GCdelay - differencetofullhour) - MAXLOGAGE;
+		if(querytimestamp < mintime) continue;
+
 		// Test if the read line is a query line
 		if(strstr(readbuffer," query[A") != NULL)
 		{
@@ -270,12 +276,6 @@ void process_pihole_log(void)
 				if(debug) logg("Not analyzing AAAA query");
 				continue;
 			}
-
-			// Get minimum time stamp to analyze
-			int differencetofullhour = time(NULL) % GCinterval;
-			int mintime = (time(NULL) - GCdelay - differencetofullhour) - MAXLOGAGE;
-			// Skip parsing of log entries that are too old altogether if 24h window is requested
-			if(config.rolling_24h && querytimestamp < mintime) continue;
 
 			// Ensure we have enough space in the queries struct
 			memory_check(QUERIES);

--- a/routines.h
+++ b/routines.h
@@ -27,7 +27,7 @@ void initial_log_parsing(void);
 long int checkLogForChanges(void);
 void open_pihole_log(void);
 void handle_signals(void);
-void process_pihole_log(int file);
+void process_pihole_log(void);
 void *pihole_log_thread(void *val);
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file);
 void validate_access_oTfd(int timeidx, int forwardID, int line, const char * function, const char * file);

--- a/structs.c
+++ b/structs.c
@@ -21,7 +21,6 @@ FTLFileNamesStruct FTLfiles = {
 
 logFileNamesStruct files = {
 	"/var/log/pihole.log",
-	"/var/log/pihole.log.1",
 	"/etc/pihole/list.preEventHorizon",
 	"/etc/pihole/whitelist.txt",
 	"/etc/pihole/blacklist.txt",


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Since the new way of getting historic data is to import them from the long-term database, there is no need for interpreting (and skipping!) each line of `pihole.log.1` any longer. If users disabled the long-term database, he will notice that some historic data is missing. This is intended as we want to encourage users to re-enable the database at least for the most recent two days (this is something we want to mention in the next blog post @jacobsalmela ) in planing for a future version of `FTL` that will not need any of the log files *at all*.

Due to this change, the option `TIMEFRAME` becomes useless and is removed (it will just be ignored if still present in the user's config files).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
