### PR TITLE
Fix dnsmasq v2.80 implementation

### DIFF
--- a/dnsmasq/dhcp6.c
+++ b/dnsmasq/dhcp6.c
@@ -668,7 +668,7 @@ static int construct_worker(struct in6_addr *local, int prefix,
 	setaddr6part(&end6, addr6part(&template->end6));
 
 	for (context = daemon->dhcp6; context; context = context->next)
-	  if ((context->flags & CONTEXT_TEMPLATE) &&
+	  if (!(context->flags & CONTEXT_TEMPLATE) &&
 	      IN6_ARE_ADDR_EQUAL(&start6, &context->start6) &&
 	      IN6_ARE_ADDR_EQUAL(&end6, &context->end6))
 	    {

--- a/dnsmasq/inotify.c
+++ b/dnsmasq/inotify.c
@@ -237,6 +237,7 @@ int inotify_check(time_t now)
 	      (in->name[0] == '#' && in->name[namelen - 1] == '#') ||
 	      in->name[0] == '.')
 	    continue;
+
 	  for (res = daemon->resolv_files; res; res = res->next)
 	    if (res->wd == in->wd && strcmp(res->file, in->name) == 0)
 	      hit = 1;

--- a/dnsmasq/network.c
+++ b/dnsmasq/network.c
@@ -1571,8 +1571,7 @@ void check_servers(void)
 	      else if (strlen(serv->domain) == 0)
 		s1 = _("default"), s2 = "";
 	      else
-		//s1 = _("domain"), s2 = serv->domain;
-		continue;
+		s1 = _("domain"), s2 = serv->domain;
 
 	      if (serv->flags & SERV_NO_ADDR)
 		{
@@ -1596,10 +1595,10 @@ void check_servers(void)
 	}
     }
 
-  // if (locals > LOCALS_LOGGED)
-  //   my_syslog(LOG_INFO, _("using %d more local addresses"), locals - LOCALS_LOGGED);
-  // if (count - 1 > SERVERS_LOGGED)
-  //   my_syslog(LOG_INFO, _("using %d more nameservers"), count - SERVERS_LOGGED - 1);
+  if (locals > LOCALS_LOGGED)
+    my_syslog(LOG_INFO, _("using %d more local addresses"), locals - LOCALS_LOGGED);
+  if (count - 1 > SERVERS_LOGGED)
+    my_syslog(LOG_INFO, _("using %d more nameservers"), count - SERVERS_LOGGED - 1);
 
   /* Remove unused sfds */
   for (sfd = daemon->sfds, up = &daemon->sfds; sfd; sfd = tmp)

--- a/dnsmasq/rfc1035.c
+++ b/dnsmasq/rfc1035.c
@@ -1725,8 +1725,8 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			      nxdomain = 1;
 			    if (!dryrun)
 			    {
-			      log_query(crecp->flags, name, NULL, record_source(crecp->uid));
-			      FTL_cache(crecp->flags, name, NULL, record_source(crecp->uid), daemon->log_display_id);
+			      log_query(crecp->flags, name, NULL, NULL);
+			      FTL_cache(crecp->flags, name, NULL, NULL, daemon->log_display_id);
 			    }
 			  }
 			else

--- a/dnsmasq/util.c
+++ b/dnsmasq/util.c
@@ -294,7 +294,6 @@ void safe_strncpy(char *dest, const char *src, size_t size)
     }
 }
 
-
 void safe_pipe(int *fd, int read_noblock)
 {
   if (pipe(fd) == -1 ||


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10
---

I repeated the merging procedure for dnsmasq v2.79 -> v2.80 and slowly went through all code lines over the past few hours. There are a few differences including one fatal error (a logic inversion!) concerning DHCP + IPv6 which was causing crashes in IPv6 enabled networks when the Pi-hole DHCP server was enabled.

This code is verified to work with a fully IPv6 enabled network whereas `release/v2.80` and `development` currently crash on the same box.

The goal of this PR is to again achieve what we're aiming at: reducing the amount of changes between `FTL/dnsmasq` and `dnsmasq` to the absolute minimum. Hence, there are also a few empty lines being added or removed and also some debugging code from `dnsmasq` being re-enabled.