### PR TITLE
Align overTime shared memory to struct size

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -195,7 +195,7 @@ bool init_shmem(void)
 	counters->queries_MAX = pagesize;
 
 	/****************************** shared overTime struct ******************************/
-	size_t size = ((OVERTIME_SLOTS*sizeof(overTimeDataStruct))/pagesize + 1)*pagesize;
+	size_t size = (OVERTIME_SLOTS/pagesize + 1)*pagesize*sizeof(overTimeDataStruct);
 	// Try to create shared memory object
 	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size);
 	overTime = (overTimeDataStruct*)shm_overTime.ptr;

--- a/shmem.c
+++ b/shmem.c
@@ -45,6 +45,8 @@ static ShmLock *shmLock = NULL;
 static int pagesize;
 static unsigned int next_pos = 0;
 
+static size_t get_optimal_object_size(size_t objsize);
+
 unsigned long long addstr(const char *str)
 {
 	if(str == NULL)
@@ -195,7 +197,12 @@ bool init_shmem(void)
 	counters->queries_MAX = pagesize;
 
 	/****************************** shared overTime struct ******************************/
-	size_t size = (OVERTIME_SLOTS/pagesize + 1)*pagesize*sizeof(overTimeDataStruct);
+	size_t size = get_optimal_object_size(sizeof(overTimeDataStruct));
+	size_t required_size = OVERTIME_SLOTS*sizeof(overTimeDataStruct);
+	if(size < required_size)
+	{
+		logg("FATAL: LCM(%i, %zu) == %zu < %zu", pagesize, sizeof(overTimeDataStruct), size, required_size);
+	}
 	// Try to create shared memory object
 	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size);
 	overTime = (overTimeDataStruct*)shm_overTime.ptr;
@@ -390,4 +397,35 @@ void delete_shm(SharedMemory *sharedMemory)
 	ret = shm_unlink(sharedMemory->name);
 	if(ret != 0)
 		logg("delete_shm(): shm_unlink(%s) failed: %s", sharedMemory->name, strerror(errno));
+}
+
+// Recursive function to return GCD of a and b
+// Credits: https://www.geeksforgeeks.org/program-to-find-lcm-of-two-numbers/
+// The code in this link has been modified by the Pi-hole developers
+static size_t gcd(size_t a, size_t b)
+{
+	// Everything divides 0
+	// (except maybe zero)
+	if (a == 0 || b == 0)
+		return 1;
+
+	// Base case
+	if (a == b)
+		return a;
+
+	// a is greater
+	if (a > b)
+		return gcd(a-b, b);
+
+	// b is greater
+	return gcd(a, b-a);
+}
+
+// Function to return the optimal (minimum) size for page-aligned
+// shared memory objects. This routine works by computing the LCM
+// of two numbers, the pagesize and the size of a single element
+// in the shared memory object
+static size_t get_optimal_object_size(size_t objsize)
+{
+	return (pagesize*objsize)/gcd(pagesize, objsize);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

The overTime shared memory size is now a multiple of the struct size, which is required for the API to safely connect to shared memory.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
