### PR TITLE
Fix shm crash caused by an insufficient obtained optimal structure size

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -229,15 +229,15 @@ bool init_shmem(void)
 	counters->domains_MAX = pagesize;
 
 	/****************************** shared clients struct ******************************/
-	// Try to create shared memory object
 	size_t size = get_optimal_object_size(sizeof(clientsDataStruct));
+	// Try to create shared memory object
 	shm_clients = create_shm(SHARED_CLIENTS_NAME, size*sizeof(clientsDataStruct));
 	clients = (clientsDataStruct*)shm_clients.ptr;
 	counters->clients_MAX = size;
 
 	/****************************** shared forwarded struct ******************************/
-	// Try to create shared memory object
 	size = get_optimal_object_size(sizeof(forwardedDataStruct));
+	// Try to create shared memory object
 	shm_forwarded = create_shm(SHARED_FORWARDED_NAME, size*sizeof(forwardedDataStruct));
 	forwarded = (forwardedDataStruct*)shm_forwarded.ptr;
 	counters->forwarded_MAX = size;
@@ -257,6 +257,7 @@ bool init_shmem(void)
 		     pagesize, sizeof(overTimeDataStruct),
 		     size*sizeof(overTimeDataStruct),
 		     required_size*sizeof(overTimeDataStruct));
+		exit(EXIT_FAILURE);
 	}
 	// Try to create shared memory object
 	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size*sizeof(overTimeDataStruct));

--- a/shmem.c
+++ b/shmem.c
@@ -500,7 +500,7 @@ static size_t get_optimal_object_size(size_t objsize, unsigned int minsize)
 		// First part: Integer division, may cause clipping, e.g., 5/3 = 1
 		// Second part: Catch a possibly happened clipping event by adding
 		//              one to the number: (5 % 3 != 0) is 1
-		unsigned int multiplier = minsize/optsize + (minsize % optsize != 0);
+		unsigned int multiplier = minsize/optsize + (minsize % optsize != 0) ? 1 : 0;
 		// As optsize ensures perfect page-alignment,
 		// any multiple of it will be aligned as well
 		return optsize*multiplier;

--- a/shmem.c
+++ b/shmem.c
@@ -66,7 +66,7 @@ unsigned long long addstr(const char *str)
 
 	// Debugging output
 	if(config.debug & DEBUG_SHMEM)
-		logg("Adding \"%s\" (len %i) to buffer. next_str_pos is %i", str, len, shmSettings->next_str_pos);
+		logg("Adding \"%s\" (len %zu) to buffer. next_str_pos is %u", str, len, shmSettings->next_str_pos);
 
 	// Reserve additional memory if necessary
 	size_t required_size = shmSettings->next_str_pos + len + 1;
@@ -92,7 +92,14 @@ unsigned long long addstr(const char *str)
 
 char *getstr(unsigned long long pos)
 {
-	return &((char*)shm_strings.ptr)[pos];
+	// Only access the string memory if this memory region has already been set
+	if(pos < shmSettings->next_str_pos)
+		return &((char*)shm_strings.ptr)[pos];
+	else
+	{
+		logg("WARN: Tried to access %llu but next_str_pos is %u", pos, shmSettings->next_str_pos);
+		return "";
+	}
 }
 
 /// Create a mutex for shared memory


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Under certain circumstances, it happened that the obtained optimal (= minimum) page-aligned was too small to hold the entire `overTime` array. Although there was a check for this, we only logged that there is an issue but a `exit(1);` was missing so FTL kept running. This inevitably lead to memory corruption.

We extend this by adding an additional parameter with which we can specify how many slots we want to have *at least*.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
