### PR TITLE
Allow starting FTLDNS as any user

### DIFF
--- a/main.c
+++ b/main.c
@@ -38,7 +38,7 @@ int main (int argc, char* argv[])
 
 	// pihole-FTL should really be run as user "pihole" to not mess up with file permissions
 	// print warning otherwise
-	if(strcmp(username, "pihole"))
+	if(strcmp(username, "pihole") != 0)
 		logg("WARNING: Starting pihole-FTL as user %s is not recommended", username);
 
 	// Process pihole-FTL.conf

--- a/main.c
+++ b/main.c
@@ -19,6 +19,10 @@ int main_dnsmasq(int argc, char **argv);
 
 int main (int argc, char* argv[])
 {
+	// Get user pihole-FTL is running as
+	// We store this in a global variable
+	// such that the log routine can access
+	// it if needed
 	username = getUserName();
 
 	// Parse arguments
@@ -32,17 +36,12 @@ int main (int argc, char* argv[])
 	log_FTL_version();
 	init_thread_lock();
 
-	// pihole-FTL should really be run as user "pihole" to not mess up with the file permissions
-	// Exception: allow to be run under user "root" in debug mode to allow binding to port 53
-	//            inside the debugger
-	if(strcmp(username, "pihole") != 0 && !debug)
-	{
-		logg("FATAL: Starting pihole-FTL directly is not recommended.");
-		logg("       Instead, use system commands for starting pihole-FTL as service (systemctl / service)");
-		logg("       or use: sudo -u pihole pihole-FTL");
-		exit(EXIT_FAILURE);
-	}
+	// pihole-FTL should really be run as user "pihole" to not mess up with file permissions
+	// print warning otherwise
+	if(strcmp(username, "pihole"))
+		logg("WARNING: Starting pihole-FTL as user %s is not recommended", username);
 
+	// Process pihole-FTL.conf
 	read_FTLconf();
 
 	// Catch signals like SIGTERM and SIGINT


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Don't terminate FTL when invoked from a user != `pihole`. It seems we might want to run `pihole-FTL` as `root` on OSes that (for whatever reason) cannot use `setcap`. This is currently prevented by the code. This PR removes this restriction.

While we're at it, we add some comments in the vicinity.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
