### PR TITLE
Create new table "counters" and store integrated counters therein

### DIFF
--- a/database.c
+++ b/database.c
@@ -18,7 +18,14 @@ long int lastDBimportedtimestamp = 0;
 
 pthread_mutex_t dblock;
 
-enum { DB_VERSION, DB_LASTTIMESTAMP };
+// TABLE ftl
+enum { DB_VERSION, DB_LASTTIMESTAMP, DB_FIRSTCOUNTERTIMESTAMP };
+// TABLE counters
+enum { DB_TOTALQUERIES, DB_BLOCKEDQUERIES };
+
+bool db_set_counter(unsigned int ID, int value);
+bool db_set_FTL_property(unsigned int ID, int value);
+int db_get_FTL_property(unsigned int ID);
 
 void check_database(int rc)
 {
@@ -113,6 +120,32 @@ bool dbquery(const char *format, ...)
 
 }
 
+bool create_counter_table(void)
+{
+	bool ret;
+	// Create FTL table in the database (holds properties like database version, etc.)
+	ret = dbquery("CREATE TABLE counters ( id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL );");
+	if(!ret){ dbclose(); return false; }
+
+	// ID 0 = total queries
+	ret = db_set_counter(DB_TOTALQUERIES, 0);
+	if(!ret){ dbclose(); return false; }
+
+	// ID 1 = total blocked queries
+	ret = db_set_counter(DB_BLOCKEDQUERIES, 0);
+	if(!ret){ dbclose(); return false; }
+
+	// Time stamp of creation of the counters database
+	ret = db_set_FTL_property(DB_FIRSTCOUNTERTIMESTAMP, time(NULL));
+	if(!ret){ dbclose(); return false; }
+
+	// Update database version to 2
+	ret = db_set_FTL_property(DB_VERSION, 2);
+	if(!ret){ dbclose(); return false; }
+
+	return true;
+}
+
 bool db_create(void)
 {
 	bool ret;
@@ -133,17 +166,17 @@ bool db_create(void)
 	ret = dbquery("CREATE TABLE ftl ( id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL );");
 	if(!ret){ dbclose(); return false; }
 
-	// DB version 1
-	ret = dbquery("INSERT INTO ftl (ID,VALUE) VALUES(0,1);");
+	// DB version 2
+	ret = dbquery("INSERT INTO ftl (ID,VALUE) VALUES(%i,2);", DB_VERSION);
 	if(!ret){ dbclose(); return false; }
 
 	// Most recent timestamp initialized to 00:00 1 Jan 1970
-	ret = dbquery("INSERT INTO ftl (ID,VALUE) VALUES(1,0);");
+	ret = dbquery("INSERT INTO ftl (ID,VALUE) VALUES(%i,0);", DB_LASTTIMESTAMP);
 	if(!ret){ dbclose(); return false; }
 
-	// Time stamp of last DB garbage collection
-	ret = dbquery("INSERT INTO ftl (ID,VALUE) VALUES(2,%i);",time(NULL));
-	if(!ret){ dbclose(); return false; }
+	// Create counter table
+	if(!create_counter_table())
+		return false;
 
 	dbclose();
 
@@ -174,6 +207,9 @@ void db_init(void)
 			return;
 		}
 	}
+
+	if(db_get_FTL_property(DB_VERSION) < 2)
+		create_counter_table();
 
 	// Close database to prevent having it opened all time
 	sqlite3_close(db);
@@ -232,6 +268,20 @@ int db_get_FTL_property(unsigned int ID)
 bool db_set_FTL_property(unsigned int ID, int value)
 {
 	return dbquery("INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %i );", ID, value);
+}
+
+bool db_set_counter(unsigned int ID, int value)
+{
+	return dbquery("INSERT OR REPLACE INTO counters (id, value) VALUES ( %u, %i );", ID, value);
+}
+
+bool db_update_counters(int total, int blocked)
+{
+	if(!dbquery("UPDATE counters SET value = value + %i WHERE id = %i;", total, DB_TOTALQUERIES))
+		return false;
+	if(!dbquery("UPDATE counters SET value = value + %i WHERE id = %i;", blocked, DB_BLOCKEDQUERIES))
+		return false;
+	return true;
 }
 
 int number_of_queries_in_DB(void)
@@ -321,6 +371,7 @@ void save_to_DB(void)
 		return;
 	}
 
