### PR TITLE
Fix usage of wrong variable in query_externally_blocked()

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -351,7 +351,7 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 
 void FTL_dnsmasq_reload(void)
 {
-	// This funtion is called by the dnsmasq code on receive of SIGHUP
+	// This function is called by the dnsmasq code on receive of SIGHUP
 	// *before* clearing the cache and rereading the lists
 	// This is the only hook that is not skipped in PRIVACY_NOSTATS mode
 
@@ -365,9 +365,9 @@ void FTL_dnsmasq_reload(void)
 
 	// Reread pihole-FTL.conf to see which blocking mode the user wants to use
 	// It is possible to change the blocking mode here as we anyhow clear the
-	// cahce and reread all blocking lists
+	// cache and reread all blocking lists
 	// Passing NULL to this function means it has to open the config file on
-	// its own behalf (on initial reading, the confg file is already opened)
+	// its own behalf (on initial reading, the config file is already opened)
 	get_blocking_mode(NULL);
 
 	// Reread regex.list
@@ -535,7 +535,7 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 static void query_externally_blocked(int i)
 {
 	// Correct counters as we won't count this as forwarded ...
-	counters.forwarded--;
+	counters.forwardedqueries--;
 	overTime[queries[i].timeidx].forwarded--;
 	validate_access("forwarded", queries[i].forwardID, true, __LINE__, __FUNCTION__, __FILE__);
 	forwarded[queries[i].forwardID].count--;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix usage of wrong variable in `query_externally_blocked()`. This bug is only present in the `development` version of FTL.
Due to this error, *FTL*DNS may get instable when seeing externally (OpenDNS, Quad9) blocked queries.

The previously used counter (`counters.forwarded`) count the number of known forward destinations and should not have been changed here. The correct counter for the number of forwarded queries is `counters.forwardedqueries`.

This PR also fixes some random typos in comments, I've seen.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
