### PR TITLE
Fix counters->clients getting incremented twice due to v4.2 merge

### DIFF
--- a/datastructure.c
+++ b/datastructure.c
@@ -227,8 +227,6 @@ int findClientID(const char *client, bool count)
 	// No query seen so far
 	clients[clientID].lastQuery = 0;
 	clients[clientID].numQueriesARP = 0;
-	// Increase counter by one
-	counters->clients++;
 
 	// Create new overTime client data
 	newOverTimeClient(clientID);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

In release/v4.2, the `counters->clients++` call was moved to be after `newOverTimeClient`. When that change was merged to development, the first call was accidentally not deleted, causing it to happen twice (before and after `newOverTimeClient`).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
