### PR TITLE
Gravity domains should not have REVERSE set

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1069,7 +1069,7 @@ static int add_blocked_domain_cache(struct all_addr *addr4, struct all_addr *add
 	   (cache4 = malloc(sizeof(struct crec) + strlen(domain)+1-SMALLDNAME)))
 	{
 		strcpy(cache4->name.sname, domain);
-		cache4->flags = F_HOSTS | F_IMMORTAL | F_FORWARD | F_REVERSE | F_IPV4;
+		cache4->flags = F_HOSTS | F_IMMORTAL | F_FORWARD | F_IPV4;
 		int memorysize = INADDRSZ;
 		if(config.blockingmode == MODE_NX)
 		{
@@ -1099,7 +1099,7 @@ static int add_blocked_domain_cache(struct all_addr *addr4, struct all_addr *add
 	   (cache6 = malloc(sizeof(struct crec) + strlen(domain)+1-SMALLDNAME)))
 	{
 		strcpy(cache6->name.sname, domain);
-		cache6->flags = F_HOSTS | F_IMMORTAL | F_FORWARD | F_REVERSE | F_IPV6;
+		cache6->flags = F_HOSTS | F_IMMORTAL | F_FORWARD | F_IPV6;
 		if(config.blockingmode == MODE_IP_NODATA_AAAA) cache6->flags |= F_NEG;
 		cache6->ttd = daemon->local_ttl;
 		add_hosts_entry(cache6, addr6, IN6ADDRSZ, index, rhash, hashsz);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Blocked domains should not have the `REVERSE` flag set, i.e., they should never be the answer to reverse lookups to the IPs they are assigned to (0.0.0.0, RPi's IP address, ...)

This fixes a bug reported on [Discourse](https://discourse.pi-hole.net/t/very-strange-ipv6-blocking-addresses/15197/56?u=dl6er).

Example: With FTL v4.1.2:
```
$ dig +short ptr 0.0.0.0.in-addr.arpa
facebook.com.
```
(can be any blocked domain)

With this PR:
```
$ dig +short ptr 0.0.0.0.in-addr.arpa

```
(`NXDOMAIN` reply)
