### PR TITLE
Fix IPv6 blocking and blocking reason detection

### DIFF
--- a/dnsmasq/rfc1035.c
+++ b/dnsmasq/rfc1035.c
@@ -1696,7 +1696,7 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			    if (!dryrun)
 			    {
 			      log_query(crecp->flags, name, NULL, record_source(crecp->uid));
-			      FTL_cache(crecp->flags, name, NULL, NULL, daemon->log_display_id);
+			      FTL_cache(crecp->flags, name, NULL, record_source(crecp->uid), daemon->log_display_id);
 			    }
 			  }
 			else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This fixes two bugs:

- IPv6 blocking doesn't work as the test for if the conversion of the IPv6 address from text to binary form worked was incorrect (`inet_pton` returns `1` on success and `0` on failure, I mixed that up due to how `bash` does it...).
- When switching on NXDOMAIN blocking, FTLDNS wasn't aware of if a domain was blocked from gravity.list or black.list as a necessary parameter for the determination of this wasn't passed through.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
