### PR TITLE
findQueryID(): Ensure indices are non-negative

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -229,9 +229,9 @@ static int findQueryID(int id)
 	// Validate access only once for the maximum index (all lower will work)
 	validate_access("queries", counters->queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 	int until = MAX(0, counters->queries-MAXITER);
-	int i;
+	int start = MAX(0, counters->queries-1);
 	// Check UUIDs of queries
-	for(i = counters->queries-1; i >= until; i--)
+	for(int i = start; i >= until; i--)
 		if(queries[i].id == id)
 			return i;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Ensure that the loop in `findQueryID()` cannot start with negative indices. This was the case when there where zero queries in the memory.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
