### PR TITLE
Ensure that we do never send data that is older than maxlogtime

### DIFF
--- a/api.c
+++ b/api.c
@@ -107,18 +107,25 @@ void getStats(int *sock)
 void getOverTime(int *sock)
 {
 	int i, j = 9999999;
+	bool found = false;
+	time_t mintime = time(NULL) - config.maxlogage;
 
 	// Start with the first non-empty overTime slot
 	for(i=0; i < counters.overTime; i++)
 	{
 		validate_access("overTime", i, true, __LINE__, __FUNCTION__, __FILE__);
 		if((overTime[i].total > 0 || overTime[i].blocked > 0) &&
-		   overTime[i].timestamp)
+		   overTime[i].timestamp >= mintime)
 		{
 			j = i;
+			found = true;
 			break;
 		}
 	}
+
+	// Check if there is any data to be sent
+	if(!found)
+		return;
 
 	if(istelnet[*sock])
 	{
@@ -787,10 +794,11 @@ void getClientID(int *sock)
 void getQueryTypesOverTime(int *sock)
 {
 	int i, sendit = -1;
+	time_t mintime = time(NULL) - config.maxlogage;
 	for(i = 0; i < counters.overTime; i++)
 	{
 		validate_access("overTime", i, true, __LINE__, __FUNCTION__, __FILE__);
-		if((overTime[i].total > 0 || overTime[i].blocked > 0))
+		if((overTime[i].total > 0 || overTime[i].blocked > 0) && overTime[i].timestamp >= mintime)
 		{
 			sendit = i;
 			break;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

# 10

---

See title. Although this situation is unlikely to occur, it ensures that both the queries over time and clients over time start at the same time and there is no offset between the two.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
