### PR TITLE
Fix signedness of integer constant

### DIFF
--- a/msgpack.c
+++ b/msgpack.c
@@ -96,7 +96,7 @@ bool pack_str32(int sock, char *string) {
 	// Make sure that the length is less than 4294967296
 	size_t length = strlen(string);
 
-	if(length >= 2147483648) {
+	if(length >= 2147483648u) {
 		logg("Tried to send a str32 longer than 2147483647 bytes!");
 		return false;
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This fixes the issue of a too large number in our msgpack implementation on 32bit systems.
```
msgpack.c: In function ‘pack_str32’:
msgpack.c:99:2: warning: this decimal constant is unsigned only in ISO C90
  if(length >= 2147483648) {
  ^
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
