### PR TITLE
Change default blocking mode to NULL

### DIFF
--- a/config.c
+++ b/config.c
@@ -308,7 +308,7 @@ void get_privacy_level(FILE *fp)
 void get_blocking_mode(FILE *fp)
 {
 	// Set default value
-	config.blockingmode = MODE_IP_NODATA_AAAA;
+	config.blockingmode = MODE_NULL;
 
 	// See if we got a file handle, if not we have to open
 	// the config file ourselves


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

See title.

Changing the default blocking mode to `NULL` should resolve all known issues with HTTPS requests resulting in time-outs even without users having to install custom firewall rules.

Furthermore, it will resolve issues with non-static IPv6 prefixes as handed out by several ISPs.

It will suppress the blocking page.

Users may overwrite this at any point through `/etc/pihole/pihole-FTL.conf`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
