### PR TITLE
Add an "/FTL-settings" shared memory block

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -216,6 +216,10 @@ typedef struct {
 	char **domains;
 } whitelistStruct;
 
+typedef struct {
+	int version;
+} ShmSettings;
+
 // Prepare timers, used mainly for debugging purposes
 #define NUMTIMERS LAST_TIMER
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The SHM settings currently contain the version of shared memory that FTL is exposing. The current version of shared memory is 1. Whenever a change is made to structures stored in shared memory, or the layout of shared memory, the version should be incremented (like how the database version is
incremented when the database changes).

This version number will be used by the API to verify it is using the same version of shared memory as FTL.

Note that when the API adds the version verification, it will not be compatible with FTL v4.2, due to that branch not having this change.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
