### PR TITLE
Log externally blocked domains to file

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -152,6 +152,7 @@ typedef struct {
 	bool regex_debugmode;
 	bool analyze_only_A_AAAA;
 	bool DBimport;
+	char *externalblockfile;
 } ConfigStruct;
 
 // Dynamic structs

--- a/config.c
+++ b/config.c
@@ -244,6 +244,46 @@ void read_FTLconf(void)
 	else
 		logg("   DBIMPORT: Not importing history from database");
 
+	// EXTERNALBLOCKFILE
+	// defaults to: (not set)
+	config.externalblockfile = NULL;
+	buffer = parse_FTLconf(fp, "EXTERNALBLOCKFILE");
+
+	errno = 0;
+	// Use sscanf() to obtain filename from config file parameter only if buffer != NULL
+	if(buffer != NULL)
+	{
+		// Read and allocate memory for file path
+		sscanf(buffer, "%127ms", &config.externalblockfile);
+	}
+
+	// Test if memory allocation was successful
+	if(config.externalblockfile == NULL && errno != 0)
+	{
+		logg("FATAL: Allocating memory for config.externalblockfile failed (%s, %i). Exiting.", strerror(errno), errno);
+		exit(EXIT_FAILURE);
+	}
+	// Test to open file
+	if(config.externalblockfile != NULL)
+	{
+		FILE *file = fopen(config.externalblockfile, "a");
+		if(file == NULL)
+		{
+			logg("WARN: Opening %s failed (%s, %i), not using file", config.externalblockfile, strerror(errno), errno);
+			free(config.externalblockfile);
+			config.externalblockfile = NULL;
+		}
+		else
+		{
+			fclose(file);
+		}
+	}
+
+	if(config.externalblockfile != NULL && strlen(config.externalblockfile) > 0)
+		logg("   EXTERNALBLOCKFILE: Using %s", config.externalblockfile);
+	else
+		logg("   EXTERNALBLOCKFILE: Not using file for storing externally blocked domains");
+
 	logg("Finished config file parsing");
 
 	// Release memory

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -280,7 +280,7 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	// Proceed only if
 	// - current query has not been marked as replied to so far
 	//   (it could be that answers from multiple forward
-	//    destionations are coimg in for the same query)
+	//    destinations are coming in for the same query)
 	// - the query was formally known as cached but had to be forwarded
 	//   (this is a special case further described below)
 	if(queries[i].complete && queries[i].status != QUERY_CACHE)
@@ -549,6 +549,34 @@ static void query_externally_blocked(int i)
 	clients[queries[i].clientID].blockedcount++;
 
 	queries[i].status = QUERY_EXTERNAL_BLOCKED;
+
+	// Store externally blocked domain in local file (if configured)
+	if(config.externalblockfile != NULL)
+	{
+		// Search for an exact match in this file
+		int res = countlineswith(domains[queries[i].domainID].domain, config.externalblockfile);
+
+		if(res < 0)
+		{
+			logg("WARN: Opening %s failed", config.externalblockfile, strerror(errno));
+			return;
+		}
+		else if(res > 0)
+		{
+			// Domain already present, nothing to do here
+			return;
+		}
+
+		// else: Not present, append domain to file
+		FILE *file = fopen(config.externalblockfile, "a");
+		if(file == NULL)
+		{
+			logg("WARN: Appending to %s failed", config.externalblockfile, strerror(errno));
+			return;
+		}
+		fprintf(file, "%s\n", domains[queries[i].domainID].domain);
+		fclose(file);
+	}
 }
 
 void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg, int id)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Add possibility to have externally blocked domains being written to a user specifiable file. This allows subsequent investigations which domains were blocked by upstream providers.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
