### PR TITLE
Fix typo in >memory telnet response

### DIFF
--- a/api.c
+++ b/api.c
@@ -793,7 +793,7 @@ void getMemoryUsage(int *sock)
 	format_memory_size(dynamicprefix, dynamicbytes, &formated);
 
 	if(istelnet[*sock])
-		ssend(*sock,"dynamically allocated allocated memory used for strings: %lu bytes (%.2f %sB)\n",dynamicbytes,formated,dynamicprefix);
+		ssend(*sock,"dynamically allocated memory used for strings: %lu bytes (%.2f %sB)\n",dynamicbytes,formated,dynamicprefix);
 	else
 		pack_uint64(*sock, dynamicbytes);
 	free(dynamicprefix);


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

The word «allocated» was repeated in the telnet response to >memory.
