### PR TITLE
Pi-hole FTL v4.2.3

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -221,6 +221,10 @@ typedef struct {
 	char **domains;
 } whitelistStruct;
 
+typedef struct {
+	int version;
+} ShmSettings;
+
 // Prepare timers, used mainly for debugging purposes
 #define NUMTIMERS 5
 

--- a/FTL.h
+++ b/FTL.h
@@ -224,6 +224,7 @@ typedef struct {
 typedef struct {
 	int version;
 	unsigned int global_shm_counter;
+	unsigned int next_str_pos;
 } ShmSettings;
 
 // Prepare timers, used mainly for debugging purposes

--- a/FTL.h
+++ b/FTL.h
@@ -223,6 +223,7 @@ typedef struct {
 
 typedef struct {
 	int version;
+	unsigned int global_shm_counter;
 } ShmSettings;
 
 // Prepare timers, used mainly for debugging purposes

--- a/FTL.h
+++ b/FTL.h
@@ -130,7 +130,7 @@ typedef struct {
 	int forwarded_MAX;
 	int clients_MAX;
 	int domains_MAX;
-	int overTime_MAX;
+	int strings_MAX;
 	int gravity;
 	int gravity_conf;
 	int querytype[TYPE_MAX-1];

--- a/shmem.c
+++ b/shmem.c
@@ -110,6 +110,7 @@ void remap_shm(void)
 {
 	// Remap shared object pointers which might have changed
 	realloc_shm(&shm_queries, 0);
+	realloc_shm(&shm_strings, 0);
 	realloc_shm(&shm_domains, 0);
 	realloc_shm(&shm_clients, 0);
 	realloc_shm(&shm_forwarded, 0);

--- a/shmem.c
+++ b/shmem.c
@@ -12,7 +12,7 @@
 #include "shmem.h"
 
 /// The version of shared memory used
-#define SHARED_MEMORY_VERSION 5
+#define SHARED_MEMORY_VERSION 4
 
 /// The name of the shared memory. Use this when connecting to the shared memory.
 #define SHARED_LOCK_NAME "/FTL-lock"

--- a/shmem.h
+++ b/shmem.h
@@ -33,8 +33,9 @@ SharedMemory create_shm(char *name, size_t size);
 ///
 /// \param sharedMemory the shared memory struct
 /// \param size the new size
+/// \param resize whether the object should be resized or only remapped
 /// \return if reallocation was successful
-bool realloc_shm(SharedMemory *sharedMemory, size_t size);
+bool realloc_shm(SharedMemory *sharedMemory, size_t size, bool resize);
 
 /// Disconnect from shared memory. If there are no other connections to shared memory, it will be deleted.
 ///


### PR DESCRIPTION
**This release fixes #496**

Issue
---

DNS requests and responses can happen over UDP or TCP. UDP is the most common, but TCP is used often for large responses or by some specific products (we have seen this with Netflix in the past). Handling TCP connections requires more communication with the client and server, so `pihole-FTL` creates TCP helper **processes** by forking.

When dynamically allocated shared memory objects get resized, they get resized, and then re-mapped. The problem is that if our shared memory object is now significantly larger and if this happens on a TCP handler process, the other processes were not notified about the virtual memory change keep using the old shared memory, i.e., they were using dangling pointers. This caused a memory corruption or access error when accessed.

Solution
---
This pull requests ensures that, when the space of virtual addresses changes, the other forks get notified and can re-map the shared memory objects to get possibly updated virtual memory addresses for their pointers.