### PR TITLE
Mark queries we mark as not completed again as unknown

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -546,6 +546,8 @@ void process_pihole_log(void)
 						validate_access("overTime", queries[i].timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 						overTime[queries[i].timeidx].cached--;
 
+						// Mark this query again as (temporarily) unknown
+						counters.unknown++;
 						queries[i].complete = false;
 					}
 					queries[i].status = 2;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This is a minor fix for a bug introduced in 2443b231e194acbb2e34c8e3fa912dad5ef798bb
Although harmless, it could cause wrong negative `Unknown DNS Queries` displays.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
