### PR TITLE
Update resolver to v2.79

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ FTLDEPS = FTL.h routines.h version.h api.h dnsmasq_interface.h
 FTLOBJ = main.o memory.o log.o daemon.o datastructure.o signals.o socket.o request.o grep.o setupVars.o args.o threads.o gc.o config.o database.o msgpack.o api.o dnsmasq_interface.o
 
 DNSMASQDEPS = config.h dhcp-protocol.h dns-protocol.h radv-protocol.h dhcp6-protocol.h dnsmasq.h ip6addr.h
-DNSMASQOBJ = arp.o dbus.o domain.o lease.o outpacket.o rrfilter.o auth.o dhcp6.o edns0.o log.o poll.o slaac.o blockdata.o dhcp.o forward.o loop.o radv.o tables.o bpf.o dhcp-common.o helper.o netlink.o rfc1035.o tftp.o cache.o dnsmasq.o inotify.o network.o rfc2131.o util.o conntrack.o dnssec.o ipset.o option.o rfc3315.o
+DNSMASQOBJ = arp.o dbus.o domain.o lease.o outpacket.o rrfilter.o auth.o dhcp6.o edns0.o log.o poll.o slaac.o blockdata.o dhcp.o forward.o loop.o radv.o tables.o bpf.o dhcp-common.o helper.o netlink.o rfc1035.o tftp.o cache.o dnsmasq.o inotify.o network.o rfc2131.o util.o conntrack.o dnssec.o ipset.o option.o rfc3315.o crypto.o
 
 # Get git commit version and date
 GIT_BRANCH := $(shell git branch | sed -n 's/^\* //p')

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-DNSMASQVERSION = "pi-hole-2.78"
+DNSMASQVERSION = "pi-hole-2.79"
 DNSMASQOPTS = -DHAVE_DNSSEC -DHAVE_DNSSEC_STATIC -DNO_FORK
 # Flags for compiling with libidn : -DHAVE_IDN
 # Flags for compiling with libidn2: -DHAVE_LIBIDN2 -DIDN2_VERSION_NUMBER=0x02000003
@@ -48,7 +48,7 @@ CCFLAGS=-I$(IDIR) -Wall -Wextra -Wno-unused-parameter -D_FILE_OFFSET_BITS=64 $(H
 # for dnsmasq we need the nettle crypto library and the gmp maths library
 # We link the two libraries statically. Althougth this increases the binary file size by about 1 MB, it saves about 5 MB of shared libraries and makes deployment easier
 #LIBS=-pthread -lnettle -lgmp -lhogweed
-LIBS=-pthread -Wl,-Bstatic -lhogweed -lgmp -lnettle  -Wl,-Bdynamic
+LIBS=-pthread -Wl,-Bstatic -lhogweed -lgmp -L/usr/local/lib -lnettle  -Wl,-Bdynamic
 # Flags for compiling with libidn : -lidn
 # Flags for compiling with libidn2: -lidn2
 

--- a/dnsmasq/arp.c
+++ b/dnsmasq/arp.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/auth.c
+++ b/dnsmasq/auth.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/blockdata.c
+++ b/dnsmasq/blockdata.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -24,11 +24,11 @@ static unsigned int blockdata_count, blockdata_hwm, blockdata_alloced;
 static void blockdata_expand(int n)
 {
   struct blockdata *new = whine_malloc(n * sizeof(struct blockdata));
-  
-  if (n > 0 && new)
+
+  if (new)
     {
       int i;
-      
+
       new[n-1].next = keyblock_free;
       keyblock_free = new;
 
@@ -47,9 +47,9 @@ void blockdata_init(void)
   blockdata_count = 0;
   blockdata_hwm = 0;
 
-  /* Note that daemon->cachesize is enforced to have non-zero size if OPT_DNSSEC_VALID is set */  
+  /* Note that daemon->cachesize is enforced to have non-zero size if OPT_DNSSEC_VALID is set */
   if (option_bool(OPT_DNSSEC_VALID))
-    blockdata_expand((daemon->cachesize * 100) / sizeof(struct blockdata));
+    blockdata_expand(daemon->cachesize);
 }
 
 void blockdata_report(void)
@@ -99,6 +99,7 @@ struct blockdata *blockdata_alloc(char *data, size_t len)
   
   return ret;
 }
+
 
 void blockdata_free(struct blockdata *blocks)
 {

--- a/dnsmasq/bpf.c
+++ b/dnsmasq/bpf.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/cache.c
+++ b/dnsmasq/cache.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -46,6 +46,7 @@ static const struct {
   { 24,  "SIG" },
   { 25,  "KEY" },
   { 28,  "AAAA" },
+  { 29,  "LOC" },
   { 33,  "SRV" },
   { 35,  "NAPTR" },
   { 36,  "KX" },
@@ -58,6 +59,10 @@ static const struct {
   { 47,  "NSEC" },
   { 48,  "DNSKEY" },
   { 50,  "NSEC3" },
+  { 51,  "NSEC3PARAM" },
+  { 52,  "TLSA" },
+  { 53,  "SMIMEA" },
+  { 55,  "HIP" },
   { 249, "TKEY" },
   { 250, "TSIG" },
   { 251, "IXFR" },

--- a/dnsmasq/config.h
+++ b/dnsmasq/config.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 #define TIMEOUT 10 /* drop UDP queries after TIMEOUT seconds */
 #define FORWARD_TEST 50 /* try all servers every 50 queries */
 #define FORWARD_TIME 20 /* or 20 seconds */
+#define UDP_TEST_TIME 60 /* How often to reset our idea of max packet size. */
 #define SERVERS_LOGGED 30 /* Only log this many servers when logging state */
 #define LOCALS_LOGGED 8 /* Only log this many local addresses when logging state */
 #define RANDOM_SOCKS 64 /* max simultaneous random ports */
@@ -133,12 +134,9 @@ NO_LARGEFILE
 NO_AUTH
 NO_INOTIFY
    these are available to explicitly disable compile time options which would 
-   otherwise be enabled automatically (HAVE_IPV6, >2Gb file sizes) or 
+   otherwise be enabled automatically (HAVE_IPV6, >2Gb file sizes) or
    which are enabled  by default in the distributed source tree. Building dnsmasq
    with something like "make COPTS=-DNO_SCRIPT" will do the trick.
-
-NO_NETTLE_ECC
-   Don't include the ECDSA cypher in DNSSEC validation. Needed for older Nettle versions.
 NO_GMP
    Don't use and link against libgmp, Useful if nettle is built with --enable-mini-gmp.
 

--- a/dnsmasq/conntrack.c
+++ b/dnsmasq/conntrack.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/crypto.c
+++ b/dnsmasq/crypto.c
@@ -1,0 +1,460 @@
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991, or
+   (at your option) version 3 dated 29 June, 2007.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dnsmasq.h"
+
+#ifdef HAVE_DNSSEC
+
+#include <nettle/rsa.h>
+#include <nettle/dsa.h>
+#include <nettle/ecdsa.h>
+#include <nettle/ecc-curve.h>
+#include <nettle/eddsa.h>
+#include <nettle/nettle-meta.h>
+#include <nettle/bignum.h>
+
+/* Implement a "hash-function" to the nettle API, which simply returns
+   the input data, concatenated into a single, statically maintained, buffer.
+
+   Used for the EdDSA sigs, which operate on the whole message, rather
+   than a digest. */
+
+struct null_hash_digest
+{
+  uint8_t *buff;
+  size_t len;
+};
+
+struct null_hash_ctx
+{
+  size_t len;
+};
+
+static size_t null_hash_buff_sz = 0;
+static uint8_t *null_hash_buff = NULL;
+#define BUFF_INCR 128
+
+static void null_hash_init(void *ctx)
+{
+  ((struct null_hash_ctx *)ctx)->len = 0;
+}
+
+static void null_hash_update(void *ctxv, size_t length, const uint8_t *src)
+{
+  struct null_hash_ctx *ctx = ctxv;
+  size_t new_len = ctx->len + length;
+
+  if (new_len > null_hash_buff_sz)
+    {
+      uint8_t *new;
+
+      if (!(new = whine_malloc(new_len + BUFF_INCR)))
+	return;
+
+      if (null_hash_buff)
+	{
+	  if (ctx->len != 0)
+	    memcpy(new, null_hash_buff, ctx->len);
+	  free(null_hash_buff);
+	}
+
+      null_hash_buff_sz = new_len + BUFF_INCR;
+      null_hash_buff = new;
+    }
+
+  memcpy(null_hash_buff + ctx->len, src, length);
+  ctx->len += length;
+}
+
+
+static void null_hash_digest(void *ctx, size_t length, uint8_t *dst)
+{
+  (void)length;
+
+  ((struct null_hash_digest *)dst)->buff = null_hash_buff;
+  ((struct null_hash_digest *)dst)->len = ((struct null_hash_ctx *)ctx)->len;
+}
+
+static struct nettle_hash null_hash = {
+  "null_hash",
+  sizeof(struct null_hash_ctx),
+  sizeof(struct null_hash_digest),
+  0,
+  (nettle_hash_init_func *) null_hash_init,
+  (nettle_hash_update_func *) null_hash_update,
+  (nettle_hash_digest_func *) null_hash_digest
+};
+
+/* Find pointer to correct hash function in nettle library */
+const struct nettle_hash *hash_find(char *name)
+{
+  if (!name)
+    return NULL;
+
+  /* We provide a "null" hash which returns the input data as digest. */
+  if (strcmp(null_hash.name, name) == 0)
+    return &null_hash;
+
+  /* libnettle >= 3.4 provides nettle_lookup_hash() which avoids nasty ABI
+     incompatibilities if sizeof(nettle_hashes) changes between library
+     versions. It also #defines nettle_hashes, so use that to tell
+     if we have the new facilities. */
+
+#ifdef nettle_hashes
+  return nettle_lookup_hash(name);
+#else
+  {
+    int i;
+
+    for (i = 0; nettle_hashes[i]; i++)
+      if (strcmp(nettle_hashes[i]->name, name) == 0)
+	return nettle_hashes[i];
+  }
+
+  return NULL;
+#endif
+}
+
+/* expand ctx and digest memory allocations if necessary and init hash function */
+int hash_init(const struct nettle_hash *hash, void **ctxp, unsigned char **digestp)
+{
+  static void *ctx = NULL;
+  static unsigned char *digest = NULL;
+  static unsigned int ctx_sz = 0;
+  static unsigned int digest_sz = 0;
+
+  void *new;
+
+  if (ctx_sz < hash->context_size)
+    {
+      if (!(new = whine_malloc(hash->context_size)))
+	return 0;
+      if (ctx)
+	free(ctx);
+      ctx = new;
+      ctx_sz = hash->context_size;
+    }
+
+  if (digest_sz < hash->digest_size)
+    {
+      if (!(new = whine_malloc(hash->digest_size)))
+	return 0;
+      if (digest)
+	free(digest);
+      digest = new;
+      digest_sz = hash->digest_size;
+    }
+
+  *ctxp = ctx;
+  *digestp = digest;
+
+  hash->init(ctx);
+
+  return 1;
+}
+
+static int dnsmasq_rsa_verify(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
+			      unsigned char *digest, size_t digest_len, int algo)
+{
+  unsigned char *p;
+  size_t exp_len;
+
+  static struct rsa_public_key *key = NULL;
+  static mpz_t sig_mpz;
+
+  (void)digest_len;
+
+  if (key == NULL)
+    {
+      if (!(key = whine_malloc(sizeof(struct rsa_public_key))))
+	return 0;
+
+      nettle_rsa_public_key_init(key);
+      mpz_init(sig_mpz);
+    }
+
+  if ((key_len < 3) || !(p = blockdata_retrieve(key_data, key_len, NULL)))
+    return 0;
+
+  key_len--;
+  if ((exp_len = *p++) == 0)
+    {
+      GETSHORT(exp_len, p);
+      key_len -= 2;
+    }
+
+  if (exp_len >= key_len)
+    return 0;
+
+  key->size =  key_len - exp_len;
+  mpz_import(key->e, exp_len, 1, 1, 0, 0, p);
+  mpz_import(key->n, key->size, 1, 1, 0, 0, p + exp_len);
+
+  mpz_import(sig_mpz, sig_len, 1, 1, 0, 0, sig);
+
+  switch (algo)
+    {
+    case 1:
+      return nettle_rsa_md5_verify_digest(key, digest, sig_mpz);
+    case 5: case 7:
+      return nettle_rsa_sha1_verify_digest(key, digest, sig_mpz);
+    case 8:
+      return nettle_rsa_sha256_verify_digest(key, digest, sig_mpz);
+    case 10:
+      return nettle_rsa_sha512_verify_digest(key, digest, sig_mpz);
+    }
+
+  return 0;
+}
+
+static int dnsmasq_dsa_verify(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
+			      unsigned char *digest, size_t digest_len, int algo)
+{
+  unsigned char *p;
+  unsigned int t;
+
+  static mpz_t y;
+  static struct dsa_params *params = NULL;
+  static struct dsa_signature *sig_struct;
+
+  (void)digest_len;
+
+  if (params == NULL)
+    {
+      if (!(sig_struct = whine_malloc(sizeof(struct dsa_signature))) ||
+	  !(params = whine_malloc(sizeof(struct dsa_params))))
+	return 0;
+
+      mpz_init(y);
+      nettle_dsa_params_init(params);
+      nettle_dsa_signature_init(sig_struct);
+    }
+
+  if ((sig_len < 41) || !(p = blockdata_retrieve(key_data, key_len, NULL)))
+    return 0;
+
+  t = *p++;
+
+  if (key_len < (213 + (t * 24)))
+    return 0;
+
+  mpz_import(params->q, 20, 1, 1, 0, 0, p); p += 20;
+  mpz_import(params->p, 64 + (t*8), 1, 1, 0, 0, p); p += 64 + (t*8);
+  mpz_import(params->g, 64 + (t*8), 1, 1, 0, 0, p); p += 64 + (t*8);
+  mpz_import(y, 64 + (t*8), 1, 1, 0, 0, p); p += 64 + (t*8);
+
+  mpz_import(sig_struct->r, 20, 1, 1, 0, 0, sig+1);
+  mpz_import(sig_struct->s, 20, 1, 1, 0, 0, sig+21);
+
+  (void)algo;
+
+  return nettle_dsa_verify(params, y, digest_len, digest, sig_struct);
+}
+
+static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len,
+				unsigned char *sig, size_t sig_len,
+				unsigned char *digest, size_t digest_len, int algo)
+{
+  unsigned char *p;
+  unsigned int t;
+  struct ecc_point *key;
+
+  static struct ecc_point *key_256 = NULL, *key_384 = NULL;
+  static mpz_t x, y;
+  static struct dsa_signature *sig_struct;
+
+  if (!sig_struct)
+    {
+      if (!(sig_struct = whine_malloc(sizeof(struct dsa_signature))))
+	return 0;
+
+      nettle_dsa_signature_init(sig_struct);
+      mpz_init(x);
+      mpz_init(y);
+    }
+
+  switch (algo)
+    {
+    case 13:
+      if (!key_256)
+	{
+	  if (!(key_256 = whine_malloc(sizeof(struct ecc_point))))
+	    return 0;
+
+	  nettle_ecc_point_init(key_256, &nettle_secp_256r1);
+	}
+
+      key = key_256;
+      t = 32;
+      break;
+
+    case 14:
+      if (!key_384)
+	{
+	  if (!(key_384 = whine_malloc(sizeof(struct ecc_point))))
+	    return 0;
+
+	  nettle_ecc_point_init(key_384, &nettle_secp_384r1);
+	}
+
+      key = key_384;
+      t = 48;
+      break;
+
+    default:
+      return 0;
+    }
+
+  if (sig_len != 2*t || key_len != 2*t ||
+      !(p = blockdata_retrieve(key_data, key_len, NULL)))
+    return 0;
+
+  mpz_import(x, t , 1, 1, 0, 0, p);
+  mpz_import(y, t , 1, 1, 0, 0, p + t);
+
+  if (!ecc_point_set(key, x, y))
+    return 0;
+
+  mpz_import(sig_struct->r, t, 1, 1, 0, 0, sig);
+  mpz_import(sig_struct->s, t, 1, 1, 0, 0, sig + t);
+
+  return nettle_ecdsa_verify(key, digest_len, digest, sig_struct);
+}
+
+static int dnsmasq_eddsa_verify(struct blockdata *key_data, unsigned int key_len,
+				unsigned char *sig, size_t sig_len,
+				unsigned char *digest, size_t digest_len, int algo)
+{
+  unsigned char *p;
+
+  if (key_len != ED25519_KEY_SIZE ||
+      sig_len != ED25519_SIGNATURE_SIZE ||
+      digest_len != sizeof(struct null_hash_digest) ||
+      !(p = blockdata_retrieve(key_data, key_len, NULL)))
+    return 0;
+
+  /* The "digest" returned by the null_hash function is simply a struct null_hash_digest
+     which has a pointer to the actual data and a length, because the buffer
+     may need to be extended during "hashing". */
+
+  switch (algo)
+    {
+    case 15:
+      return ed25519_sha512_verify(p,
+				   ((struct null_hash_digest *)digest)->len,
+				   ((struct null_hash_digest *)digest)->buff,
+				   sig);
+    case 16:
+      /* Ed448 when available */
+      return 0;
+    }
+
+  return 0;
+}
+
+static int (*verify_func(int algo))(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
+			     unsigned char *digest, size_t digest_len, int algo)
+{
+
+  /* Enure at runtime that we have support for this digest */
+  if (!hash_find(algo_digest_name(algo)))
+    return NULL;
+
+  /* This switch defines which sig algorithms we support, can't introspect Nettle for that. */
+  switch (algo)
+    {
+    case 1: case 5: case 7: case 8: case 10:
+      return dnsmasq_rsa_verify;
+
+    case 3: case 6:
+      return dnsmasq_dsa_verify;
+
+    case 13: case 14:
+      return dnsmasq_ecdsa_verify;
+
+    case 15: case 16:
+      return dnsmasq_eddsa_verify;
+    }
+
+  return NULL;
+}
+
+int verify(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
+	   unsigned char *digest, size_t digest_len, int algo)
+{
+
+  int (*func)(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
+	      unsigned char *digest, size_t digest_len, int algo);
+
+  func = verify_func(algo);
+
+  if (!func)
+    return 0;
+
+  return (*func)(key_data, key_len, sig, sig_len, digest, digest_len, algo);
+}
+
+/* Note the ds_digest_name(), algo_digest_name() and nsec3_digest_name()
+   define which algo numbers we support. If algo_digest_name() returns
+   non-NULL for an algorithm number, we assume that algorithm is
+   supported by verify(). */
+
+/* http://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml */
+char *ds_digest_name(int digest)
+{
+  switch (digest)
+    {
+    case 1: return "sha1";
+    case 2: return "sha256";
+    case 3: return "gosthash94";
+    case 4: return "sha384";
+    default: return NULL;
+    }
+}
+
+/* http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml */
+char *algo_digest_name(int algo)
+{
+  switch (algo)
+    {
+    case 1: return NULL;          /* RSA/MD5 - Must Not Implement.  RFC 6944 para 2.3. */
+    case 2: return NULL;          /* Diffie-Hellman */
+    case 3: return "sha1";        /* DSA/SHA1 */
+    case 5: return "sha1";        /* RSA/SHA1 */
+    case 6: return "sha1";        /* DSA-NSEC3-SHA1 */
+    case 7: return "sha1";        /* RSASHA1-NSEC3-SHA1 */
+    case 8: return "sha256";      /* RSA/SHA-256 */
+    case 10: return "sha512";     /* RSA/SHA-512 */
+    case 12: return NULL;         /* ECC-GOST */
+    case 13: return "sha256";     /* ECDSAP256SHA256 */
+    case 14: return "sha384";     /* ECDSAP384SHA384 */
+    case 15: return "null_hash";  /* ED25519 */
+    case 16: return NULL;         /* ED448 */
+    default: return NULL;
+    }
+}
+
+/* http://www.iana.org/assignments/dnssec-nsec3-parameters/dnssec-nsec3-parameters.xhtml */
+char *nsec3_digest_name(int digest)
+{
+  switch (digest)
+    {
+    case 1: return "sha1";
+    default: return NULL;
+    }
+}
+
+#endif

--- a/dnsmasq/dbus.c
+++ b/dnsmasq/dbus.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/dhcp-common.c
+++ b/dnsmasq/dhcp-common.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -482,14 +482,11 @@ char *whichdevice(void)
 
   return NULL;
 }
- 
+
 void  bindtodevice(char *device, int fd)
 {
-  struct ifreq ifr;
-  
-  strcpy(ifr.ifr_name, device);
   /* only allowed by root. */
-  if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr)) == -1 &&
+  if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, device, IFNAMSIZ) == -1 &&
       errno != EPERM)
     die(_("failed to set SO_BINDTODEVICE on DHCP socket: %s"), NULL, EC_BADNET);
 }

