### PR TITLE
Include counters for individual reply types in ">stats"

### DIFF
--- a/api.c
+++ b/api.c
@@ -83,6 +83,10 @@ void getStats(int *sock)
 			sumalltypes += counters.querytype[i];
 		}
 		ssend(*sock, "dns_queries_all_types %i\n", sumalltypes);
+
+		// Send individual reply type counters
+		ssend(*sock, "reply_NODATA %i\nreply_NXDOMAIN %i\nreply_CNAME %i\nreply_IP %i\n",
+		      counters.reply_NODATA, counters.reply_NXDOMAIN, counters.reply_CNAME, counters.reply_IP);
 	}
 	else
 	{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Include counters for reply types (NODATA, NXDOMAIN, CNAME, IP) within the most 24 hours.

Note: This data only covers the time where *FTL*DNS actually ran. It cannot be derived from historic information in the database.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
