### PR TITLE
Explicitly use clientID for newOverTimeClient()

### DIFF
--- a/datastructure.c
+++ b/datastructure.c
@@ -218,11 +218,12 @@ int findClientID(const char *client)
 	// to be done separately to be non-blocking
 	clients[clientID].new = true;
 	clients[clientID].namepos = 0;
-	// Increase counter by one
-	counters->clients++;
 
 	// Create new overTime client data
-	newOverTimeClient();
+	newOverTimeClient(clientID);
+
+	// Increase counter by one
+	counters->clients++;
 
 	return clientID;
 }

--- a/routines.h
+++ b/routines.h
@@ -119,7 +119,7 @@ void *enlarge_shmem_struct(char type);
  * Create a new overTime client shared memory block.
  * This also updates `overTimeClientData`.
  */
-void newOverTimeClient();
+void newOverTimeClient(int clientID);
 
 /**
  * Add a new overTime slot to each overTime client shared memory block.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Explicitly use `clientID` for `newOverTimeClient()` instead of using the private variable `overTimeClientCount` to avoid (possibly) error-prone double-entry bookkeeping.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
