### PR TITLE
Define our own strdup()

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -225,15 +225,22 @@ char *FTLstrdup(const char *src, const char * file, const char * function, int l
 {
 	// The FTLstrdup() function returns a pointer to a new string which is a
 	// duplicate of the string s. Memory for the new string is obtained with
-	// malloc(3), and can be freed with free(3).
+	// calloc(3), and can be freed with free(3).
 	if(src == NULL)
 	{
 		logg("WARN: Trying to copy a NULL string in %s() (%s:%i)", function, file, line);
 		return NULL;
 	}
-	char *dest = __strdup(src);
+	size_t len = strlen(src);
+	char *dest = calloc(len+1, sizeof(char));
 	if(dest == NULL)
+	{
 		logg("FATAL: Memory allocation failed in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	// Use memcpy as memory areas cannot overlap
+	memcpy(dest, src, len);
+	dest[len] = '\0';
 
 	return dest;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Previously, we relied on that the `strdup()` function is given by `__strdup()` on all operating systems. However, that doesn't seem to be the case. We now define our own `strdup()` function to avoid this problem.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
