### PR TITLE
Don't count locally blocked queries as externally blocked

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -499,6 +499,13 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 
 static void detect_blocked_IP(unsigned short flags, char* answer, int queryID)
 {
+	// Skip replies which originated locally. Otherwise, we would count
+	// gravity.list blocked queries as externally blocked.
+	if(flags & F_HOSTS)
+	{
+		return;
+	}
+
 	// If received one of the following IPs as reply, OpenDNS
 	// (Cisco Umbrella) blocked this query
 	// See https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses-


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Previously the externally blocked query check only considered the answer IP address, so it marked queries blocked by gravity.list and regex.list as externally blocked. Now it will skip locally resolved queries (with the `F_HOSTS` flag).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
