### PR TITLE
Send zero length indicator for socket clients if the privacy level prevents real data

### DIFF
--- a/api.c
+++ b/api.c
@@ -164,8 +164,13 @@ void getTopDomains(char *client_message, int *sock)
 
 	// Exit before processing any data if requested via config setting
 	get_privacy_level(NULL);
-	if(config.privacylevel >= PRIVACY_HIDE_DOMAINS)
+	if(config.privacylevel >= PRIVACY_HIDE_DOMAINS) {
+		// Always send the total number of domains, but pretend it's 0
+		if(!istelnet[*sock])
+			pack_int32(*sock, 0);
+
 		return;
+	}
 
 	// Match both top-domains and top-ads
 	// example: >top-domains (15)
@@ -318,8 +323,13 @@ void getTopClients(char *client_message, int *sock)
 
 	// Exit before processing any data if requested via config setting
 	get_privacy_level(NULL);
-	if(config.privacylevel >= PRIVACY_HIDE_DOMAINS_CLIENTS)
+	if(config.privacylevel >= PRIVACY_HIDE_DOMAINS_CLIENTS) {
+		// Always send the total number of clients, but pretend it's 0
+		if(!istelnet[*sock])
+			pack_int32(*sock, 0);
+
 		return;
+	}
 
 	// Match both top-domains and top-ads
 	// example: >top-clients (15)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

When the privacy level restricted domains or clients, the socket API would not send any data at all, while it should have sent a zero length indicator.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
