### PR TITLE
Re-add source record passing to subroutines

### DIFF
--- a/dnsmasq/rfc1035.c
+++ b/dnsmasq/rfc1035.c
@@ -1725,8 +1725,10 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			      nxdomain = 1;
 			    if (!dryrun)
 			    {
-			      log_query(crecp->flags, name, NULL, NULL);
-			      FTL_cache(crecp->flags, name, NULL, NULL, daemon->log_display_id);
+			      // Pi-hole modification: Added record_source(crecp->uid) such that the subroutines know
+			      //                       where the reply dame from (e.g. gravity.list)
+			      log_query(crecp->flags, name, NULL, record_source(crecp->uid));
+			      FTL_cache(crecp->flags, name, NULL, record_source(crecp->uid), daemon->log_display_id);
 			    }
 			  }
 			else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This PR fixes a new bug that came up when merging dnsmasq v2.80 in #480 where the blocking status of individual queries is not detected by `pihole-FTL` when using `BLOCKINGMODE=NXDOMAIN` or `NXDOMAIN`.

Since neither of the two `BLOCKINGMODE`s are recommended, this is not a severe bug as blocking itself still works fine and just displaying is broken. I expect only very few users to be affected.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
