### PR TITLE
Recompile Regex API Command

### DIFF
--- a/request.c
+++ b/request.c
@@ -120,13 +120,19 @@ void process_request(char *client_message, int *sock)
 	else if(command(client_message, ">reresolve"))
 	{
 		processed = true;
-		logg("Received API request for re-resolving host names");
+		logg("Received API request to re-resolve host names");
 		// Need to release the thread lock already here to allow
 		// the resolver to process the incoming PTR requests
 		disable_thread_lock();
 		reresolveHostnames();
 		logg("Done re-resolving host names");
-		ssend(*sock, "done\n");
+	}
+	else if(command(client_message, ">recompile-regex"))
+	{
+		processed = true;
+		logg("Received API request to recompile regex");
+		free_regex();
+		read_regex_from_file();
 	}
 
 	// Test only at the end if we want to quit or kill


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Add an API command to recompile the blocking regex. This will be used by the API instead of sending SIGHUP because that would require more possibly sudo-level permissions.

API command: `>recompile-regex`

The `done` message was removed from the `>reresolve` command to avoid issues with the msgpack API, and there is already an EOM sent at the end.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
