### PR TITLE
Suppress wrong warning

### DIFF
--- a/datastructure.c
+++ b/datastructure.c
@@ -239,15 +239,18 @@ int detectStatus(const char *domain)
 	// Note that this is a really expensive subroutine and trying to match
 	// blocked domains against all configured wildcards will take some time
 	int i;
+
+	// Return early if no wildcard domains are defined
+	if(counters.wildcarddomains < 1)
+		return QUERY_CACHE;
+
 	validate_access("wildcarddomains", counters.wildcarddomains-1, false, __LINE__, __FUNCTION__, __FILE__);
 	for(i=0; i < counters.wildcarddomains; i++)
 	{
 		if(strcasecmp(wildcarddomains[i], domain) == 0)
 		{
 			// Exact match with wildcard domain
-			// if(debug)
-			// 	printf("%s / %s (exact wildcard match)\n",wildcarddomains[i], domain);
-			return 4;
+			return QUERY_WILDCARD;
 		}
 		// Create copy of domain under investigation
 		char * part = strdup(domain);
@@ -272,13 +275,11 @@ int detectStatus(const char *domain)
 			// Test for a match
 			if(strcasecmp(wildcarddomains[i], partbuffer) == 0)
 			{
-				// Free allocated memory before return'ing
+				// Free allocated memory before returning
 				free(part);
 				free(partbuffer);
 				// Return match with wildcard domain
-				// if(debug)
-				// 	printf("%s / %s (wildcard match)\n",wildcarddomains[i], partbuffer);
-				return 4;
+				return QUERY_WILDCARD;
 			}
 			if(strlen(partbuffer) > 0)
 			{
@@ -297,5 +298,5 @@ int detectStatus(const char *domain)
 	// wildcard blocking, but from e.g. an
 	// address=// configuration
 	// Answer as "cached"
-	return 3;
+	return QUERY_CACHE;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Return early if no wildcard domains are defined to avoid warning to be printed although for-loop will anyhow be skipped.

This fixes a bug reported on [Discourse](https://discourse.pi-hole.net/t/fltdns-fatal-errors/9470/).

While I was working on this function, I also replaced the fixed values for the query status by their `enum` equivalents (`QUERY_CACHE == 3`, `QUERY_WILDCARD == 4`) and removed some old commented out code.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
