### PR TITLE
Use armv6 soft-float for the arm build

### DIFF
--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,22 +1,8 @@
 FROM debian:stretch
 
-RUN dpkg --add-architecture armhf && \
+RUN dpkg --add-architecture armel && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nettle-dev:armhf \
-        make file wget netcat-traditional sqlite3 git ca-certificates ssh
+    apt-get install -y --no-install-recommends nettle-dev:armel gcc-arm-linux-gnueabi libc6-dev-armel-cross \
+        make file wget netcat-traditional sqlite3 git ca-certificates ssh libcap-dev:armel
 
-# Use Raspbian's GCC
-# This command was taken from https://github.com/dockcross/dockcross/blob/master/linux-armv6/Dockerfile
-# Slightly modified from the original
-RUN mkdir rpi_tools && cd rpi_tools && git init && git remote add origin https://github.com/raspberrypi/tools && \
-    git config core.sparseCheckout true && \
-    echo "arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64" >> .git/info/sparse-checkout && \
-    git pull --depth=1 origin master && \
-    cp -a arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/* /usr/ && rm -rf ../rpi_tools
-
-RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
-    wget ftl.pi-hole.net/libraries/libnettle.a -O /usr/local/lib/libnettle.a && \
-    wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a
-
-# Allow libnettle to be used, because this GCC doesn't have all the right header and library directories
-ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf"
+ENV CC arm-linux-gnueabi-gcc


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

There have been a few issues trying to support armv6 hard-float, notably nettle crashes even when not using DNSSEC. This change will also increase the amount of devices able to run FTL by supporting armv6 devices without hard-float. The performance impact is expected to be low.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
