### PR TITLE
Add new ">reresolve" API endpoint

### DIFF
--- a/request.c
+++ b/request.c
@@ -117,6 +117,17 @@ void process_request(char *client_message, int *sock)
 		processed = true;
 		getCacheInformation(sock);
 	}
+	else if(command(client_message, ">reresolve"))
+	{
+		processed = true;
+		logg("Received API request for re-resolving host names");
+		// Need to release the thread lock already here to allow
+		// the resolver to process the incoming PTR requests
+		disable_thread_lock();
+		reresolveHostnames();
+		logg("Done re-resolving host names");
+		ssend(*sock, "done\n");
+	}
 
 	// Test only at the end if we want to quit or kill
 	// so things can be processed before


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add new ">reresolve" API endpoint that triggers PTR queries for all clients *FTL*DNS is aware of. This may come in handy if host names have been changed and you want FTL to acknowledge that already now instead of waiting until the next routinely re-resolving happens (at the end of GC, typically once an hour).

Example for usage:
```
$ echo ">reresolve" | nc pi.hole 4711
done
---EOM---
```

It will create a log entry in `pihole-FTL.log`:
```
[2018-05-31 11:50:46.759] Received API request for re-resolving host names
[2018-05-31 11:50:46.873] Done re-resolving host names
```

Also, if Pi-hole logging is enabled, you will see the activity through logged PTR requests in `pihole.log`:
```
May 31 11:50:46 dnsmasq[2223]: 340 127.0.0.1/48916 query[PTR] 2.0.8.10.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 340 127.0.0.1/48916 /etc/pihole/local.list 10.8.0.2 is xyz.vpn
May 31 11:50:46 dnsmasq[2223]: 341 127.0.0.1/60645 query[PTR] 1.2.168.192.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 341 127.0.0.1/60645 config 192.168.2.1 is NXDOMAIN
May 31 11:50:46 dnsmasq[2223]: 342 127.0.0.1/60674 query[PTR] 118.2.168.192.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 342 127.0.0.1/60674 DHCP 192.168.2.118 is xyz.lan
May 31 11:50:46 dnsmasq[2223]: 343 127.0.0.1/45341 query[PTR] 119.2.168.192.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 343 127.0.0.1/45341 DHCP 192.168.2.119 is zyx.lan
May 31 11:50:46 dnsmasq[2223]: 344 127.0.0.1/47995 query[PTR] 127.2.168.192.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 344 127.0.0.1/47995 DHCP 192.168.2.127 is android-xyz.lan
May 31 11:50:46 dnsmasq[2223]: 345 127.0.0.1/46063 query[PTR] 116.2.168.192.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 345 127.0.0.1/46063 DHCP 192.168.2.116 is android-yzx.lan
May 31 11:50:46 dnsmasq[2223]: 346 127.0.0.1/58841 query[PTR] 109.2.168.192.in-addr.arpa from 127.0.0.1
May 31 11:50:46 dnsmasq[2223]: 346 127.0.0.1/58841 DHCP 192.168.2.109 is yzx.lan
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
