### PR TITLE
Zero initialize all_addr structs

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1069,7 +1069,7 @@ static int add_blocked_domain_cache(struct all_addr *addr4, struct all_addr *add
 // Add a single domain to resolver's cache. This respects the configured blocking mode
 static void block_single_domain(char *domain)
 {
-	struct all_addr addr4 = { 0 }, addr6 = { 0 };
+	struct all_addr addr4 = {{{ 0 }}}, addr6 = {{{ 0 }}};
 	bool has_IPv4 = false, has_IPv6 = false;
 
 	// Get IPv4/v6 addresses for blocking depending on user configures blocking mode
@@ -1088,7 +1088,7 @@ int FTL_listsfile(char* filename, unsigned int index, FILE *f, int cache_size, s
 	int added = 0;
 	size_t size = 0;
 	char *buffer = NULL;
-	struct all_addr addr4 = { 0 }, addr6 = { 0 };
+	struct all_addr addr4 = {{{ 0 }}}, addr6 = {{{ 0 }}};
 	bool has_IPv4 = false, has_IPv6 = false;
 
 	// Handle only gravity.list and black.list

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -987,27 +987,29 @@ unsigned long converttimeval(struct timeval time)
 // This subroutine prepares IPv4 and IPv6 addresses for blocking queries depending on the configured blocking mode
 static void prepare_blocking_mode(struct all_addr *addr4, struct all_addr *addr6, bool *has_IPv4, bool *has_IPv6)
 {
-	if(config.blockingmode == MODE_IP || config.blockingmode == MODE_IP_NODATA_AAAA)
+	// Read IPv4 address for host entries from setupVars.conf
+	char* const IPv4addr = read_setupVarsconf("IPV4_ADDRESS");
+	if((config.blockingmode == MODE_IP || config.blockingmode == MODE_IP_NODATA_AAAA) &&
+	   IPv4addr != NULL && strlen(IPv4addr) > 0)
 	{
-		// Read IPv4 address for host entries from setupVars.conf
-		char* const IPv4addr = read_setupVarsconf("IPV4_ADDRESS");
 		// Strip off everything at the end of the IP (CIDR might be there)
 		char* a=IPv4addr; for(;*a;a++) if(*a == '/') *a = 0;
 		// Prepare IPv4 address for records
 		if(inet_pton(AF_INET, IPv4addr, addr4) > 0)
 			*has_IPv4 = true;
-		clearSetupVarsArray(); // will free/invalidate IPv4addr
 	}
 	else
 	{
 		// Blocking mode will use zero-initialized all_addr struct
 		*has_IPv4 = true;
 	}
+	clearSetupVarsArray(); // will free/invalidate IPv4addr
 
-	if(config.blockingmode == MODE_IP)
+	// Read IPv6 address for host entries from setupVars.conf
+	char* const IPv6addr = read_setupVarsconf("IPV6_ADDRESS");
+	if(config.blockingmode == MODE_IP &&
+	   IPv6addr != NULL && strlen(IPv6addr) > 0)
 	{
-		// Read IPv6 address for host entries from setupVars.conf
-		char* const IPv6addr = read_setupVarsconf("IPV6_ADDRESS");
 		// Strip off everything at the end of the IP (CIDR might be there)
 		char* a=IPv6addr; for(;*a;a++) if(*a == '/') *a = 0;
 		// Prepare IPv6 address for records


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])**:

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Make sure to zero initialize the `all_addr` structs we are using for the IPv4 and IPv6 target addresses.

This should resolve a bug that was reported on [Discourse](https://discourse.pi-hole.net/t/very-strange-ipv6-blocking-addresses/15197/9).

Furthermore, this zero initialization allows a great simplification of `prepare_blocking_mode()` as `inet_pton("0.0.0.0")` resp. `inet_pton("::")` do nothing else than filling the corresponding structs with zeroes.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
