### PR TITLE
Bugfix for API_QUERY_LOG_SHOW option

### DIFF
--- a/api.c
+++ b/api.c
@@ -667,8 +667,10 @@ void getAllQueries(char *client_message, int *sock)
 		else
 			strcpy(qtype,"IPv6");
 
-		if((queries[i].status == 1 || queries[i].status == 4) && !showblocked)
+		// 1 = gravity.list, 4 = wildcard, 5 = black.list
+		if((queries[i].status == 1 || queries[i].status == 4 || queries[i].status == 5) && !showblocked)
 			continue;
+		// 2 = forwarded, 3 = cached
 		if((queries[i].status == 2 || queries[i].status == 3) && !showpermitted)
 			continue;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Don't show queries with status `5` (blocked by black.list) when
```
API_QUERY_LOG_SHOW=permittedonly
```
or
```
API_QUERY_LOG_SHOW=nothing
```
is set in `setupVars.conf`.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
