### PR TITLE
Always send the commit hash

### DIFF
--- a/api.c
+++ b/api.c
@@ -827,24 +827,33 @@ void getVersion(int *sock)
 	const char * commit = GIT_HASH;
 	const char * tag = GIT_TAG;
 
+	// Extract first 7 characters of the hash
+	char hash[8];
+	strncpy(hash, commit, 7); hash[7] = 0;
+
 	if(strlen(tag) > 1) {
 		if(istelnet[*sock])
-			ssend(*sock, "version %s\ntag %s\nbranch %s\ndate %s\n", GIT_VERSION, tag, GIT_BRANCH, GIT_DATE);
+			ssend(
+					*sock,
+					"version %s\ntag %s\nbranch %s\nhash %s\ndate %s\n",
+					GIT_VERSION, tag, GIT_BRANCH, hash, GIT_DATE
+			);
 		else {
 			if(!pack_str32(*sock, GIT_VERSION) ||
 					!pack_str32(*sock, (char *) tag) ||
 					!pack_str32(*sock, GIT_BRANCH) ||
+					!pack_str32(*sock, hash) ||
 					!pack_str32(*sock, GIT_DATE))
 				return;
 		}
 	}
 	else {
-		char hash[8];
-		// Extract first 7 characters of the hash
-		strncpy(hash, commit, 7); hash[7] = 0;
-
 		if(istelnet[*sock])
-			ssend(*sock, "version vDev-%s\ntag %s\nbranch %s\ndate %s\n", hash, tag, GIT_BRANCH, GIT_DATE);
+			ssend(
+					*sock,
+					"version vDev-%s\ntag %s\nbranch %s\nhash %s\ndate %s\n",
+					hash, tag, GIT_BRANCH, hash, GIT_DATE
+			);
 		else {
 			char *hashVersion = calloc(6 + strlen(hash), sizeof(char));
 			if(hashVersion == NULL) return;
@@ -853,6 +862,7 @@ void getVersion(int *sock)
 			if(!pack_str32(*sock, hashVersion) ||
 					!pack_str32(*sock, (char *) tag) ||
 					!pack_str32(*sock, GIT_BRANCH) ||
+					!pack_str32(*sock, hash) ||
 					!pack_str32(*sock, GIT_DATE))
 				return;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Always sends the commit hash. In release builds, the commit hash was not being sent.

Example:
```
version v3.0
tag v3.0
branch v3.0
date 2018-02-14 12:45:47 -0800
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
