### PR TITLE
Use improved "externally blocked" criterion

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -772,10 +772,11 @@ void FTL_header_ADbit(unsigned char header4, unsigned int rcode, int id)
 	if(config.privacylevel >= PRIVACY_NOSTATS)
 		return;
 
-	// Check if AD bit is set in DNS header
-	if(!(header4 & 0x20))
+	// Check if AD is set and RA bit is unset in DNS header
+	//              AD                  RA
+	if(!(header4 & 0x20) || (header4 & 0x80))
 	{
-		// AD bit not set
+		// AD bit not set or RA bit set
 		return;
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Use improved criterion for detecting "externally blocked" status.

All three points must now be met:

- `AD` bit set, 
- `RA` bit **un**set (new!), and 
- `RCODE` is `NXDOMAIN`


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
