### PR TITLE
Half memory usage of NULL blocking mode

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1050,12 +1050,14 @@ static int add_blocked_domain_cache(struct all_addr *addr4, struct all_addr *add
 		// If we block in NXDOMAIN mode, we add the NXDOMAIN flag and make this host record
 		// also valid for AAAA requests
 		if(config.blockingmode == MODE_NX) cache4->flags |= F_IPV6 | F_NEG | F_NXDOMAIN;
+		// If we block in NULL mode, we make this host record also valid for AAAA requests
+		else if(config.blockingmode == MODE_NULL) cache4->flags |= F_IPV6;
 		cache4->ttd = daemon->local_ttl;
 		add_hosts_entry(cache4, addr4, INADDRSZ, index, rhash, hashsz);
 		name_count++;
 	}
-	// Add IPv6 record only if we respond with an IP address to blocked domains
-	if(has_IPv6 && config.blockingmode != MODE_NX &&
+	// Add IPv6 record only if we respond with a non-NULL IP address to blocked domains
+	if(has_IPv6 && config.blockingmode != MODE_NX && config.blockingmode != MODE_NULL &&
 	   (cache6 = malloc(sizeof(struct crec) + strlen(domain)+1-SMALLDNAME)))
 	{
 		strcpy(cache6->name.sname, domain);

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1035,7 +1035,7 @@ void add_hosts_entry(struct crec *cache, struct all_addr *addr, int addrlen, uns
 void rehash(int size);
 
 // This routine adds one domain to the resolver's cache. Depending on the configured blocking mode it may create
-// a single entry valid for IPv4 & IPv6 (containing only NXDOMAIN) or two entries one for IPv4 and one for IPv6
+// a single entry valid for IPv4 & IPv6 or two entries one for IPv4 and one for IPv6.
 // When IPv6 is not available on the machine, we do not add IPv6 cache entries (likewise for IPv4)
 static int add_blocked_domain_cache(struct all_addr *addr4, struct all_addr *addr6, bool has_IPv4, bool has_IPv6,
                                     char *domain, struct crec **rhash, int hashsz, unsigned int index)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This PR changes the default blocking mode to use a combined cache entry that is valid for both, `A` and `AAAA` entries. This will lead to a memory saving of exactly 50% concerning the blocked domains DNS cache. Almost all users will immediately benefit from a lowered memory footprint of `pihole-FTL`. Furthermore, it will make `NULL` blocking mode usable for those who have hit memory limitations with millions of blocked domains on low-end periphery like Raspberry Pi Zero devices.

FTLDNS offers several blocking modes. We add one or two cache entries per blocked domain:

1. `NULL` blocking (default)
  - previously:
    - `A: 0.0.0.0`
    - `AAAA: ::`
  - with this PR:
    - `A` and `AAAA` combined in one cache entry that expands to `0.0.0.0` and `::`

2. `IP` blocking (pre-v4.0 default)
- `A: IPv4 of Pi-hole`
- `AAAA: IPv6 of Pi-hole` 

3. `IP-NODATA-AAAA` blocking
- `A: IPv4 of Pi-hole`
- `AAAA: NODATA-IPV6`

4. `NXDOMAIN` blocking
- `A` and `AAAA` combined in one cache entry returning `NXDOMAIN`

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
