### PR TITLE
Add guarding {} around if statement

### DIFF
--- a/dnsmasq/rfc1035.c
+++ b/dnsmasq/rfc1035.c
@@ -1482,8 +1482,10 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			      if (crecp->flags & F_NXDOMAIN)
 				nxdomain = 1;
 			      if (!dryrun)
+			      {
 				log_query(crecp->flags & ~F_FORWARD, name, &addr, NULL);
 				FTL_cache(crecp->flags & ~F_FORWARD, name, &addr, NULL, daemon->log_display_id);
+			      }
 			    }
 			  else
 			    {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Fixes compilation warning
```
dnsmasq/rfc1035.c: In function ‘answer_request’:
dnsmasq/rfc1035.c:1484:10: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
          if (!dryrun)
          ^~
dnsmasq/rfc1035.c:1486:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
     FTL_cache(crecp->flags & ~F_FORWARD, name, &addr, NULL, daemon->log_display_id);
     ^~~~~~~~~
```
Fortunately, this error
- is only in `development` not in `master`
- should never had a real effect as `dryrun` is (almost always) `false`


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
