### PR TITLE
Remove memory sub-structure

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -207,15 +207,6 @@ typedef struct {
 } overTimeDataStruct;
 
 typedef struct {
-	int domainnames;
-	int clientips;
-	int forwardedips;
-	int forwarddata;
-	int clientdata;
-	int querytypedata;
-} memoryStruct;
-
-typedef struct {
 	int count;
 	char **domains;
 } whitelistStruct;
@@ -248,8 +239,6 @@ extern bool debug;
 extern bool threadwritelock;
 extern bool threadreadlock;
 extern unsigned char blockingstatus;
-
-extern memoryStruct memory;
 
 extern char * username;
 extern char timestamp[16];

--- a/api.c
+++ b/api.c
@@ -773,43 +773,6 @@ void getRecentBlocked(char *client_message, int *sock)
 	}
 }
 
-void getMemoryUsage(int *sock)
-{
-	unsigned long int structbytes = sizeof(countersStruct) + sizeof(ConfigStruct) + counters.queries_MAX*sizeof(queriesDataStruct) + counters.forwarded_MAX*sizeof(forwardedDataStruct) + counters.clients_MAX*sizeof(clientsDataStruct) + counters.domains_MAX*sizeof(domainsDataStruct) + counters.overTime_MAX*sizeof(overTimeDataStruct);
-	char *structprefix = calloc(2, sizeof(char));
-	if(structprefix == NULL) return;
-	double formated = 0.0;
-	format_memory_size(structprefix, structbytes, &formated);
-
-	if(istelnet[*sock])
-		ssend(*sock,"memory allocated for internal data structure: %lu bytes (%.2f %sB)\n",structbytes,formated,structprefix);
-	else
-		pack_uint64(*sock, structbytes);
-	free(structprefix);
-
-	unsigned long int dynamicbytes = memory.domainnames + memory.clientips + memory.forwardedips + memory.forwarddata;
-	char *dynamicprefix = calloc(2, sizeof(char));
-	if(dynamicprefix == NULL) return;
-	format_memory_size(dynamicprefix, dynamicbytes, &formated);
-
-	if(istelnet[*sock])
-		ssend(*sock,"dynamically allocated memory used for strings: %lu bytes (%.2f %sB)\n",dynamicbytes,formated,dynamicprefix);
-	else
-		pack_uint64(*sock, dynamicbytes);
-	free(dynamicprefix);
-
-	unsigned long int totalbytes = structbytes + dynamicbytes;
-	char *totalprefix = calloc(2, sizeof(char));
-	if(totalprefix == NULL) return;
-	format_memory_size(totalprefix, totalbytes, &formated);
-
-	if(istelnet[*sock])
-		ssend(*sock,"Sum: %lu bytes (%.2f %sB)\n",totalbytes,formated,totalprefix);
-	else
-		pack_uint64(*sock, totalbytes);
-	free(totalprefix);
-}
-
 void getClientID(int *sock)
 {
 	if(istelnet[*sock])

--- a/api.h
+++ b/api.h
@@ -23,7 +23,6 @@ void getClientNames(int *sock);
 void getDomainDetails(char *client_message, int *sock);
 
 // FTL methods
-void getMemoryUsage(int *sock);
 void getClientID(int *sock);
 void getVersion(int *sock);
 void getDBstats(int *sock);

--- a/datastructure.c
+++ b/datastructure.c
@@ -68,7 +68,6 @@ int findOverTimeID(int overTimetimestamp)
 		// overTime[timeidx].querytypedata is static
 		overTime[timeidx].clientnum = 0;
 		overTime[timeidx].clientdata = NULL;
-		memory.querytypedata += (TYPE_MAX-1)*sizeof(int);
 		counters.overTime++;
 
 		// Update time stamp for next loop interation
@@ -114,7 +113,6 @@ int findForwardID(const char * forward, bool count)
 		forwarded[forwardID].count = 0;
 	// Save forward destination IP address
 	forwarded[forwardID].ip = strdup(forward);
-	memory.forwardedips += (strlen(forward) + 1) * sizeof(char);
 	forwarded[forwardID].failed = 0;
 	// Initialize forward hostname
 	// Due to the nature of us being the resolver,
@@ -163,7 +161,6 @@ int findDomainID(const char *domain)
 	domains[domainID].blockedcount = 0;
 	// Store domain name - no need to check for NULL here as it doesn't harm
 	domains[domainID].domain = strdup(domain);
-	memory.domainnames += (strlen(domain) + 1) * sizeof(char);
 	// RegEx needs to be evaluated for this new domain
 	domains[domainID].regexmatch = REGEX_UNKNOWN;
 	// Increase counter by one
@@ -208,7 +205,6 @@ int findClientID(const char *client)
 	clients[clientID].blockedcount = 0;
 	// Store client IP - no need to check for NULL here as it doesn't harm
 	clients[clientID].ip = strdup(client);
-	memory.clientips += (strlen(client) + 1) * sizeof(char);
 	// Initialize client hostname
 	// Due to the nature of us being the resolver,
 	// the actual resolving of the host name has

--- a/log.c
+++ b/log.c
@@ -116,17 +116,7 @@ void format_memory_size(char *prefix, unsigned long int bytes, double *formated)
 
 void logg_struct_resize(const char* str, int to, int step)
 {
-	unsigned long int structbytes = sizeof(countersStruct) + sizeof(ConfigStruct) + counters.queries_MAX*sizeof(queriesDataStruct) + counters.forwarded_MAX*sizeof(forwardedDataStruct) + counters.clients_MAX*sizeof(clientsDataStruct) + counters.domains_MAX*sizeof(domainsDataStruct) + counters.overTime_MAX*sizeof(overTimeDataStruct);
-	unsigned long int dynamicbytes = memory.domainnames + memory.clientips + memory.forwardedips + memory.forwarddata + memory.querytypedata;
-
-	unsigned long int bytes = structbytes + dynamicbytes;
-	char *prefix = calloc(2, sizeof(char));
-	if(prefix == NULL) return;
-	double formated = 0.0;
-	format_memory_size(prefix, bytes, &formated);
-
-	logg("Notice: Increasing %s struct size from %i to %i (%.2f %sB)", str, (to-step), to, formated, prefix);
-	free(prefix);
+	logg("Notice: Increasing %s struct size from %i to %i", str, (to-step), to);
 }
 
 void log_counter_info(void)

--- a/memory.c
+++ b/memory.c
@@ -34,7 +34,6 @@ logFileNamesStruct files = {
 // Fixed size structs
 countersStruct counters = { 0 };
 ConfigStruct config;
-memoryStruct memory;
 
 // Variable size array structs
 queriesDataStruct *queries;
@@ -177,7 +176,6 @@ void validate_access_oTcl(int timeidx, int clientID, int line, const char * func
 		for(i = overTime[timeidx].clientnum; i <= clientID; i++)
 		{
 			overTime[timeidx].clientdata[i] = 0;
-			memory.clientdata++;
 		}
 		// Update counter
 		overTime[timeidx].clientnum = clientID + 1;

--- a/request.c
+++ b/request.c
@@ -67,11 +67,6 @@ void process_request(char *client_message, int *sock)
 		processed = true;
 		getRecentBlocked(client_message, sock);
 	}
-	else if(command(client_message, ">memory"))
-	{
-		processed = true;
-		getMemoryUsage(sock);
-	}
 	else if(command(client_message, ">clientID"))
 	{
 		processed = true;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This PR removes the `memory` sub-structure. It has been there since the very early days of FTL and was only meant for debugging reasons. As we have never used it (and cannot account for the memory used by the DNS resolver), it should be removed as more and more features make it less and less 
accurate (read as: wrong).

This PR has no negative effects besides removal of the telnet endpoint `>memory` which is, however, also not exposed through the API so only a few (or no) users should be aware of it.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
