### PR TITLE
Use negative query IDs for queries loaded from the database

### DIFF
--- a/database.c
+++ b/database.c
@@ -617,12 +617,6 @@ void read_data_from_DB(void)
 	// Loop through returned database rows
 	while((rc = sqlite3_step(stmt)) == SQLITE_ROW)
 	{
-		// Ensure we have enough space in the queries struct
-		memory_check(QUERIES);
-
-		// Set ID for this query
-		int queryID = counters->queries;
-
 		int queryTimeStamp = sqlite3_column_int(stmt, 1);
 		// 1483228800 = 01/01/2017 @ 12:00am (UTC)
 		if(queryTimeStamp < 1483228800)
@@ -699,21 +693,31 @@ void read_data_from_DB(void)
 		int timeidx = findOverTimeID(overTimeTimeStamp);
 		validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 
+		// Ensure we have enough space in the queries struct
+		memory_check(QUERIES);
+
+		// Set index for this query
+		int queryIndex = counters->queries;
+
+		// Set the ID for this query. Queries loaded from the database use negative IDs.
+		// 1 is added to the counter before flipping the sign so the IDs start at -1 instead of 0.
+		int queryID = -1 * (counters->queries + 1);
+
 		// Store this query in memory
-		validate_access("queries", queryID, false, __LINE__, __FUNCTION__, __FILE__);
-		queries[queryID].magic = MAGICBYTE;
-		queries[queryID].timestamp = queryTimeStamp;
-		queries[queryID].type = type;
-		queries[queryID].status = status;
-		queries[queryID].domainID = domainID;
-		queries[queryID].clientID = clientID;
-		queries[queryID].forwardID = forwardID;
-		queries[queryID].timeidx = timeidx;
-		queries[queryID].db = true; // Mark this as already present in the database
-		queries[queryID].id = 0; // This is dnsmasq's internal ID. We don't store it in the database
-		queries[queryID].complete = true; // Mark as all information is avaiable
-		queries[queryID].response = 0;
-		queries[queryID].AD = false;
+		validate_access("queries", queryIndex, false, __LINE__, __FUNCTION__, __FILE__);
+		queries[queryIndex].magic = MAGICBYTE;
+		queries[queryIndex].timestamp = queryTimeStamp;
+		queries[queryIndex].type = type;
+		queries[queryIndex].status = status;
+		queries[queryIndex].domainID = domainID;
+		queries[queryIndex].clientID = clientID;
+		queries[queryIndex].forwardID = forwardID;
+		queries[queryIndex].timeidx = timeidx;
+		queries[queryIndex].db = true; // Mark this as already present in the database
+		queries[queryIndex].id = queryID;
+		queries[queryIndex].complete = true; // Mark as all information is avaiable
+		queries[queryIndex].response = 0;
+		queries[queryIndex].AD = false;
 		lastDBimportedtimestamp = queryTimeStamp;
 
 		// Handle type counters


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

This is targeted at the `new/shmem` branch.

Use negative query IDs for queries loaded from the database. This is necessary for all queries to have unique IDs. Previously, all queries loaded from the database had an ID of zero.

The API uses the query ID as a unique identifier for cursor pagination, and so queries loaded from the database cause an issue with this. There is no other unique identifier for queries. The index of the query in the queries array can't be used because it could change after garbage collection.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
