### PR TITLE
Mark queries imported from the database as having an unknown DNSSEC type

### DIFF
--- a/database.c
+++ b/database.c
@@ -741,6 +741,8 @@ void read_data_from_DB(void)
 		queries[queryIndex].complete = true; // Mark as all information is avaiable
 		queries[queryIndex].response = 0;
 		queries[queryIndex].AD = false;
+		queries[queryIndex].dnssec = DNSSEC_UNKNOWN;
+		queries[queryIndex].reply = REPLY_UNKNOWN;
 		lastDBimportedtimestamp = queryTimeStamp;
 
 		// Handle type counters


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Queries imported from the database now have the "unknown" DNSSEC type. This also explicitly marks the queries with an unknown reply type. However, this was already happening before, because `REPLY_UNKNOWN` equals 0, and the struct is zero-initialized.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
