### PR TITLE
Revert "No forking"

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -258,6 +258,7 @@ extern char * username;
 extern char timestamp[16];
 extern bool flush;
 extern bool needGC;
+extern bool daemonmode;
 extern bool database;
 extern long int lastdbindex;
 extern bool travis;

--- a/args.c
+++ b/args.c
@@ -12,6 +12,7 @@
 #include "version.h"
 
 bool debug = false;
+bool daemonmode = true;
 bool debugthreads = false;
 bool debugclients = false;
 bool debugGC = false;
@@ -113,6 +114,23 @@ void parse_args(int argc, char* argv[])
 			exit(EXIT_SUCCESS);
 		}
 
+		// pihole-FTL running
+		// will test if another pihole-FTL process is running
+		// and exits even if not (instead of starting a new one)
+		if(strcmp(argv[i], "running") == 0)
+		{
+			runtest = true;
+			ok = true;
+		}
+
+		// Don't go into background
+		if(strcmp(argv[i], "-f") == 0 ||
+		   strcmp(argv[i], "no-daemon") == 0)
+		{
+			daemonmode = false;
+			ok = true;
+		}
+
 		// Use files in local places for Travis-CI tests
 		if(strcmp(argv[i], "travis-ci") == 0)
 		{
@@ -168,10 +186,12 @@ void parse_args(int argc, char* argv[])
 			printf("\t-v, version       Return version\n");
 			printf("\t-t, tag           Return git tag\n");
 			printf("\t-b, branch        Return git branch\n");
+			printf("\t    running       Test if another pihole-FTL\n");
 			printf("\t                  process is running and exit\n");
 			printf("\t                  even if not (instead of\n");
 			printf("\t                  starting a new one)\n");
 			printf("\t-f, no-daemon     Don't go into daemon mode\n");
+			printf("\t-h, help          Display this help and exit\n");
 			printf("\tdnsmasq-test      Test syntax of dnsmasq's\n");
 			printf("\t                  config files and exit\n");
 			printf("\n\nOnline help: https://github.com/pi-hole/FTL\n");

--- a/daemon.c
+++ b/daemon.c
@@ -13,6 +13,164 @@
 
 struct timeval t0[NUMTIMERS];
 
+int detect_FTL_process(void)
+{
+	DIR* dir = opendir("/proc");
+
+	if(dir)
+	{
+		struct dirent* de = 0;
+		while((de = readdir(dir)) != 0)
+		{
+			// Skip "." and ".."
+			if(strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
+				continue;
+
+			int pid = -1;
+			if(sscanf(de->d_name, "%d", &pid) == 1)
+			{
+				// Test if that is our own process
+				if(pid == getpid())
+					continue;
+
+				char buffer[512] = { 0 };
+				sprintf(buffer, "/proc/%d/cmdline", pid);
+
+				FILE* fp;
+				if((fp = fopen(buffer, "r")) != NULL)
+				{
+					char *linebuffer = NULL;
+					size_t size = 0;
+
+					errno = 0;
+					if (getline(&linebuffer, &size, fp) != -1)
+					{
+						if (strstr(linebuffer, "pihole-FTL") != 0)
+						{
+							fclose(fp);
+							logg("%i - %s", pid, linebuffer);
+							return pid;
+						}
+					}
+
+					if(errno == ENOMEM)
+						logg("WARN: process_pihole_log failed: could not allocate memory for getline");
+
+					if(linebuffer != NULL)
+					{
+						free(linebuffer);
+						linebuffer = NULL;
+					}
+					fclose(fp);
+				}
+			}
+		}
+		closedir(dir);
+	}
+	return -1;
+}
+
+void test_singularity(void)
+{
+	if(runtest)
+	{
+		if(detect_FTL_process() > -1)
+		{
+			printf("Yes: Found a running FTL process\n");
+			exit(EXIT_FAILURE);
+		}
+		else
+		{
+			printf("No: Did not find a running FTL process\n");
+			exit(EXIT_SUCCESS);
+		}
+	}
+
+	int pid;
+	while((pid = detect_FTL_process()) > -1)
+	{
+		printf("Found pihole-FTL process with PID %i (my PID %i) - killing it ...\n", pid, getpid());
+		logg("Found pihole-FTL process with PID %i (my PID %i) - killing it ...", pid, getpid());
+		if(kill(pid, SIGTERM) != 0)
+		{
+			printf("Killing failed (%s) ... Exiting now ...\n", strerror(errno));
+			logg("Killing failed (%s) ... Exiting now ...", strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+	}
+	logg("Found no other running pihole-FTL process");
+}
+
+void go_daemon(void)
+{
+	pid_t process_id = 0;
+	pid_t sid = 0;
+
+	test_singularity();
+
+	// Create child process
+	process_id = fork();
+
+	// Indication of fork() failure
+	if (process_id < 0)
+	{
+		logg("fork failed!\n");
+		// Return failure in exit status
+		exit(EXIT_FAILURE);
+	}
+
+	// PARENT PROCESS. Need to kill it.
+	if (process_id > 0)
+	{
+		printf("FTL started!\n");
+		// return success in exit status
+		exit(EXIT_SUCCESS);
+	}
+
+	//unmask the file mode
+	umask(0);
+
+	//set new session
+	// creates a session and sets the process group ID
+	sid = setsid();
+	if(sid < 0)
+	{
+		// Return failure
+		logg("setsid failed!\n");
+		exit(EXIT_FAILURE);
+	}
+
+	// Create grandchild process
+	// Fork a second child and exit immediately to prevent zombies.  This
+	// causes the second child process to be orphaned, making the init
+	// process responsible for its cleanup.  And, since the first child is
+	// a session leader without a controlling terminal, it's possible for
+	// it to acquire one by opening a terminal in the future (System V-
+	// based systems).  This second fork guarantees that the child is no
+	// longer a session leader, preventing the daemon from ever acquiring
+	// a controlling terminal.
+	process_id = fork();
+
+	// Indication of fork() failure
+	if (process_id < 0)
+	{
+		logg("fork failed!\n");
+		// Return failure in exit status
+		exit(EXIT_FAILURE);
+	}
+
+	// PARENT PROCESS. Need to kill it.
+	if (process_id > 0)
+	{
+		// return success in exit status
+		exit(EXIT_SUCCESS);
+	}
+
+	savepid();
+
+	// Closing stdin, stdout and stderr is handled by dnsmasq
+}
+
 void timer_start(int i)
 {
 	if(i >= NUMTIMERS)

--- a/dnsmasq/dnsmasq.c
+++ b/dnsmasq/dnsmasq.c
@@ -570,7 +570,7 @@ int main_dnsmasq (int argc, char **argv)
 	}
     }
 
-    FTL_start_threads();
+    FTL_fork_and_bind_sockets();
 
    log_err = log_start(ent_pw, err_pipe[1]);
 

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -735,10 +735,12 @@ pthread_t socket_listenthread;
 pthread_t DBthread;
 pthread_t GCthread;
 
-void FTL_start_threads(void)
+void FTL_fork_and_bind_sockets(void)
 {
-	// Save PID
-	savepid();
+	if(!debug && daemonmode)
+		go_daemon();
+	else
+		savepid();
 
 	// We will use the attributes object later to start all threads in detached mode
 	pthread_attr_t attr;

--- a/dnsmasq_interface.h
+++ b/dnsmasq_interface.h
@@ -16,7 +16,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id);
 void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char * arg, int id);
 void FTL_dnssec(int status, int id);
 void FTL_dnsmasq_reload(void);
-void FTL_start_threads(void);
+void FTL_fork_and_bind_sockets(void);
 
 void FTL_forwarding_failed(struct server *server);
 int FTL_listsfile(char* filename, unsigned int index, FILE *f, int cache_size, struct crec **rhash, int hashsz);


### PR DESCRIPTION
Reverts pi-hole/FTL#274

As has been pointed out by @mbiebl, this may have the negative side effect of not returning anymore in the case of calling `/etc/init.d/pihole-FTL start`.

For now, I think it is best to revert this to bring `development` back in the previous state and rethink about this.