### PR TITLE
Kill the >kill command

### DIFF
--- a/request.c
+++ b/request.c
@@ -138,13 +138,6 @@ void process_request(char *client_message, int *sock)
 		close(*sock);
 		*sock = 0;
 	}
-	else if(command(client_message, ">kill"))
-	{
-		processed = true;
-		ssend(*sock, "killed\n");
-		logg("FTL killed by client ID: %i",*sock);
-		killed = 1;
-	}
 
 	if(!processed)
 	{

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -249,9 +249,5 @@ load 'libs/bats-support/load'
 }
 
 @test "Final part of the tests: Killing pihole-FTL process" {
-  run bash -c 'echo ">kill" | nc -v 127.0.0.1 4711'
-  echo "output: ${lines[@]}"
-  [[ ${lines[0]} == "Connection to 127.0.0.1 4711 port [tcp/*] succeeded!" ]]
-  [[ ${lines[1]} == "killed" ]]
-  [[ ${lines[2]} == "---EOM---" ]]
+  run bash -c 'kill $(pidof pihole-FTL)'
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

FTL now hosts the DNS server for the network, so allowing anyone to kill it is a security issue.

Replaces #394

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
