### PR TITLE
Improve Quad9 externally blocked detection

### DIFF
--- a/dnsmasq/forward.c
+++ b/dnsmasq/forward.c
@@ -648,7 +648,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
 	}
     }
 
-  FTL_header_ADbit(header->hb4, daemon->log_display_id);
+  FTL_header_ADbit(header->hb4, RCODE(header), daemon->log_display_id);
 
   /* RFC 4035 sect 4.6 para 3 */
   if (!is_sign && !option_bool(OPT_DNSSEC_PROXY))

--- a/dnsmasq_interface.h
+++ b/dnsmasq_interface.h
@@ -19,7 +19,7 @@ void FTL_dnssec(int status, int id);
 void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
 
-void FTL_header_ADbit(unsigned char header4, int id);
+void FTL_header_ADbit(unsigned char header4, unsigned int rcode, int id);
 
 void FTL_forwarding_failed(struct server *server);
 int FTL_listsfile(char* filename, unsigned int index, FILE *f, int cache_size, struct crec **rhash, int hashsz);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

If the response code of a domain is `NXDOMAIN` *and* the `AD` bit is set, we may be seeing a response from an externally blocked query. As they are not always accompanied by a necessary SOA record, they are not getting added to our cache and, therefore, `FTL_reply()` is never getting called from within the cache routines and the necessary information about the `NXDOMAIN` reply needs to be stored already earlier.

Before (FTL v4.1):
![screenshot from 2018-12-16 09-14-43](https://user-images.githubusercontent.com/16748619/50051515-05cff800-0114-11e9-8239-b09b9e8014db.png)

After this PR (planned FTL v4.1.1):
![screenshot from 2018-12-16 09-19-48](https://user-images.githubusercontent.com/16748619/50051518-0a94ac00-0114-11e9-9060-5d702a619336.png)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
