### PR TITLE
Fix query status if forwarded query was partially replied to from cache

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -321,7 +321,7 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	}
 	else
 	{
-		// Normal cache reply
+		// Normal forwarded query (status is set below)
 		// Query is no longer unknown
 		counters.unknown--;
 		// Hereby, this query is now fully determined

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -269,9 +269,6 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 		return;
 	}
 
-	// Set query status
-	queries[i].status = QUERY_FORWARDED;
-
 	// Proceed only if
 	// - current query has not been marked as replied to so far
 	//   (it could be that answers from multiple forward
@@ -332,6 +329,13 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 			// Hereby, this query is now fully determined
 			queries[i].complete = true;
 		}
+
+		// Set query status to forwarded only after the
+		// if(queries[i].status == QUERY_CACHE) { ... }
+		// from above as otherwise this check will always
+		// be negative
+		queries[i].status = QUERY_FORWARDED;
+
 		// Update overTime data
 		overTime[j].forwarded++;
 

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -272,7 +272,7 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	// Proceed only if
 	// - current query has not been marked as replied to so far
 	//   (it could be that answers from multiple forward
-	//    destionations are coimg in for the same query)
+	//    destinations are coming in for the same query)
 	// - the query was formally known as cached but had to be forwarded
 	//   (this is a special case further described below)
 	if(queries[i].complete && queries[i].status != QUERY_CACHE)
@@ -287,61 +287,58 @@ void FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int id
 	int forwardID = findForwardID(forward, true);
 	queries[i].forwardID = forwardID;
 
-	if(!queries[i].complete)
+	int j = queries[i].timeidx;
+	validate_access("overTime", j, true, __LINE__, __FUNCTION__, __FILE__);
+
+	if(queries[i].status == QUERY_CACHE)
 	{
-		int j = queries[i].timeidx;
-		validate_access("overTime", j, true, __LINE__, __FUNCTION__, __FILE__);
+		// Detect if we cached the <CNAME> but need to ask the upstream
+		// servers for the actual IPs now, we remove this query from the
+		// counters for cache replied queries as we had to forward a
+		// request for it. Example:
+		// Assume a domain a.com is a CNAME which is cached and has a very
+		// long TTL. It point to another domain server.a.com which has an
+		// A record but this has a much lower TTL.
+		// If you now query a.com and then again after some time, you end
+		// up in a situation where dnsmasq can answer the first level of
+		// the DNS result (the CNAME) from cache, hence the status of this
+		// query is marked as "answered from cache" in FTLDNS. However, for
+		// server.a.com wit the much shorter TTL, we still have to forward
+		// something and ask the upstream server for the final IP address.
+		// This code section acknowledges this by removing one entry from
+		// the cached counters as we will re-brand this query as having been
+		// forwarded in the following.
+		counters.cached--;
+		// Also correct overTime data
+		overTime[j].cached--;
 
-		if(queries[i].status == QUERY_CACHE)
-		{
-			// Detect if we cached the <CNAME> but need to ask the upstream
-			// servers for the actual IPs now, we remove this query from the
-			// counters for cache replied queries as we had to forward a
-			// request for it. Example:
-			// Assume a domain a.com is a CNAME which is cached and has a very
-			// long TTL. It point to another domain server.a.com which has an
-			// A record but this has a much lower TTL.
-			// If you now query a.com and then again after some time, you end
-			// up in a situation where dnsmasq can answer the first level of
-			// the DNS result (the CNAME) from cache, hence the status of this
-			// query is marked as "answered from cache" in FTLDNS. However, for
-			// server.a.com wit the much shorter TTL, we still have to forward
-			// something and ask the upstream server for the final IP address.
-			// This code section acknowledges this by removing one entry from
-			// the cached counters as we will re-brand this query as having been
-			// forwarded in the following.
-			counters.cached--;
-			// Also correct overTime data
-			overTime[j].cached--;
-
-			// Correct reply timer
-			struct timeval response;
-			gettimeofday(&response, 0);
-			// Reset timer, shift slightly into the past to acknowledge the time
-			// FTLDNS needed to look up the CNAME in its cache
-			queries[i].response = converttimeval(response) - queries[i].response;
-		}
-		else
-		{
-			// Normal cache reply
-			// Query is no longer unknown
-			counters.unknown--;
-			// Hereby, this query is now fully determined
-			queries[i].complete = true;
-		}
-
-		// Set query status to forwarded only after the
-		// if(queries[i].status == QUERY_CACHE) { ... }
-		// from above as otherwise this check will always
-		// be negative
-		queries[i].status = QUERY_FORWARDED;
-
-		// Update overTime data
-		overTime[j].forwarded++;
-
-		// Update couter for forwarded queries
-		counters.forwardedqueries++;
+		// Correct reply timer
+		struct timeval response;
+		gettimeofday(&response, 0);
+		// Reset timer, shift slightly into the past to acknowledge the time
+		// FTLDNS needed to look up the CNAME in its cache
+		queries[i].response = converttimeval(response) - queries[i].response;
 	}
+	else
+	{
+		// Normal cache reply
+		// Query is no longer unknown
+		counters.unknown--;
+		// Hereby, this query is now fully determined
+		queries[i].complete = true;
+	}
+
+	// Set query status to forwarded only after the
+	// if(queries[i].status == QUERY_CACHE) { ... }
+	// from above as otherwise this check will always
+	// be negative
+	queries[i].status = QUERY_FORWARDED;
+
+	// Update overTime data
+	overTime[j].forwarded++;
+
+	// Update counter for forwarded queries
+	counters.forwardedqueries++;
 
 	// Release allocated memory
 	free(forward);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix query status if forwarded query was partially replied to from cache. This may happen if we were able to answer a CNAME from cache but need to ask the upstream server for details concering one of its components. This PR ensures that the query status is set to forwarded only *after* the check if it has been replied to from cache as the latter is a null-op otherwise.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
