### PR TITLE
Fix for externally blocked detection

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -505,6 +505,21 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 			{
 					query_externally_blocked(i);
 			}
+
+			// If upstream replied with 0.0.0.0 or ::,
+			// we assume that it filtered the reply as
+			// nothing is reachable under these addresses
+			else if(flags & F_IPV4 && answer != NULL &&
+				strcmp("0.0.0.0", answer) == 0)
+			{
+					query_externally_blocked(i);
+			}
+
+			else if(flags & F_IPV6 && answer != NULL &&
+				strcmp("::", answer) == 0)
+			{
+					query_externally_blocked(i);
+			}
 		}
 	}
 	else if(flags & F_REVERSE)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This PR implements two new things:
- Also compare the IPs of queries replied to from cache against the known upstream blacklist IPs. We previously missed these ans displayed them in green as `OK (cached)` as they are - at first sight - perfectly valid IP addresses in our cache.
- Detect upstream returned NULL address as externally blocked query ([Discourse Feature Request](https://discourse.pi-hole.net/t/seeing-upstream-null-results-non-changeable/12539))

Test of the two point above:
```
$ dig c.cx +short
0.0.0.0
$ dig c.cx +short
0.0.0.0
```

The first query is forwarded to my local `unbound` (1.8ms) whereas the second is replied to from `pi-hole-FTL`'s cache (1.1ms):
![screenshot at 2018-09-02 10-17-44](https://user-images.githubusercontent.com/16748619/44953978-ddd9c300-ae9b-11e8-921f-eb8370ff4c3c.png)



_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
