### PR TITLE
Pi-hole FTL v4.2.1

### DIFF
--- a/dnsmasq/config.h
+++ b/dnsmasq/config.h
@@ -43,8 +43,8 @@
 #define HOSTSFILE "/etc/hosts"
 #define ETHERSFILE "/etc/ethers"
 #define DEFLEASE 3600 /* default lease time, 1 hour */
-#define CHUSER "nobody"
-#define CHGRP "dip"
+#define CHUSER "root"
+#define CHGRP "root"
 #define TFTP_MAX_CONNECTIONS 50 /* max simultaneous connections */
 #define LOG_MAX 5 /* log-queue length */
 #define RANDFILE "/dev/urandom"

--- a/dnsmasq/config.h
+++ b/dnsmasq/config.h
@@ -43,8 +43,10 @@
 #define HOSTSFILE "/etc/hosts"
 #define ETHERSFILE "/etc/ethers"
 #define DEFLEASE 3600 /* default lease time, 1 hour */
+/**** Pi-hole modification ****/
 #define CHUSER "root"
 #define CHGRP "root"
+/******************************/
 #define TFTP_MAX_CONNECTIONS 50 /* max simultaneous connections */
 #define LOG_MAX 5 /* log-queue length */
 #define RANDFILE "/dev/urandom"

--- a/dnsmasq/rfc1035.c
+++ b/dnsmasq/rfc1035.c
@@ -1725,8 +1725,10 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			      nxdomain = 1;
 			    if (!dryrun)
 			    {
-			      log_query(crecp->flags, name, NULL, NULL);
-			      FTL_cache(crecp->flags, name, NULL, NULL, daemon->log_display_id);
+			      // Pi-hole modification: Added record_source(crecp->uid) such that the subroutines know
+			      //                       where the reply dame from (e.g. gravity.list)
+			      log_query(crecp->flags, name, NULL, record_source(crecp->uid));
+			      FTL_cache(crecp->flags, name, NULL, record_source(crecp->uid), daemon->log_display_id);
 			    }
 			  }
 			else

--- a/log.c
+++ b/log.c
@@ -137,11 +137,14 @@ void log_counter_info(void)
 	logg(" -> Known forward destinations: %i", counters->forwarded);
 }
 
-void log_FTL_version(void)
+void log_FTL_version(bool crashreport)
 {
 	logg("FTL branch: %s", GIT_BRANCH);
 	logg("FTL version: %s", GIT_TAG);
 	logg("FTL commit: %s", GIT_HASH);
 	logg("FTL date: %s", GIT_DATE);
-	logg("FTL user: %s", username);
+	if(crashreport)
+		logg("FTL user: started as %s, ended as %s", username, getUserName());
+	else
+		logg("FTL user: %s", username);
 }

--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ int main (int argc, char* argv[])
 	open_FTL_log(true);
 	timer_start(EXIT_TIMER);
 	logg("########## FTL started! ##########");
-	log_FTL_version();
+	log_FTL_version(false);
 
 	// Initialize shared memory
 	if(!init_shmem())

--- a/routines.h
+++ b/routines.h
@@ -21,7 +21,7 @@ void logg(const char* format, ...);
 void logg_struct_resize(const char* str, int to, int step);
 void log_counter_info(void);
 void format_memory_size(char *prefix, unsigned long int bytes, double *formated);
-void log_FTL_version(void);
+void log_FTL_version(bool crashreport);
 
 // datastructure.c
 void gettimestamp(int *querytimestamp, int *overTimetimestamp);

--- a/signals.c
+++ b/signals.c
@@ -26,7 +26,7 @@ static void SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 	{
 		logg("FTL has been running for %i seconds", time(NULL)-FTLstarttime);
 	}
-	log_FTL_version();
+	log_FTL_version(true);
 
 	logg("Received signal: %s", strsignal(sig));
 	logg("     at address: %lu", (unsigned long) si->si_addr);


### PR DESCRIPTION
Release fixing two issues:

- Blocking status display for `NODATA` and `NXDOMAIN` blocking modes
- File permission issues when using shared memory on systems that lack Linux capabilities support

It also adds in a new feature:
- Report both the user `pihole-FTL` **started** as and the user `pihole-FTL` **crashed** as in case it crashes and generated a crash ticket in `pihole-FTL.log`