### PR TITLE
Fix last timestamp getting set to zero if no queries were saved

### DIFF
--- a/database.c
+++ b/database.c
@@ -539,14 +539,14 @@ void save_to_DB(void)
 
 	// Store index for next loop interation round and update last time stamp
 	// in the database only if all queries have been saved successfully
-	if(saved_error == 0)
+	if(saved > 0 && saved_error == 0)
 	{
 		lastdbindex = i;
 		db_set_FTL_property(DB_LASTTIMESTAMP, newlasttimestamp);
 	}
 
 	// Update total counters in DB
-	if(!db_update_counters(total, blocked))
+	if(saved > 0 && !db_update_counters(total, blocked))
 	{
 		dbclose();
 		return;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

If no queries were saved to the database, the last timestamp field would be set to zero instead of left as it was. In addition, this commit skips adding zero to the other counters in the database if there were no saved queries.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
