### PR TITLE
Always store client IP in the database (never the host name)

### DIFF
--- a/database.c
+++ b/database.c
@@ -354,10 +354,7 @@ void save_to_DB(void)
 		sqlite3_bind_text(stmt, 4, domains[queries[i].domainID].domain, -1, SQLITE_TRANSIENT);
 
 		// CLIENT
-		if(strlen(clients[queries[i].clientID].name) > 0)
-			sqlite3_bind_text(stmt, 5, clients[queries[i].clientID].name, -1, SQLITE_TRANSIENT);
-		else
-			sqlite3_bind_text(stmt, 5, clients[queries[i].clientID].ip, -1, SQLITE_TRANSIENT);
+		sqlite3_bind_text(stmt, 5, clients[queries[i].clientID].ip, -1, SQLITE_TRANSIENT);
 
 		// FORWARD
 		if(queries[i].status == 2 && queries[i].forwardID > -1)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Always store client IP in the database (never the host name). We do this for consistency as we will always have IP addresses but not always host names so the current situation can actually be messy in the database. Furthermore, it should be noted that we also only ever store IP addresses (and never host names!) for the forward destinations.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
