### PR TITLE
Fix behavior when no whitelist file is present

### DIFF
--- a/regex.c
+++ b/regex.c
@@ -69,8 +69,12 @@ static void free_whitelist_domains(void)
 
 	whitelist.count = 0;
 
-	free(whitelist.domains);
-	whitelist.domains = NULL;
+	// Free whitelist domains array only allocated
+	if(whitelist.domains != NULL)
+	{
+		free(whitelist.domains);
+		whitelist.domains = NULL;
+	}
 }
 
 bool match_regex(char *input)
@@ -297,5 +301,5 @@ void read_regex_from_file(void)
 	// Read whitelisted domains from file
 	read_whitelist_from_file();
 
-	logg("Compiled %i Regex filters and %i whitelisted domains in %.1f msec (%i errors)", (num_regex-skipped), whitelist.count, timer_elapsed_msec(REGEX_TIMER), errors);
+	logg("Compiled %i Regex filters and %i whitelisted domains in %.1f msec (%i errors)", (num_regex-skipped), whitelist.count > 0 ? whitelist.count : 0, timer_elapsed_msec(REGEX_TIMER), errors);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

- Don't return -1 as number of read whitelist domains if there is no whitelist file.
- Also, don't try to free the array of whitelist domains if there are none.

Both "bugs" are harmless, I have just seen them on a fresh install.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
