### PR TITLE
Reuse the empty string at position 0 in string shared memory

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -55,6 +55,11 @@ unsigned long long addstr(const char *str)
 	// Get string length
 	size_t len = strlen(str);
 
+	// If this is an empty string, use the one at position zero
+	if(len == 0) {
+		return 0;
+	}
+
 	if(debug) logg("Adding \"%s\" (len %i) to buffer. next_pos is %i", str, len, next_pos);
 
 	// Reserve additional memory if necessary


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

If an empty string is being added, reuse the one at position zero. This makes sure all empty strings used elsewhere in shared memory have a position of zero.

This fixes a slight bug in API, which assumes that all empty strings have position zero.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
