### PR TITLE
Limit Regex Logging

### DIFF
--- a/regex.c
+++ b/regex.c
@@ -68,7 +68,13 @@ bool match_regex(char *input)
 			break;
 		}
 	}
-	logg("Regex evaluation took %.3f msec", timer_elapsed_msec(REGEX_TIMER));
+
+	double elapsed = timer_elapsed_msec(REGEX_TIMER);
+
+	// Only log evaluation times if they are longer than normal
+	if(elapsed > 100.0)
+		logg("WARN: Regex evaluation took %.3f msec", elapsed);
+
 	// No match, no error, return false
 	return matched;
 }

--- a/regex.c
+++ b/regex.c
@@ -72,7 +72,7 @@ bool match_regex(char *input)
 	double elapsed = timer_elapsed_msec(REGEX_TIMER);
 
 	// Only log evaluation times if they are longer than normal
-	if(elapsed > 10.0)
+	if(elapsed > 10.0 || debug)
 		logg("WARN: Regex evaluation took %.3f msec", elapsed);
 
 	// No match, no error, return false

--- a/regex.c
+++ b/regex.c
@@ -72,7 +72,7 @@ bool match_regex(char *input)
 	double elapsed = timer_elapsed_msec(REGEX_TIMER);
 
 	// Only log evaluation times if they are longer than normal
-	if(elapsed > 100.0)
+	if(elapsed > 10.0)
 		logg("WARN: Regex evaluation took %.3f msec", elapsed);
 
 	// No match, no error, return false


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Previously every regex evaluation would be logged even if they took very little time:
```
[2018-06-02 00:59:14.450] Regex evaluation took 0.036 msec
[2018-06-02 00:59:15.553] Regex evaluation took 0.006 msec
[2018-06-02 00:59:16.602] Regex evaluation took 0.007 msec
[2018-06-02 00:59:18.110] Regex evaluation took 0.009 msec
[2018-06-02 00:59:18.589] Regex evaluation took 0.006 msec
[2018-06-02 00:59:19.437] Regex evaluation took 0.007 msec
```

Now they will only be logged if they go over 100ms (up for debate if we want this lower).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
