### PR TITLE
Fix incorrect fatal error message in findQueryID

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -231,9 +231,10 @@ static int findQueryID(int id)
 	// MAX(0, a) is used to return 0 in case a is negative (negative array indices are harmful)
 
 	// Validate access only once for the maximum index (all lower will work)
-	validate_access("queries", counters->queries-1, false, __LINE__, __FUNCTION__, __FILE__);
 	int until = MAX(0, counters->queries-MAXITER);
 	int start = MAX(0, counters->queries-1);
+	validate_access("queries", until, false, __LINE__, __FUNCTION__, __FILE__);
+
 	// Check UUIDs of queries
 	for(int i = start; i >= until; i--)
 		if(queries[i].id == id)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The code was changed to prevent negative indices from being used, but the `validate_access` call was not updated. This causes "fatal" errors to be written to the log even though there is no fatal error.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
