### PR TITLE
Skip empty regex.list lines

### DIFF
--- a/regex.c
+++ b/regex.c
@@ -239,7 +239,10 @@ void read_regex_from_file(void)
 		// empty lines in regex.list are probably not expected to have such an
 		// effect
 		if(strlen(buffer) < 1)
+		{
+			logg("Skipping empty regex filter in line %i", i);
 			continue;
+		}
 
 		// Compile this regex
 		regexconfigured[i] = init_regex(buffer, i);

--- a/regex.c
+++ b/regex.c
@@ -241,7 +241,7 @@ void read_regex_from_file(void)
 		if(strlen(buffer) < 1)
 		{
 			regexconfigured[i] = false;
-			logg("Skipping empty regex filter in line %i", i);
+			logg("Skipping empty regex filter on line %i", i+1);
 			skipped++;
 			continue;
 		}

--- a/regex.c
+++ b/regex.c
@@ -196,7 +196,7 @@ void read_regex_from_file(void)
 	FILE *fp;
 	char *buffer = NULL;
 	size_t size = 0;
-	int errors = 0;
+	int errors = 0, skipped = 0;
 
 	// Start timer for regex compilation analysis
 	timer_start(REGEX_TIMER);
@@ -240,7 +240,9 @@ void read_regex_from_file(void)
 		// effect
 		if(strlen(buffer) < 1)
 		{
+			regexconfigured[i] = false;
 			logg("Skipping empty regex filter in line %i", i);
+			skipped++;
 			continue;
 		}
 
@@ -262,5 +264,5 @@ void read_regex_from_file(void)
 	// Read whitelisted domains from file
 	read_whitelist_from_file();
 
-	logg("Compiled %i Regex filters and %i whitelisted domains in %.1f msec (%i errors)", num_regex, whitelist.count, timer_elapsed_msec(REGEX_TIMER), errors);
+	logg("Compiled %i Regex filters and %i whitelisted domains in %.1f msec (%i errors)", (num_regex-skipped), whitelist.count, timer_elapsed_msec(REGEX_TIMER), errors);
 }

--- a/regex.c
+++ b/regex.c
@@ -233,6 +233,14 @@ void read_regex_from_file(void)
 		if(buffer[strlen(buffer)-1] == '\n')
 			buffer[strlen(buffer)-1] = '\0';
 
+		// Skip this entry is empty; an empty regex filter "" would match
+		// anything anywhere and hence block all incoming queries (unless
+		// explicitly whitelisted). A user can still do this with ".*", however
+		// empty lines in regex.list are probably not expected to have such an
+		// effect
+		if(strlen(buffer) < 1)
+			continue;
+
 		// Compile this regex
 		regexconfigured[i] = init_regex(buffer, i);
 		if(!regexconfigured[i]) errors++;

--- a/regex.c
+++ b/regex.c
@@ -233,11 +233,11 @@ void read_regex_from_file(void)
 		if(buffer[strlen(buffer)-1] == '\n')
 			buffer[strlen(buffer)-1] = '\0';
 
-		// Skip this entry is empty; an empty regex filter "" would match
-		// anything anywhere and hence block all incoming queries (unless
-		// explicitly whitelisted). A user can still do this with ".*", however
+		// Skip this entry if empty: an empty regex filter would match
+		// anything anywhere and hence match (and block) all incoming domains.
+		// A user can still achieve this with a filter such as ".*", however
 		// empty lines in regex.list are probably not expected to have such an
-		// effect
+		// effect and would immediately lead to "blocking the entire Internet"
 		if(strlen(buffer) < 1)
 		{
 			regexconfigured[i] = false;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Empty regex filters (` `) match *anything anywhere*. Hence, they would match **all** incoming domains. Empty lines in regex.list are probably not expected to have such an effect and hence we should explicitly ignore empty lines.

A user can still decide to block everything using an explicit `.*`, however empty lines should probably not do this.

Because empty lines still ask for memory (these filters just aren't initialized), we log a warning, like:
```
[2018-06-30 13:57:29.260] Skipping empty regex filter in line 1
[2018-06-30 13:57:29.260] Skipping empty regex filter in line 7
[2018-06-30 13:57:29.261] Compiled 15 Regex filters and 6 whitelisted domains in 1.4 msec (0 errors)
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
