### PR TITLE
Always allocate also empty strings in getMACVendor()

### DIFF
--- a/networktable.c
+++ b/networktable.c
@@ -200,13 +200,13 @@ static char* getMACVendor(const char* hwaddr)
 	{
 		// File does not exist
 		if(debug) logg("getMACVenor(%s): %s does not exist", hwaddr, FTLfiles.macvendordb);
-		return "";
+		return strdup("");
 	}
 	else if(strlen(hwaddr) != 17)
 	{
 		// MAC address is incomplete
 		if(debug) logg("getMACVenor(%s): MAC invalid (length %lu)", hwaddr, strlen(hwaddr));
-		return "";
+		return strdup("");
 	}
 
 	sqlite3 *macdb;
@@ -214,7 +214,7 @@ static char* getMACVendor(const char* hwaddr)
 	if( rc ){
 		logg("getMACVendor(%s) - SQL error (%i): %s", hwaddr, rc, sqlite3_errmsg(macdb));
 		sqlite3_close(macdb);
-		return "";
+		return strdup("");
 	}
 
 	char *querystr = NULL;
@@ -226,7 +226,7 @@ static char* getMACVendor(const char* hwaddr)
 	{
 		logg("getMACVendor(%s) - Allocation error (%i)", hwaddr, rc);
 		sqlite3_close(macdb);
-		return "";
+		return strdup("");
 	}
 	free(hwaddrshort);
 
@@ -235,7 +235,7 @@ static char* getMACVendor(const char* hwaddr)
 	if( rc ){
 		logg("getMACVendor(%s) - SQL error prepare (%s, %i): %s", hwaddr, querystr, rc, sqlite3_errmsg(macdb));
 		sqlite3_close(macdb);
-		return "";
+		return strdup("");
 	}
 	free(querystr);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes #462 
The problem was that when any SQL error happened (including `macvendor.db` not present), we returned a static string. A subsequent call to `free()` tried to release this static string which failed.

We fix this by always ensuring that we return a `free`-able pointer.

This PR does not need to be mentioned in the Release notes as if fixes a bug that is only present in the `development` branch.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
