### PR TITLE
Trim any whitespace characters around config keys

### DIFF
--- a/config.c
+++ b/config.c
@@ -389,9 +389,6 @@ static char *parse_FTLconf(FILE *fp, const char * key)
 	errno = 0;
 	while(getline(&conflinebuffer, &size, fp) != -1)
 	{
-		// Strip (possible) newline
-		conflinebuffer[strcspn(conflinebuffer, "\n")] = '\0';
-
 		// Skip comment lines
 		if(conflinebuffer[0] == '#' || conflinebuffer[0] == ';')
 			continue;
@@ -402,7 +399,13 @@ static char *parse_FTLconf(FILE *fp, const char * key)
 
 		// otherwise: key found
 		free(keystr);
-		return (find_equals(conflinebuffer) + 1);
+		// Note: value is still a pointer into the conflinebuffer
+		//       its memory will get released in release_config_memory()
+		char* value = find_equals(conflinebuffer) + 1;
+		// Trim whitespace at beginning and end, this function
+		// modifies the string inplace
+		trim_whitespace(value);
+		return value;
 	}
 
 	if(errno == ENOMEM)

--- a/routines.h
+++ b/routines.h
@@ -66,7 +66,9 @@ bool getSetupVarsBool(char * input);
 
 void parse_args(int argc, char* argv[]);
 
+// setupVars.c
 char* find_equals(const char* s);
+void trim_whitespace(char *string);
 
 // config.c
 void getLogFilePath(void);

--- a/setupVars.c
+++ b/setupVars.c
@@ -38,6 +38,26 @@ char* find_equals(const char* s)
 	return (char*)s;
 }
 
+void trim_whitespace(char *string)
+{
+	// isspace(char*) man page:
+	// checks for white-space  characters. In the "C" and "POSIX"
+	// locales, these are: space, form-feed ('\f'), newline ('\n'),
+	// carriage return ('\r'), horizontal tab ('\t'), and vertical tab
+	// ('\v').
+	char *original = string, *modified = string;
+	// Trim any whitespace characters (see above) at the beginning by increasing the pointer address
+	while (isspace((unsigned char)*original))
+		original++;
+	// Copy the content of original into modified as long as there is something in original
+	while ((*modified = *original++) != '\0')
+		modified++;
+	// Trim any whitespace characters (see above) at the end of the string by overwriting it
+	// with the zero character (marking the end of a C string)
+	while (modified > string && isspace((unsigned char)*--modified))
+		*modified = '\0';
+}
+
 // This will hold the read string
 // in memory and will serve the space
 // we will point to in the rest of the


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The config file parser is too sensitive towards possibly existing extra characters that may be in a line but are invisible to the user. This includes that lines terminated in CR-LF (e.g., config file stored by a non-Unix system) and ones including spaces at the end of the string have not been recognized and skipped. This PR implements trimming of the config file values by using the inbuilt `isspace()` function which will remove any of the following characters from both, the head and the tail of the read value string:

![screenshot from 2019-01-20 09-48-15](https://user-images.githubusercontent.com/16748619/51437054-9d3ae480-1c98-11e9-8ac9-edafa27889d9.png)

With this modification, even a config line such as
```
AAAA_QUERY_ANALYSIS=  	no  
```
is parsed correctly (there are spaces and tabs in the value string).