### PR TITLE
Determine blocking status enabled/disabled by reading setupVars.conf

### DIFF
--- a/grep.c
+++ b/grep.c
@@ -132,7 +132,7 @@ void check_blocking_status(void)
 		// Parameter either not present in setupVars.conf
 		// or explicitly set to true
 		blockingstatus = BLOCKING_ENABLED;
-		message = "enable";
+		message = "enabled";
 		clearSetupVarsArray();
 	}
 	else

--- a/grep.c
+++ b/grep.c
@@ -124,26 +124,22 @@ int countlineswith(const char* str, const char* fname)
 
 void check_blocking_status(void)
 {
-	int disabled = countlineswith("#addn-hosts=/etc/pihole/gravity.list", files.dnsmasqconfig);
-	char *message = "";
+	char* blocking = read_setupVarsconf("BLOCKING");
+	char* message;
 
-	if(disabled < 0)
+	if(blocking == NULL || getSetupVarsBool(blocking))
 	{
-		// Failed to open file -> unknown status
-		blockingstatus = BLOCKING_UNKNOWN;
-		message = "unknown";
+		// Parameter either not present in setupVars.conf
+		// or explicitly set to true
+		blockingstatus = BLOCKING_ENABLED;
+		message = "enable";
+		clearSetupVarsArray();
 	}
-	else if(disabled > 0)
+	else
 	{
 		// Disabled
 		blockingstatus = BLOCKING_DISABLED;
 		message = "disabled";
-	}
-	else
-	{
-		// Enabled
-		blockingstatus = BLOCKING_ENABLED;
-		message = "enabled";
 	}
 
 	if(debug) logg("Blocking status is %s", message);

--- a/grep.c
+++ b/grep.c
@@ -124,7 +124,7 @@ int countlineswith(const char* str, const char* fname)
 
 void check_blocking_status(void)
 {
-	char* blocking = read_setupVarsconf("BLOCKING");
+	char* blocking = read_setupVarsconf("BLOCKING_ENABLED");
 	char* message;
 
 	if(blocking == NULL || getSetupVarsBool(blocking))


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Let `FTL` determine the blocking status using the new variable `BLOCKING` introduced in https://github.com/pi-hole/pi-hole/pull/2356

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
