### PR TITLE
Properly account for user-defined wildcards

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -438,16 +438,6 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		// Answered from local configuration, might be a wildcard or user-provided
 		// This query is no longer unknown
 		counters.unknown--;
-		// Answered from a custom (user provided) cache file
-		counters.cached++;
-
-		// Detect user-defined blocking rules
-		if(strcmp(answer, "(NXDOMAIN)") == 0 ||
-		   strcmp(answer, "0.0.0.0") == 0 ||
-		   strcmp(answer, "::") == 0)
-			queries[i].status = QUERY_WILDCARD;
-		else
-			queries[i].status = QUERY_CACHE;
 
 		// Get time index
 		int querytimestamp, overTimetimestamp;
@@ -455,7 +445,30 @@ void FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id)
 		int timeidx = findOverTimeID(overTimetimestamp);
 		validate_access("overTime", timeidx, true, __LINE__, __FUNCTION__, __FILE__);
 
-		overTime[timeidx].cached++;
+		if(strcmp(answer, "(NXDOMAIN)") == 0 ||
+		   strcmp(answer, "0.0.0.0") == 0 ||
+		   strcmp(answer, "::") == 0)
+		{
+			// Answered from user-defined blocking rules (dnsmasq config files)
+			counters.blocked++;
+			overTime[timeidx].blocked++;
+
+			validate_access("domains", queries[i].domainID, true, __LINE__, __FUNCTION__, __FILE__);
+			domains[queries[i].domainID].blockedcount++;
+
+			validate_access("clients", queries[i].clientID, true, __LINE__, __FUNCTION__, __FILE__);
+			clients[queries[i].clientID].blockedcount++;
+
+			queries[i].status = QUERY_WILDCARD;
+		}
+		else
+		{
+			// Answered from a custom (user provided) cache file
+			counters.cached++;
+			overTime[timeidx].cached++;
+
+			queries[i].status = QUERY_CACHE;
+		}
 
 		// Save reply type and update individual reply counters
 		save_reply_type(flags, i, response);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Modify the correct corresponding counters for user-defined dnsmasq config file blocking rules (may it be `NXDOMAIN` or `NULL` based). Thanks to @jpgpi250 for pointing out negative blocked numbers (private communication).


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
