### PR TITLE
Show "regex.list" as source of regex blocked queries

### DIFF
--- a/dnsmasq/cache.c
+++ b/dnsmasq/cache.c
@@ -1534,6 +1534,10 @@ char *record_source(unsigned int index)
     return "config";
   else if (index == SRC_HOSTS)
     return HOSTSFILE;
+  /*----- Pi-hole modification -----*/
+  else if (index == SRC_REGEX)
+    return (char*)regexlistname;
+  /*--------------------------------*/
 
   for (ah = daemon->addn_hosts; ah; ah = ah->next)
     if (ah->index == index)

--- a/dnsmasq/dnsmasq.h
+++ b/dnsmasq/dnsmasq.h
@@ -464,7 +464,10 @@ struct crec {
 #define SRC_CONFIG    1
 #define SRC_HOSTS     2
 #define SRC_AH        3
-
+/*----- Pi-hole modification -----*/
+#define SRC_REGEX     4
+const char *regexlistname;
+/*--------------------------------*/
 
 /* struct sockaddr is not large enough to hold any address,
    and specifically not big enough to hold an IPv6 address.

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -946,7 +946,8 @@ static void block_single_domain(char *domain)
 
 	// Get IPv4/v6 addresses for blocking depending on user configures blocking mode
 	prepare_blocking_mode(&addr4, &addr6, &has_IPv4, &has_IPv6);
-	add_blocked_domain_cache(&addr4, &addr6, has_IPv4, has_IPv6, domain, NULL, 0, 0);
+	regexlistname = files.regexlist;
+	add_blocked_domain_cache(&addr4, &addr6, has_IPv4, has_IPv6, domain, NULL, 0, SRC_REGEX);
 
 	if(debug) logg("Added %s to cache", domain);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Show "regex.list" as source of regex blocked queries instead of `unknown`. Exemplary log lines are now:

```plain
Aug 12 21:31:30 dnsmasq[14331]: 1507 127.0.0.1/47018 query[A] twitter.com from 127.0.0.1
Aug 12 21:31:30 dnsmasq[14331]: 1507 127.0.0.1/47018 /etc/pihole/regex.list twitter.com is 0.0.0.0
```


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
