### PR TITLE
Store database ID in queries struct

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -160,7 +160,7 @@ typedef struct {
 	int domainID;
 	int clientID;
 	int forwardID;
-	bool db;
+	sqlite3_int64 db;
 	int id; // the ID is a (signed) int in dnsmasq, so no need for a long int here
 	bool complete;
 	bool private;

--- a/database.c
+++ b/database.c
@@ -382,6 +382,9 @@ void save_to_DB(void)
 	long int i;
 	sqlite3_stmt* stmt;
 
+	// Get last ID stored in the database
+	sqlite3_int64 lastID = last_ID_in_DB();
+
 	bool ret = dbquery("BEGIN TRANSACTION");
 	if(!ret)
 	{
@@ -478,9 +481,8 @@ void save_to_DB(void)
 		}
 
 		saved++;
-		// Mark this query as saved in the database by setting to a non-zero
-		// value. The correct ID will be inserted later
-		queries[i].db = 1;
+		// Mark this query as saved in the database by setting the corresponding ID
+		queries[i].db = ++lastID;
 
 		// Total counter information (delta computation)
 		total++;
@@ -513,15 +515,6 @@ void save_to_DB(void)
 	{
 		dbclose();
 		return;
-	}
-
-	// Update individual queryIDs in the queries struct
-	sqlite3_int64 lastID = last_ID_in_DB();
-	for(i=0; i < total; i++)
-	{
-		// Subtract i from coutners-queries-1 as the database
-		// loop goes only until i < counters->queries
-		queries[(counters->queries-1)-i].db = lastID-i;
 	}
 
 	// Close database

--- a/database.c
+++ b/database.c
@@ -728,10 +728,6 @@ void read_data_from_DB(void)
 		// Set index for this query
 		int queryIndex = counters->queries;
 
-		// Set the ID for this query. Queries loaded from the database use negative IDs.
-		// 1 is added to the counter before flipping the sign so the IDs start at -1 instead of 0.
-		int queryID = -1 * (counters->queries + 1);
-
 		// Store this query in memory
 		validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 		validate_access("queries", queryIndex, false, __LINE__, __FUNCTION__, __FILE__);

--- a/database.c
+++ b/database.c
@@ -744,7 +744,7 @@ void read_data_from_DB(void)
 		queries[queryIndex].forwardID = forwardID;
 		queries[queryIndex].timeidx = timeidx;
 		queries[queryIndex].db = dbid;
-		queries[queryIndex].id = queryID;
+		queries[queryIndex].id = 0;
 		queries[queryIndex].complete = true; // Mark as all information is avaiable
 		queries[queryIndex].response = 0;
 		queries[queryIndex].AD = false;

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -164,7 +164,8 @@ void FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char *
 	queries[queryID].domainID = domainID;
 	queries[queryID].clientID = clientID;
 	queries[queryID].timeidx = timeidx;
-	queries[queryID].db = false;
+	// Initialize database rowID with zero, will be set when the query is stored in the long-term DB
+	queries[queryID].db = 0;
 	queries[queryID].id = id;
 	queries[queryID].complete = false;
 	queries[queryID].private = (config.privacylevel == PRIVACY_MAXIMUM);


### PR DESCRIPTION
This DB ID will be available through shmem to the API to support transparent overlap with the SQlite3 database. It is marked `[WIP]` as it needs to be further tested (e.g. when no database is present on the system).