### PR TITLE
Apply patch: Fix crash parsing a --synth-domain with no prefix.

### DIFF
--- a/dnsmasq/option.c
+++ b/dnsmasq/option.c
@@ -2212,7 +2212,9 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		      char *star;
 		      new->next = daemon->synth_domains;
 		      daemon->synth_domains = new;
-		      if ((star = strrchr(new->prefix, '*')) && *(star+1) == 0)
+		      if (new->prefix &&
+			  (star = strrchr(new->prefix, '*'))
+			  && *(star+1) == 0)
 			{
 			  *star = 0;
 			  new->indexed = 1;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Apply a [patch](http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=dd33e98da09c487a58b6cb6693b8628c0b234a3b) streamlined for `dnsmasq v2.80`.

This problem was introduced in [2.79](http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=6b2b564ac34cb3c862f168e6b1457f9f0b9ca69c). This fixes #367.

This patch would also be part of `dnsmasq v2.80`, however, it is unclear if 2.80 will be stable before we release Pi-hole v4.1. It won't be an issue to upgrade the internal `dnsmasq` code to `2.80` later as we do the update by applying a series of patches where this patch will then simply be skipped with "nothing to do".

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
