### PR TITLE
Fix exit message showing invalid program run time

### DIFF
--- a/main.c
+++ b/main.c
@@ -32,6 +32,7 @@ int main (int argc, char* argv[])
 
 	// Try to open FTL log
 	open_FTL_log(true);
+	timer_start(EXIT_TIMER);
 	logg("########## FTL started! ##########");
 	log_FTL_version();
 	init_thread_lock();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The exit timer was not started, so now it is started when FTL logs that it has started.

Bug symptom:
```
########## FTL terminated after 1536432013312.0 ms! ##########
```

Fixed output:
```
########## FTL terminated after 23132.3 ms! ##########
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
