### PR TITLE
Include backtrace on SIGSEGV

### DIFF
--- a/signals.c
+++ b/signals.c
@@ -9,6 +9,7 @@
 *  Please see LICENSE file for your rights under this license. */
 
 #include "FTL.h"
+#include <execinfo.h>
 
 volatile sig_atomic_t killed = 0;
 time_t FTLstarttime = 0;
@@ -39,14 +40,31 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 		default: logg("      with code: Unknown (%i), ",si->si_code); break;
 	}
 
+	// Try to obtain backtrace. This may not always be helpful, but it is better than nothing
+	void *buffer[255];
+	const int calls = backtrace(buffer, sizeof(buffer)/sizeof(void *));
+	char ** bcktrace = backtrace_symbols(buffer, calls);
+	if(bcktrace == NULL)
+	{
+		logg("Unable to obtain backtrace (%i)!",calls);
+	}
+	else
+	{
+		logg("Backtrace:");
+		int j;
+		for (j = 0; j < calls; j++)
+		{
+			logg("B[%04i]: %s",j,bcktrace[j]);
+		}
+	}
+	free(bcktrace);
+
 	// Print memory usage
 	unsigned long int structbytes = sizeof(countersStruct) + sizeof(ConfigStruct) + counters.queries_MAX*sizeof(queriesDataStruct) + counters.forwarded_MAX*sizeof(forwardedDataStruct) + counters.clients_MAX*sizeof(clientsDataStruct) + counters.domains_MAX*sizeof(domainsDataStruct) + counters.overTime_MAX*sizeof(overTimeDataStruct) + (counters.wildcarddomains)*sizeof(*wildcarddomains);
 	unsigned long int dynamicbytes = memory.wildcarddomains + memory.domainnames + memory.clientips + memory.forwardedips + memory.forwarddata + memory.querytypedata;
 	logg("Memory usage (structs): %lu", structbytes);
 	logg("Memory usage (dynamic): %lu\n", dynamicbytes);
 
-	// Getting backtrace symbols is meaningless here since if we would now start a backtrace
-	// then the addresses would only point to this signal handler
 	logg("Thank you for helping us to improve our FTL engine!");
 
 	// Print message and abort

--- a/signals.c
+++ b/signals.c
@@ -28,16 +28,16 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 	}
 	log_FTL_version();
 
-	logg("\nReceived signal: %s", strsignal(sig));
+	logg("Received signal: %s", strsignal(sig));
 	logg("     at address: %lu", (unsigned long) si->si_addr);
 	switch (si->si_code)
 	{
-		case SEGV_MAPERR: logg("      with code: SEGV_MAPERR (Address not mapped to object)"); break;
-		case SEGV_ACCERR: logg("      with code: SEGV_ACCERR (Invalid permissions for mapped object)"); break;
+		case SEGV_MAPERR: logg("     with code: SEGV_MAPERR (Address not mapped to object)"); break;
+		case SEGV_ACCERR: logg("     with code: SEGV_ACCERR (Invalid permissions for mapped object)"); break;
 #if defined(SEGV_BNDERR)
-		case SEGV_BNDERR: logg("      with code: SEGV_BNDERR (Failed address bound checks)"); break;
+		case SEGV_BNDERR: logg("     with code: SEGV_BNDERR (Failed address bound checks)"); break;
 #endif
-		default: logg("      with code: Unknown (%i), ",si->si_code); break;
+		default: logg("     with code: Unknown (%i), ",si->si_code); break;
 	}
 
 	// Try to obtain backtrace. This may not always be helpful, but it is better than nothing


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Try to obtain and log a simple backtrace on `SIGSEGV`. Although this is much less powerful than the backtrace we get from a debugger (e.g., it cannot give precise line numbers) it should at least be able to show in which function the crash happened.

As an experiment, I included this code at the very end of the function `FTL_reply()`:
```c
int *foo = (int*)-1; // makes a bad pointer
printf("%d\n", *foo); // causes the segfault 
```

On the next query that triggers this FTL hook (receiving a reply from a forward destination, *FTL*DNS crashed as expected and the following was logged:
```
[2018-05-11 17:02:02.857] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[2018-05-11 17:02:02.857] ---------------------------->  FTL crashed!  <----------------------------
[2018-05-11 17:02:02.857] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[2018-05-11 17:02:02.858] Please report a bug at https://github.com/pi-hole/FTL/issues
[2018-05-11 17:02:02.858] and include in your report already the following details:
[2018-05-11 17:02:02.858] FTL has been running for 8 seconds
[2018-05-11 17:02:02.858] FTL branch: new/SIGSEGV_backtrace
[2018-05-11 17:02:02.858] FTL version: v3.0
[2018-05-11 17:02:02.858] FTL commit: acbfbf1-dirty
[2018-05-11 17:02:02.858] FTL date: 2018-05-11 16:28:44 +0200
[2018-05-11 17:02:02.858] FTL user: root
[2018-05-11 17:02:02.859] Received signal: Segmentation fault
[2018-05-11 17:02:02.859]      at address: 0
[2018-05-11 17:02:02.859]      with code: SEGV_MAPERR (Address not mapped to object)
[2018-05-11 17:02:02.860] Backtrace:
[2018-05-11 17:02:02.860] B[0000]: ./pihole-FTL(+0x1d220) [0x54b1e220]
[2018-05-11 17:02:02.860] B[0001]: /usr/lib/arm-linux-gnueabihf/libarmmem.so(__default_rt_sa_restorer_v2+0) [0x76dea1a0]
[2018-05-11 17:02:02.861] B[0002]: ./pihole-FTL(FTL_reply+0x39c) [0x54b2a164]
[2018-05-11 17:02:02.861] B[0003]: ./pihole-FTL(cache_insert+0x154) [0x54b510ac]
[2018-05-11 17:02:02.861] B[0004]: ./pihole-FTL(extract_addresses+0x524) [0x54b473f0]
[2018-05-11 17:02:02.861] B[0005]: ./pihole-FTL(+0x39a08) [0x54b3aa08]
[2018-05-11 17:02:02.861] B[0006]: ./pihole-FTL(reply_query+0x564) [0x54b3e6bc]
[2018-05-11 17:02:02.861] B[0007]: ./pihole-FTL(+0x508b8) [0x54b518b8]
[2018-05-11 17:02:02.861] B[0008]: ./pihole-FTL(main_dnsmasq+0xf04) [0x54b532a0]
[2018-05-11 17:02:02.862] B[0009]: ./pihole-FTL(main+0xc0) [0x54b1b724]
[2018-05-11 17:02:02.862] B[0010]: /usr/lib/arm-linux-gnueabihf/libarmmem.so(__libc_start_main+0x114) [0x76dd3294]
[2018-05-11 17:02:02.862] Memory usage (structs): 1472444
[2018-05-11 17:02:02.862] Memory usage (dynamic): 22299
```

From
```
[2018-05-11 17:02:02.860] B[0001]: /usr/lib/arm-linux-gnueabihf/libarmmem.so(__default_rt_sa_restorer_v2+0) [0x76dea1a0]
```
we conclude that it was a memory access that caused the crash

From 
```
[2018-05-11 17:02:02.861] B[0002]: ./pihole-FTL(FTL_reply+0x39c) [0x54b2a164]
```
we conclude that the crash happened inside of `FTL_reply()`.

We will not get more information from this but it is surely better than nothing!

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