--- a/dnsmasq/dhcp-protocol.h
+++ b/dnsmasq/dhcp-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/dhcp.c
+++ b/dnsmasq/dhcp.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/dhcp6-protocol.h
+++ b/dnsmasq/dhcp6-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/dhcp6.c
+++ b/dnsmasq/dhcp6.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/dns-protocol.h
+++ b/dnsmasq/dns-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
 
 #define NAMESERVER_PORT 53
 #define TFTP_PORT       69
+#define MIN_PORT        1024           /* first non-reserved port */
 #define MAX_PORT        65535u
 
 #define IN6ADDRSZ       16

--- a/dnsmasq/dnsmasq.c
+++ b/dnsmasq/dnsmasq.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -49,6 +49,7 @@ int main_dnsmasq (int argc, char **argv)
   long i, max_fd = sysconf(_SC_OPEN_MAX);
   char *baduser = NULL;
   int log_err;
+  int chown_warn = 0;
 #if defined(HAVE_LINUX_NETWORK)
   cap_user_header_t hdr = NULL;
   cap_user_data_t data = NULL;
@@ -78,6 +79,7 @@ int main_dnsmasq (int argc, char **argv)
   sigaction(SIGTERM, &sigact, NULL);
   sigaction(SIGALRM, &sigact, NULL);
   sigaction(SIGCHLD, &sigact, NULL);
+  sigaction(SIGINT, &sigact, NULL);
 
   /* ignore SIGPIPE */
   sigact.sa_handler = SIG_IGN;
@@ -119,6 +121,9 @@ int main_dnsmasq (int argc, char **argv)
       daemon->namebuff = safe_malloc(MAXDNAME * 2);
       daemon->keyname = safe_malloc(MAXDNAME * 2);
       daemon->workspacename = safe_malloc(MAXDNAME * 2);
+      /* one char flag per possible RR in answer section (may get extended). */
+      daemon->rr_status_sz = 64;
+      daemon->rr_status = safe_malloc(daemon->rr_status_sz);
     }
 #endif
 
@@ -220,9 +225,6 @@ int main_dnsmasq (int argc, char **argv)
   if (option_bool(OPT_LOOP_DETECT))
     die(_("loop detection not available: set HAVE_LOOP in src/config.h"), NULL, EC_BADCONF);
 #endif
-
-  if (daemon->max_port != MAX_PORT && daemon->min_port == 0)
-    daemon->min_port = 1024u;
 
   if (daemon->max_port < daemon->min_port)
     die(_("max_port cannot be smaller than min_port"), NULL, EC_BADCONF);
@@ -359,7 +361,8 @@ int main_dnsmasq (int argc, char **argv)
     }
 
 #ifdef HAVE_INOTIFY
-  if (daemon->port != 0 || daemon->dhcp || daemon->doing_dhcp6)
+  if ((daemon->port != 0 || daemon->dhcp || daemon->doing_dhcp6)
+      && (!option_bool(OPT_NO_RESOLV) || daemon->dynamic_dirs))
     inotify_dnsmasq_init();
   else
     daemon->inotifyfd = -1;
