### PR TITLE
Add DBIMPORT config boolean

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -151,6 +151,7 @@ typedef struct {
 	unsigned char blockingmode;
 	bool regex_debugmode;
 	bool analyze_only_A_AAAA;
+	bool DBimport;
 } ConfigStruct;
 
 // Dynamic structs

--- a/config.c
+++ b/config.c
@@ -233,6 +233,17 @@ void read_FTLconf(void)
 	else
 		logg("   ANALYZE_ONLY_A_AND_AAAA: Disabled. Analyzing all queries");
 
+	// DBIMPORT
+	// defaults to: Yes
+	config.DBimport = true;
+	buffer = parse_FTLconf(fp, "DBIMPORT");
+	if(buffer != NULL && strcasecmp(buffer, "no") == 0)
+		config.DBimport = false;
+	if(config.DBimport)
+		logg("   DBIMPORT: Importing history from database");
+	else
+		logg("   DBIMPORT: Not importing history from database");
+
 	logg("Finished config file parsing");
 
 	// Release memory

--- a/main.c
+++ b/main.c
@@ -56,7 +56,7 @@ int main (int argc, char* argv[])
 		db_init();
 
 	// Try to import queries from long-term database if available
-	if(database)
+	if(database && config.DBimport)
 		read_data_from_DB();
 
 	log_counter_info();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Add `DBIMPORT` config boolean that allows skipping the initial import of historic information from the database.
This may come in handy on very large networks where the startup of FTL is large delayed when it imports millions of queries.
It provides an alternative fix for problems like https://github.com/pi-hole/pi-hole/issues/2374, retaining the possibility to use the long-term database for subsequent queries.