### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,13 +61,26 @@ jobs:
 workflows:
   version: 2
   build:
-    filters:
-      tags:
-        only: /^v.*/
     jobs:
-      - arm
-      - armhf
-      - aarch64
-      - x86_64
+      - arm:
+          filters:
+            tags:
+              only: /^v.*/
+      - armhf:
+          filters:
+            tags:
+              only: /^v.*/
+      - aarch64:
+          filters:
+            tags:
+              only: /^v.*/
+      - x86_64:
+          filters:
+            tags:
+              only: /^v.*/
 #      - x86_64-musl
-      - x86_32
+      - x86_32:
+          filters:
+            tags:
+              only: /^v.*/
+


### PR DESCRIPTION
This fixes the v4.0 version issue, where a build was not triggered by the v4.0 tag.

After this is merged, tag v4.0