### PR TITLE
Test for wildcarddomains == NULL in flush.c

### DIFF
--- a/flush.c
+++ b/flush.c
@@ -54,13 +54,17 @@ void pihole_log_flushed(bool message)
 	memory.domainnames = 0;
 
 	// wildcarddomains struct: Free allocated substructure
-	for(i=0;i<counters.wildcarddomains;i++)
+	// Do this only when we actually imported wildcards
+	if(wildcarddomains != NULL)
 	{
-		free(wildcarddomains[i]);
+		for(i=0;i<counters.wildcarddomains;i++)
+		{
+			free(wildcarddomains[i]);
+		}
+		free(wildcarddomains);
+		wildcarddomains = NULL;
+		memory.wildcarddomains = 0;
 	}
-	free(wildcarddomains);
-	wildcarddomains = NULL;
-	memory.wildcarddomains = 0;
 
 	// overTime struct: Free allocated substructure
 	for(i=0;i<counters.overTime;i++)

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -238,6 +238,12 @@ load 'libs/bats-support/load'
   [[ ${lines[2]} == "d2 ff ff ff ff d2 00 00 00 07 d2 00 00 00 02 ca 41 e4 92 49 d2 00 00 00 06 d2 00 00 00 03 d2 00 00 00 02 d2 00 00 00 03 d2 00 00 00 03 cc 02 c1 " ]]
 }
 
+@test "Verify no FATAL warnings are present in the generated log" {
+  run bash -c 'grep -c "FATAL" pihole-FTL.log'
+  echo "output: ${lines[@]}"
+  [[ ${lines[0]} == "0" ]]
+}
+
 @test "Final part of the tests: Killing pihole-FTL process" {
   run bash -c 'echo ">kill" | nc -v 127.0.0.1 4711'
   echo "output: ${lines[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

- Check for `wildcarddomains != NULL` before trying to free them in `pihole_log_flush()`
- Extend tests to verify that no `FATAL` lines are present in `pihole-FTL.log`


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
