### PR TITLE
Fix accidentally trying to free NULL

### DIFF
--- a/flush.c
+++ b/flush.c
@@ -65,7 +65,8 @@ void pihole_log_flushed(bool message)
 	// overTime struct: Free allocated substructure
 	for(i=0;i<counters.overTime;i++)
 	{
-		free(overTime[i].forwarddata);
+		if(overTime[i].forwarddata != NULL )
+			free(overTime[i].forwarddata);
 		free(overTime[i].querytypedata);
 	}
 	free(overTime);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

`forwarddata` is set to `NULL` on lines 79 and 1357 of parser.c, and so it could be null when flush is called.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
