### PR TITLE
Don't forget to reset "new" flag on client struct when name is resolved

### DIFF
--- a/resolve.c
+++ b/resolve.c
@@ -89,6 +89,7 @@ void reresolveHostnames(void)
 
 			// Store client hostname
 			clients[clientID].name = strdup(hostname);
+			clients[clientID].new = false;
 		}
 		free(hostname);
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The "new" flag on the client struct seems to indicate if the name has not been resolved. It is true when the client is created, and then set to false when the name is resolved. There was one place where the name was resolved and the flag was not updated though, which this fixes.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
