### PR TITLE
Tweaks for ">getallqueries"

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -151,6 +151,7 @@ typedef struct {
 	unsigned char blockingmode;
 	bool regex_debugmode;
 	bool analyze_only_A_AAAA;
+	bool DBimport;
 } ConfigStruct;
 
 // Dynamic structs

--- a/api.c
+++ b/api.c
@@ -643,6 +643,7 @@ void getAllQueries(char *client_message, int *sock)
 		{
 			// Iterate through all known forward destinations
 			int i;
+			validate_access("forwards", counters.forwarded, true, __LINE__, __FUNCTION__, __FILE__);
 			forwarddestid = -3;
 			for(i = 0; i < counters.forwarded; i++)
 			{
@@ -675,6 +676,7 @@ void getAllQueries(char *client_message, int *sock)
 		filterdomainname = true;
 		// Iterate through all known domains
 		int i;
+		validate_access("domains", counters.domains, true, __LINE__, __FUNCTION__, __FILE__);
 		for(i = 0; i < counters.domains; i++)
 		{
 			// Try to match the requested string
@@ -700,7 +702,9 @@ void getAllQueries(char *client_message, int *sock)
 		if(clientname == NULL) return;
 		sscanf(client_message, ">getallqueries-client %255s", clientname);
 		filterclientname = true;
+		// Iterate through all known clients
 		int i;
+		validate_access("clients", counters.clients, true, __LINE__, __FUNCTION__, __FILE__);
 		for(i = 0; i < counters.clients; i++)
 		{
 			// Try to match the requested string

--- a/api.c
+++ b/api.c
@@ -781,11 +781,11 @@ void getAllQueries(char *client_message, int *sock)
 
 		// Skip if domain is not identical with what the user wants to see
 		if(filterdomainname && queries[i].domainID != domainid)
-				continue;
+			continue;
 
 		// Skip if client name and IP are not identical with what the user wants to see
 		if(filterclientname && queries[i].clientID != clientid)
-				continue;
+			continue;
 
 		// Skip if query type is not identical with what the user wants to see
 		if(querytype != 0 && querytype != queries[i].type)

--- a/api.c
+++ b/api.c
@@ -643,7 +643,7 @@ void getAllQueries(char *client_message, int *sock)
 		{
 			// Iterate through all known forward destinations
 			int i;
-			validate_access("forwards", counters.forwarded, true, __LINE__, __FUNCTION__, __FILE__);
+			validate_access("forwards", MAX(0,counters.forwarded-1), true, __LINE__, __FUNCTION__, __FILE__);
 			forwarddestid = -3;
 			for(i = 0; i < counters.forwarded; i++)
 			{
@@ -676,7 +676,7 @@ void getAllQueries(char *client_message, int *sock)
 		filterdomainname = true;
 		// Iterate through all known domains
 		int i;
-		validate_access("domains", counters.domains, true, __LINE__, __FUNCTION__, __FILE__);
+		validate_access("domains", MAX(0,counters.domains-1), true, __LINE__, __FUNCTION__, __FILE__);
 		for(i = 0; i < counters.domains; i++)
 		{
 			// Try to match the requested string
@@ -704,7 +704,7 @@ void getAllQueries(char *client_message, int *sock)
 		filterclientname = true;
 		// Iterate through all known clients
 		int i;
-		validate_access("clients", counters.clients, true, __LINE__, __FUNCTION__, __FILE__);
+		validate_access("clients", MAX(0,counters.clients-1), true, __LINE__, __FUNCTION__, __FILE__);
 		for(i = 0; i < counters.clients; i++)
 		{
 			// Try to match the requested string
@@ -784,7 +784,7 @@ void getAllQueries(char *client_message, int *sock)
 				continue;
 
 		// Skip if client name and IP are not identical with what the user wants to see
-		if(filterclientname && queries[i].domainID != domainid)
+		if(filterclientname && queries[i].clientID != clientid)
 				continue;
 
 		// Skip if query type is not identical with what the user wants to see

--- a/api.c
+++ b/api.c
@@ -599,6 +599,7 @@ void getAllQueries(char *client_message, int *sock)
 
 	char *domainname = NULL;
 	bool filterdomainname = false;
+	int domainid = -1;
 
 	char *clientname = NULL;
 	bool filterclientname = false;
@@ -671,6 +672,24 @@ void getAllQueries(char *client_message, int *sock)
 		if(domainname == NULL) return;
 		sscanf(client_message, ">getallqueries-domain %255s", domainname);
 		filterdomainname = true;
+		// Iterate through all known domains
+		int i;
+		for(i = 0; i < counters.domains; i++)
+		{
+			// Try to match the requested string
+			if(strcmp(domains[i].domain, domainname) == 0)
+			{
+				domainid = i;
+				break;
+			}
+		}
+		if(domainid < 0)
+		{
+			// Requested domain has not been found, we directly
+			// exit here as there is no data to be returned
+			free(domainname);
+			return;
+		}
 	}
 
 	// Client filtering?
@@ -738,8 +757,8 @@ void getAllQueries(char *client_message, int *sock)
 
 		if(filterdomainname)
 		{
-			// Skip if domain name is not identical with what the user wants to see
-			if(strcmp(domains[queries[i].domainID].domain, domainname) != 0)
+			// Skip if domain is not identical with what the user wants to see
+			if(domainid >= 0 && queries[i].domainID != domainid)
 				continue;
 		}
 

--- a/config.c
+++ b/config.c
@@ -233,6 +233,17 @@ void read_FTLconf(void)
 	else
 		logg("   ANALYZE_ONLY_A_AND_AAAA: Disabled. Analyzing all queries");
 
+	// DBIMPORT
+	// defaults to: Yes
+	config.DBimport = true;
+	buffer = parse_FTLconf(fp, "DBIMPORT");
+	if(buffer != NULL && strcasecmp(buffer, "no") == 0)
+		config.DBimport = false;
+	if(config.DBimport)
+		logg("   DBIMPORT: Importing history from database");
+	else
+		logg("   DBIMPORT: Not importing history from database");
+
 	logg("Finished config file parsing");
 
 	// Release memory

--- a/main.c
+++ b/main.c
@@ -56,7 +56,7 @@ int main (int argc, char* argv[])
 		db_init();
 
 	// Try to import queries from long-term database if available
-	if(database)
+	if(database && config.DBimport)
 		read_data_from_DB();
 
 	log_counter_info();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR speeds-up the specialized `>getallqueries` subquery types as we outsource the client / domain detection.

Previously, we compared the domain name / client host name / client IP address in each query to the requested address. Instead, we do now determine the ID of the requested domain / client in front of the large loop. The comparison in the expensive loop itself reduces to an integer comparison, speeding up the code.

There is no functional change involved with this PR.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
