### PR TITLE
Add libcap-dev to docker container and optimize container for changes

### DIFF
--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -15,7 +15,8 @@ RUN mkdir rpi_tools && cd rpi_tools && git init && git remote add origin https:/
 
 RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
     wget ftl.pi-hole.net/libraries/libnettle.a -O /usr/local/lib/libnettle.a && \
-    wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a
+    wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a && \
+    wget ftl.pi-hole.net/libraries/libcap.so.2.25 -O /usr/local/lib/libcap.so
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
@@ -23,4 +24,4 @@ RUN dpkg --add-architecture armhf && \
         nettle-dev:armhf libcap-dev sqlite3
 
 # Allow libnettle to be used, because this GCC doesn't have all the right header and library directories
-ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf"
+ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf -L/usr/local/lib"

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,9 +1,8 @@
 FROM debian:stretch
 
-RUN dpkg --add-architecture armhf && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends nettle-dev:armhf libcap-dev:armhf \
-        make file wget netcat-traditional sqlite3 git ca-certificates ssh
+# Packages required to install compiler and libraries
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget git ca-certificates
 
 # Use Raspbian's GCC
 # This command was taken from https://github.com/dockcross/dockcross/blob/master/linux-armv6/Dockerfile
@@ -17,6 +16,11 @@ RUN mkdir rpi_tools && cd rpi_tools && git init && git remote add origin https:/
 RUN wget ftl.pi-hole.net/libraries/libgmp.a -O /usr/local/lib/libgmp.a && \
     wget ftl.pi-hole.net/libraries/libnettle.a -O /usr/local/lib/libnettle.a && \
     wget ftl.pi-hole.net/libraries/libhogweed.a -O /usr/local/lib/libhogweed.a
+
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends make file netcat-traditional ssh \
+        nettle-dev:armhf libcap-dev sqlite3
 
 # Allow libnettle to be used, because this GCC doesn't have all the right header and library directories
 ENV CC "arm-linux-gnueabihf-gcc -I/usr/include -I/usr/include/arm-linux-gnueabihf"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The `libcap-dev` dependency was installed from `libcap-dev:armhf`, but it seems the compiler did not find it when compiling development builds, causing the development arm build to fail. Before the armv6 change, the dependency was installed as `libcap-dev`, so it has been changed back to that since it works.

The package installation has been split into two sections, one for the packages required to install the compiler and custom libraries, and the second for the rest of the packages. The first section is earlier in the container, as it does not change much, whereas the second section changes more often then the compiler and libraries, so it is after both.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
