### PR TITLE
Detect externally blocked based on returned IP address (e.g., for OpenDNS)

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -17,6 +17,7 @@ void print_flags(unsigned int flags);
 void save_reply_type(unsigned int flags, int queryID, struct timeval response);
 unsigned long converttimeval(struct timeval time);
 static void block_single_domain(char *domain);
+static void query_externally_blocked(int i);
 
 char flagnames[28][12] = {"F_IMMORTAL ", "F_NAMEP ", "F_REVERSE ", "F_FORWARD ", "F_DHCP ", "F_NEG ", "F_HOSTS ", "F_IPV4 ", "F_IPV6 ", "F_BIGNAME ", "F_NXDOMAIN ", "F_CNAME ", "F_DNSKEY ", "F_CONFIG ", "F_DS ", "F_DNSSECOK ", "F_UPSTREAM ", "F_RRNAME ", "F_SERVER ", "F_QUERY ", "F_NOERR ", "F_AUTH ", "F_DNSSEC ", "F_KEYTAG ", "F_SECSTAT ", "F_NO_RR ", "F_IPSET ", "F_NOEXTRA "};
 
@@ -470,23 +471,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 
 			// If received NXDOMAIN and AD bit is set, Quad9 may have blocked this query
 			if(flags & F_NXDOMAIN && queries[i].AD)
-			{
-				// Correct counters as we won't count this as forwarded ...
-				counters.forwarded--;
-				overTime[queries[i].timeidx].forwarded--;
-				validate_access("forwarded", queries[i].forwardID, true, __LINE__, __FUNCTION__, __FILE__);
-				forwarded[queries[i].forwardID].count--;
-
-				// ... but as blocked
-				counters.blocked++;
-				overTime[queries[i].timeidx].blocked++;
-				validate_access("domains", queries[i].domainID, true, __LINE__, __FUNCTION__, __FILE__);
-				domains[queries[i].domainID].blockedcount++;
-				validate_access("clients", queries[i].clientID, true, __LINE__, __FUNCTION__, __FILE__);
-				clients[queries[i].clientID].blockedcount++;
-
-				queries[i].status = QUERY_EXTERNAL_BLOCKED;
-			}
+				query_externally_blocked(i);
 		}
 	}
 	else if(flags & F_REVERSE)
@@ -501,6 +486,25 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 	}
 
 	disable_thread_lock();
+}
+
+static void query_externally_blocked(int i)
+{
+	// Correct counters as we won't count this as forwarded ...
+	counters.forwarded--;
+	overTime[queries[i].timeidx].forwarded--;
+	validate_access("forwarded", queries[i].forwardID, true, __LINE__, __FUNCTION__, __FILE__);
+	forwarded[queries[i].forwardID].count--;
+
+	// ... but as blocked
+	counters.blocked++;
+	overTime[queries[i].timeidx].blocked++;
+	validate_access("domains", queries[i].domainID, true, __LINE__, __FUNCTION__, __FILE__);
+	domains[queries[i].domainID].blockedcount++;
+	validate_access("clients", queries[i].clientID, true, __LINE__, __FUNCTION__, __FILE__);
+	clients[queries[i].clientID].blockedcount++;
+
+	queries[i].status = QUERY_EXTERNAL_BLOCKED;
 }
 
 void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg, int id)

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -479,26 +479,26 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 			// (Cisco Umbrella) blocked this query
 			// See https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses-
 			// for a full list of these IP addresses
-			else if(flags & F_IPV4 &&
+			else if(flags & F_IPV4 && answer != NULL &&
 				(strcmp("146.112.61.104", answer) == 0 ||
 				 strcmp("146.112.61.105", answer) == 0 ||
 				 strcmp("146.112.61.106", answer) == 0 ||
 				 strcmp("146.112.61.107", answer) == 0 ||
 				 strcmp("146.112.61.108", answer) == 0 ||
 				 strcmp("146.112.61.109", answer) == 0 ||
-				 strcmp("146.112.61.110", answer) == 0))
+				 strcmp("146.112.61.110", answer) == 0 ))
 			{
 					query_externally_blocked(i);
 			}
 
-			else if(flags & F_IPV6 &&
+			else if(flags & F_IPV6 && answer != NULL &&
 				(strcmp("::ffff:146.112.61.104", answer) == 0 ||
 				 strcmp("::ffff:146.112.61.105", answer) == 0 ||
 				 strcmp("::ffff:146.112.61.106", answer) == 0 ||
 				 strcmp("::ffff:146.112.61.107", answer) == 0 ||
 				 strcmp("::ffff:146.112.61.108", answer) == 0 ||
 				 strcmp("::ffff:146.112.61.109", answer) == 0 ||
-				 strcmp("::ffff:146.112.61.110", answer) == 0))
+				 strcmp("::ffff:146.112.61.110", answer) == 0 ))
 			{
 					query_externally_blocked(i);
 			}

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -471,7 +471,37 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 
 			// If received NXDOMAIN and AD bit is set, Quad9 may have blocked this query
 			if(flags & F_NXDOMAIN && queries[i].AD)
+			{
 				query_externally_blocked(i);
+			}
+
+			// If received one of the following IPs as reply, OpenDNS
+			// (Cisco Umbrella) blocked this query
+			// See https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses-
+			// for a full list of these IP addresses
+			else if(flags & F_IPV4 &&
+				(strcmp("146.112.61.104", answer) == 0 ||
+				 strcmp("146.112.61.105", answer) == 0 ||
+				 strcmp("146.112.61.106", answer) == 0 ||
+				 strcmp("146.112.61.107", answer) == 0 ||
+				 strcmp("146.112.61.108", answer) == 0 ||
+				 strcmp("146.112.61.109", answer) == 0 ||
+				 strcmp("146.112.61.110", answer) == 0))
+			{
+					query_externally_blocked(i);
+			}
+
+			else if(flags & F_IPV6 &&
+				(strcmp("::ffff:146.112.61.104", answer) == 0 ||
+				 strcmp("::ffff:146.112.61.105", answer) == 0 ||
+				 strcmp("::ffff:146.112.61.106", answer) == 0 ||
+				 strcmp("::ffff:146.112.61.107", answer) == 0 ||
+				 strcmp("::ffff:146.112.61.108", answer) == 0 ||
+				 strcmp("::ffff:146.112.61.109", answer) == 0 ||
+				 strcmp("::ffff:146.112.61.110", answer) == 0))
+			{
+					query_externally_blocked(i);
+			}
 		}
 	}
 	else if(flags & F_REVERSE)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

With #353, we introduced a new blocking type that is shown in the Query Log (`Blocked (external)`). This PR introduced this for Quad9 (blocking signaled by returning NXDOMAIN with set AD bit). This PR adds support for a different type of blocking that is used by OpenDNS. OpenDNS uses Cisco Umbrella which is a cloud security platform that blocks certain domains. Blocking is signaled by returning one of the IP addresses listed [here](https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses-) serving a block page:
![screenshot at 2018-08-17 18-52-04](https://user-images.githubusercontent.com/16748619/44278867-a8a06480-a24f-11e8-9aa8-c532cf78925e.png)

We detect if the upstream server returned one of these IP addresses and mark a query as `Blocked (external)` in this case:
![screenshot at 2018-08-17 18-55-44](https://user-images.githubusercontent.com/16748619/44278877-af2edc00-a24f-11e8-8342-4e137dfb29ed.png)

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