@@ -387,10 +390,12 @@ int main_dnsmasq (int argc, char **argv)
       daemon->scriptuser &&
       (daemon->lease_change_command || daemon->luascript))
     {
-      if ((ent_pw = getpwnam(daemon->scriptuser)))
+      struct passwd *scr_pw;
+
+      if ((scr_pw = getpwnam(daemon->scriptuser)))
 	{
-	  script_uid = ent_pw->pw_uid;
-	  script_gid = ent_pw->pw_gid;
+	  script_uid = scr_pw->pw_uid;
+	  script_gid = scr_pw->pw_gid;
 	 }
       else
 	baduser = daemon->scriptuser;
@@ -538,6 +543,15 @@ int main_dnsmasq (int argc, char **argv)
 	    }
 	  else
 	    {
+	      /* We're still running as root here. Change the ownership of the PID file
+		 to the user we will be running as. Note that this is not to allow
+		 us to delete the file, since that depends on the permissions
+		 of the directory containing the file. That directory will
+		 need to by owned by the dnsmasq user, and the ownership of the
+		 file has to match, to keep systemd >273 happy. */
+	      if (getuid() == 0 && ent_pw && ent_pw->pw_uid != 0 && fchown(fd, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
+		chown_warn = errno;
+
 	      if (!read_write(fd, (unsigned char *)daemon->namebuff, strlen(daemon->namebuff), 0))
 		err = 1;
 	      else
@@ -730,6 +744,9 @@ int main_dnsmasq (int argc, char **argv)
 
   my_syslog(LOG_INFO, _("compile time options: %s"), compile_opts);
 
+  if (chown_warn != 0)
+    my_syslog(LOG_WARNING, "chown of PID file %s failed: %s", daemon->runfile, strerror(chown_warn));
+
 #ifdef HAVE_DBUS
   if (option_bool(OPT_DBUS))
     {
@@ -758,7 +775,7 @@ int main_dnsmasq (int argc, char **argv)
 
       daemon->dnssec_no_time_check = option_bool(OPT_DNSSEC_TIME);
       if (option_bool(OPT_DNSSEC_TIME) && !daemon->back_to_the_future)
-	my_syslog(LOG_INFO, _("DNSSEC signature timestamps not checked until first cache reload"));
+	my_syslog(LOG_INFO, _("DNSSEC signature timestamps not checked until receipt of SIGINT"));
 
       if (rc == 1)
 	my_syslog(LOG_INFO, _("DNSSEC signature timestamps not checked until system time valid"));
@@ -1082,7 +1099,7 @@ static void sig_handler(int sig)
     {
       /* ignore anything other than TERM during startup
 	 and in helper proc. (helper ignore TERM too) */
-      if (sig == SIGTERM)
+      if (sig == SIGTERM || sig == SIGINT)
 	exit(EC_MISC);
     }
   else if (pid != getpid())
@@ -1108,6 +1125,15 @@ static void sig_handler(int sig)
 	event = EVENT_DUMP;
       else if (sig == SIGUSR2)
 	event = EVENT_REOPEN;
+      else if (sig == SIGINT)
+	{
+	  /* Handle SIGINT normally in debug mode, so
+	     ctrl-c continues to operate. */
+	  if (option_bool(OPT_DEBUG))
+	    exit(EC_MISC);
+	  else
+	    event = EVENT_TIME;
+	}
       else
 	return;
 
@@ -1191,30 +1217,39 @@ static void fatal_event(struct event_desc *ev, char *msg)
     case EVENT_FORK_ERR:
       die(_("cannot fork into background: %s"), NULL, EC_MISC);
 
+      /* fall through */
     case EVENT_PIPE_ERR:
       die(_("failed to create helper: %s"), NULL, EC_MISC);
 
+      /* fall through */
     case EVENT_CAP_ERR:
       die(_("setting capabilities failed: %s"), NULL, EC_MISC);
 
+      /* fall through */
     case EVENT_USER_ERR:
       die(_("failed to change user-id to %s: %s"), msg, EC_MISC);
 
+      /* fall through */
     case EVENT_GROUP_ERR:
       die(_("failed to change group-id to %s: %s"), msg, EC_MISC);
 
+      /* fall through */
     case EVENT_PIDFILE:
       die(_("failed to open pidfile %s: %s"), msg, EC_FILE);
 
+      /* fall through */
     case EVENT_LOG_ERR:
       die(_("cannot open log %s: %s"), msg, EC_FILE);
 
+      /* fall through */
     case EVENT_LUA_ERR:
       die(_("failed to load Lua script: %s"), msg, EC_MISC);
 
+      /* fall through */
     case EVENT_TFTP_ERR:
       die(_("TFTP directory %s inaccessible: %s"), msg, EC_FILE);
 
+      /* fall through */
     case EVENT_TIME_ERR:
       die(_("cannot create timestamp file %s: %s" ), msg, EC_BADCONF);
     }
@@ -1236,13 +1271,6 @@ static void async_event(int pipe, time_t now)
       case EVENT_RELOAD:
 	daemon->soa_sn++; /* Bump zone serial, as it may have changed. */
 
-#ifdef HAVE_DNSSEC
-	if (daemon->dnssec_no_time_check && option_bool(OPT_DNSSEC_VALID) && option_bool(OPT_DNSSEC_TIME))
-	  {
-	    my_syslog(LOG_INFO, _("now checking DNSSEC signature timestamps"));
-	    daemon->dnssec_no_time_check = 0;
-	  }
-#endif
 	/* fall through */
 
       case EVENT_INIT:
@@ -1349,6 +1377,17 @@ static void async_event(int pipe, time_t now)
 	resend_query();
 	/* Force re-reading resolv file right now, for luck. */
 	poll_resolv(0, 1, now);
+	break;
+
+      case EVENT_TIME:
+#ifdef HAVE_DNSSEC
+	if (daemon->dnssec_no_time_check && option_bool(OPT_DNSSEC_VALID) && option_bool(OPT_DNSSEC_TIME))
+	  {
+	    my_syslog(LOG_INFO, _("now checking DNSSEC signature timestamps"));
+	    daemon->dnssec_no_time_check = 0;
+	    clear_cache_and_reload(now);
+	  }
+#endif
 	break;
 
       case EVENT_TERM:
@@ -1477,9 +1516,6 @@ void clear_cache_and_reload(time_t now)
       if (option_bool(OPT_ETHERS))
 	dhcp_read_ethers();
       reread_dhcp();
-#ifdef HAVE_INOTIFY
-      set_dynamic_inotify(AH_DHCP_HST | AH_DHCP_OPT, 0, NULL, 0);
-#endif
       dhcp_update_configs(daemon->dhcp_conf);
       lease_update_from_configs();
       lease_update_file(now);

--- a/dnsmasq/dnssec.c
+++ b/dnsmasq/dnssec.c
@@ -1,5 +1,5 @@
 /* dnssec.c is Copyright (c) 2012 Giovanni Bajo <rasky@develer.com>
-           and Copyright (c) 2012-2017 Simon Kelley
+           and Copyright (c) 2012-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -19,331 +19,10 @@
 
 #ifdef HAVE_DNSSEC
 
-#include <nettle/rsa.h>
-#include <nettle/dsa.h>
-#ifndef NO_NETTLE_ECC
-#  include <nettle/ecdsa.h>
-#  include <nettle/ecc-curve.h>
-#endif
-#include <nettle/nettle-meta.h>
-#include <nettle/bignum.h>
-
-/* Nettle-3.0 moved to a new API for DSA. We use a name that's defined in the new API
-   to detect Nettle-3, and invoke the backwards compatibility mode. */
-#ifdef dsa_params_init
-#include <nettle/dsa-compat.h>
-#endif
-
 #define SERIAL_UNDEF  -100
 #define SERIAL_EQ        0
 #define SERIAL_LT       -1
 #define SERIAL_GT        1
-
-/* http://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml */
-static char *ds_digest_name(int digest)
-{
-  switch (digest)
-    {
-    case 1: return "sha1";
-    case 2: return "sha256";
-    case 3: return "gosthash94";
-    case 4: return "sha384";
-    default: return NULL;
-    }
-}
- 
-/* http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml */
-static char *algo_digest_name(int algo)
-{
-  switch (algo)
-    {
-    case 1: return "md5";
-    case 3: return "sha1";
-    case 5: return "sha1";
-    case 6: return "sha1";
-    case 7: return "sha1";
-    case 8: return "sha256";
-    case 10: return "sha512";
-    case 12: return "gosthash94";
-    case 13: return "sha256";
-    case 14: return "sha384";
-    default: return NULL;
-    }
-}
-  
-/* http://www.iana.org/assignments/dnssec-nsec3-parameters/dnssec-nsec3-parameters.xhtml */
-static char *nsec3_digest_name(int digest)
-{
-  switch (digest)
-    {
-    case 1: return "sha1";
-    default: return NULL;
-    }
-}
- 
-/* Find pointer to correct hash function in nettle library */
-static const struct nettle_hash *hash_find(char *name)
-{
-  int i;
-  
-  if (!name)
-    return NULL;
-  
-  for (i = 0; nettle_hashes[i]; i++)
-    {
-      if (strcmp(nettle_hashes[i]->name, name) == 0)
-	return nettle_hashes[i];
-    }
-
-  return NULL;
-}
-
-/* expand ctx and digest memory allocations if necessary and init hash function */
-static int hash_init(const struct nettle_hash *hash, void **ctxp, unsigned char **digestp)
-{
-  static void *ctx = NULL;
-  static unsigned char *digest = NULL;
-  static unsigned int ctx_sz = 0;
-  static unsigned int digest_sz = 0;
-
-  void *new;
-
-  if (ctx_sz < hash->context_size)
-    {
-      if (!(new = whine_malloc(hash->context_size)))
-	return 0;
-      if (ctx)
-	free(ctx);
-      ctx = new;
-      ctx_sz = hash->context_size;
-    }
-  
-  if (digest_sz < hash->digest_size)
-    {
-      if (!(new = whine_malloc(hash->digest_size)))
-	return 0;
-      if (digest)
-	free(digest);
-      digest = new;
-      digest_sz = hash->digest_size;
-    }
-
-  *ctxp = ctx;
-  *digestp = digest;
-
-  hash->init(ctx);
-
-  return 1;
-}
-  
-static int dnsmasq_rsa_verify(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
-			      unsigned char *digest, size_t digest_len, int algo)
-{
-  unsigned char *p;
-  size_t exp_len;
-  
-  static struct rsa_public_key *key = NULL;
-  static mpz_t sig_mpz;
-
-  (void)digest_len;
-  
-  if (key == NULL)
-    {
-      if (!(key = whine_malloc(sizeof(struct rsa_public_key))))
-	return 0;
-      
-      nettle_rsa_public_key_init(key);
-      mpz_init(sig_mpz);
-    }
-  
-  if ((key_len < 3) || !(p = blockdata_retrieve(key_data, key_len, NULL)))
-    return 0;
-  
-  key_len--;
-  if ((exp_len = *p++) == 0)
-    {
-      GETSHORT(exp_len, p);
-      key_len -= 2;
-    }
-  
-  if (exp_len >= key_len)
-    return 0;
-  
-  key->size =  key_len - exp_len;
-  mpz_import(key->e, exp_len, 1, 1, 0, 0, p);
-  mpz_import(key->n, key->size, 1, 1, 0, 0, p + exp_len);
-
-  mpz_import(sig_mpz, sig_len, 1, 1, 0, 0, sig);
-  
-  switch (algo)
-    {
-    case 1:
-      return nettle_rsa_md5_verify_digest(key, digest, sig_mpz);
-    case 5: case 7:
-      return nettle_rsa_sha1_verify_digest(key, digest, sig_mpz);
-    case 8:
-      return nettle_rsa_sha256_verify_digest(key, digest, sig_mpz);
-    case 10:
-      return nettle_rsa_sha512_verify_digest(key, digest, sig_mpz);
-    }
-
-  return 0;
-}  
-
-static int dnsmasq_dsa_verify(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
-			      unsigned char *digest, size_t digest_len, int algo)
-{
-  unsigned char *p;
-  unsigned int t;
-  
-  static struct dsa_public_key *key = NULL;
-  static struct dsa_signature *sig_struct;
-  
-  (void)digest_len;
-
-  if (key == NULL)
-    {
-      if (!(sig_struct = whine_malloc(sizeof(struct dsa_signature))) || 
-	  !(key = whine_malloc(sizeof(struct dsa_public_key)))) 
-	return 0;
-      
-      nettle_dsa_public_key_init(key);
-      nettle_dsa_signature_init(sig_struct);
-    }
-  
-  if ((sig_len < 41) || !(p = blockdata_retrieve(key_data, key_len, NULL)))
-    return 0;
-  
-  t = *p++;
-  
-  if (key_len < (213 + (t * 24)))
-    return 0;
-  
-  mpz_import(key->q, 20, 1, 1, 0, 0, p); p += 20;
-  mpz_import(key->p, 64 + (t*8), 1, 1, 0, 0, p); p += 64 + (t*8);
-  mpz_import(key->g, 64 + (t*8), 1, 1, 0, 0, p); p += 64 + (t*8);
-  mpz_import(key->y, 64 + (t*8), 1, 1, 0, 0, p); p += 64 + (t*8);
-  
-  mpz_import(sig_struct->r, 20, 1, 1, 0, 0, sig+1);
-  mpz_import(sig_struct->s, 20, 1, 1, 0, 0, sig+21);
-  
-  (void)algo;
-  
-  return nettle_dsa_sha1_verify_digest(key, digest, sig_struct);
-} 
- 
-#ifndef NO_NETTLE_ECC
-static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len, 
-				unsigned char *sig, size_t sig_len,
-				unsigned char *digest, size_t digest_len, int algo)
-{
-  unsigned char *p;
-  unsigned int t;
-  struct ecc_point *key;
-
-  static struct ecc_point *key_256 = NULL, *key_384 = NULL;
-  static mpz_t x, y;
-  static struct dsa_signature *sig_struct;
-  
-  if (!sig_struct)
-    {
-      if (!(sig_struct = whine_malloc(sizeof(struct dsa_signature))))
-	return 0;
-      
-      nettle_dsa_signature_init(sig_struct);
-      mpz_init(x);
-      mpz_init(y);
-    }
-  
-  switch (algo)
-    {
-    case 13:
-      if (!key_256)
-	{
-	  if (!(key_256 = whine_malloc(sizeof(struct ecc_point))))
-	    return 0;
-	  
-	  nettle_ecc_point_init(key_256, &nettle_secp_256r1);
-	}
-      
-      key = key_256;
-      t = 32;
-      break;
-      
-    case 14:
-      if (!key_384)
-	{
-	  if (!(key_384 = whine_malloc(sizeof(struct ecc_point))))
-	    return 0;
-	  
-	  nettle_ecc_point_init(key_384, &nettle_secp_384r1);
-	}
-      
-      key = key_384;
-      t = 48;
-      break;
-        
-    default:
-      return 0;
-    }
-  
-  if (sig_len != 2*t || key_len != 2*t ||
-      !(p = blockdata_retrieve(key_data, key_len, NULL)))
-    return 0;
-  
-  mpz_import(x, t , 1, 1, 0, 0, p);
-  mpz_import(y, t , 1, 1, 0, 0, p + t);
-
-  if (!ecc_point_set(key, x, y))
-    return 0;
-  
-  mpz_import(sig_struct->r, t, 1, 1, 0, 0, sig);
-  mpz_import(sig_struct->s, t, 1, 1, 0, 0, sig + t);
-  
-  return nettle_ecdsa_verify(key, digest_len, digest, sig_struct);
-} 
-#endif 
-
-static int (*verify_func(int algo))(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
-				    unsigned char *digest, size_t digest_len, int algo)
-{
-    
-  /* Enure at runtime that we have support for this digest */
-  if (!hash_find(algo_digest_name(algo)))
-    return NULL;
-  
-  /* This switch defines which sig algorithms we support, can't introspect Nettle for that. */
-  switch (algo)
-    {
-    case 1: case 5: case 7: case 8: case 10:
-      return dnsmasq_rsa_verify;
-      
-    case 3: case 6: 
-      return dnsmasq_dsa_verify;
- 
-#ifndef NO_NETTLE_ECC   
-    case 13: case 14:
-      return dnsmasq_ecdsa_verify;
-#endif
-    }
-  
-  return NULL;
-}
-
-static int verify(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
-		  unsigned char *digest, size_t digest_len, int algo)
-{
-
-  int (*func)(struct blockdata *key_data, unsigned int key_len, unsigned char *sig, size_t sig_len,
-	      unsigned char *digest, size_t digest_len, int algo);
-  
-  func = verify_func(algo);
-  
-  if (!func)
-    return 0;
-
-  return (*func)(key_data, key_len, sig, sig_len, digest, digest_len, algo);
-}
 
 /* Convert from presentation format to wire format, in place.
    Also map UC -> LC.
@@ -424,15 +103,17 @@ static void from_wire(char *name)
 static int count_labels(char *name)
 {
   int i;
+  char *p;
 
   if (*name == 0)
     return 0;
 
-  for (i = 0; *name; name++)
-    if (*name == '.')
+  for (p = name, i = 0; *p; p++)
+    if (*p == '.')
       i++;
 
-  return i+1;
+  /* Don't count empty first label. */
+  return *name == '.' ? i : i+1;
 }
 
 /* Implement RFC1982 wrapped compare for 32-bit numbers */
@@ -598,11 +279,11 @@ static int get_rdata(struct dns_header *header, size_t plen, unsigned char *end,
    leaving the following bytes as deciding the order. Hence the nasty left1 and left2 variables.
 */
 
-static void sort_rrset(struct dns_header *header, size_t plen, u16 *rr_desc, int rrsetidx, 
-		       unsigned char **rrset, char *buff1, char *buff2)
+static int sort_rrset(struct dns_header *header, size_t plen, u16 *rr_desc, int rrsetidx,
+		      unsigned char **rrset, char *buff1, char *buff2)
 {
-  int swap, quit, i;
-  
+  int swap, quit, i, j;
+
   do
     {
       for (swap = 0, i = 0; i < rrsetidx-1; i++)
@@ -663,11 +344,21 @@ static void sort_rrset(struct dns_header *header, size_t plen, u16 *rr_desc, int
 		  rrset[i] = tmp;
 		  swap = quit = 1;
 		}
+	      else if (rc == 0 && quit && len1 == len2)
+		{
+		  /* Two RRs are equal, remove one copy. RFC 4034, para 6.3 */
+		  for (j = i+1; j < rrsetidx-1; j++)
+		    rrset[j] = rrset[j+1];
+		  rrsetidx--;
+		  i--;
+		}
 	      else if (rc < 0)
 		quit = 1;
 	    }
 	}
     } while (swap);
+
+  return rrsetidx;
 }
 
 static unsigned char **rrset = NULL, **sigs = NULL;
