### PR TITLE
Modify type of lastGCrun to avoid overflow

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11,7 +11,7 @@
 #include "FTL.h"
 bool doGC = false;
 
-int lastGCrun = 0;
+time_t lastGCrun = 0;
 void *GC_thread(void *val)
 {
 	// Set thread name


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

1
---
This PR modifies the type of lastGCrun in gc.c from `int` to `time_t`. 
The reason is as follows:

- time() returns a 64bit integer in recent c libraries
- the previous implementation implicitly casted 64 bit value to 32 bit value in the following code segment
`lastGCrun = time(NULL) - time(NULL) % GCinterval;`
- if the subtraction returns a value that overflows int value,  `lastGCrun` will be a negative number, which will affect later if clause and the rest of the code
- to prevent this, `lastGCrun` should be `time_t`.  

Thanks in advance for your consideration.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
