### PR TITLE
Fix negative display of read domains

### DIFF
--- a/dnsmasq/cache.c
+++ b/dnsmasq/cache.c
@@ -934,7 +934,7 @@ int read_hostsfile(char *filename, unsigned int index, int cache_size, struct cr
   eatspace(f);
 
   name_count = FTL_listsfile(filename, index, f, cache_size, rhash, hashsz);
-  addr_count = cache_size - name_count;
+  addr_count = name_count - cache_size;
 
   while ((atnl = gettok(f, token)) != EOF)
     {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

`pihole.log` contains
```
read /etc/hosts - 13 addresses
read /etc/pihole/local.list - 9 addresses
read /etc/pihole/black.list - -4 addresses
read /etc/pihole/gravity.list - -232034 addresses
```

As can be seen, the displayed number of parsed domains has a (wrong) negative sign. This affects only the lists read by our custom parser (for the simple domain list format). As it has no negative effect (it is just a cosmetic issue), we haven't noticed it so far.

This PR fixes the sign by correctly computing the number from
```
name_count - cache_size  (which is >= 0)
```
instead of its inverse (`name_count` is the number of cache entries *after* parsing (return value from our parser), and `cache_size` is the number of cache entries *before* parsing the file).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
