### PR TITLE
Fix no-daemon mode forking dnsmasq and not logging

### DIFF
--- a/args.c
+++ b/args.c
@@ -35,6 +35,7 @@ void parse_args(int argc, char* argv[])
 		   strcmp(argv[i], "debug") == 0)
 		{
 			debug = true;
+			daemonmode = false;
 			ok = true;
 
 			// Replace "-k" by "-d" (debug mode implies nofork)

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -863,7 +863,7 @@ pthread_t DNSclientthread;
 
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 {
-	if(!debug && daemonmode)
+	if(daemonmode)
 		go_daemon();
 	else
 		savepid();

--- a/log.c
+++ b/log.c
@@ -71,7 +71,7 @@ void logg(const char *format, ...)
 	get_timestr(timestring);
 
 	// Print to stdout before writing to file
-	if(debug)
+	if(!daemonmode)
 	{
 		printf("[%s] ", timestring);
 		va_start(args, format);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

no-daemon mode operates just like debug mode, but without the debug output, and dnsmasq is not in debug mode.

Note that there is an issue in no-daemon mode where Ctrl-C and other such signals do not stop FTL like in debug mode. However, I could only fix this by putting dnsmasq in debug mode...

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
