### PR TITLE
Fix missing information bug in findClientID()

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -929,6 +929,18 @@ void process_pihole_log(void)
 	fclose(fp);
 }
 
+bool isValidIPv4(const char *addr)
+{
+	struct sockaddr_in sa;
+	return inet_pton(AF_INET, addr, &(sa.sin_addr)) != 0;
+}
+
+bool isValidIPv6(const char *addr)
+{
+	struct sockaddr_in6 sa;
+	return inet_pton(AF_INET6, addr, &(sa.sin6_addr)) != 0;
+}
+
 char *resolveHostname(const char *addr)
 {
 	// Get host name
@@ -1186,6 +1198,7 @@ int findDomainID(const char *domain)
 int findClientID(const char *client)
 {
 	int i;
+	// Compare content of client against known client IP addresses
 	for(i=0; i < counters.clients; i++)
 	{
 		validate_access("clients", i, true, __LINE__, __FUNCTION__, __FILE__);
@@ -1193,18 +1206,55 @@ int findClientID(const char *client)
 		if(clients[i].ip[0] != client[0])
 			continue;
 
-		// If so, compare the full domain using strcmp
+		// If so, compare the full IP using strcmp
 		if(strcmp(clients[i].ip, client) == 0)
 		{
 			clients[i].count++;
 			return i;
 		}
 	}
-	// If we did not return until here, then this client is not known
+	// If we did not return until here, then this client is either
+	// a) new or
+	// b) only known by its hostname (after importing from the database)
+
+	// First try to resolve the IP to a hostname to compare again
+	char *hostname = NULL;
+	if(isValidIPv4(client) || isValidIPv6(client))
+	{
+		hostname = resolveHostname(client);
+
+		// Compare again with resolved host name if resoltuino succeeded
+		if(hostname[0] != '\0')
+		{
+			for(i=0; i < counters.clients; i++)
+			{
+				validate_access("clients", i, true, __LINE__, __FUNCTION__, __FILE__);
+				// Quick test: Does the clients host name start with the same character?
+				if(clients[i].name[0] != hostname[0])
+					continue;
+
+				// If so, compare the full host name using strcmp
+				if(strcmp(clients[i].name, hostname) == 0)
+				{
+					// Store IP address
+					free(clients[i].ip);
+					clients[i].ip = strdup(client);
+
+					clients[i].count++;
+					return i;
+				}
+			}
+		}
+	}
+	else
+	{
+		hostname = strdup(client);
+	}
+
+	// If we did not return until here, then this client is definitely new
 	// Store ID
 	int clientID = counters.clients;
-	//Get client host name
-	char *hostname = resolveHostname(client);
+
 	// Debug output
 	if(strlen(hostname) > 0)
 		logg("New client: %s %s (%i/%i)", client, hostname, clientID, counters.clients_MAX);

--- a/parser.c
+++ b/parser.c
@@ -1223,7 +1223,7 @@ int findClientID(const char *client)
 	{
 		hostname = resolveHostname(client);
 
-		// Compare again with resolved host name if resoltuino succeeded
+		// Compare again with resolved host name if resolution succeeded
 		if(hostname[0] != '\0')
 		{
 			for(i=0; i < counters.clients; i++)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes #216 

When reading from `dnsmasq`'s log we always only got the IP address. We used internal name resolution to obtain a possible host name and stored both data in `FTL`'s internal data structure. However, when saving to `FTL`'s database, we only ever save the highest available level of data (that is we store the host name if it is available as host names <-> IP address correlations may change over time and having host names in the database seems to be the better choice in terms of archiving data).

On importing from the database, we erroneously copied the host name into the IP field of `FTL`'s internal data structure. This is not an issue and was not causing issues. However, if we now see of of the already known clients in `dnsmasq`'s log, we actually only see its IP address. We compare this IP address against all already known IP addresses and conclude that we have not seen this client before. Hence, we add a new client with the same host name.

This PR fixes this misbehavior by refining the algorithm from

1. Compare input string against all already known IP addresses
2. Create new client if no match was found

to
1. Compare input string against all already known IP addresses
2. If the input string is a valid IP address, we try to resolve it to a host name
3. If 2. was successful, we compare the host name we just obtained against all already known host names.
4. Create new client only if no match was found for all already known IP addresses and all already known host names.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
