### PR TITLE
Properly initialize lastdbindex

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -36,8 +36,6 @@
 #include <pwd.h>
 // syslog
 #include <syslog.h>
-// SQLite
-#include "sqlite3.h"
 // tolower()
 #include <ctype.h>
 // Unix socket
@@ -174,7 +172,7 @@ typedef struct {
 	int domainID;
 	int clientID;
 	int forwardID;
-	sqlite3_int64 db;
+	int64_t db;
 	int id; // the ID is a (signed) int in dnsmasq, so no need for a long int here
 	bool complete;
 	unsigned char privacylevel;

--- a/api.c
+++ b/api.c
@@ -11,6 +11,8 @@
 #include "FTL.h"
 #include "api.h"
 #include "version.h"
+// needed for sqlite3_libversion()
+#include "sqlite3.h"
 
 #define min(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
 

--- a/database.c
+++ b/database.c
@@ -10,6 +10,7 @@
 
 #include "FTL.h"
 #include "shmem.h"
+#include "sqlite3.h"
 
 static sqlite3 *db;
 bool database = false;

--- a/database.c
+++ b/database.c
@@ -439,7 +439,7 @@ void save_to_DB(void)
 	int total = 0, blocked = 0;
 	time_t currenttimestamp = time(NULL);
 	time_t newlasttimestamp = 0;
-	for(i = lastdbindex; i < counters->queries; i++)
+	for(i = MAX(0, lastdbindex); i < counters->queries; i++)
 	{
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);
 		if(queries[i].db != 0)
@@ -836,6 +836,10 @@ void read_data_from_DB(void)
 		}
 	}
 	logg("Imported %i queries from the long-term database", counters->queries);
+
+	// Update lastdbindex so that the next call to save_to_DB()
+	// skips the queries that we just imported from the database
+	lastdbindex = counters->queries;
 
 	if( rc != SQLITE_DONE ){
 		logg("read_data_from_DB() - SQL error step (%i): %s", rc, sqlite3_errmsg(db));

--- a/networktable.c
+++ b/networktable.c
@@ -10,6 +10,7 @@
 
 #include "FTL.h"
 #include "shmem.h"
+#include "sqlite3.h"
 #define ARPCACHE "/proc/net/arp"
 
 // Private prototypes


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes a bug that has been introduced in https://github.com/pi-hole/FTL/commit/36d14998043f7c27eabaa0d6a0aec4e1dda6cfc5. This bug is only present in the `development` branch.

This bug has not been discovered before as a really unlikely coincidence had to happen to trigger a crash: It can only happen when GC is run before the first call to `save_to_DB()` happened. The problem is that `lastdbindex` was not properly initialized and only got set *after* `save_to_DB()` ran. However, when GC ran *before* `save_to_DB()`, it might subtract outdated queries from the `lastdbindex` integer, resulting in a negative starting index for the query loop in the database routine.

This PR also introduces a secondary feature, moving the inclusion of `sqlite3.h` to only those `c` files which depend on SQLite3 routines/definitions. This should improve compilation speed slightly.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
