### PR TITLE
Simplify upstream percentage computation

### DIFF
--- a/api.c
+++ b/api.c
@@ -443,16 +443,13 @@ void getTopClients(char *client_message, int *sock)
 void getForwardDestinations(char *client_message, int *sock)
 {
 	bool sort = true;
-	int i, temparray[counters.forwarded][2], forwardedsum = 0, totalqueries = 0;
+	int i, temparray[counters.forwarded][2], totalqueries = 0;
 
 	if(command(client_message, "unsorted"))
 		sort = false;
 
 	for(i=0; i < counters.forwarded; i++) {
 		validate_access("forwarded", i, true, __LINE__, __FUNCTION__, __FILE__);
-		// Compute forwardedsum
-		forwardedsum += forwarded[i].count;
-
 		// If we want to print a sorted output, we fill the temporary array with
 		// the values we will use for sorting afterwards
 		if(sort) {
@@ -513,24 +510,9 @@ void getForwardDestinations(char *client_message, int *sock)
 			else
 				name = "";
 
-			// Math explanation:
-			// A single query may result in requests being forwarded to multiple destinations
-			// Hence, in order to be able to give percentages here, we have to normalize the
-			// number of forwards to each specific destination by the total number of forward
-			// events. This term is done by
-			//   a = forwarded[j].count / forwardedsum
-			//
-			// The fraction a describes now how much share an individual forward destination
-			// has on the total sum of sent requests.
-			// We also know the share of forwarded queries on the total number of queries
-			//   b = counters.forwardedqueries / c
-			// where c is the number of valid queries,
-			//   c = counters.forwardedqueries + counters.cached + counters.blocked
-			//
-			// To get the total percentage of a specific query on the total number of queries,
-			// we simply have to scale b by a which is what we do in the following.
-			if(forwardedsum > 0 && totalqueries > 0)
-				percentage = 1e2f * forwarded[j].count / forwardedsum * counters.forwardedqueries / totalqueries;
+			// Get percentage
+			if(totalqueries > 0)
+				percentage = 1e2f * forwarded[j].count / totalqueries;
 		}
 
 		// Send data:


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Simplify upstream percentage computation.

The way we compute the forward destination percentage is a leftover from pre-v3.0 times. Back then we counted each `forwarded to ...` line as one forwarded query. With v3.0, we started to skip duplicated `forwarded to ...` lines as we had now the query IDs and were able to rule out what was a duplicate.

This check is now here:
https://github.com/pi-hole/FTL/blob/da8c2765a58fcd701bdbcb0f7a4528990f554dea/dnsmasq_interface.c#L275-L286

Hence, `forwardedsum` happens to exactly cancel out with `counters->forwardedqueries` such that the computation can be simplified but still gives the exact same result in all cases.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