@@ -809,11 +500,11 @@ static int validate_rrset(time_t now, struct dns_header *header, size_t plen, in
   
   name_labels = count_labels(name); /* For 4035 5.3.2 check */
 
-  /* Sort RRset records into canonical order. 
+  /* Sort RRset records into canonical order.
      Note that at this point keyname and daemon->workspacename buffs are
      unused, and used as workspace by the sort. */
-  sort_rrset(header, plen, rr_desc, rrsetidx, rrset, daemon->workspacename, keyname);
-         
+  rrsetidx = sort_rrset(header, plen, rr_desc, rrsetidx, rrset, daemon->workspacename, keyname);
+
   /* Now try all the sigs to try and find one which validates */
   for (j = 0; j <sigidx; j++)
     {
@@ -864,9 +555,10 @@ static int validate_rrset(time_t now, struct dns_header *header, size_t plen, in
 	  int seg;
 	  unsigned char *end, *cp;
 	  u16 len, *dp;
-	  
+
 	  p = rrset[i];
-	  if (!extract_name(header, plen, &p, name, 1, 10)) 
+
+	  if (!extract_name(header, plen, &p, name, 1, 10))
 	    return STAT_BOGUS;
 
 	  name_start = name;
@@ -1120,7 +812,7 @@ int dnssec_validate_by_ds(time_t now, struct dns_header *header, size_t plen, ch
 			{
 			  a.addr.log.keytag = keytag;
 			  a.addr.log.algo = algo;
-			  if (verify_func(algo))
+			  if (algo_digest_name(algo))
 			    log_query(F_NOEXTRA | F_KEYTAG | F_UPSTREAM, name, &a, "DNSKEY keytag %hu, algo %hu");
 			  else
 			    log_query(F_NOEXTRA | F_KEYTAG | F_UPSTREAM, name, &a, "DNSKEY keytag %hu, algo %hu (not supported)");
@@ -1181,8 +873,7 @@ int dnssec_validate_ds(time_t now, struct dns_header *header, size_t plen, char 
     rc = STAT_BOGUS;
   else
     rc = dnssec_validate_reply(now, header, plen, name, keyname, NULL, 0, &neganswer, &nons);
-  /* Note dnssec_validate_reply() will have cached positive answers */
-  
+
   if (rc == STAT_INSECURE)
     rc = STAT_BOGUS;
  
@@ -1248,7 +939,7 @@ int dnssec_validate_ds(time_t now, struct dns_header *header, size_t plen, char 
 		      a.addr.log.keytag = keytag;
 		      a.addr.log.algo = algo;
 		      a.addr.log.digest = digest;
-		      if (hash_find(ds_digest_name(digest)) && verify_func(algo))
+		      if (ds_digest_name(digest) && algo_digest_name(algo))
 			log_query(F_NOEXTRA | F_KEYTAG | F_UPSTREAM, name, &a, "DS keytag %hu, algo %hu, digest %hu");
 		      else
 			log_query(F_NOEXTRA | F_KEYTAG | F_UPSTREAM, name, &a, "DS keytag %hu, algo %hu, digest %hu (not supported)");
@@ -1405,8 +1096,8 @@ static int hostname_cmp(const char *a, const char *b)
     }
 }
 
-static int prove_non_existence_nsec(struct dns_header *header, size_t plen, unsigned char **nsecs, int nsec_count,
-				    char *workspace1, char *workspace2, char *name, int type, int *nons)
+static int prove_non_existence_nsec(struct dns_header *header, size_t plen, unsigned char **nsecs, unsigned char **labels, int nsec_count,
+				    char *workspace1_in, char *workspace2, char *name, int type, int *nons)
 {
   int i, rc, rdlen;
   unsigned char *p, *psave;
@@ -1419,6 +1110,9 @@ static int prove_non_existence_nsec(struct dns_header *header, size_t plen, unsi
   /* Find NSEC record that proves name doesn't exist */
   for (i = 0; i < nsec_count; i++)
     {
+      char *workspace1 = workspace1_in;
+      int sig_labels, name_labels;
+
       p = nsecs[i];
       if (!extract_name(header, plen, &p, workspace1, 1, 10))
 	return 0;
@@ -1427,9 +1121,29 @@ static int prove_non_existence_nsec(struct dns_header *header, size_t plen, unsi
       psave = p;
       if (!extract_name(header, plen, &p, workspace2, 1, 10))
 	return 0;
-      
+
+      /* If NSEC comes from wildcard expansion, use original wildcard
+	 as name for computation. */
+      sig_labels = *labels[i];
+      name_labels = count_labels(workspace1);
+
+      if (sig_labels < name_labels)
+	{
+	  int k;
+	  for (k = name_labels - sig_labels; k != 0; k--)
+	    {
+	      while (*workspace1 != '.' && *workspace1 != 0)
+		workspace1++;
+	      if (k != 1 && *workspace1 == '.')
+		workspace1++;
+	    }
+
+	  workspace1--;
+	  *workspace1 = '*';
+	}
+
       rc = hostname_cmp(workspace1, name);
-      
+
       if (rc == 0)
 	{
 	  /* 4035 para 5.4. Last sentence */
@@ -1451,10 +1165,11 @@ static int prove_non_existence_nsec(struct dns_header *header, size_t plen, unsi
 		 have been returned. */
 	      if ((p[2] & (0x80 >> T_CNAME)) != 0)
 		return 0;
-	      
+
 	      /* If the SOA bit is set for a DS record, then we have the
-		 DS from the wrong side of the delegation. */
-	      if (type == T_DS && (p[2] & (0x80 >> T_SOA)) != 0)
+		 DS from the wrong side of the delegation. For the root DS,
+		 this is expected. */
+	      if (name_labels != 0 && type == T_DS && (p[2] & (0x80 >> T_SOA)) != 0)
 		return 0;
 	    }
 
@@ -1559,7 +1274,7 @@ static int base32_decode(char *in, unsigned char *out)
 }
 
 static int check_nsec3_coverage(struct dns_header *header, size_t plen, int digest_len, unsigned char *digest, int type,
-				char *workspace1, char *workspace2, unsigned char **nsecs, int nsec_count, int *nons)
+				char *workspace1, char *workspace2, unsigned char **nsecs, int nsec_count, int *nons, int name_labels)
 {
   int i, hash_len, salt_len, base32_len, rdlen, flags;
   unsigned char *p, *psave;
@@ -1612,10 +1327,11 @@ static int check_nsec3_coverage(struct dns_header *header, size_t plen, int dige
 		       have been returned. */
 		    if ((p[2] & (0x80 >> T_CNAME)) != 0)
 		      return 0;
-		    
+
 		    /* If the SOA bit is set for a DS record, then we have the
-		       DS from the wrong side of the delegation. */
-		    if (type == T_DS && (p[2] & (0x80 >> T_SOA)) != 0)
+		       DS from the wrong side of the delegation. For the root DS,
+		       this is expected.  */
+		    if (name_labels != 0 && type == T_DS && (p[2] & (0x80 >> T_SOA)) != 0)
 		      return 0;
 		  }
 
@@ -1755,11 +1471,11 @@ static int prove_non_existence_nsec3(struct dns_header *header, size_t plen, uns
 
   if ((digest_len = hash_name(name, &digest, hash, salt, salt_len, iterations)) == 0)
     return 0;
-  
-  if (check_nsec3_coverage(header, plen, digest_len, digest, type, workspace1, workspace2, nsecs, nsec_count, nons))
+
+  if (check_nsec3_coverage(header, plen, digest_len, digest, type, workspace1, workspace2, nsecs, nsec_count, nons, count_labels(name)))
     return 1;
 
-  /* Can't find an NSEC3 which covers the name directly, we need the "closest encloser NSEC3" 
+  /* Can't find an NSEC3 which covers the name directly, we need the "closest encloser NSEC3"
      or an answer inferred from a wildcard record. */
   closest_encloser = name;
   next_closest = NULL;
@@ -1801,9 +1517,9 @@ static int prove_non_existence_nsec3(struct dns_header *header, size_t plen, uns
   if ((digest_len = hash_name(next_closest, &digest, hash, salt, salt_len, iterations)) == 0)
     return 0;
 
-  if (!check_nsec3_coverage(header, plen, digest_len, digest, type, workspace1, workspace2, nsecs, nsec_count, NULL))
+  if (!check_nsec3_coverage(header, plen, digest_len, digest, type, workspace1, workspace2, nsecs, nsec_count, NULL, 1))
     return 0;
-  
+
   /* Finally, check that there's no seat of wildcard synthesis */
   if (!wildname)
     {
@@ -1815,35 +1531,37 @@ static int prove_non_existence_nsec3(struct dns_header *header, size_t plen, uns
       
       if ((digest_len = hash_name(wildcard, &digest, hash, salt, salt_len, iterations)) == 0)
 	return 0;
-      
-      if (!check_nsec3_coverage(header, plen, digest_len, digest, type, workspace1, workspace2, nsecs, nsec_count, NULL))
+
+      if (!check_nsec3_coverage(header, plen, digest_len, digest, type, workspace1, workspace2, nsecs, nsec_count, NULL, 1))
 	return 0;
     }
-  
+
   return 1;
 }
 
 static int prove_non_existence(struct dns_header *header, size_t plen, char *keyname, char *name, int qtype, int qclass, char *wildname, int *nons)
 {
-  static unsigned char **nsecset = NULL;
-  static int nsecset_sz = 0;
-  
+  static unsigned char **nsecset = NULL, **rrsig_labels = NULL;
+  static int nsecset_sz = 0, rrsig_labels_sz = 0;
+
   int type_found = 0;
-  unsigned char *p = skip_questions(header, plen);
+  unsigned char *auth_start, *p = skip_questions(header, plen);
   int type, class, rdlen, i, nsecs_found;
-  
+
   /* Move to NS section */
   if (!p || !(p = skip_section(p, ntohs(header->ancount), header, plen)))
     return 0;
-  
+
+  auth_start = p;
+
   for (nsecs_found = 0, i = ntohs(header->nscount); i != 0; i--)
     {
       unsigned char *pstart = p;
-      
-      if (!(p = skip_name(p, header, plen, 10)))
+
+      if (!extract_name(header, plen, &p, daemon->workspacename, 1, 10))
 	return 0;
-      
-      GETSHORT(type, p); 
+
+      GETSHORT(type, p);
       GETSHORT(class, p);
       p += 4; /* TTL */
       GETSHORT(rdlen, p);
@@ -1857,17 +1575,79 @@ static int prove_non_existence(struct dns_header *header, size_t plen, char *key
 	  type_found = type;
 
 	  if (!expand_workspace(&nsecset, &nsecset_sz, nsecs_found))
-	    return 0; 
-	  
+	    return 0;
+
+	  if (type == T_NSEC)
+	    {
+	      /* If we're looking for NSECs, find the corresponding SIGs, to
+		 extract the labels value, which we need in case the NSECs
+		 are the result of wildcard expansion.
+		 Note that the NSEC may not have been validated yet
+		 so if there are multiple SIGs, make sure the label value
+		 is the same in all, to avoid be duped by a rogue one.
+		 If there are no SIGs, that's an error */
+	      unsigned char *p1 = auth_start;
+	      int res, j, rdlen1, type1, class1;
+
+	      if (!expand_workspace(&rrsig_labels, &rrsig_labels_sz, nsecs_found))
+		return 0;
+
+	      rrsig_labels[nsecs_found] = NULL;
+
+	      for (j = ntohs(header->nscount); j != 0; j--)
+		{
+		  if (!(res = extract_name(header, plen, &p1, daemon->workspacename, 0, 10)))
+		    return 0;
+
+		   GETSHORT(type1, p1);
+		   GETSHORT(class1, p1);
+		   p1 += 4; /* TTL */
+		   GETSHORT(rdlen1, p1);
+
+		   if (!CHECK_LEN(header, p1, plen, rdlen1))
+		     return 0;
+
+		   if (res == 1 && class1 == qclass && type1 == T_RRSIG)
+		     {
+		       int type_covered;
+		       unsigned char *psav = p1;
+
+		       if (rdlen1 < 18)
+			 return 0; /* bad packet */
+
+		       GETSHORT(type_covered, p1);
+
+		       if (type_covered == T_NSEC)
+			 {
+			   p1++; /* algo */
+
+			   /* labels field must be the same in every SIG we find. */
+			   if (!rrsig_labels[nsecs_found])
+			     rrsig_labels[nsecs_found] = p1;
+			   else if (*rrsig_labels[nsecs_found] != *p1) /* algo */
+			     return 0;
+			   }
+		       p1 = psav;
+		     }
+
+		   if (!ADD_RDLEN(header, p1, plen, rdlen1))
+		     return 0;
+		}
+
+	      /* Must have found at least one sig. */
+	      if (!rrsig_labels[nsecs_found])
+		return 0;
+	    }
+
 	  nsecset[nsecs_found++] = pstart;
 	}
-      
+
       if (!ADD_RDLEN(header, p, plen, rdlen))
 	return 0;
     }
-  
+
   if (type_found == T_NSEC)
-    return prove_non_existence_nsec(header, plen, nsecset, nsecs_found, daemon->workspacename, keyname, name, qtype, nons);
+    return prove_non_existence_nsec(header, plen, nsecset, rrsig_labels, nsecs_found, daemon->workspacename, keyname, name, qtype, nons);
   else if (type_found == T_NSEC3)
     return prove_non_existence_nsec3(header, plen, nsecset, nsecs_found, daemon->workspacename, keyname, name, qtype, wildname, nons);
   else
@@ -1932,11 +1712,11 @@ static int zone_status(char *name, int class, char *keyname, time_t now)
 	     to assume we can validate the zone and if we can't later,
 	     because an RRSIG is missing we return BOGUS.
 	  */
-	  do 
+	  do
 	    {
 	      if (crecp->uid == (unsigned int)class &&
-		  hash_find(ds_digest_name(crecp->addr.ds.digest)) &&
-		  verify_func(crecp->addr.ds.algo))
+		  ds_digest_name(crecp->addr.ds.digest) &&
+		  algo_digest_name(crecp->addr.ds.algo))
 		break;
 	    }
 	  while ((crecp = cache_find_by_name(crecp, keyname, now, F_DS)));
@@ -1965,21 +1745,40 @@ static int zone_status(char *name, int class, char *keyname, time_t now)
    STAT_INSECURE at least one RRset not validated, because in unsigned zone.
    STAT_BOGUS    signature is wrong, bad packet, no validation where there should be.
    STAT_NEED_KEY need DNSKEY to complete validation (name is returned in keyname, class in *class)
-   STAT_NEED_DS  need DS to complete validation (name is returned in keyname) 
+   STAT_NEED_DS  need DS to complete validation (name is returned in keyname)
+
+   daemon->rr_status points to a char array which corressponds to the RRs in the
+   answer section (only). This is set to 1 for each RR which is validated, and 0 for any which aren't.
 */
-int dnssec_validate_reply(time_t now, struct dns_header *header, size_t plen, char *name, char *keyname, 
+int dnssec_validate_reply(time_t now, struct dns_header *header, size_t plen, char *name, char *keyname,
 			  int *class, int check_unsigned, int *neganswer, int *nons)
 {
   static unsigned char **targets = NULL;
   static int target_sz = 0;
 
   unsigned char *ans_start, *p1, *p2;
-  int type1, class1, rdlen1, type2, class2, rdlen2, qclass, qtype, targetidx;
+  int type1, class1, rdlen1 = 0, type2, class2, rdlen2, qclass, qtype, targetidx;
   int i, j, rc;
+  int secure = STAT_SECURE;
+
+  /* extend rr_status if necessary */
+  if (daemon->rr_status_sz < ntohs(header->ancount))
+    {
+      char *new = whine_malloc(ntohs(header->ancount) + 64);
+
+      if (!new)
+	return STAT_BOGUS;
+
+      free(daemon->rr_status);
+      daemon->rr_status = new;
+      daemon->rr_status_sz = ntohs(header->ancount) + 64;
+    }
+
+  memset(daemon->rr_status, 0, ntohs(header->ancount));
 
   if (neganswer)
     *neganswer = 0;
-  
+
   if (RCODE(header) == SERVFAIL || ntohs(header->qdcount) != 1)
     return STAT_BOGUS;
   
@@ -2030,118 +1829,140 @@ int dnssec_validate_reply(time_t now, struct dns_header *header, size_t plen, ch
 	if (!ADD_RDLEN(header, p1, plen, rdlen2))
 	  return STAT_BOGUS;
       }
-  
+
   for (p1 = ans_start, i = 0; i < ntohs(header->ancount) + ntohs(header->nscount); i++)
     {
-      if (!extract_name(header, plen, &p1, name, 1, 10))
+       if (i != 0 && !ADD_RDLEN(header, p1, plen, rdlen1))
+	 return STAT_BOGUS;
+
+       if (!extract_name(header, plen, &p1, name, 1, 10))
 	return STAT_BOGUS; /* bad packet */
-      
+
       GETSHORT(type1, p1);
       GETSHORT(class1, p1);
       p1 += 4; /* TTL */
       GETSHORT(rdlen1, p1);
-      
-      /* Don't try and validate RRSIGs! */
-      if (type1 != T_RRSIG)
-	{
-	  /* Check if we've done this RRset already */
-	  for (p2 = ans_start, j = 0; j < i; j++)
-	    {
-	      if (!(rc = extract_name(header, plen, &p2, name, 0, 10)))
-		return STAT_BOGUS; /* bad packet */
-	      
-	      GETSHORT(type2, p2);
-	      GETSHORT(class2, p2);
-	      p2 += 4; /* TTL */
-	      GETSHORT(rdlen2, p2);
-	      
-	      if (type2 == type1 && class2 == class1 && rc == 1)
-		break; /* Done it before: name, type, class all match. */
-	      
-	      if (!ADD_RDLEN(header, p2, plen, rdlen2))
-		return STAT_BOGUS;
-	    }
-	  
-	  /* Not done, validate now */
-	  if (j == i)
-	    {
-	      int sigcnt, rrcnt;
-	      char *wildname;
-	      
-	      if (!explore_rrset(header, plen, class1, type1, name, keyname, &sigcnt, &rrcnt))
-		return STAT_BOGUS;
 
-	      /* No signatures for RRset. We can be configured to assume this is OK and return a INSECURE result. */
-	      if (sigcnt == 0)
+      /* Don't try and validate RRSIGs! */
+      if (type1 == T_RRSIG)
+	continue;
+
+      /* Check if we've done this RRset already */
+      for (p2 = ans_start, j = 0; j < i; j++)
+	{
+	  if (!(rc = extract_name(header, plen, &p2, name, 0, 10)))
+	    return STAT_BOGUS; /* bad packet */
+
+	  GETSHORT(type2, p2);
+	  GETSHORT(class2, p2);
+	  p2 += 4; /* TTL */
+	  GETSHORT(rdlen2, p2);
+
+	  if (type2 == type1 && class2 == class1 && rc == 1)
+	    break; /* Done it before: name, type, class all match. */
+
+	  if (!ADD_RDLEN(header, p2, plen, rdlen2))
+	    return STAT_BOGUS;
+	}
+
+      if (j != i)
+	{
+	  /* Done already: copy the validation status */
+	  if (i < ntohs(header->ancount))
+	    daemon->rr_status[i] = daemon->rr_status[j];
+	}
+      else
+	{
+	  /* Not done, validate now */
+	  int sigcnt, rrcnt;
+	  char *wildname;
+
+	  if (!explore_rrset(header, plen, class1, type1, name, keyname, &sigcnt, &rrcnt))
+	    return STAT_BOGUS;
+
+	  /* No signatures for RRset. We can be configured to assume this is OK and return an INSECURE result. */
+	  if (sigcnt == 0)
+	    {
+	      if (check_unsigned)
 		{
-		  if (check_unsigned)
-		    {
-		      rc = zone_status(name, class1, keyname, now);
-		      if (rc == STAT_SECURE)
-			rc = STAT_BOGUS;
-		       if (class)
-			 *class = class1; /* Class for NEED_DS or NEED_KEY */
-		    }
-		  else 
-		    rc = STAT_INSECURE; 
-		  
-		  return rc;
+		  rc = zone_status(name, class1, keyname, now);
+		  if (rc == STAT_SECURE)
+		    rc = STAT_BOGUS;
+		  if (class)
+		    *class = class1; /* Class for NEED_DS or NEED_KEY */
 		}
-	      
+	      else
+		rc = STAT_INSECURE;
+
+	      if (rc != STAT_INSECURE)
+		return rc;
+	    }
+	  else
+	    {
 	      /* explore_rrset() gives us key name from sigs in keyname.
 		 Can't overwrite name here. */
 	      strcpy(daemon->workspacename, keyname);
 	      rc = zone_status(daemon->workspacename, class1, keyname, now);
 
-	      if (rc != STAT_SECURE)
+	      if (rc == STAT_BOGUS || rc == STAT_NEED_KEY || rc == STAT_NEED_DS)
 		{
 		  /* Zone is insecure, don't need to validate RRset */
 		  if (class)
 		    *class = class1; /* Class for NEED_DS or NEED_KEY */
 		  return rc;
-		} 
-	      
-	      rc = validate_rrset(now, header, plen, class1, type1, sigcnt, rrcnt, name, keyname, &wildname, NULL, 0, 0, 0);
-	      
-	      if (rc == STAT_BOGUS || rc == STAT_NEED_KEY || rc == STAT_NEED_DS)
+		}
+
+	      /* Zone is insecure, don't need to validate RRset */
+	      if (rc == STAT_SECURE)
 		{
-		  if (class)
-		    *class = class1; /* Class for DS or DNSKEY */
-		  return rc;
-		} 
-	      else 
-		{
+		  rc = validate_rrset(now, header, plen, class1, type1, sigcnt,
+				      rrcnt, name, keyname, &wildname, NULL, 0, 0, 0);
+
+		  if (rc == STAT_BOGUS || rc == STAT_NEED_KEY || rc == STAT_NEED_DS)
+		    {
+		      if (class)
+			*class = class1; /* Class for DS or DNSKEY */
+		      return rc;
+		    }
+
 		  /* rc is now STAT_SECURE or STAT_SECURE_WILDCARD */
-		 
+
+		  /* Note that RR is validated */
+		   if (i < ntohs(header->ancount))
+		     daemon->rr_status[i] = 1;
+
 		  /* Note if we've validated either the answer to the question
 		     or the target of a CNAME. Any not noted will need NSEC or
 		     to be in unsigned space. */
-
 		  for (j = 0; j <targetidx; j++)
 		    if ((p2 = targets[j]))
 		      {
-			if (!(rc = extract_name(header, plen, &p2, name, 0, 10)))
+			int rc1;
+			if (!(rc1 = extract_name(header, plen, &p2, name, 0, 10)))
 			  return STAT_BOGUS; /* bad packet */
-			
-			if (class1 == qclass && rc == 1 && (type1 == T_CNAME || type1 == qtype || qtype == T_ANY ))
+
+			if (class1 == qclass && rc1 == 1 && (type1 == T_CNAME || type1 == qtype || qtype == T_ANY ))
 			  targets[j] = NULL;
 		      }
-			    
-		   /* An attacker replay a wildcard answer with a different
-		      answer and overlay a genuine RR. To prove this
-		      hasn't happened, the answer must prove that
-		      the genuine record doesn't exist. Check that here. 
-		      Note that we may not yet have validated the NSEC/NSEC3 RRsets. 
-		      That's not a problem since if the RRsets later fail
-		      we'll return BOGUS then. */
-		  if (rc == STAT_SECURE_WILDCARD && !prove_non_existence(header, plen, keyname, name, type1, class1, wildname, NULL))
+
+		  /* An attacker replay a wildcard answer with a different
+		     answer and overlay a genuine RR. To prove this
+		     hasn't happened, the answer must prove that
+		     the genuine record doesn't exist. Check that here.
+		     Note that we may not yet have validated the NSEC/NSEC3 RRsets.
+		     That's not a problem since if the RRsets later fail
+		     we'll return BOGUS then. */
+		  if (rc == STAT_SECURE_WILDCARD &&
+		      !prove_non_existence(header, plen, keyname, name, type1, class1, wildname, NULL))
 		    return STAT_BOGUS;
+
+		  rc = STAT_SECURE;
 		}
 	    }
 	}
 
-      if (!ADD_RDLEN(header, p1, plen, rdlen1))
-	return STAT_BOGUS;
+      if (rc == STAT_INSECURE)
+	secure = STAT_INSECURE;
     }
 
   /* OK, all the RRsets validate, now see if we have a missing answer or CNAME target. */
@@ -2174,8 +1995,8 @@ int dnssec_validate_reply(time_t now, struct dns_header *header, size_t plen, ch
 	    return STAT_BOGUS; /* signed zone, no NSECs */
 	  }
       }
-  
-  return STAT_SECURE;
+
+  return secure;
 }
 
 

--- a/dnsmasq/domain.c
+++ b/dnsmasq/domain.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -52,85 +52,135 @@ int is_name_synthetic(int flags, char *name, struct all_addr *addr)
 	  if (c1 != c2)
 	    break;
 	}
-      
+
       if (pref && *pref != 0)
 	continue; /* prefix match fail */
-      
-      /* NB, must not alter name if we return zero */
-      for (p = tail; *p; p++)
+
+      if (c->indexed)
 	{
-	  char c = *p;
-	  
-	  if ((c >='0' && c <= '9') || c == '-')
+	  for (p = tail; *p; p++)
+	    {
+	      char c = *p;
+
+	      if (c < '0' || c > '9')
+		break;
+	    }
+
+	  if (*p != '.')
 	    continue;
-	  
+
+	  *p = 0;
+
+	  if (hostname_isequal(c->domain, p+1))
+	    {
+	      if (prot == AF_INET)
+		{
+		  unsigned int index = atoi(tail);
+
+		   if (!c->is6 &&
+		      index <= ntohl(c->end.s_addr) - ntohl(c->start.s_addr))
+		    {
+		      addr->addr.addr4.s_addr = htonl(ntohl(c->start.s_addr) + index);
+		      found = 1;
+		    }
+		}
 #ifdef HAVE_IPV6
-	  if (prot == AF_INET6 && ((c >='A' && c <= 'F') || (c >='a' && c <= 'f'))) 
-	    continue;
+	      else
+		{
+		  u64 index = atoll(tail);
+
+		  if (c->is6 &&
+		      index <= addr6part(&c->end6) - addr6part(&c->start6))
+		    {
+		      u64 start = addr6part(&c->start6);
+		      addr->addr.addr6 = c->start6;
+		      setaddr6part(&addr->addr.addr6, start + index);
+		      found = 1;
+		    }
+		}
 #endif
-	  
-	  break;
-	}
-      
-      if (*p != '.')
-	continue;
-      
-      *p = 0;	
-      
- #ifdef HAVE_IPV6
-      if (prot == AF_INET6 && strstr(tail, "--ffff-") == tail)
-	{
-	  /* special hack for v4-mapped. */
-	  memcpy(tail, "::ffff:", 7);
-	  for (p = tail + 7; *p; p++)
-	    if (*p == '-')
-	      *p = '.';
+	    }
 	}
       else
-#endif
 	{
-	  /* swap . or : for - */
+	  /* NB, must not alter name if we return zero */
 	  for (p = tail; *p; p++)
-	    if (*p == '-')
-	      {
-		if (prot == AF_INET)
-		  *p = '.';
+	    {
+	      char c = *p;
+
+	      if ((c >='0' && c <= '9') || c == '-')
+		continue;
+
 #ifdef HAVE_IPV6
-		else
-		  *p = ':';
+	      if (prot == AF_INET6 && ((c >='A' && c <= 'F') || (c >='a' && c <= 'f')))
+		continue;
 #endif
-	      }
+
+	      break;
+	    }
+
+	  if (*p != '.')
+	    continue;
+
+	  *p = 0;
+
+#ifdef HAVE_IPV6
+	  if (prot == AF_INET6 && strstr(tail, "--ffff-") == tail)
+	    {
+	      /* special hack for v4-mapped. */
+	      memcpy(tail, "::ffff:", 7);
+	      for (p = tail + 7; *p; p++)
+		if (*p == '-')
+		  *p = '.';
+	    }
+	  else
+#endif
+	    {
+	      /* swap . or : for - */
+	      for (p = tail; *p; p++)
+		if (*p == '-')
+		  {
+		    if (prot == AF_INET)
+		      *p = '.';
+#ifdef HAVE_IPV6
+		    else
+		      *p = ':';
+#endif
+		  }
+	    }
+
+	  if (hostname_isequal(c->domain, p+1) && inet_pton(prot, tail, addr))
+	    {
+	      if (prot == AF_INET)
+		{
+		  if (!c->is6 &&
+		      ntohl(addr->addr.addr4.s_addr) >= ntohl(c->start.s_addr) &&
+		      ntohl(addr->addr.addr4.s_addr) <= ntohl(c->end.s_addr))
+		    found = 1;
+		}
+#ifdef HAVE_IPV6
+	      else
+		{
+		  u64 addrpart = addr6part(&addr->addr.addr6);
+
+		  if (c->is6 &&
+		      is_same_net6(&addr->addr.addr6, &c->start6, 64) &&
+		      addrpart >= addr6part(&c->start6) &&
+		      addrpart <= addr6part(&c->end6))
+		    found = 1;
+		}
+#endif
+	    }
+
 	}
 
-      if (hostname_isequal(c->domain, p+1) && inet_pton(prot, tail, addr))
-	{
-	  if (prot == AF_INET)
-	    {
-	      if (!c->is6 &&
-		  ntohl(addr->addr.addr4.s_addr) >= ntohl(c->start.s_addr) &&
-		  ntohl(addr->addr.addr4.s_addr) <= ntohl(c->end.s_addr))
-		found = 1;
-	    }
-#ifdef HAVE_IPV6
-	  else
-	    {
-	      u64 addrpart = addr6part(&addr->addr.addr6);
-	      
-	      if (c->is6 &&
-		  is_same_net6(&addr->addr.addr6, &c->start6, 64) &&
-		  addrpart >= addr6part(&c->start6) &&
-		  addrpart <= addr6part(&c->end6))
-		found = 1;
-	    }
-#endif
-	}
-      
       /* restore name */
       for (p = tail; *p; p++)
 	if (*p == '.' || *p == ':')
 	  *p = '-';
-      
+
       *p = '.';
+
 
       if (found)
 	return 1;
@@ -147,15 +197,23 @@ int is_rev_synth(int flag, struct all_addr *addr, char *name)
    if (flag & F_IPV4 && (c = search_domain(addr->addr.addr4, daemon->synth_domains))) 
      {
        char *p;
-       
+
        *name = 0;
-       if (c->prefix)
-	 strncpy(name, c->prefix, MAXDNAME - ADDRSTRLEN);
-       
-       inet_ntop(AF_INET, &addr->addr.addr4, name + strlen(name), ADDRSTRLEN);
-       for (p = name; *p; p++)
-	 if (*p == '.')
-	   *p = '-';
+       if (c->indexed)
+	 {
+	   unsigned int index = ntohl(addr->addr.addr4.s_addr) - ntohl(c->start.s_addr);
+	   snprintf(name, MAXDNAME, "%s%u", c->prefix ? c->prefix : "", index);
+	 }
+       else
+	 {
+	   if (c->prefix)
+	     strncpy(name, c->prefix, MAXDNAME - ADDRSTRLEN);
+
+	   inet_ntop(AF_INET, &addr->addr.addr4, name + strlen(name), ADDRSTRLEN);
+	   for (p = name; *p; p++)
+	     if (*p == '.')
+	       *p = '-';
+	 }
 
        strncat(name, ".", MAXDNAME);
        strncat(name, c->domain, MAXDNAME);
@@ -167,25 +225,34 @@ int is_rev_synth(int flag, struct all_addr *addr, char *name)
    if (flag & F_IPV6 && (c = search_domain6(&addr->addr.addr6, daemon->synth_domains))) 
      {
        char *p;
-       
+
        *name = 0;
-       if (c->prefix)
-	 strncpy(name, c->prefix, MAXDNAME - ADDRSTRLEN);
-       
-       inet_ntop(AF_INET6, &addr->addr.addr6, name + strlen(name), ADDRSTRLEN);
-
-       /* IPv6 presentation address can start with ":", but valid domain names
-	  cannot start with "-" so prepend a zero in that case. */
-       if (!c->prefix && *name == ':')
+       if (c->indexed)
 	 {
-	   *name = '0';
-	   inet_ntop(AF_INET6, &addr->addr.addr6, name+1, ADDRSTRLEN);
+	   u64 index = addr6part(&addr->addr.addr6) - addr6part(&c->start6);
+	   snprintf(name, MAXDNAME, "%s%llu", c->prefix ? c->prefix : "", index);
 	 }
+       else
+	 {
+	   if (c->prefix)
+	     strncpy(name, c->prefix, MAXDNAME - ADDRSTRLEN);
 
-       /* V4-mapped have periods.... */
-       for (p = name; *p; p++)
-	 if (*p == ':' || *p == '.')
-	   *p = '-';
+	   inet_ntop(AF_INET6, &addr->addr.addr6, name + strlen(name), ADDRSTRLEN);
+
+	   /* IPv6 presentation address can start with ":", but valid domain names
+	      cannot start with "-" so prepend a zero in that case. */
+	   if (!c->prefix && *name == ':')
+	     {
+	       *name = '0';
+	       inet_ntop(AF_INET6, &addr->addr.addr6, name+1, ADDRSTRLEN);
+	     }
+
+	   /* V4-mapped have periods.... */
+	   for (p = name; *p; p++)
+	     if (*p == ':' || *p == '.')
+	       *p = '-';
+
+	 }
 
        strncat(name, ".", MAXDNAME);
        strncat(name, c->domain, MAXDNAME);

--- a/dnsmasq/edns0.c
+++ b/dnsmasq/edns0.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/helper.c
+++ b/dnsmasq/helper.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -97,13 +97,14 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
       return pipefd[1];
     }
 
-  /* ignore SIGTERM, so that we can clean up when the main process gets hit
+  /* ignore SIGTERM and SIGINT, so that we can clean up when the main process gets hit
      and SIGALRM so that we can use sleep() */
   sigact.sa_handler = SIG_IGN;
   sigact.sa_flags = 0;
   sigemptyset(&sigact.sa_mask);
   sigaction(SIGTERM, &sigact, NULL);
   sigaction(SIGALRM, &sigact, NULL);
+  sigaction(SIGINT, &sigact, NULL);
 
   if (!option_bool(OPT_DEBUG) && uid != 0)
     {

--- a/dnsmasq/inotify.c
+++ b/dnsmasq/inotify.c
@@ -1,15 +1,15 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
- 
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 dated June, 1991, or
    (at your option) version 3 dated 29 June, 2007.
- 
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-     
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -20,17 +20,17 @@
 #include <sys/inotify.h>
 #include <sys/param.h> /* For MAXSYMLINKS */
 
-/* the strategy is to set a inotify on the directories containing
-   resolv files, for any files in the directory which are close-write 
+/* the strategy is to set an inotify on the directories containing
+   resolv files, for any files in the directory which are close-write
    or moved into the directory.
-   
+
    When either of those happen, we look to see if the file involved
    is actually a resolv-file, and if so, call poll-resolv with
    the "force" argument, to ensure it's read.
 
    This adds one new error condition: the directories containing
    all specified resolv-files must exist at start-up, even if the actual
-   files don't. 
+   files don't.
 */
 
 static char *inotify_buffer;
@@ -49,7 +49,7 @@ static char *my_readlink(char *path)
     {
       buf = safe_malloc(size);
       rc = readlink(path, buf, (size_t)size);
-      
+
       if (rc == -1)
 	{
 	  /* Not link or doesn't exist. */
@@ -64,7 +64,7 @@ static char *my_readlink(char *path)
       else if (rc < size-1)
 	{
 	  char *d;
-	  
+
 	  buf[rc] = 0;
 	  if (buf[0] != '/' && ((d = strrchr(path, '/'))))
 	    {
@@ -90,13 +90,13 @@ void inotify_dnsmasq_init()
   struct resolvc *res;
   inotify_buffer = safe_malloc(INOTIFY_SZ);
   daemon->inotifyfd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
-  
+
   if (daemon->inotifyfd == -1)
     die(_("failed to create inotify: %s"), NULL, EC_MISC);
 
   if (option_bool(OPT_NO_RESOLV))
     return;
-  
+
   for (res = daemon->resolv_files; res; res = res->next)
     {
       char *d, *new_path, *path = safe_malloc(strlen(res->name) + 1);
@@ -122,14 +122,14 @@ void inotify_dnsmasq_init()
 
 	  res->file = d+1; /* pointer to filename */
 	  *d = '/';
-	  
+
 	  if (res->wd == -1 && errno == ENOENT)
 	    die(_("directory %s for resolv-file is missing, cannot poll"), res->name, EC_MISC);
-	}	  
-	 
+	}
+
       if (res->wd == -1)
 	die(_("failed to create inotify for %s: %s"), res->name, EC_MISC);
-	
+
     }
 }
 
@@ -138,23 +138,23 @@ void inotify_dnsmasq_init()
 void set_dynamic_inotify(int flag, int total_size, struct crec **rhash, int revhashsz)
 {
   struct hostsfile *ah;
-  
+
   for (ah = daemon->dynamic_dirs; ah; ah = ah->next)
     {
       DIR *dir_stream = NULL;
       struct dirent *ent;
       struct stat buf;
-     
+
       if (!(ah->flags & flag))
 	continue;
- 
+
       if (stat(ah->fname, &buf) == -1 || !(S_ISDIR(buf.st_mode)))
 	{
-	  my_syslog(LOG_ERR, _("bad dynamic directory %s: %s"), 
+	  my_syslog(LOG_ERR, _("bad dynamic directory %s: %s"),
 		    ah->fname, strerror(errno));
 	  continue;
 	}
-      
+
        if (!(ah->flags & AH_WD_DONE))
 	 {
 	   ah->wd = inotify_add_watch(daemon->inotifyfd, ah->fname, IN_CLOSE_WRITE | IN_MOVED_TO);
@@ -175,20 +175,20 @@ void set_dynamic_inotify(int flag, int total_size, struct crec **rhash, int revh
 	   size_t lendir = strlen(ah->fname);
 	   size_t lenfile = strlen(ent->d_name);
 	   char *path;
-	   
+
 	   /* ignore emacs backups and dotfiles */
-	   if (lenfile == 0 || 
+	   if (lenfile == 0 ||
 	       ent->d_name[lenfile - 1] == '~' ||
 	       (ent->d_name[0] == '#' && ent->d_name[lenfile - 1] == '#') ||
 	       ent->d_name[0] == '.')
 	     continue;
-	   
+
 	   if ((path = whine_malloc(lendir + lenfile + 2)))
 	     {
 	       strcpy(path, ah->fname);
 	       strcat(path, "/");
 	       strcat(path, ent->d_name);
-	       
+
 	       /* ignore non-regular files */
 	       if (stat(path, &buf) != -1 && S_ISREG(buf.st_mode))
 		 {
@@ -197,7 +197,7 @@ void set_dynamic_inotify(int flag, int total_size, struct crec **rhash, int revh
 #ifdef HAVE_DHCP
 		   else if (ah->flags & (AH_DHCP_HST | AH_DHCP_OPT))
 		     option_read_dynfile(path, ah->flags);
-#endif		   
+#endif
 		 }
 
 	       free(path);
@@ -221,50 +221,50 @@ int inotify_check(time_t now)
       struct inotify_event *in;
 
       while ((rc = read(daemon->inotifyfd, inotify_buffer, INOTIFY_SZ)) == -1 && errno == EINTR);
-      
+
       if (rc <= 0)
 	break;
-      
-      for (p = inotify_buffer; rc - (p - inotify_buffer) >= (int)sizeof(struct inotify_event); p += sizeof(struct inotify_event) + in->len) 
+
+      for (p = inotify_buffer; rc - (p - inotify_buffer) >= (int)sizeof(struct inotify_event); p += sizeof(struct inotify_event) + in->len)
 	{
+	  size_t namelen;
+
 	  in = (struct inotify_event*)p;
-	  
-	  for (res = daemon->resolv_files; res; res = res->next)
-	    if (res->wd == in->wd && in->len != 0 && strcmp(res->file, in->name) == 0)
-	      hit = 1;
 
 	  /* ignore emacs backups and dotfiles */
-	  char lastchar = in->name[strlen(in->name)-1];
-	  if (in->len == 0 ||
-	      lastchar == '~' ||
-	      (in->name[0] == '#' && lastchar == '#') ||
+	  if (in->len == 0 || (namelen = strlen(in->name)) == 0 ||
+	      in->name[namelen - 1] == '~' ||
+	      (in->name[0] == '#' && in->name[namelen - 1] == '#') ||
 	      in->name[0] == '.')
 	    continue;
+	  for (res = daemon->resolv_files; res; res = res->next)
+	    if (res->wd == in->wd && strcmp(res->file, in->name) == 0)
+	      hit = 1;
 
 	  for (ah = daemon->dynamic_dirs; ah; ah = ah->next)
 	    if (ah->wd == in->wd)
 	      {
 		size_t lendir = strlen(ah->fname);
 		char *path;
-		
+
 		if ((path = whine_malloc(lendir + in->len + 2)))
 		  {
 		    strcpy(path, ah->fname);
 		    strcat(path, "/");
 		    strcat(path, in->name);
-		     
+
 		    my_syslog(LOG_INFO, _("inotify, new or changed file %s"), path);
 
 		    if (ah->flags & AH_HOSTS)
 		      {
 			read_hostsfile(path, ah->index, 0, NULL, 0);
 #ifdef HAVE_DHCP
-			if (daemon->dhcp || daemon->doing_dhcp6) 
+			if (daemon->dhcp || daemon->doing_dhcp6)
 			  {
 			    /* Propagate the consequences of loading a new dhcp-host */
 			    dhcp_update_configs(daemon->dhcp_conf);
-			    lease_update_from_configs(); 
-			    lease_update_file(now); 
+			    lease_update_from_configs();
+			    lease_update_file(now);
 			    lease_update_dns(1);
 			  }
 #endif
@@ -276,15 +276,15 @@ int inotify_check(time_t now)
 			  {
 			    /* Propagate the consequences of loading a new dhcp-host */
 			    dhcp_update_configs(daemon->dhcp_conf);
-			    lease_update_from_configs(); 
-			    lease_update_file(now); 
+			    lease_update_from_configs();
+			    lease_update_file(now);
 			    lease_update_dns(1);
 			  }
 		      }
 		    else if (ah->flags & AH_DHCP_OPT)
 		      option_read_dynfile(path, AH_DHCP_OPT);
 #endif
-		    
+
 		    free(path);
 		  }
 	      }
@@ -294,4 +294,4 @@ int inotify_check(time_t now)
 }
 
 #endif  /* INOTIFY */
-  
+

--- a/dnsmasq/ip6addr.h
+++ b/dnsmasq/ip6addr.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/lease.c
+++ b/dnsmasq/lease.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/log.c
+++ b/dnsmasq/log.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/loop.c
+++ b/dnsmasq/loop.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/netlink.c
+++ b/dnsmasq/netlink.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/option.c
+++ b/dnsmasq/option.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1163,7 +1163,7 @@ static int parse_dhcp_opt(char *errstr, char *arg, int flags)
 	    case 'd':
 	    case 'D':
 	      fac *= 24;
-	      /* fall though */
+	      /* fall through */
 	    case 'h':
 	    case 'H':
 	      fac *= 60;
@@ -2069,8 +2069,9 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		{
 		  struct cond_domain *new = opt_malloc(sizeof(struct cond_domain));
 		  char *netpart;
-		  
+
 		  new->prefix = NULL;
+		  new->indexed = 0;
 
 		  unhide_metas(comma);
 		  if ((netpart = split_chr(comma, '/')))
@@ -2208,8 +2209,14 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		    }
 		  else
 		    {
+		      char *star;
 		      new->next = daemon->synth_domains;
 		      daemon->synth_domains = new;
+		      if ((star = strrchr(new->prefix, '*')) && *(star+1) == 0)
+			{
+			  *star = 0;
+			  new->indexed = 1;
+			}
 		    }
 		}
 	      else if (option == 's')
@@ -2730,17 +2737,26 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
         ret_err(gen_err);
       break;
 #endif
-	      
+
     case LOPT_BRIDGE:   /* --bridge-interface */
       {
-	struct dhcp_bridge *new = opt_malloc(sizeof(struct dhcp_bridge));
+	struct dhcp_bridge *new;
+
 	if (!(comma = split(arg)) || strlen(arg) > IF_NAMESIZE - 1 )
 	  ret_err(_("bad bridge-interface"));
-	
-	strcpy(new->iface, arg);
-	new->alias = NULL;
-	new->next = daemon->bridges;
-	daemon->bridges = new;
+
+	for (new = daemon->bridges; new; new = new->next)
+	  if (strcmp(new->iface, arg) == 0)
+	    break;
+
+	if (!new)
+	  {
+	     new = opt_malloc(sizeof(struct dhcp_bridge));
+	     strcpy(new->iface, arg);
+	     new->alias = NULL;
+	     new->next = daemon->bridges;
+	     daemon->bridges = new;
+	  }
 
 	do {
 	  arg = comma;
@@ -2961,7 +2977,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		      case 'd':
 		      case 'D':
 			fac *= 24;
-			/* fall though */
+			/* fall through */
 		      case 'h':
 		      case 'H':
 			fac *= 60;
@@ -3847,6 +3863,7 @@ err:
 
 	while (arg != last)
 	  {
+	    int arglen = strlen(arg);
 	    alias = canonicalise_opt(arg);
 
 	    if (!alias || !target)
@@ -3862,9 +3879,9 @@ err:
 	    new->target = target;
 	    new->ttl = ttl;
 
-	    arg += strlen(arg)+1;
+	    for (arg += arglen+1; *arg && isspace(*arg); arg++);
 	  }
-      
+
 	break;
       }
 
@@ -4318,7 +4335,7 @@ static void read_file(char *file, FILE *f, int hard_opt)
   fclose(f);
 }
 
-#ifdef HAVE_DHCP
+#if defined(HAVE_DHCP) && defined(HAVE_INOTIFY)
 int option_read_dynfile(char *file, int flags)
 {
   my_syslog(MS_DHCP | LOG_INFO, _("read %s"), file);
@@ -4516,89 +4533,102 @@ void read_servers_file(void)
   
   read_file(daemon->servers_file, f, LOPT_REV_SERV);
 }
- 
+
 
 #ifdef HAVE_DHCP
+static void clear_dynamic_conf(void)
+{
+  struct dhcp_config *configs, *cp, **up;
+
+  /* remove existing... */
+  for (up = &daemon->dhcp_conf, configs = daemon->dhcp_conf; configs; configs = cp)
+    {
+      cp = configs->next;
+
+      if (configs->flags & CONFIG_BANK)
+	{
+	  struct hwaddr_config *mac, *tmp;
+	  struct dhcp_netid_list *list, *tmplist;
+
+	  for (mac = configs->hwaddr; mac; mac = tmp)
+	    {
+	      tmp = mac->next;
+	      free(mac);
+	    }
+
+	  if (configs->flags & CONFIG_CLID)
+	    free(configs->clid);
+
+	  for (list = configs->netid; list; list = tmplist)
+	    {
+	      free(list->list);
+	      tmplist = list->next;
+	      free(list);
+	    }
+
+	  if (configs->flags & CONFIG_NAME)
+	    free(configs->hostname);
+
+	  *up = configs->next;
+	  free(configs);
+	}
+      else
+	up = &configs->next;
+    }
+}
+
+static void clear_dynamic_opt(void)
+{
+  struct dhcp_opt *opts, *cp, **up;
+  struct dhcp_netid *id, *next;
+
+  for (up = &daemon->dhcp_opts, opts = daemon->dhcp_opts; opts; opts = cp)
+    {
+      cp = opts->next;
+
+      if (opts->flags & DHOPT_BANK)
+	{
+	  if ((opts->flags & DHOPT_VENDOR))
+	    free(opts->u.vendor_class);
+	  free(opts->val);
+	  for (id = opts->netid; id; id = next)
+	    {
+	      next = id->next;
+	      free(id->net);
+	      free(id);
+	    }
+	  *up = opts->next;
+	  free(opts);
+	}
+      else
+	up = &opts->next;
+    }
+}
+
 void reread_dhcp(void)
 {
-  struct hostsfile *hf;
+   struct hostsfile *hf;
 
-  if (daemon->dhcp_hosts_file)
+   /* Do these even if there is no daemon->dhcp_hosts_file or
+      daemon->dhcp_opts_file since entries may have been created by the
+      inotify dynamic file reading system. */
+
+   clear_dynamic_conf();
+   clear_dynamic_opt();
+
+   if (daemon->dhcp_hosts_file)
     {
-      struct dhcp_config *configs, *cp, **up;
-  
-      /* remove existing... */
-      for (up = &daemon->dhcp_conf, configs = daemon->dhcp_conf; configs; configs = cp)
-	{
-	  cp = configs->next;
-	  
-	  if (configs->flags & CONFIG_BANK)
-	    {
-	      struct hwaddr_config *mac, *tmp;
-	      struct dhcp_netid_list *list, *tmplist;
-	      
-	      for (mac = configs->hwaddr; mac; mac = tmp)
-		{
-		  tmp = mac->next;
-		  free(mac);
-		}
-
-	      if (configs->flags & CONFIG_CLID)
-		free(configs->clid);
-
-	      for (list = configs->netid; list; list = tmplist)
-		{
-		  free(list->list);
-		  tmplist = list->next;
-		  free(list);
-		}
-	      
-	      if (configs->flags & CONFIG_NAME)
-		free(configs->hostname);
-	      
-	      *up = configs->next;
-	      free(configs);
-	    }
-	  else
-	    up = &configs->next;
-	}
-      
       daemon->dhcp_hosts_file = expand_filelist(daemon->dhcp_hosts_file);
       for (hf = daemon->dhcp_hosts_file; hf; hf = hf->next)
-	 if (!(hf->flags & AH_INACTIVE))
-	   {
-	     if (one_file(hf->fname, LOPT_BANK))  
-	       my_syslog(MS_DHCP | LOG_INFO, _("read %s"), hf->fname);
-	   }
+	if (!(hf->flags & AH_INACTIVE))
+	  {
+	    if (one_file(hf->fname, LOPT_BANK))
+	      my_syslog(MS_DHCP | LOG_INFO, _("read %s"), hf->fname);
+	  }
     }
 
   if (daemon->dhcp_opts_file)
     {
-      struct dhcp_opt *opts, *cp, **up;
-      struct dhcp_netid *id, *next;
-
-      for (up = &daemon->dhcp_opts, opts = daemon->dhcp_opts; opts; opts = cp)
-	{
-	  cp = opts->next;
-	  
-	  if (opts->flags & DHOPT_BANK)
-	    {
-	      if ((opts->flags & DHOPT_VENDOR))
-		free(opts->u.vendor_class);
-	      free(opts->val);
-	      for (id = opts->netid; id; id = next)
-		{
-		  next = id->next;
-		  free(id->net);
-		  free(id);
-		}
-	      *up = opts->next;
-	      free(opts);
-	    }
-	  else
-	    up = &opts->next;
-	}
-      
       daemon->dhcp_opts_file = expand_filelist(daemon->dhcp_opts_file);
       for (hf = daemon->dhcp_opts_file; hf; hf = hf->next)
 	if (!(hf->flags & AH_INACTIVE))
@@ -4607,11 +4637,18 @@ void reread_dhcp(void)
 	      my_syslog(MS_DHCP | LOG_INFO, _("read %s"), hf->fname);
 	  }
     }
+
+#  ifdef HAVE_INOTIFY
+  /* Setup notify and read pre-existing files. */
+  set_dynamic_inotify(AH_DHCP_HST | AH_DHCP_OPT, 0, NULL, 0);
+#  endif
 }
 #endif
-    
+
 void read_opts(int argc, char **argv, char *compile_opts)
 {
+  size_t argbuf_size = MAXDNAME;
+  char *argbuf = opt_malloc(argbuf_size);
   char *buff = opt_malloc(MAXDNAME);
   int option, conffile_opt = '7', testmode = 0;
   char *arg, *conffile = CONFFILE;
@@ -4642,6 +4679,7 @@ void read_opts(int argc, char **argv, char *compile_opts)
   daemon->soa_retry = SOA_RETRY;
   daemon->soa_expiry = SOA_EXPIRY;
   daemon->max_port = MAX_PORT;
+  daemon->min_port = MIN_PORT;
 
 #ifndef NO_ID
   add_txt("version.bind", "dnsmasq-" VERSION, 0 );
@@ -4681,9 +4719,15 @@ void read_opts(int argc, char **argv, char *compile_opts)
       /* Copy optarg so that argv doesn't get changed */
       if (optarg)
 	{
-	  strncpy(buff, optarg, MAXDNAME);
-	  buff[MAXDNAME-1] = 0;
-	  arg = buff;
+	  if (strlen(optarg) >= argbuf_size)
+	    {
+	      free(argbuf);
+	      argbuf_size = strlen(optarg) + 1;
+	      argbuf = opt_malloc(argbuf_size);
+	    }
+	  strncpy(argbuf, optarg, argbuf_size);
+	  argbuf[argbuf_size-1] = 0;
+	  arg = argbuf;
 	}
       else
 	arg = NULL;
@@ -4730,6 +4774,8 @@ void read_opts(int argc, char **argv, char *compile_opts)
 	    die(_("bad command line options: %s"), daemon->namebuff, EC_BADCONF);
 	}
     }
+
+  free(argbuf);
 
   if (conffile)
     {

--- a/dnsmasq/outpacket.c
+++ b/dnsmasq/outpacket.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/poll.c
+++ b/dnsmasq/poll.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/radv-protocol.h
+++ b/dnsmasq/radv-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/radv.c
+++ b/dnsmasq/radv.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -407,7 +407,7 @@ static void send_ra_alias(time_t now, int iface, char *iface_name, struct in6_ad
   if (ra_param)
     mtu = ra_param->mtu;
 #ifdef HAVE_LINUX_NETWORK
-  /* Note that IPv6 MTU is not neccessarily the same as the IPv4 MTU
+  /* Note that IPv6 MTU is not necessarily the same as the IPv4 MTU
      available from SIOCGIFMTU */
   if (mtu == 0)
     {

--- a/dnsmasq/rfc1035.c
+++ b/dnsmasq/rfc1035.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@ int extract_name(struct dns_header *header, size_t plen, unsigned char **pp,
       if ((l = *p++) == 0)
 	/* end marker */
 	{
-	  /* check that there are the correct no of bytes after the name */
+	  /* check that there are the correct no. of bytes after the name */
 	  if (!CHECK_LEN(header, p1 ? p1 : p, plen, extrabytes))
 	    return 0;
 
@@ -157,7 +157,7 @@ int in_arpa_name_2_addr(char *namein, struct all_addr *addrp)
   memset(addrp, 0, sizeof(struct all_addr));
 
   /* turn name into a series of asciiz strings */
-  /* j counts no of labels */
+  /* j counts no. of labels */
   for(j = 1,cp1 = name; *namein; cp1++, namein++)
     if (*namein == '.')
       {
@@ -585,7 +585,8 @@ static int find_soa(struct dns_header *header, size_t qlen, char *name, int *doc
    expired and cleaned out that way.
    Return 1 if we reject an address because it look like part of dns-rebinding attack. */
 int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t now,
-		      char **ipsets, int is_sign, int check_rebind, int no_cache_dnssec, int secure, int *doctored)
+		      char **ipsets, int is_sign, int check_rebind, int no_cache_dnssec,
+		      int secure, int *doctored)
 {
   unsigned char *p, *p1, *endrr, *namep;
   int i, j, qtype, qclass, aqtype, aqclass, ardlen, res, searched_soa = 0;
@@ -597,6 +598,7 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
   (void)ipsets; /* unused */
 #endif
 
+
   cache_start_insert();
 
   /* find_soa is needed for dns_doctor and logging side-effects, so don't call it lazily if there are any. */
@@ -604,10 +606,18 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
     {
       searched_soa = 1;
       ttl = find_soa(header, qlen, name, doctored);
+
+      if (*doctored)
+	{
+	  if (secure)
+	    return 0;
 #ifdef HAVE_DNSSEC
-      if (*doctored && secure)
-	return 0;
+	  if (option_bool(OPT_DNSSEC_VALID))
+	    for (i = 0; i < ntohs(header->ancount); i++)
+	      if (daemon->rr_status[i])
+		return 0;
 #endif
+	}
     }
 
   /* go through the questions. */
@@ -618,7 +628,9 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
       int found = 0, cname_count = CNAME_CHAIN;
       struct crec *cpp = NULL;
       int flags = RCODE(header) == NXDOMAIN ? F_NXDOMAIN : 0;
-      int secflag = secure ?  F_DNSSECOK : 0;
+#ifdef HAVE_DNSSEC
+      int cname_short = 0;
+#endif
       unsigned long cttl = ULONG_MAX, attl;
 
       namep = p;
@@ -646,8 +658,9 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	      if (!(p1 = skip_questions(header, qlen)))
 		return 0;
 
-	      for (j = ntohs(header->ancount); j != 0; j--)
+	      for (j = 0; j < ntohs(header->ancount); j++)
 		{
+		  int secflag = 0;
 		  unsigned char *tmp = namep;
 		  /* the loop body overwrites the original name, so get it back here. */
 		  if (!extract_name(header, qlen, &tmp, name, 1, 0) ||
@@ -673,11 +686,24 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 		    {
 		      if (!extract_name(header, qlen, &p1, name, 1, 0))
 			return 0;
+#ifdef HAVE_DNSSEC
+		      if (option_bool(OPT_DNSSEC_VALID) && daemon->rr_status[j])
+			{
+			  /* validated RR anywhere in CNAME chain, don't cache. */
+			  if (cname_short || aqtype == T_CNAME)
+			    return 0;
+
+			  secflag = F_DNSSECOK;
+			}
+#endif
 
 		      if (aqtype == T_CNAME)
 			{
-			  if (!cname_count-- || secure)
-			    return 0; /* looped CNAMES, or DNSSEC, which we can't cache. */
+			  if (!cname_count--)
+			    return 0; /* looped CNAMES, we can't cache. */
+#ifdef HAVE_DNSSEC
+			  cname_short = 1;
+#endif
 			  goto cname_loop;
 			}
 
@@ -699,7 +725,7 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 		  ttl = find_soa(header, qlen, NULL, doctored);
 		}
 	      if (ttl)
-		cache_insert(NULL, &addr, now, ttl, name_encoding | F_REVERSE | F_NEG | flags | secflag);
+		cache_insert(NULL, &addr, now, ttl, name_encoding | F_REVERSE | F_NEG | flags | (secure ?  F_DNSSECOK : 0));
 	    }
 	}
       else
@@ -727,8 +753,10 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	  if (!(p1 = skip_questions(header, qlen)))
 	    return 0;
 
-	  for (j = ntohs(header->ancount); j != 0; j--)
+	  for (j = 0; j < ntohs(header->ancount); j++)
 	    {
+	      int secflag = 0;
+
 	      if (!(res = extract_name(header, qlen, &p1, name, 0, 10)))
 		return 0; /* bad packet */
 
@@ -745,6 +773,10 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 
 	      if (aqclass == C_IN && res != 2 && (aqtype == T_CNAME || aqtype == qtype))
 		{
+#ifdef HAVE_DNSSEC
+		  if (option_bool(OPT_DNSSEC_VALID) && daemon->rr_status[j])
+		      secflag = F_DNSSECOK;
+#endif
 		  if (aqtype == T_CNAME)
 		    {
 		      if (!cname_count--)
@@ -836,7 +868,7 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 		 pointing at this, inherit its TTL */
 	      if (ttl || cpp)
 		{
-		  newc = cache_insert(name, NULL, now, ttl ? ttl : cttl, F_FORWARD | F_NEG | flags | secflag);
+		  newc = cache_insert(name, NULL, now, ttl ? ttl : cttl, F_FORWARD | F_NEG | flags | (secure ? F_DNSSECOK : 0));
 		  if (newc && cpp)
 		    {
 		      cpp->addr.cname.target.cache = newc;
@@ -916,6 +948,8 @@ size_t setup_reply(struct dns_header *header, size_t qlen,
     SET_RCODE(header, NOERROR); /* empty domain */
   else if (flags == F_NXDOMAIN)
     SET_RCODE(header, NXDOMAIN);
+  else if (flags == F_SERVFAIL)
+    SET_RCODE(header, SERVFAIL);
   else if (flags == F_IPV4)
     { /* we know the address */
       SET_RCODE(header, NOERROR);
@@ -951,7 +985,7 @@ int check_for_local_domain(char *name, time_t now)
   /* Note: the call to cache_find_by_name is intended to find any record which matches
      ie A, AAAA, CNAME. */
 
-  if ((crecp = cache_find_by_name(NULL, name, now, F_IPV4 | F_IPV6 | F_CNAME |F_NO_RR)) &&
+  if ((crecp = cache_find_by_name(NULL, name, now, F_IPV4 | F_IPV6 | F_CNAME | F_NO_RR)) &&
       (crecp->flags & (F_HOSTS | F_DHCP | F_CONFIG)))
     return 1;
 
@@ -1075,17 +1109,14 @@ int add_resource_record(struct dns_header *header, char *limit, int *truncp, int
   unsigned short usval;
   long lval;
   char *sval;
-#define CHECK_LIMIT(size) \
-  if (limit && p + (size) > (unsigned char*)limit) \
-    { \
-      va_end(ap); \
-      goto truncated; \
-    }
 
-  if (truncp && *truncp)
-    return 0;
+#define CHECK_LIMIT(size) \
+  if (limit && p + (size) > (unsigned char*)limit) goto truncated;
 
   va_start(ap, format);   /* make ap point to 1st unamed argument */
+
+  if (truncp && *truncp)
+    goto truncated;
 
   if (nameoffset > 0)
     {
@@ -1096,10 +1127,7 @@ int add_resource_record(struct dns_header *header, char *limit, int *truncp, int
     {
       char *name = va_arg(ap, char *);
       if (name && !(p = do_rfc1035_name(p, name, limit)))
-	{
-	  va_end(ap);
-	  goto truncated;
-	}
+	goto truncated;
 
       if (nameoffset < 0)
 	{
@@ -1164,13 +1192,9 @@ int add_resource_record(struct dns_header *header, char *limit, int *truncp, int
         /* get domain-name answer arg and store it in RDATA field */
         if (offset)
           *offset = p - (unsigned char *)header;
-        p = do_rfc1035_name(p, va_arg(ap, char *), limit);
-        if (!p)
-          {
-            va_end(ap);
-            goto truncated;
-          }
-        CHECK_LIMIT(1);
+        if (!(p = do_rfc1035_name(p, va_arg(ap, char *), limit)))
+	  goto truncated;
+	CHECK_LIMIT(1);
         *p++ = 0;
 	break;
 
@@ -1195,24 +1219,22 @@ int add_resource_record(struct dns_header *header, char *limit, int *truncp, int
 	break;
       }
 
-#undef CHECK_LIMIT
   va_end(ap);	/* clean up variable argument pointer */
 
+  /* Now, store real RDLength. sav already checked against limit. */
   j = p - sav - 2;
- /* this has already been checked against limit before */
- PUTSHORT(j, sav);     /* Now, store real RDLength */
-
-  /* check for overflow of buffer */
-  if (limit && ((unsigned char *)limit - p) < 0)
-    {
-truncated:
-      if (truncp)
-	*truncp = 1;
-      return 0;
-    }
+  PUTSHORT(j, sav);
 
   *pp = p;
   return 1;
+
+ truncated:
+  va_end(ap);
+  if (truncp)
+    *truncp = 1;
+  return 0;
+
+#undef CHECK_LIMIT
 }
 
 static unsigned long crec_ttl(struct crec *crecp, time_t now)
@@ -1266,6 +1288,10 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
       ntohs(header->qdcount) == 0 ||
       OPCODE(header) != QUERY )
     return 0;
+
+  /* always servfail queries with RD unset, to avoid cache snooping. */
+  if (!(header->hb3 & HB3_RD))
+    return setup_reply(header, qlen, NULL, F_SERVFAIL, 0);
 
   /* Don't return AD set if checking disabled. */
   if (header->hb4 & HB4_CD)
@@ -1543,44 +1569,6 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 	      if (qtype != type && qtype != T_ANY)
 		continue;
 
-	      /* Check for "A for A"  queries; be rather conservative
-		 about what looks like dotted-quad.  */
-	      if (qtype == T_A)
-		{
-		  char *cp;
-		  unsigned int i, a;
-		  int x;
-
-		  for (cp = name, i = 0, a = 0; *cp; i++)
-		    {
-		      if (!isdigit((unsigned char)*cp) || (x = strtol(cp, &cp, 10)) > 255)
-			{
-			  i = 5;
-			  break;
-			}
-
-		      a = (a << 8) + x;
-
-		      if (*cp == '.')
-			cp++;
-		    }
-
-		  if (i == 4)
-		    {
-		      ans = 1;
-		      sec_data = 0;
-		      if (!dryrun)
-			{
-			  addr.addr.addr4.s_addr = htonl(a);
-			  log_query(F_FORWARD | F_CONFIG | F_IPV4, name, &addr, NULL);
-			  if (add_resource_record(header, limit, &trunc, nameoffset, &ansp,
-						  daemon->local_ttl, NULL, type, C_IN, "4", &addr))
-			    anscount++;
-			}
-		      continue;
-		    }
-		}
-
 	      /* interface name stuff */
 	    intname_restart:
 	      for (intr = daemon->int_names; intr; intr = intr->next)
@@ -1756,8 +1744,9 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 
 	  if (qtype == T_CNAME || qtype == T_ANY)
 	    {
-	      if ((crecp = cache_find_by_name(NULL, name, now, F_CNAME)) &&
-		  (qtype == T_CNAME || (crecp->flags & (F_HOSTS | F_DHCP | F_CONFIG  | (dryrun ? F_NO_RR : 0)))))
+	      if ((crecp = cache_find_by_name(NULL, name, now, F_CNAME | (dryrun ? F_NO_RR : 0))) &&
+		  (qtype == T_CNAME || (crecp->flags & F_CONFIG)) &&
+		  ((crecp->flags & F_CONFIG) || !do_bit || !(crecp->flags & F_DNSSECOK)))
 		{
 		  if (!(crecp->flags & F_DNSSECOK))
 		    sec_data = 0;

--- a/dnsmasq/rfc2131.c
+++ b/dnsmasq/rfc2131.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -906,12 +906,12 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
 		  /* Returns true if only one matching service is available. On port 4011, 
 		     it also inserts the boot file and server name. */
 		  workaround = pxe_uefi_workaround(pxearch, tagif_netid, mess, tmp->local, now, pxe);
-		  
+
 		  if (!workaround && boot)
 		    {
-		      /* Provide the bootfile here, for gPXE, and in case we have no menu items
+		      /* Provide the bootfile here, for iPXE, and in case we have no menu items
 			 and set discovery_control = 8 */
-		      if (boot->next_server.s_addr) 
+		      if (boot->next_server.s_addr)
 			mess->siaddr = boot->next_server;
 		      else if (boot->tftp_sname) 
 			mess->siaddr = a_record_from_hosts(boot->tftp_sname, now);
@@ -2283,9 +2283,9 @@ static void do_options(struct dhcp_context *context,
   
   /* See if we can send the boot stuff as options.
      To do this we need a requested option list, BOOTP
-     and very old DHCP clients won't have this, we also 
-     provide an manual option to disable it.
-     Some PXE ROMs have bugs (surprise!) and need zero-terminated 
+     and very old DHCP clients won't have this, we also
+     provide a manual option to disable it.
+     Some PXE ROMs have bugs (surprise!) and need zero-terminated
      names, so we always send those.  */
   if ((boot = find_boot(tagif)))
     {

--- a/dnsmasq/rfc3315.c
+++ b/dnsmasq/rfc3315.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -213,12 +213,12 @@ static int dhcp6_maybe_relay(struct state *state, void *inbuff, size_t sz,
       state->mac_len = opt6_len(opt) - 2;
       memcpy(&state->mac[0], opt6_ptr(opt, 2), state->mac_len);
     }
-  
+
   for (opt = opts; opt; opt = opt6_next(opt, end))
     {
-      if (opt6_ptr(opt, 0) + opt6_len(opt) >= end) {
+      if (opt6_ptr(opt, 0) + opt6_len(opt) > end)
         return 0;
-      }
+
       int o = new_opt6(opt6_type(opt));
       if (opt6_type(opt) == OPTION6_RELAY_MSG)
 	{
@@ -882,10 +882,10 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 
 	     if (!ia_option)
 	       {
-		 /* If we get a request with a IA_*A without addresses, treat it exactly like
+		 /* If we get a request with an IA_*A without addresses, treat it exactly like
 		    a SOLICT with rapid commit set. */
 		 save_counter(start);
-		 goto request_no_address; 
+		 goto request_no_address;
 	       }
 
 	    o = build_ia(state, &t1cntr);
@@ -1625,7 +1625,7 @@ static void end_ia(int t1cntr, unsigned int min_time, int do_fuzz)
 {
   if (t1cntr != 0)
     {
-      /* go back an fill in fields in IA_NA option */
+      /* go back and fill in fields in IA_NA option */
       int sav = save_counter(t1cntr);
       unsigned int t1, t2, fuzz = 0;
 

--- a/dnsmasq/rrfilter.c
+++ b/dnsmasq/rrfilter.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* Code to safely remove RRs from an DNS answer */ 
+/* Code to safely remove RRs from a DNS answer */
 
 #include "dnsmasq.h"
 
@@ -244,10 +244,10 @@ size_t rrfilter(struct dns_header *header, size_t plen, int mode)
   
   check_name(&p, header, plen, 1, rrs, rr_found);
   p += 4; /* qclass, qtype */
-  
+
   check_rrs(p, header, plen, 1, rrs, rr_found);
 
-  /*  Fouth pass, elide records */
+  /* Fourth pass, elide records */
   for (p = rrs[0], i = 1; i < rr_found; i += 2)
     {
       unsigned char *start = rrs[i];
@@ -270,7 +270,7 @@ u16 *rrfilter_desc(int type)
 {
   /* List of RRtypes which include domains in the data.
      0 -> domain
-     integer -> no of plain bytes
+     integer -> no. of plain bytes
      -1 -> end
 
      zero is not a valid RRtype, so the final entry is returned for

--- a/dnsmasq/slaac.c
+++ b/dnsmasq/slaac.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/tftp.c
+++ b/dnsmasq/tftp.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/dnsmasq/util.c
+++ b/dnsmasq/util.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2017 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2018 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -243,28 +243,32 @@ char *canonicalise(char *in, int *nomem)
 unsigned char *do_rfc1035_name(unsigned char *p, char *sval, char *limit)
 {
   int j;
-  
+
   while (sval && *sval)
     {
-      if (limit && p + 1 > (unsigned char*)limit)
-        return p;
-
       unsigned char *cp = p++;
+
+      if (limit && p > (unsigned char*)limit)
+        return NULL;
+
       for (j = 0; *sval && (*sval != '.'); sval++, j++)
 	{
           if (limit && p + 1 > (unsigned char*)limit)
-            return p;
+            return NULL;
+
 #ifdef HAVE_DNSSEC
 	  if (option_bool(OPT_DNSSEC_VALID) && *sval == NAME_ESCAPE)
 	    *p++ = (*(++sval))-1;
 	  else
-#endif		
+#endif
 	    *p++ = *sval;
 	}
+
       *cp  = j;
       if (*sval)
 	sval++;
     }
+
   return p;
 }
 

--- a/signals.c
+++ b/signals.c
@@ -13,13 +13,6 @@
 volatile sig_atomic_t killed = 0;
 int FTLstarttime = 0;
 
-static void SIGINT_handler(int sig, siginfo_t *si, void *unused)
-{
-	logg("FATAL: FTL received SIGINT (Ctrl + C, PID/UID %i/%i), exiting immediately!", (int)si->si_pid, (int)si->si_uid);
-	logg("       There may be queries that have not been saved in the long-term data base");
-	exit(EXIT_FAILURE);
-}
-
 static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 {
 	logg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
@@ -64,17 +57,7 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 void handle_signals(void)
 {
 	struct sigaction old_action;
-	// Catch SIGINT
-	sigaction (SIGTERM, NULL, &old_action);
-	if(old_action.sa_handler != SIG_IGN)
-	{
-		struct sigaction INTaction;
-		memset(&INTaction, 0, sizeof(struct sigaction));
-		INTaction.sa_flags = SA_SIGINFO;
-		sigemptyset(&INTaction.sa_mask);
-		INTaction.sa_sigaction = &SIGINT_handler;
-		sigaction(SIGINT, &INTaction, NULL);
-	}
+
 	// Catch SIGSEGV
 	sigaction (SIGSEGV, NULL, &old_action);
 	if(old_action.sa_handler != SIG_IGN)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Updates the internal resolver from 2.78 to 2.79.

Changelog:

	version 2.79
	Fix parsing of CNAME arguments, which are confused by extra spaces.
	Thanks to Diego Aguirre for spotting the bug.

	Where available, use IP_UNICAST_IF or IPV6_UNICAST_IF to bind
	upstream servers to an interface, rather than SO_BINDTODEVICE.
	Thanks to Beniamino Galvani for the patch.

	Always return a SERVFAIL answer to DNS queries without the
	recursion desired bit set, UNLESS acting as an authoritative
	DNS server. This avoids a potential route to cache snooping.

	Add support for Ed25519 signatures in DNSSEC validation.

	No longer support RSA/MD5 signatures in DNSSEC validation,
	since these are not secure. This behaviour is mandated in
	RFC-6944.

	Fix incorrect error exit code from dhcp_release6 utility.
	Thanks Gaudenz Steinlin for the bug report.

	Use SIGINT (instead of overloading SIGHUP) to turn on DNSSEC
	time validation when --dnssec-no-timecheck is in use.
	Note that this is an incompatible change from earlier releases.

	Allow more than one --bridge-interface option to refer to an
	interface, so that we can use
	--bridge-interface=int1,alias1
	--bridge-interface=int1,alias2
	as an alternative to
	--bridge-interface=int1,alias1,alias2
	Thanks to Neil Jerram for work on this.

	Fix for DNSSEC with wildcard-derived NSEC records.
	It's OK for NSEC records to be expanded from wildcards,
	but in that case, the proof of non-existence is only valid
	starting at the wildcard name, *.<domain> NOT the name expanded
	from the wildcard. Without this check it's possible for an
	attacker to craft an NSEC which wrongly proves non-existence.
	Thanks to Ralph Dolmans for finding this, and co-ordinating 
	the vulnerability tracking and fix release.
	CVE-2017-15107 applies.

	Remove special handling of A-for-A DNS queries. These
	are no longer a significant problem in the global DNS.
	http://cs.northwestern.edu/~ychen/Papers/DNS_ToN15.pdf
	Thanks to Mattias Hellström for the initial patch.

	Fix failure to delete dynamically created dhcp options
	from files in -dhcp-optsdir directories. Thanks to
	Lindgren Fredrik for the bug report.

	Add to --synth-domain the ability to create names using
	sequential numbers, as well as encodings of IP addresses.
	For instance,
	--synth-domain=thekelleys.org.uk,192.168.0.50,192.168.0.70,internal-*
	creates 21 domain names of the form
	internal-4.thekelleys.org.uk over the address range given, with
	internal-0.thekelleys.org.uk being 192.168.0.50 and
	internal-20.thekelleys.org.uk being 192.168.0.70
	Thanks to Andy Hawkins for the suggestion.

	Tidy up Crypto code, removing workarounds for ancient
	versions of libnettle. We now require libnettle 3.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
