### PR TITLE
Use LCM to compute optimal allocation step for dynamic shared memory objects

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -230,9 +230,10 @@ bool init_shmem(void)
 
 	/****************************** shared forwarded struct ******************************/
 	// Try to create shared memory object
-	shm_forwarded = create_shm(SHARED_FORWARDED_NAME, pagesize*sizeof(forwardedDataStruct));
+	size = get_optimal_object_size(sizeof(forwardedDataStruct));
+	shm_forwarded = create_shm(SHARED_FORWARDED_NAME, size*sizeof(forwardedDataStruct));
 	forwarded = (forwardedDataStruct*)shm_forwarded.ptr;
-	counters->forwarded_MAX = pagesize;
+	counters->forwarded_MAX = size;
 
 	/****************************** shared queries struct ******************************/
 	// Try to create shared memory object

--- a/shmem.c
+++ b/shmem.c
@@ -366,7 +366,7 @@ void *enlarge_shmem_struct(char type)
 			break;
 		case FORWARDED:
 			sharedMemory = &shm_forwarded;
-			allocation_step = pagesize;
+			allocation_step = get_optimal_object_size(sizeof(forwardedDataStruct));
 			sizeofobj = sizeof(forwardedDataStruct);
 			counter = &counters->forwarded_MAX;
 			break;

--- a/shmem.c
+++ b/shmem.c
@@ -223,9 +223,10 @@ bool init_shmem(void)
 
 	/****************************** shared clients struct ******************************/
 	// Try to create shared memory object
-	shm_clients = create_shm(SHARED_CLIENTS_NAME, pagesize*sizeof(clientsDataStruct));
+	size_t size = get_optimal_object_size(sizeof(clientsDataStruct));
+	shm_clients = create_shm(SHARED_CLIENTS_NAME, size*sizeof(clientsDataStruct));
 	clients = (clientsDataStruct*)shm_clients.ptr;
-	counters->clients_MAX = pagesize;
+	counters->clients_MAX = size;
 
 	/****************************** shared forwarded struct ******************************/
 	// Try to create shared memory object
@@ -240,14 +241,17 @@ bool init_shmem(void)
 	counters->queries_MAX = pagesize;
 
 	/****************************** shared overTime struct ******************************/
-	size_t size = get_optimal_object_size(sizeof(overTimeDataStruct));
-	size_t required_size = OVERTIME_SLOTS*sizeof(overTimeDataStruct);
+	size = get_optimal_object_size(sizeof(overTimeDataStruct));
+	size_t required_size = OVERTIME_SLOTS;
 	if(size < required_size)
 	{
-		logg("FATAL: LCM(%i, %zu) == %zu < %zu", pagesize, sizeof(overTimeDataStruct), size, required_size);
+		logg("FATAL: LCM(%i, %zu) == %zu < %zu",
+		     pagesize, sizeof(overTimeDataStruct),
+		     size*sizeof(overTimeDataStruct),
+		     required_size*sizeof(overTimeDataStruct));
 	}
 	// Try to create shared memory object
-	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size);
+	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size*sizeof(overTimeDataStruct));
 	overTime = (overTimeDataStruct*)shm_overTime.ptr;
 	initOverTime();
 
@@ -334,30 +338,34 @@ SharedMemory create_shm(char *name, size_t size)
 
 void *enlarge_shmem_struct(char type)
 {
-	SharedMemory *sharedMemory;
-	size_t sizeofobj;
-	int *counter;
+	SharedMemory *sharedMemory = NULL;
+	size_t sizeofobj, allocation_step;
+	int *counter = NULL;
 
 	// Select type of struct that should be enlarged
 	switch(type)
 	{
 		case QUERIES:
 			sharedMemory = &shm_queries;
+			allocation_step = pagesize;
 			sizeofobj = sizeof(queriesDataStruct);
 			counter = &counters->queries_MAX;
 			break;
 		case CLIENTS:
 			sharedMemory = &shm_clients;
+			allocation_step = get_optimal_object_size(sizeof(clientsDataStruct));
 			sizeofobj = sizeof(clientsDataStruct);
 			counter = &counters->clients_MAX;
 			break;
 		case DOMAINS:
 			sharedMemory = &shm_domains;
+			allocation_step = pagesize;
 			sizeofobj = sizeof(domainsDataStruct);
 			counter = &counters->domains_MAX;
 			break;
 		case FORWARDED:
 			sharedMemory = &shm_forwarded;
+			allocation_step = pagesize;
 			sizeofobj = sizeof(forwardedDataStruct);
 			counter = &counters->forwarded_MAX;
 			break;
@@ -367,10 +375,10 @@ void *enlarge_shmem_struct(char type)
 	}
 
 	// Reallocate enough space for 4096 instances of requested object
-	realloc_shm(sharedMemory, sharedMemory->size + pagesize*sizeofobj, true);
+	realloc_shm(sharedMemory, sharedMemory->size + allocation_step*sizeofobj, true);
 
 	// Add allocated memory to corresponding counter
-	*counter += pagesize;
+	*counter += allocation_step;
 
 	return sharedMemory->ptr;
 }
@@ -476,5 +484,5 @@ static size_t gcd(size_t a, size_t b)
 // in the shared memory object
 static size_t get_optimal_object_size(size_t objsize)
 {
-	return (pagesize*objsize)/gcd(pagesize, objsize);
+	return pagesize / gcd(pagesize, objsize);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Due to the requirement of having to be perfectly page-aligned for the API, we used to allocate the shared memory objects in steps of `pagesize`. While this seems meaningful for both, `queries` and `domains`, it doesn't seem useful for `clients` and `forwarded` as rarely any user should see more than 1000 entries in them.

This PR uses the recently added LCM calculator to compute the optimal (minimum) amount of memory that ensures perfect page-alignment.

- `clients`: Allocation step is now 512 instead of 4096. Memory initially needed by this object is now 324KB instead of 2.6MB. The effect is especially notable for `clients` as each client contains its private `overTime` structure which is consuming quite a bit of memory (648 bytes per client).

- `forwarded`: Allocation step is now 512 instead of 4096. Memory initially needed by this object is now 20KB instead of 160KB. The difference is smaller as the `forwarded` data is only 40 bytes each.
