### PR TITLE
Run CI on version tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
 workflows:
   version: 2
   build:
+    filters:
+      tags:
+        only: /^v.*/
     jobs:
       - arm
       - armhf


### PR DESCRIPTION
This fixes the v4.0 version issue, where a build was not triggered by the v4.0 tag.

After this is merged, tag v4.0