### PR TITLE
Fix record_source() sometimes incorrectly returning regex.list

### DIFF
--- a/dnsmasq/dnsmasq.h
+++ b/dnsmasq/dnsmasq.h
@@ -463,9 +463,11 @@ struct crec {
 #define SRC_INTERFACE 0
 #define SRC_CONFIG    1
 #define SRC_HOSTS     2
-#define SRC_AH        3
 /*----- Pi-hole modification -----*/
-#define SRC_REGEX     4
+// ID 3 will be used for the regex list file name
+// ID 4 will be used as starting index for any Additional Hosts (AH) files
+#define SRC_REGEX     3
+#define SRC_AH        4
 const char *regexlistname;
 /*--------------------------------*/
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix interchanged indices in `dnsmasq.h`. This bug resulted in sometimes having displayed `regex.list` even though the blocking was done due to a `gravity.list` entry. Although being of only cosmetic nature, this bug showed up every now and then and was never really traceable.

The problem appeared when more than one additional hosts file was loaded (e.g. `gravity.list` + `black.list`). As the first file would have gotten index `3` and the second `4`, and `record_source(4)` returned the path of `regex.list`. This is now fixed by defining `regex.list` to ID 3 and start all additional HOSTS files from 4 onward.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
