### PR TITLE
Put overTime data into shared memory

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -203,9 +203,7 @@ typedef struct {
 	int blocked;
 	int cached;
 	int forwarded;
-	int clientnum;
-	int *clientdata;
-	int querytypedata[7];
+	int querytypedata[TYPE_MAX-1];
 } overTimeDataStruct;
 
 typedef struct {
@@ -229,6 +227,10 @@ extern forwardedDataStruct *forwarded;
 extern clientsDataStruct *clients;
 extern domainsDataStruct *domains;
 extern overTimeDataStruct *overTime;
+
+/// Indexed by client ID, then time index (like `overTime`).
+/// This gets automatically updated whenever a new client or overTime slot is added.
+extern int **overTimeClientData;
 
 extern FILE *logfile;
 extern volatile sig_atomic_t killed;

--- a/api.c
+++ b/api.c
@@ -1063,17 +1063,10 @@ void getClientsOverTime(int *sock)
 		int j;
 		for(j = 0; j < counters->clients; j++)
 		{
-			int thisclient = 0;
-
 			if(skipclient[j])
 				continue;
 
-			if(j < overTime[i].clientnum)
-			{
-				// This client entry does already exist at this timestamp
-				// -> use counter of requests sent to this destination
-				thisclient = overTime[i].clientdata[j];
-			}
+			int thisclient = overTimeClientData[j][i];
 
 			if(istelnet[*sock])
 				ssend(*sock, " %i", thisclient);

--- a/database.c
+++ b/database.c
@@ -671,10 +671,6 @@ void read_data_from_DB(void)
 			continue;
 		}
 
-		// Obtain IDs only after filtering which queries we want to keep
-		int domainID = findDomainID(domain);
-		int clientID = findClientID(client);
-
 		const char *forwarddest = (const char *)sqlite3_column_text(stmt, 6);
 		int forwardID = 0;
 		// Determine forwardID only when status == 2 (forwarded) as the
@@ -689,9 +685,11 @@ void read_data_from_DB(void)
 			forwardID = findForwardID(forwarddest, true);
 		}
 
+		// Obtain IDs only after filtering which queries we want to keep
 		int overTimeTimeStamp = queryTimeStamp - (queryTimeStamp % 600) + 300;
 		int timeidx = findOverTimeID(overTimeTimeStamp);
-		validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
+		int domainID = findDomainID(domain);
+		int clientID = findClientID(client);
 
 		// Ensure we have enough space in the queries struct
 		memory_check(QUERIES);
@@ -704,6 +702,7 @@ void read_data_from_DB(void)
 		int queryID = -1 * (counters->queries + 1);
 
 		// Store this query in memory
+		validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 		validate_access("queries", queryIndex, false, __LINE__, __FUNCTION__, __FILE__);
 		queries[queryIndex].magic = MAGICBYTE;
 		queries[queryIndex].timestamp = queryTimeStamp;
@@ -731,8 +730,7 @@ void read_data_from_DB(void)
 		overTime[timeidx].total++;
 
 		// Update overTime data structure with the new client
-		validate_access_oTcl(timeidx, clientID, __LINE__, __FUNCTION__, __FILE__);
-		overTime[timeidx].clientdata[clientID]++;
+		overTimeClientData[clientID][timeidx]++;
 
 		// Increase DNS queries counter
 		counters->queries++;

--- a/datastructure.c
+++ b/datastructure.c
@@ -66,11 +66,12 @@ int findOverTimeID(int overTimetimestamp)
 		overTime[timeidx].blocked = 0;
 		overTime[timeidx].cached = 0;
 		// overTime[timeidx].querytypedata is static
-		overTime[timeidx].clientnum = 0;
-		overTime[timeidx].clientdata = NULL;
 		counters->overTime++;
 
-		// Update time stamp for next loop interation
+		// Create new overTime slot in client shared memory
+		addOverTimeClientSlot();
+
+		// Update time stamp for next loop interaction
 		if(counters->overTime != 0)
 		{
 			validate_access("overTime", counters->overTime-1, false, __LINE__, __FUNCTION__, __FILE__);
@@ -213,6 +214,9 @@ int findClientID(const char *client)
 	clients[clientID].namepos = 0;
 	// Increase counter by one
 	counters->clients++;
+
+	// Create new overTime client data
+	newOverTimeClient();
 
 	return clientID;
 }

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -187,8 +187,7 @@ void FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char *
 	overTime[timeidx].total++;
 
 	// Update overTime data structure with the new client
-	validate_access_oTcl(timeidx, clientID, __LINE__, __FUNCTION__, __FILE__);
-	overTime[timeidx].clientdata[clientID]++;
+	overTimeClientData[clientID][timeidx]++;
 
 	// Try blocking regex if configured
 	validate_access("domains", domainID, false, __LINE__, __FUNCTION__, __FILE__);

--- a/gc.c
+++ b/gc.c
@@ -63,8 +63,7 @@ void *GC_thread(void *val)
 				clients[clientID].count--;
 
 				// Adjust corresponding overTime counters
-				validate_access_oTcl(timeidx, clientID, __LINE__, __FUNCTION__, __FILE__);
-				overTime[timeidx].clientdata[clientID]--;
+				overTimeClientData[timeidx][clientID]--;
 
 				// Adjust domain counter (no overTime information)
 				int domainID = queries[i].domainID;

--- a/routines.h
+++ b/routines.h
@@ -92,7 +92,6 @@ void *FTLcalloc(size_t nmemb, size_t size, const char *file, const char *functio
 void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *function, int line);
 void FTLfree(void *ptr, const char* file, const char *function, int line);
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file);
-void validate_access_oTcl(int timeidx, int clientID, int line, const char * function, const char * file);
 
 int main_dnsmasq(int argc, char **argv);
 
@@ -115,3 +114,15 @@ void destroy_shmem(void);
 unsigned long long addstr(const char *str);
 char *getstr(unsigned long long pos);
 void *enlarge_shmem_struct(char type);
+
+/**
+ * Create a new overTime client shared memory block.
+ * This also updates `overTimeClientData`.
+ */
+void newOverTimeClient();
+
+/**
+ * Add a new overTime slot to each overTime client shared memory block.
+ * This also updates `overTimeClientData`.
+ */
+void addOverTimeClientSlot();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The array of overTime structs is separate from the client data, because the client data is dynamically sized. Each client has a separate shared memory block named `/FTL-client-ID` where `ID` is the numerical ID of the client. The client data is an array of ints, which is indexed using
the overTime time indexes.

Before, the code referenced the client data via
```
overTime[timeIndex].clientdata[clientID]
```
Now, the code references the data via
```
overTimeClientData[clientID][timeIndex]
```

The client data is updated whenever a new client or overTime slot is added, so referencing the client data should always be valid.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