+	int total = 0, blocked = 0;
 	int currenttimestamp = time(NULL);
 	for(i = lastdbindex; i < counters.queries; i++)
 	{
@@ -395,6 +446,13 @@ void save_to_DB(void)
 		// Mark this query as saved in the database only if successful
 		queries[i].db = true;
 
+		// Total counter information (delta computation)
+		total++;
+		if(queries[i].status == 1 ||
+		   queries[i].status == 4 ||
+		   queries[i].status == 5)
+			blocked++;
+
 		// Update lasttimestamp variable with timestamp of the latest stored query
 		if(queries[i].timestamp > lasttimestamp)
 			newlasttimestamp = queries[i].timestamp;
@@ -411,6 +469,13 @@ void save_to_DB(void)
 	{
 		lastdbindex = i;
 		db_set_FTL_property(DB_LASTTIMESTAMP, newlasttimestamp);
+	}
+
+	// Update total counters in DB
+	if(!db_update_counters(total, blocked))
+	{
+		dbclose();
+		return;
 	}
 
 	// Close database

--- a/database.c
+++ b/database.c
@@ -178,8 +178,6 @@ bool db_create(void)
 	if(!create_counter_table())
 		return false;
 
-	dbclose();
-
 	return true;
 }
 
@@ -208,10 +206,28 @@ void db_init(void)
 		}
 	}
 
-	if(db_get_FTL_property(DB_VERSION) < 2)
-		create_counter_table();
+	// Test DB version and see if we need to upgrade the database file
+	int dbversion = db_get_FTL_property(DB_VERSION);
+	if(dbversion < 1)
+	{
+		logg("Database version incorrect, database not available");
+		database = false;
+		return;
+	}
+	else if(dbversion < 2)
+	{
+		// Database is still in version 1
+		// Update to version 2 and create counters table
+		if (!create_counter_table())
+		{
+			logg("Counter table not initialized, database not available");
+			database = false;
+			return;
+		}
+	}
 
 	// Close database to prevent having it opened all time
+	// we already closed the database when we returned earlier
 	sqlite3_close(db);
 
 	if (pthread_mutex_init(&dblock, NULL) != 0)
@@ -221,7 +237,7 @@ void db_init(void)
 		exit(EXIT_FAILURE);
 	}
 
-	logg("Database initialized");
+	logg("Database successfully initialized");
 	database = true;
 }
 

--- a/database.c
+++ b/database.c
@@ -243,6 +243,7 @@ int db_get_FTL_property(unsigned int ID)
 	rc = sqlite3_prepare(db, querystring, -1, &dbstmt, NULL);
 	if( rc ){
 		logg("db_get_FTL_property() - SQL error prepare (%i): %s", rc, sqlite3_errmsg(db));
+		logg("Query: \"%s\"", querystring);
 		dbclose();
 		check_database(rc);
 		return -1;

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -214,7 +214,11 @@ load 'libs/bats-support/load'
   echo "output: ${lines[@]}"
   [[ "${lines[@]}" == *"CREATE TABLE queries ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain TEXT NOT NULL, client TEXT NOT NULL, forward TEXT );"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE ftl ( id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL );"* ]]
-  [[ "${lines[@]}" == *"INSERT INTO \"ftl\" VALUES(0,1);"* ]]
+  [[ "${lines[@]}" == *"CREATE TABLE counters ( id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL );"* ]]
+  [[ "${lines[@]}" == *"INSERT INTO \"counters\" VALUES(0,0);"* ]]
+  [[ "${lines[@]}" == *"INSERT INTO \"counters\" VALUES(1,0);"* ]]
+  [[ "${lines[@]}" == *"INSERT INTO \"ftl\" VALUES(0,2);"* ]]
+  [[ "${lines[@]}" == *"CREATE INDEX idx_queries_timestamps ON queries (timestamp);"* ]]
 }
 
 @test "Arguments check: Invalid option" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

See title. We create a new table in which we store the number of total and blocked queries since the beginning of this integration. On new systems, the tables are created from the beginning and set the DB version to 2. On existing installations (FTL DB version 1), we add the table and initialize it and set the DB version to 2 to signal that the counters table has been created.

![screenshot at 2018-02-08 19-10-52](https://user-images.githubusercontent.com/16748619/35990285-d0a11ab0-0d03-11e8-8615-339978a6132f.png)

We also store the time stamp of when this new table has been created so that we can later respond with something like: `123,456 queries (56,789 blocked) since Deb 8, 2018, 19:09.`

As this is a more fundamental change (although a safe one) merging this is scheduled for after the release of `FTL v3.0` and hence does not go towards the release branch.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
