### PR TITLE
Fix incorrect log_regex_error() subroutine

### DIFF
--- a/regex.c
+++ b/regex.c
@@ -24,9 +24,8 @@ static void log_regex_error(char *where, int errcode, int index)
 	size_t length = regerror(errcode, &regex[index], NULL, 0);
 	char *buffer = calloc(length,sizeof(char));
 	(void) regerror (errcode, &regex[index], buffer, length);
-	logg("ERROR %s regex %i: %s (%i)", index, where, buffer, errcode);
+	logg("ERROR %s regex %i: %s (%i)", where, index+1, buffer, errcode);
 	free(buffer);
-	free_regex();
 }
 
 static bool init_regex(const char *regexin, int index)

--- a/regex.c
+++ b/regex.c
@@ -24,7 +24,7 @@ static void log_regex_error(char *where, int errcode, int index)
 	size_t length = regerror(errcode, &regex[index], NULL, 0);
 	char *buffer = calloc(length,sizeof(char));
 	(void) regerror (errcode, &regex[index], buffer, length);
-	logg("ERROR %s regex in line %i: %s (%i)", where, index+1, buffer, errcode);
+	logg("ERROR %s regex on line %i: %s (%i)", where, index+1, buffer, errcode);
 	free(buffer);
 }
 
@@ -282,11 +282,6 @@ void read_regex_from_file(void)
 
 		// Compile this regex
 		regexconfigured[i] = init_regex(buffer, i);
-		if(!regexconfigured[i])
-		{
-			logg("Error compiling regex on line %i", i+1);
-			errors++;
-		}
 	}
 
 	// Free allocated memory

--- a/regex.c
+++ b/regex.c
@@ -24,7 +24,7 @@ static void log_regex_error(char *where, int errcode, int index)
 	size_t length = regerror(errcode, &regex[index], NULL, 0);
 	char *buffer = calloc(length,sizeof(char));
 	(void) regerror (errcode, &regex[index], buffer, length);
-	logg("ERROR %s regex %i: %s (%i)", where, index+1, buffer, errcode);
+	logg("ERROR %s regex in line %i: %s (%i)", where, index+1, buffer, errcode);
 	free(buffer);
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

In `log_regex_error()`, the `logg()` routing was given the arguments in the wrong order. Further, we should not call `free_regex()` when a single regex compilation fails as this will `free` all regex filters (incl. the correct ones).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
