### PR TITLE
Don't create IPv6 cache entries when IPV6_ADDRESS is empty

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1126,7 +1126,7 @@ static void prepare_blocking_mode(struct all_addr *addr4, struct all_addr *addr6
 	else
 	{
 		// Don't create IPv6 cache entries when we don't need them
-		// Also, don't create them if we ate in IP blocking mode and
+		// Also, don't create them if we are in IP blocking mode and
 		// strlen(IPv6addr) == 0
 		*has_IPv6 = false;
 	}

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1115,10 +1115,20 @@ static void prepare_blocking_mode(struct all_addr *addr4, struct all_addr *addr6
 		if(inet_pton(AF_INET6, IPv6addr, addr6) > 0)
 			*has_IPv6 = true;
 	}
-	else
+	else if(config.blockingmode == MODE_IP_NODATA_AAAA)
 	{
 		// Blocking mode will use zero-initialized all_addr struct
+		// This is irrelevant, however, as this blocking mode will
+		// reply with NODATA to AAAA queries. Still, we need to
+		// generate separate IPv4 (IP) and AAAA (NODATA) records
 		*has_IPv6 = true;
+	}
+	else
+	{
+		// Don't create IPv6 cache entries when we don't need them
+		// Also, don't create them if we ate in IP blocking mode and
+		// strlen(IPv6addr) == 0
+		*has_IPv6 = false;
 	}
 	clearSetupVarsArray(); // will free/invalidate IPv6addr
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Don't create IPv6 cache entries when `IPV6_ADDRESS` is empty in `setupVars.conf`.

Currently, we create empty (`::`) IPv6 entries when users set `BLOCKINGMODE=IP` in `pihole-FTL.conf` when the `IPV6_ADDRESS` variable is empty (or unset) in `setupVars.conf`.
This PR ensures that IPv6 entries are not created in `IP` mode when we don't have a suitable address for them.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
