### PR TITLE
Use reverse iterations for searching queryIDs

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -46,6 +46,9 @@
 #include <ifaddrs.h>
 #include <net/if.h>
 
+// Define MIN and MAX macros, use them only when x and y are of the same type
+#define MAX(x,y) (((x) > (y)) ? (x) : (y))
+// MIN(x,y) is already defined in dnsmasq.h
 
 #include "routines.h"
 
@@ -71,6 +74,9 @@
 
 // How many client connection do we accept at once?
 #define MAXCONNS 255
+
+// Over how many queries do we iterate at most when trying to find a match?
+#define MAXITER 1000
 
 // FTLDNS enums
 enum { DATABASE_WRITE_TIMER, EXIT_TIMER, GC_TIMER, LISTS_TIMER, REGEX_TIMER };

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -231,7 +231,7 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	// Save status and forwardID in corresponding query identified by dnsmasq's ID
 	bool found = false;
 	int i;
-	// Loop through all queries - this is an expensive loop, however, there is no
+	// Loop over all queries - this is an expensive loop, however, there is no
 	// good alternative as we will loose the relation between dnsmasq's id and our
 	// id due to garbage collection, hence, it may be that a query that with an ID
 	// of dnsmasq of 123.456 is our query with ID 567 when the other queries have
@@ -244,7 +244,12 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 
 	// Validate access only once for the maximum index (all lower will work)
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-	for(i = counters.queries-1; i > 0; i--)
+	// Iterate from the maximum down to at most 100 queries in the past
+	// This avoids iterating through the entire array of queries when
+	// analyzing queries that have not been recorded (like PTR queries, etc.)
+	// MAX(0, a) is used to return 0 in case a is negative (negative array indices are harmful)
+	int until = MAX(0, counters.queries-MAXITER);
+	for(i = counters.queries-1; i > until; i--)
 	{
 		// Check UUID of this query
 		if(queries[i].id == id)
@@ -397,10 +402,11 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		bool found = false;
 		int i;
 
-		// Validate access only once for the maximum index (all lower will work)
-		// See comments in FTL_forwarded() for further details on computational costs
+		// Search match in known queries
+		// See comments in FTL_forwarded() for further details about this loop
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-		for(i = counters.queries-1; i > 0; i--)
+		int until = MAX(0, counters.queries-MAXITER);
+		for(i = counters.queries-1; i > until; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
@@ -452,10 +458,11 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		bool found = false;
 		int i;
 
-		// Validate access only once for the maximum index (all lower will work)
-		// See comments in FTL_forwarded() for further details on computational costs
+		// Search match in known queries
+		// See comments in FTL_forwarded() for further details about this loop
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-		for(i = counters.queries-1; i > 0; i--)
+		int until = MAX(0, counters.queries-MAXITER);
+		for(i = counters.queries-1; i > until; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
@@ -560,10 +567,11 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 
 		bool found = false;
 		int i;
-		// Validate access only once for the maximum index (all lower will work)
-		// See comments in FTL_forwarded() for further details on computational costs
+		// Search match in known queries
+		// See comments in FTL_forwarded() for further details about this loop
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-		for(i = counters.queries-1; i > 0; i--)
+		int until = MAX(0, counters.queries-MAXITER);
+		for(i = counters.queries-1; i > until; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
@@ -643,10 +651,11 @@ void FTL_dnssec(int status, int id)
 	// Search for corresponding query indentified by ID
 	bool found = false;
 	int i;
-	// Validate access only once for the maximum index (all lower will work)
-	// See comments in FTL_forwarded() for further details on computational costs
+	// Search match in known queries
+	// See comments in FTL_forwarded() for further details about this loop
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-	for(i = counters.queries-1; i > 0; i--)
+	int until = MAX(0, counters.queries-MAXITER);
+	for(i = counters.queries-1; i > until; i--)
 	{
 		// Check both UUID and generation of this query
 		if(queries[i].id == id)

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -231,23 +231,17 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	// Save status and forwardID in corresponding query identified by dnsmasq's ID
 	bool found = false;
 	int i;
-	// Loop over all queries - this is an expensive loop, however, there is no
-	// good alternative as we will loose the relation between dnsmasq's id and our
-	// id due to garbage collection, hence, it may be that a query that with an ID
-	// of dnsmasq of 123.456 is our query with ID 567 when the other queries have
-	// already been removed due to their age. This is the price ofour very memory
-	// efficient datastructure which, however, allows us to have FTL run non-stop.
-	// Previously, FTL had to flush its internal data structure at midnight and re-
-	// parse the history from the pihole.log.1 file. Something like this is not
-	// needed anymore. We only have to get historic information from the database
-	// once on startup but then never again.
+	// Loop over all queries - we loop in reverse order (start from the most recent query and
+	// continuously walk older queries while trying to find a match. Ideally, we should always
+	// find the correct query with zero iterations, but it may happen that queries are processed
+	// asynchronously, e.g. for slow upstream relies to a huge amount of requests.
+	// We iterate from the most recent query down to at most MAXITER queries in the past to avoid
+	// iterating through the entire array of queries when queries that have not been recorded
+	// (like PTR queries, etc.) are processed.
+	// MAX(0, a) is used to return 0 in case a is negative (negative array indices are harmful)
 
 	// Validate access only once for the maximum index (all lower will work)
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-	// Iterate from the maximum down to at most 100 queries in the past
-	// This avoids iterating through the entire array of queries when
-	// analyzing queries that have not been recorded (like PTR queries, etc.)
-	// MAX(0, a) is used to return 0 in case a is negative (negative array indices are harmful)
 	int until = MAX(0, counters.queries-MAXITER);
 	for(i = counters.queries-1; i > until; i--)
 	{
@@ -397,7 +391,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 	if(flags & F_CONFIG)
 	{
 		// Answered from local configuration, might be a wildcard or user-provided
-		// Save status in corresponding query indentified by dnsmasq's ID
+		// Save status in corresponding query identified by dnsmasq's ID
 		bool found = false;
 		int i;
 

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -243,7 +243,7 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	// Validate access only once for the maximum index (all lower will work)
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 	int until = MAX(0, counters.queries-MAXITER);
-	for(i = counters.queries-1; i > until; i--)
+	for(i = counters.queries-1; i >= until; i--)
 	{
 		// Check UUID of this query
 		if(queries[i].id == id)
@@ -399,7 +399,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		// See comments in FTL_forwarded() for further details about this loop
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 		int until = MAX(0, counters.queries-MAXITER);
-		for(i = counters.queries-1; i > until; i--)
+		for(i = counters.queries-1; i >= until; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
@@ -454,7 +454,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		// See comments in FTL_forwarded() for further details about this loop
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 		int until = MAX(0, counters.queries-MAXITER);
-		for(i = counters.queries-1; i > until; i--)
+		for(i = counters.queries-1; i >= until; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
@@ -562,7 +562,7 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 		// See comments in FTL_forwarded() for further details about this loop
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 		int until = MAX(0, counters.queries-MAXITER);
-		for(i = counters.queries-1; i > until; i--)
+		for(i = counters.queries-1; i >= until; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
@@ -645,7 +645,7 @@ void FTL_dnssec(int status, int id)
 	// See comments in FTL_forwarded() for further details about this loop
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 	int until = MAX(0, counters.queries-MAXITER);
-	for(i = counters.queries-1; i > until; i--)
+	for(i = counters.queries-1; i >= until; i--)
 	{
 		// Check both UUID and generation of this query
 		if(queries[i].id == id)

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -256,7 +256,6 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 		{
 			queries[i].status = QUERY_FORWARDED;
 			found = true;
-			if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 			break;
 		}
 	}
@@ -412,7 +411,6 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 			if(queries[i].id == id)
 			{
 				found = true;
-				if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 				break;
 			}
 		}
@@ -468,7 +466,6 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 			if(queries[i].id == id)
 			{
 				found = true;
-				if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 				break;
 			}
 		}
@@ -577,7 +574,6 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 			if(queries[i].id == id)
 			{
 				found = true;
-				if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 				break;
 			}
 		}
@@ -661,7 +657,6 @@ void FTL_dnssec(int status, int id)
 		if(queries[i].id == id)
 		{
 			found = true;
-			if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 			break;
 		}
 	}

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -244,13 +244,14 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 
 	// Validate access only once for the maximum index (all lower will work)
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-	for(i=0; i<counters.queries; i++)
+	for(i = counters.queries-1; i > 0; i--)
 	{
 		// Check UUID of this query
 		if(queries[i].id == id)
 		{
 			queries[i].status = QUERY_FORWARDED;
 			found = true;
+			if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 			break;
 		}
 	}
@@ -399,12 +400,13 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		// Validate access only once for the maximum index (all lower will work)
 		// See comments in FTL_forwarded() for further details on computational costs
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-		for(i=0; i<counters.queries; i++)
+		for(i = counters.queries-1; i > 0; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
 			{
 				found = true;
+				if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 				break;
 			}
 		}
@@ -453,12 +455,13 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		// Validate access only once for the maximum index (all lower will work)
 		// See comments in FTL_forwarded() for further details on computational costs
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-		for(i=0; i<counters.queries; i++)
+		for(i = counters.queries-1; i > 0; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
 			{
 				found = true;
+				if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 				break;
 			}
 		}
@@ -560,12 +563,13 @@ void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg,
 		// Validate access only once for the maximum index (all lower will work)
 		// See comments in FTL_forwarded() for further details on computational costs
 		validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-		for(i=0; i<counters.queries; i++)
+		for(i = counters.queries-1; i > 0; i--)
 		{
 			// Check UUID of this query
 			if(queries[i].id == id)
 			{
 				found = true;
+				if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 				break;
 			}
 		}
@@ -642,12 +646,13 @@ void FTL_dnssec(int status, int id)
 	// Validate access only once for the maximum index (all lower will work)
 	// See comments in FTL_forwarded() for further details on computational costs
 	validate_access("queries", counters.queries-1, false, __LINE__, __FUNCTION__, __FILE__);
-	for(i=0; i<counters.queries; i++)
+	for(i = counters.queries-1; i > 0; i--)
 	{
 		// Check both UUID and generation of this query
 		if(queries[i].id == id)
 		{
 			found = true;
+			if(debug) logg("Found query after %i iterations", counters.queries-1-i);
 			break;
 		}
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Use reverse iterations when searching for `queryID` matches. This greatly increases computational efficiency of several subroutines critical for the performance of *FTL*DNS.

This renders #306 obsolete as queries will most likely be found in the first iteration. However, if this is not the case, then we will do at most 1000 iterations to avoid expensive looping for queries that have not been stored in FTL's data structure.