### PR TITLE
Ensure proper file ownerships if pihole-FTL is started as root

### DIFF
--- a/dnsmasq/dnsmasq.c
+++ b/dnsmasq/dnsmasq.c
@@ -570,7 +570,7 @@ int main_dnsmasq (int argc, char **argv)
 	}
     }
 
-    FTL_fork_and_bind_sockets();
+    FTL_fork_and_bind_sockets(ent_pw);
 
    log_err = log_start(ent_pw, err_pipe[1]);
 

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -925,12 +925,9 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 	if(ent_pw != NULL && getuid() == 0)
 	{
 		if(chown(FTLfiles.log, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			logg("Setting ownership (%i:%i) of %s failed: %s (%i)", ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.log, errno, strerror(errno));
-		if(database)
-		{
-			if(chown(FTLfiles.db, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-				logg("Setting ownership (%i:%i) of %s failed: %s (%i)", ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.db, errno, strerror(errno));
-		}
+			logg("Setting ownership (%i:%i) of %s failed: %s (%i)", ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.log, strerror(errno), errno);
+		if(database && chown(FTLfiles.db, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
+			logg("Setting ownership (%i:%i) of %s failed: %s (%i)", ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.db, strerror(errno), errno);
 	}
 }
 

--- a/dnsmasq_interface.h
+++ b/dnsmasq_interface.h
@@ -16,7 +16,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id);
 void FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char * arg, int id);
 void FTL_dnssec(int status, int id);
 void FTL_dnsmasq_reload(void);
-void FTL_fork_and_bind_sockets(void);
+void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
 
 void FTL_header_ADbit(unsigned char header4, int id);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

When started as `root`, e.g., because capabilities are not available on the current system, we drop from `root` to some unprivileged user as soon as we did everything we needed to do as `root` (open privileged ports, etc.).

Unfortunately, the log and database files were still owned by `root` in this case and hence no further logging was possible, neither to the database nor to the `pihole-FTL.log` file.

This PR fixes a bug discussed on [Discourse](https://discourse.pi-hole.net/t/ftldns-upgrade-failed-solved/12022/47).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
