### PR TITLE
Properly terminate FTL on receipt of ">kill"

### DIFF
--- a/dnsmasq/dnsmasq.c
+++ b/dnsmasq/dnsmasq.c
@@ -24,7 +24,6 @@ struct daemon *daemon;
 
 static volatile pid_t pid = 0;
 static volatile int pipewrite;
-static char terminate = 0;
 
 static int set_dns_listeners(time_t now);
 static void check_dns_listeners(time_t now);
@@ -907,7 +906,7 @@ int main_dnsmasq (int argc, char **argv)
   poll_resolv(1, 0, now);
 #endif
 
-  while (!terminate)
+  while (!killed)
     {
       int t, timeout = -1;
 
@@ -1430,7 +1429,7 @@ static void async_event(int pipe, time_t now)
 	my_syslog(LOG_INFO, _("exiting on receipt of SIGTERM"));
 	flush_log();
 //	exit(EC_GOOD);
-	terminate = 1;
+	killed = 1;
       }
 }
 

--- a/dnsmasq_interface.h
+++ b/dnsmasq_interface.h
@@ -8,6 +8,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 extern int socketfd, telnetfd4, telnetfd6;
+extern volatile sig_atomic_t killed;
 enum { TCP, UDP };
 
 void FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char *types, int id, char type);

--- a/main.c
+++ b/main.c
@@ -90,5 +90,5 @@ int main (int argc, char* argv[])
 	//Remove PID file
 	removepid();
 	logg("########## FTL terminated after %.1f ms! ##########", timer_elapsed_msec(EXIT_TIMER));
-	return 1;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Use the global variable `killed` to signal the `dnsmasq` subprocess to be terminated. This fixes #379.

Debugger output after `echo ">kill" | nc ::1 4711`:
```
[New Thread 0x742ff460 (LWP 2771)]
[2018-09-28 11:29:15.828] FTL killed by client ID: 19
[Thread 0x742ff460 (LWP 2771) exited]
[Thread 0x74c63460 (LWP 2741) exited]
[Thread 0x75463460 (LWP 2740) exited]
[2018-09-28 11:29:18.931] Shutting down...
[Thread 0x75c63460 (LWP 2739) exited]
[Thread 0x76c63460 (LWP 2737) exited]
[Thread 0x76463460 (LWP 2738) exited]
[2018-09-28 11:29:20.302] Notice: Queries stored in DB: 1 (took 1365.0 ms)
[2018-09-28 11:29:20.303] Finished final database update
[2018-09-28 11:29:20.304] ########## FTL terminated after 24310.1 ms! ##########
[Inferior 1 (process 2734) exited with code 0]
```


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
