### PR TITLE
Only send client names (and IP for socket connection) in getClientNames

### DIFF
--- a/api.c
+++ b/api.c
@@ -1019,12 +1019,14 @@ void getClientNames(int *sock)
 			client = clients[i].ip;
 
 		if(istelnet[*sock])
-			ssend(*sock, "%i %i %s\n", i, clients[i].count, client);
+			ssend(*sock, "%s\n", client);
 		else {
-			if(!pack_str32(*sock, "") || !pack_str32(*sock, clients[i].ip))
-				return;
+			if(clients[i].name != NULL)
+				pack_str32(*sock, clients[i].name);
+			else
+				pack_str32(*sock, "");
 
-			pack_int32(*sock, clients[i].count);
+			pack_str32(*sock, clients[i].ip);
 		}
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Previously the client query count (and an incrementing number) was also sent along, although it made no sense to do so (it basically mirrored the top clients response, and was never used by the receiver). Now it only sends the client name for the telnet API, and sends both the hostname and IP for the socket API.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
