### PR TITLE
Properly exit FTL on receipt of SIGTERM

### DIFF
--- a/dnsmasq/dnsmasq.c
+++ b/dnsmasq/dnsmasq.c
@@ -24,6 +24,7 @@ struct daemon *daemon;
 
 static volatile pid_t pid = 0;
 static volatile int pipewrite;
+static char terminate = 0;
 
 static int set_dns_listeners(time_t now);
 static void check_dns_listeners(time_t now);
@@ -906,7 +907,7 @@ int main_dnsmasq (int argc, char **argv)
   poll_resolv(1, 0, now);
 #endif
 
-  while (1)
+  while (!terminate)
     {
       int t, timeout = -1;
 
@@ -1091,6 +1092,7 @@ int main_dnsmasq (int argc, char **argv)
 #endif
 
     }
+    return 0;
 }
 
 static void sig_handler(int sig)
@@ -1427,7 +1429,8 @@ static void async_event(int pipe, time_t now)
 
 	my_syslog(LOG_INFO, _("exiting on receipt of SIGTERM"));
 	flush_log();
-	exit(EC_GOOD);
+//	exit(EC_GOOD);
+	terminate = 1;
       }
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Properly exit `pihole-FTL` on receipt of SIGTERM (save remaining queries to database, etc.). This was prevented by dnsmasq itself calling `exit()` itself instead of just returning from its main loop.

Output after having received `SIGTERM` (`debug` mode):
```
[2018-09-08 20:39:34.825] Shutting down...
[Thread 0x75d4e460 (LWP 6178) exited]
[Thread 0x7654e460 (LWP 6177) exited]
[Thread 0x76d4e460 (LWP 6176) exited]
[2018-09-08 20:39:34.879] Notice: Queries stored in DB: 0 (took 48.5 ms)
[2018-09-08 20:39:34.879] Finished final database update
[2018-09-08 20:39:34.880] ########## FTL terminated after 1536432013312.0 ms! ##########
[Thread 0x7554e460 (LWP 6179) exited]
[Thread 0x76e37000 (LWP 6173) exited]
[Inferior 1 (process 6173) exited with code 01]
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
