### PR TITLE
Fix: Deadlock situation in resolving subroutines

### DIFF
--- a/request.c
+++ b/request.c
@@ -26,100 +26,134 @@ void process_request(char *client_message, int *sock)
 	if(command(client_message, ">stats"))
 	{
 		processed = true;
+		lock_shm();
 		getStats(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">overTime"))
 	{
 		processed = true;
+		lock_shm();
 		getOverTime(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">top-domains") || command(client_message, ">top-ads"))
 	{
 		processed = true;
+		lock_shm();
 		getTopDomains(client_message, sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">top-clients"))
 	{
 		processed = true;
+		lock_shm();
 		getTopClients(client_message, sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">forward-dest"))
 	{
 		processed = true;
+		lock_shm();
 		getForwardDestinations(client_message, sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">forward-names"))
 	{
 		processed = true;
+		lock_shm();
 		getForwardDestinations(">forward-dest unsorted", sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">querytypes"))
 	{
 		processed = true;
+		lock_shm();
 		getQueryTypes(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">getallqueries"))
 	{
 		processed = true;
+		lock_shm();
 		getAllQueries(client_message, sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">recentBlocked"))
 	{
 		processed = true;
+		lock_shm();
 		getRecentBlocked(client_message, sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">clientID"))
 	{
 		processed = true;
+		lock_shm();
 		getClientID(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">QueryTypesoverTime"))
 	{
 		processed = true;
+		lock_shm();
 		getQueryTypesOverTime(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">version"))
 	{
 		processed = true;
+		// No lock required
 		getVersion(sock);
 	}
 	else if(command(client_message, ">dbstats"))
 	{
 		processed = true;
+		// No lock required. Access to the database
+		// is guaranteed to be atomic
 		getDBstats(sock);
 	}
 	else if(command(client_message, ">ClientsoverTime"))
 	{
 		processed = true;
+		lock_shm();
 		getClientsOverTime(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">client-names"))
 	{
 		processed = true;
+		lock_shm();
 		getClientNames(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">unknown"))
 	{
 		processed = true;
+		lock_shm();
 		getUnknownQueries(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">domain"))
 	{
 		processed = true;
+		lock_shm();
 		getDomainDetails(client_message, sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">cacheinfo"))
 	{
 		processed = true;
+		lock_shm();
 		getCacheInformation(sock);
+		unlock_shm();
 	}
 	else if(command(client_message, ">reresolve"))
 	{
 		processed = true;
 		logg("Received API request to re-resolve host names");
-		// Need to release the thread lock already here to allow
-		// the resolver to process the incoming PTR requests
-		unlock_shm();
+		// Important: Don't obtain a lock for this request
+		//            Locking will be done internally when needed
 		// onlynew=false -> reresolve all host names
 		resolveClients(false);
 		resolveForwardDestinations(false);
@@ -129,8 +163,10 @@ void process_request(char *client_message, int *sock)
 	{
 		processed = true;
 		logg("Received API request to recompile regex");
+		lock_shm();
 		free_regex();
 		read_regex_from_file();
+		unlock_shm();
 	}
 
 	// Test only at the end if we want to quit or kill

--- a/shmem.c
+++ b/shmem.c
@@ -155,11 +155,15 @@ pthread_mutex_t create_mutex() {
 	return lock;
 }
 
-void lock_shm() {
+void _lock_shm(const char* function, const int line) {
 	// Signal that FTL is waiting for a lock
 	shmLock->waitingForLock = true;
 
+	if(debug) logg("Waiting for lock in %s():%i", function, line);
+
 	int result = pthread_mutex_lock(&shmLock->lock);
+
+	if(debug) logg("Obtained lock for %s():%i", function, line);
 
 	// Turn off the waiting for lock signal to notify everyone who was
 	// deferring to FTL that they can jump in the lock queue.
@@ -175,8 +179,10 @@ void lock_shm() {
 		logg("Failed to obtain SHM lock: %s", strerror(result));
 }
 
-void unlock_shm() {
+void _unlock_shm(const char* function, const int line) {
 	int result = pthread_mutex_unlock(&shmLock->lock);
+
+	if(debug) logg("Removed lock in %s():%i", function, line);
 
 	if(result != 0)
 		logg("Failed to unlock SHM lock: %s", strerror(result));

--- a/shmem.c
+++ b/shmem.c
@@ -155,15 +155,15 @@ pthread_mutex_t create_mutex() {
 	return lock;
 }
 
-void _lock_shm(const char* function, const int line) {
+void _lock_shm(const char* function, const int line, const char * file) {
 	// Signal that FTL is waiting for a lock
 	shmLock->waitingForLock = true;
 
-	if(debug) logg("Waiting for lock in %s():%i", function, line);
+	if(debug) logg("Waiting for lock in %s() (%s:%i)", function, file, line);
 
 	int result = pthread_mutex_lock(&shmLock->lock);
 
-	if(debug) logg("Obtained lock for %s():%i", function, line);
+	if(debug) logg("Obtained lock for %s() (%s:%i)", function, file, line);
 
 	// Turn off the waiting for lock signal to notify everyone who was
 	// deferring to FTL that they can jump in the lock queue.
@@ -179,10 +179,10 @@ void _lock_shm(const char* function, const int line) {
 		logg("Failed to obtain SHM lock: %s", strerror(result));
 }
 
-void _unlock_shm(const char* function, const int line) {
+void _unlock_shm(const char* function, const int line, const char * file) {
 	int result = pthread_mutex_unlock(&shmLock->lock);
 
-	if(debug) logg("Removed lock in %s():%i", function, line);
+	if(debug) logg("Removed lock in %s() (%s:%i)", function, file, line);
 
 	if(result != 0)
 		logg("Failed to unlock SHM lock: %s", strerror(result));

--- a/shmem.h
+++ b/shmem.h
@@ -41,9 +41,11 @@ bool realloc_shm(SharedMemory *sharedMemory, size_t size);
 void delete_shm(SharedMemory *sharedMemory);
 
 /// Block until a lock can be obtained
-void lock_shm();
+#define lock_shm() _lock_shm(__FUNCTION__, __LINE__);
+void _lock_shm(const char* func, const int line);
 
 /// Unlock the lock. Only call this if there is an active lock.
-void unlock_shm();
+#define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__);
+void _unlock_shm(const char* func, const int line);
 
 #endif //SHARED_MEMORY_SERVER_H

--- a/shmem.h
+++ b/shmem.h
@@ -41,11 +41,11 @@ bool realloc_shm(SharedMemory *sharedMemory, size_t size);
 void delete_shm(SharedMemory *sharedMemory);
 
 /// Block until a lock can be obtained
-#define lock_shm() _lock_shm(__FUNCTION__, __LINE__);
-void _lock_shm(const char* func, const int line);
+#define lock_shm() _lock_shm(__FUNCTION__, __LINE__, __FILE__);
+void _lock_shm(const char* func, const int line, const char* file);
 
 /// Unlock the lock. Only call this if there is an active lock.
-#define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__);
-void _unlock_shm(const char* func, const int line);
+#define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__);
+void _unlock_shm(const char* func, const int line, const char* file);
 
 #endif //SHARED_MEMORY_SERVER_H

--- a/socket.c
+++ b/socket.c
@@ -320,15 +320,9 @@ void *telnet_connection_handler_thread(void *socket_desc)
 			// Clear client message receive buffer
 			memset(client_message, 0, sizeof client_message);
 
-			// Lock FTL data structure, since it is likely that it will be changed here
-			// Requests should not be processed/answered when data is about to change
-			lock_shm();
-
+			// Process received message
 			process_request(message, &sock);
 			free(message);
-
-			// Release thread lock
-			unlock_shm();
 
 			if(sock == 0)
 			{
@@ -377,15 +371,9 @@ void *socket_connection_handler_thread(void *socket_desc)
 			// Clear client message receive buffer
 			memset(client_message, 0, sizeof client_message);
 
-			// Lock FTL data structure, since it is likely that it will be changed here
-			// Requests should not be processed/answered when data is about to change
-			lock_shm();
-
+			// Process received message
 			process_request(message, &sock);
 			free(message);
-
-			// Release thread lock
-			unlock_shm();
 
 			if(sock == 0)
 			{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This bug does only exist in `development` and is not contained in any release code.

This PR want to merge three improvements/bugfixes concerning out internal locks:
- **Name resolution is broken in `development`.** This PR ensures that the lock is released when resolving host names. This is necessary as we otherwise block the main thread which is supposed to do the resolving.
- Add debugging output for locks. Although it increases the verbosity of the debug mode, this information can actually be quite valuable and we should keep if until we are sure there are no further obstacles with the now lock mechanism. It will greatly improve the remote support possibilities as we can look more into *where* things are currently happening in the code (at least concerning locks).
- Move obtaining/releasing locks to the place where the functions that need it are called. This fixes a bug where `socket.c` tried to release a lock that was already previously released in `request.c` (resulting in the error message `Failed to unlock SHM lock: Operation not permitted`). Furthermore, this prevents obtaining a lock for both, API calls that do not need a lock and also for unknown API calls.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
