### PR TITLE
Add blocked per client counter

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -169,6 +169,7 @@ typedef struct {
 typedef struct {
 	unsigned char magic;
 	int count;
+	int blockedcount;
 	char *ip;
 	char *name;
 	bool new;

--- a/api.c
+++ b/api.c
@@ -337,11 +337,19 @@ void getTopClients(char *client_message, int *sock)
 	if(command(client_message, " withzero"))
 		includezeroclients = true;
 
+	// Show number of blocked queries instead of total number?
+	// This option can be combined with existing options,
+	// i.e. ">top-clients withzero blocked (123)" would be valid
+	bool blockedonly = false;
+	if(command(client_message, " blocked"))
+		blockedonly = true;
+
 	for(i=0; i < counters.clients; i++)
 	{
 		validate_access("clients", i, true, __LINE__, __FUNCTION__, __FILE__);
 		temparray[i][0] = i;
-		temparray[i][1] = clients[i].count;
+		// Use either blocked or total count based on request string
+		temparray[i][1] = blockedonly ? clients[i].blockedcount : clients[i].count;
 	}
 
 	// Sort in ascending order?
@@ -375,8 +383,9 @@ void getTopClients(char *client_message, int *sock)
 	int n = 0;
 	for(i=0; i < counters.clients; i++)
 	{
-		// Get sorted indices
+		// Get sorted indices and counter values (may be either total or blocked count)
 		int j = temparray[i][0];
+		int ccount = temparray[i][1];
 		validate_access("clients", j, true, __LINE__, __FUNCTION__, __FILE__);
 
 		// Skip this client if there is a filter on it
@@ -398,16 +407,16 @@ void getTopClients(char *client_message, int *sock)
 		// Return this client if either
 		// - "withzero" option is set, and/or
 		// - the client made at least one query within the most recent 24 hours
-		if(includezeroclients || clients[j].count > 0)
+		if(includezeroclients || ccount > 0)
 		{
 			if(istelnet[*sock])
-				ssend(*sock,"%i %i %s %s\n",n,clients[j].count,clients[j].ip,name);
+				ssend(*sock,"%i %i %s %s\n", n, ccount, clients[j].ip, name);
 			else
 			{
 				if(!pack_str32(*sock, "") || !pack_str32(*sock, clients[j].ip))
 					return;
 
-				pack_int32(*sock, clients[j].count);
+				pack_int32(*sock, ccount);
 			}
 			n++;
 		}

--- a/database.c
+++ b/database.c
@@ -746,6 +746,7 @@ void read_data_from_DB(void)
 				counters.blocked++;
 				overTime[timeidx].blocked++;
 				domains[domainID].blockedcount++;
+				clients[clientID].blockedcount++;
 				break;
 
 			case QUERY_FORWARDED: // Forwarded
@@ -766,6 +767,7 @@ void read_data_from_DB(void)
 				overTime[timeidx].blocked++;
 				domains[domainID].blockedcount++;
 				domains[domainID].wildcard = true;
+				clients[clientID].blockedcount++;
 				break;
 
 			case QUERY_BLACKLIST: // black.list
@@ -774,6 +776,7 @@ void read_data_from_DB(void)
 				// Update overTime data structure
 				overTime[timeidx].blocked++;
 				domains[domainID].blockedcount++;
+				clients[clientID].blockedcount++;
 				break;
 
 			default:

--- a/datastructure.c
+++ b/datastructure.c
@@ -206,6 +206,8 @@ int findClientID(const char *client)
 	clients[clientID].magic = MAGICBYTE;
 	// Set its counter to 1
 	clients[clientID].count = 1;
+	// Initialize blocked count to zero
+	clients[clientID].blockedcount = 0;
 	// Store client IP - no need to check for NULL here as it doesn't harm
 	clients[clientID].ip = strdup(client);
 	memory.clientips += (strlen(client) + 1) * sizeof(char);

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -414,6 +414,9 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 			int domainID = queries[i].domainID;
 			validate_access("domains", domainID, true, __LINE__, __FUNCTION__, __FILE__);
 
+			int clientID = queries[i].clientID;
+			validate_access("clients", clientID, true, __LINE__, __FUNCTION__, __FILE__);
+
 			// Decide what to do depening on the result of detectStatus()
 			if(queries[i].status == QUERY_WILDCARD)
 			{
@@ -422,6 +425,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 				overTime[timeidx].blocked++;
 				domains[domainID].blockedcount++;
 				domains[domainID].wildcard = true;
+				clients[clientID].blockedcount++;
 			}
 			else if(queries[i].status == QUERY_CACHE)
 			{
@@ -435,6 +439,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 				counters.blocked++;
 				overTime[timeidx].blocked++;
 				domains[domainID].blockedcount++;
+				clients[clientID].blockedcount++;
 			}
 
 			// Save reply type and update individual reply counters
@@ -580,8 +585,6 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 			return;
 		}
 
-		int domainID = queries[i].domainID;
-		validate_access("domains", domainID, true, __LINE__, __FUNCTION__, __FILE__);
 		if(!queries[i].complete)
 		{
 			// This query is no longer unknown
@@ -593,6 +596,12 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 			int timeidx = findOverTimeID(overTimetimestamp);
 			validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 
+			int domainID = queries[i].domainID;
+			validate_access("domains", domainID, true, __LINE__, __FUNCTION__, __FILE__);
+
+			int clientID = queries[i].clientID;
+			validate_access("clients", clientID, true, __LINE__, __FUNCTION__, __FILE__);
+
 			// Handle counters accordingly
 			switch(requesttype)
 			{
@@ -601,6 +610,7 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 					counters.blocked++;
 					overTime[timeidx].blocked++;
 					domains[domainID].blockedcount++;
+					clients[clientID].blockedcount++;
 					break;
 				case QUERY_CACHE: // cached from one of the lists
 					counters.cached++;

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -876,7 +876,6 @@ int FTL_listsfile(char* filename, unsigned int index, FILE *f, int cache_size, s
 		// Strip off everything at the end of the IP (CIDR might be there)
 		a=IPv6addr; for(;*a;a++) if(*a == '/') *a = 0;
 		// Prepare IPv6 address for records
-		logg("IPv6: \"%s\" \"%s\"",IPv6addr,a);
 		if(inet_pton(AF_INET6, IPv6addr, &addr6) > 0)
 			has_IPv6 = true;
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This adds a new counter for blocked queries *per client*. This duplicates the functionality we already have for domains (either total or blocked count).

The new info can be queried from the API by specifying the keyword `blocked` in addition to `>top-clients`. This option is in agreement with other available options, e.g. `>top-clients withzero blocked (29)` will work as expected.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
