### PR TITLE
Revert blacklist file path to the original

### DIFF
--- a/config.c
+++ b/config.c
@@ -302,7 +302,7 @@ void read_FTLconf(void)
 	getpath(fp, "WHITELISTFILE", "/etc/pihole/whitelist.txt", &files.whitelist);
 
 	// BLACKLISTFILE
-	getpath(fp, "BLACKLISTFILE", "/etc/pihole/blacklist.txt", &files.blacklist);
+	getpath(fp, "BLACKLISTFILE", "/etc/pihole/black.list", &files.blacklist);
 
 	// GRAVITYFILE
 	getpath(fp, "GRAVITYFILE", "/etc/pihole/gravity.list", &files.gravity);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

This fixes the incorrect parsing of the blacklist and "bad address" errors printed to the dnsmasq log. This was a regression from stable, and appeared after #416.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
