### PR TITLE
Prevent direct access to global objects queries, clients, domains, and forward

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -313,11 +313,11 @@ extern pthread_t GCthread;
 extern pthread_t DNSclientthread;
 
 // Pointer getter functions
-#define getQuery(queryID) _getQuery(queryID, __LINE__, __FUNCTION__, __FILE__)
-queriesData* _getQuery(int queryID, int line, const char * function, const char * file);
-#define getClient(clientID) _getClient(clientID, __LINE__, __FUNCTION__, __FILE__)
-clientsData* _getClient(int clientID, int line, const char * function, const char * file);
-#define getDomain(domainID) _getDomain(domainID, __LINE__, __FUNCTION__, __FILE__)
-domainsData* _getDomain(int domainID, int line, const char * function, const char * file);
-#define getForward(forwardID) _getForward(forwardID, __LINE__, __FUNCTION__, __FILE__)
-forwardedData* _getForward(int forwardID, int line, const char * function, const char * file);
+#define getQuery(queryID, checkMagic) _getQuery(queryID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
+queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * function, const char * file);
+#define getClient(clientID, checkMagic) _getClient(clientID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
+clientsData* _getClient(int clientID, bool checkMagic, int line, const char * function, const char * file);
+#define getDomain(domainID, checkMagic) _getDomain(domainID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
+domainsData* _getDomain(int domainID, bool checkMagic, int line, const char * function, const char * file);
+#define getForward(forwardID, checkMagic) _getForward(forwardID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
+forwardedData* _getForward(int forwardID, bool checkMagic, int line, const char * function, const char * file);

--- a/FTL.h
+++ b/FTL.h
@@ -261,7 +261,6 @@ extern FTLFileNamesStruct FTLfiles;
 extern countersStruct *counters;
 extern ConfigStruct config;
 
-extern forwardedDataStruct *forwarded;
 extern overTimeDataStruct *overTime;
 
 /// Indexed by client ID, then time index (like `overTime`).
@@ -320,3 +319,5 @@ queriesDataStruct* _getQuery(int queryID, int line, const char * function, const
 clientsDataStruct* _getClient(int clientID, int line, const char * function, const char * file);
 #define getDomain(domainID) _getDomain(domainID, __LINE__, __FUNCTION__, __FILE__)
 domainsDataStruct* _getDomain(int domainID, int line, const char * function, const char * file);
+#define getForward(forwardID) _getForward(forwardID, __LINE__, __FUNCTION__, __FILE__)
+forwardedDataStruct* _getForward(int forwardID, int line, const char * function, const char * file);

--- a/FTL.h
+++ b/FTL.h
@@ -262,7 +262,6 @@ extern countersStruct *counters;
 extern ConfigStruct config;
 
 extern forwardedDataStruct *forwarded;
-extern domainsDataStruct *domains;
 extern overTimeDataStruct *overTime;
 
 /// Indexed by client ID, then time index (like `overTime`).
@@ -319,3 +318,5 @@ extern pthread_t DNSclientthread;
 queriesDataStruct* _getQuery(int queryID, int line, const char * function, const char * file);
 #define getClient(clientID) _getClient(clientID, __LINE__, __FUNCTION__, __FILE__)
 clientsDataStruct* _getClient(int clientID, int line, const char * function, const char * file);
+#define getDomain(domainID) _getDomain(domainID, __LINE__, __FUNCTION__, __FILE__)
+domainsDataStruct* _getDomain(int domainID, int line, const char * function, const char * file);

--- a/FTL.h
+++ b/FTL.h
@@ -262,7 +262,6 @@ extern countersStruct *counters;
 extern ConfigStruct config;
 
 extern forwardedDataStruct *forwarded;
-extern clientsDataStruct *clients;
 extern domainsDataStruct *domains;
 extern overTimeDataStruct *overTime;
 
@@ -318,3 +317,5 @@ extern pthread_t DNSclientthread;
 // Pointer getter functions
 #define getQuery(queryID) _getQuery(queryID, __LINE__, __FUNCTION__, __FILE__)
 queriesDataStruct* _getQuery(int queryID, int line, const char * function, const char * file);
+#define getClient(clientID) _getClient(clientID, __LINE__, __FUNCTION__, __FILE__)
+clientsDataStruct* _getClient(int clientID, int line, const char * function, const char * file);

--- a/FTL.h
+++ b/FTL.h
@@ -194,7 +194,7 @@ typedef struct {
 	unsigned char reply;
 	unsigned char dnssec;
 	bool AD;
-} queriesDataStruct;
+} queriesData;
 
 typedef struct {
 	unsigned char magic;
@@ -203,7 +203,7 @@ typedef struct {
 	unsigned long long ippos;
 	unsigned long long namepos;
 	bool new;
-} forwardedDataStruct;
+} forwardedData;
 
 typedef struct {
 	unsigned char magic;
@@ -215,7 +215,7 @@ typedef struct {
 	int overTime[OVERTIME_SLOTS];
 	time_t lastQuery;
 	unsigned int numQueriesARP;
-} clientsDataStruct;
+} clientsData;
 
 typedef struct {
 	unsigned char magic;
@@ -223,7 +223,7 @@ typedef struct {
 	int blockedcount;
 	unsigned long long domainpos;
 	unsigned char regexmatch;
-} domainsDataStruct;
+} domainsData;
 
 typedef struct {
 	unsigned char magic;
@@ -233,7 +233,7 @@ typedef struct {
 	int cached;
 	int forwarded;
 	int querytypedata[TYPE_MAX-1];
-} overTimeDataStruct;
+} overTimeData;
 
 typedef struct {
 	int count;
@@ -261,7 +261,7 @@ extern FTLFileNamesStruct FTLfiles;
 extern countersStruct *counters;
 extern ConfigStruct config;
 
-extern overTimeDataStruct *overTime;
+extern overTimeData *overTime;
 
 /// Indexed by client ID, then time index (like `overTime`).
 /// This gets automatically updated whenever a new client or overTime slot is added.
@@ -314,10 +314,10 @@ extern pthread_t DNSclientthread;
 
 // Pointer getter functions
 #define getQuery(queryID) _getQuery(queryID, __LINE__, __FUNCTION__, __FILE__)
-queriesDataStruct* _getQuery(int queryID, int line, const char * function, const char * file);
+queriesData* _getQuery(int queryID, int line, const char * function, const char * file);
 #define getClient(clientID) _getClient(clientID, __LINE__, __FUNCTION__, __FILE__)
-clientsDataStruct* _getClient(int clientID, int line, const char * function, const char * file);
+clientsData* _getClient(int clientID, int line, const char * function, const char * file);
 #define getDomain(domainID) _getDomain(domainID, __LINE__, __FUNCTION__, __FILE__)
-domainsDataStruct* _getDomain(int domainID, int line, const char * function, const char * file);
+domainsData* _getDomain(int domainID, int line, const char * function, const char * file);
 #define getForward(forwardID) _getForward(forwardID, __LINE__, __FUNCTION__, __FILE__)
-forwardedDataStruct* _getForward(int forwardID, int line, const char * function, const char * file);
+forwardedData* _getForward(int forwardID, int line, const char * function, const char * file);

--- a/FTL.h
+++ b/FTL.h
@@ -261,7 +261,6 @@ extern FTLFileNamesStruct FTLfiles;
 extern countersStruct *counters;
 extern ConfigStruct config;
 
-extern queriesDataStruct *queries;
 extern forwardedDataStruct *forwarded;
 extern clientsDataStruct *clients;
 extern domainsDataStruct *domains;
@@ -315,3 +314,7 @@ extern pthread_t socket_listenthread;
 extern pthread_t DBthread;
 extern pthread_t GCthread;
 extern pthread_t DNSclientthread;
+
+// Pointer getter functions
+#define getQuery(queryID) _getQuery(queryID, __LINE__, __FUNCTION__, __FILE__)
+queriesDataStruct* _getQuery(int queryID, int line, const char * function, const char * file);

--- a/api.c
+++ b/api.c
@@ -463,7 +463,6 @@ void getForwardDestinations(char *client_message, int *sock)
 		sort = false;
 
 	for(int i = 0; i < counters->forwarded; i++) {
-		validate_access("forwarded", i, true, __LINE__, __FUNCTION__, __FILE__);
 		// If we want to print a sorted output, we fill the temporary array with
 		// the values we will use for sorting afterwards
 		if(sort) {
@@ -643,10 +642,8 @@ void getAllQueries(char *client_message, int *sock)
 		else
 		{
 			// Iterate through all known forward destinations
-			int i;
-			validate_access("forwards", MAX(0,counters->forwarded-1), true, __LINE__, __FUNCTION__, __FILE__);
 			forwarddestid = -3;
-			for(i = 0; i < counters->forwarded; i++)
+			for(int i = 0; i < counters->forwarded; i++)
 			{
 				// Get forward pointer
 				forwardedDataStruct* forward = getForward(i);
@@ -764,9 +761,6 @@ void getAllQueries(char *client_message, int *sock)
 		queriesDataStruct* query = getQuery(i);
 		// Check if this query has been create while in maximum privacy mode
 		if(query->privacylevel >= PRIVACY_MAXIMUM) continue;
-
-		validate_access("domains", query->domainID, true, __LINE__, __FUNCTION__, __FILE__);
-		validate_access("clients", query->clientID, true, __LINE__, __FUNCTION__, __FILE__);
 
 		char *qtype = querytypes[query->type - TYPE_A];
 
@@ -1122,8 +1116,6 @@ void getClientsOverTime(int *sock)
 
 void getClientNames(int *sock)
 {
-	int i;
-
 	// Exit before processing any data if requested via config setting
 	get_privacy_level(NULL);
 	if(config.privacylevel >= PRIVACY_HIDE_DOMAINS_CLIENTS)
@@ -1141,7 +1133,7 @@ void getClientNames(int *sock)
 	{
 		getSetupVarsArray(excludeclients);
 
-		for(i=0; i < counters->clients; i++)
+		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
 			clientsDataStruct* client = getClient(i);
@@ -1153,9 +1145,8 @@ void getClientNames(int *sock)
 	}
 
 	// Loop over clients to generate output to be sent to the client
-	for(i = 0; i < counters->clients; i++)
+	for(int i = 0; i < counters->clients; i++)
 	{
-		validate_access("clients", i, true, __LINE__, __FUNCTION__, __FILE__);
 		if(skipclient[i])
 			continue;
 

--- a/api.c
+++ b/api.c
@@ -66,7 +66,7 @@ void getStats(int *sock)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(i);
+		clientsData* client = getClient(i);
 		if(client->count > 0)
 			activeclients++;
 	}
@@ -209,7 +209,7 @@ void getTopDomains(char *client_message, int *sock)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(i);
+		domainsData* domain = getDomain(i);
 
 		temparray[i][0] = i;
 		if(blocked)
@@ -270,7 +270,7 @@ void getTopDomains(char *client_message, int *sock)
 		int j = temparray[i][0];
 
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(j);
+		domainsData* domain = getDomain(j);
 
 		// Skip this domain if there is a filter on it
 		if(excludedomains != NULL && insetupVarsArray(getstr(domain->domainpos)))
@@ -376,7 +376,7 @@ void getTopClients(char *client_message, int *sock)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(i);
+		clientsData* client = getClient(i);
 		temparray[i][0] = i;
 		// Use either blocked or total count based on request string
 		temparray[i][1] = blockedonly ? client->blockedcount : client->count;
@@ -414,7 +414,7 @@ void getTopClients(char *client_message, int *sock)
 		int j = temparray[i][0];
 		int ccount = temparray[i][1];
 		// Get client pointer
-		clientsDataStruct* client = getClient(j);
+		clientsData* client = getClient(j);
 
 		// Skip this client if there is a filter on it
 		if(excludeclients != NULL &&
@@ -467,7 +467,7 @@ void getForwardDestinations(char *client_message, int *sock)
 		// the values we will use for sorting afterwards
 		if(sort) {
 			// Get forward pointer
-			forwardedDataStruct* forward = getForward(i);
+			forwardedData* forward = getForward(i);
 
 			temparray[i][0] = i;
 			temparray[i][1] = forward->count;
@@ -519,7 +519,7 @@ void getForwardDestinations(char *client_message, int *sock)
 				j = i;
 
 			// Get forward pointer
-			forwardedDataStruct* forward = getForward(j);
+			forwardedData* forward = getForward(j);
 
 			// Get IP and host name of forward destination if available
 			ip = getstr(forward->ippos);
@@ -646,7 +646,7 @@ void getAllQueries(char *client_message, int *sock)
 			for(int i = 0; i < counters->forwarded; i++)
 			{
 				// Get forward pointer
-				forwardedDataStruct* forward = getForward(i);
+				forwardedData* forward = getForward(i);
 				// Try to match the requested string against their IP addresses and
 				// (if available) their host names
 				if(strcmp(getstr(forward->ippos), forwarddest) == 0 ||
@@ -678,7 +678,7 @@ void getAllQueries(char *client_message, int *sock)
 		for(int i = 0; i < counters->domains; i++)
 		{
 			// Get domain pointer
-			domainsDataStruct* domain = getDomain(i);
+			domainsData* domain = getDomain(i);
 
 			// Try to match the requested string
 			if(strcmp(getstr(domain->domainpos), domainname) == 0)
@@ -708,7 +708,7 @@ void getAllQueries(char *client_message, int *sock)
 		for(int i = 0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsDataStruct* client = getClient(i);
+			clientsData* client = getClient(i);
 			// Try to match the requested string
 			if(strcmp(getstr(client->ippos), clientname) == 0 ||
 			   (client->namepos != 0 &&
@@ -758,7 +758,7 @@ void getAllQueries(char *client_message, int *sock)
 	int i;
 	for(i=ibeg; i < counters->queries; i++)
 	{
-		queriesDataStruct* query = getQuery(i);
+		queriesData* query = getQuery(i);
 		// Check if this query has been create while in maximum privacy mode
 		if(query->privacylevel >= PRIVACY_MAXIMUM) continue;
 
@@ -812,7 +812,7 @@ void getAllQueries(char *client_message, int *sock)
 		// Similarly for the client
 		char *clientIPName = NULL;
 		// Get client pointer
-		clientsDataStruct* client = getClient(i);
+		clientsData* client = getClient(i);
 		if(strlen(getstr(client->namepos)) > 0)
 			clientIPName = getClientNameString(i);
 		else
@@ -870,7 +870,7 @@ void getRecentBlocked(char *client_message, int *sock)
 	int found = 0;
 	for(i = counters->queries - 1; i > 0 ; i--)
 	{
-		queriesDataStruct* query = getQuery(i);
+		queriesData* query = getQuery(i);
 
 		if(query->status == QUERY_GRAVITY ||
 		   query->status == QUERY_WILDCARD ||
@@ -1071,7 +1071,7 @@ void getClientsOverTime(int *sock)
 		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsDataStruct* client = getClient(i);
+			clientsData* client = getClient(i);
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1094,7 +1094,7 @@ void getClientsOverTime(int *sock)
 				continue;
 
 			// Get client pointer
-			clientsDataStruct* client = getClient(j);
+			clientsData* client = getClient(j);
 
 			int thisclient = client->overTime[i];
 
@@ -1136,7 +1136,7 @@ void getClientNames(int *sock)
 		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsDataStruct* client = getClient(i);
+			clientsData* client = getClient(i);
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1151,7 +1151,7 @@ void getClientNames(int *sock)
 			continue;
 
 		// Get client pointer
-		clientsDataStruct* client = getClient(i);
+		clientsData* client = getClient(i);
 
 		char *client_ip = getstr(client->ippos);
 		char *client_name = getstr(client->namepos);
@@ -1178,7 +1178,7 @@ void getUnknownQueries(int *sock)
 	int i;
 	for(i=0; i < counters->queries; i++)
 	{
-		queriesDataStruct* query = getQuery(i);
+		queriesData* query = getQuery(i);
 
 		if(query->status != QUERY_UNKNOWN && query->complete) continue;
 
@@ -1193,9 +1193,9 @@ void getUnknownQueries(int *sock)
 		}
 
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID);
 		// Get client pointer
-		clientsDataStruct* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID);
 
 		char *clientIP = getstr(client->ippos);
 
@@ -1232,7 +1232,7 @@ void getDomainDetails(char *client_message, int *sock)
 	for(int i = 0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(i);
+		domainsData* domain = getDomain(i);
 
 		if(strcmp(getstr(domain->domainpos), domainString) == 0)
 		{

--- a/api.c
+++ b/api.c
@@ -772,6 +772,9 @@ void getAllQueries(const char *client_message, int *sock)
 		// Check if this query has been create while in maximum privacy mode
 		if(query->privacylevel >= PRIVACY_MAXIMUM) continue;
 
+		// Verify query type
+		if(query->type > TYPE_MAX-1)
+			continue;
 		// Get query type
 		const char *qtype = querytypes[query->type - TYPE_A];
 
@@ -818,7 +821,7 @@ void getAllQueries(const char *client_message, int *sock)
 
 		// Ask subroutine for domain. It may return "hidden" depending on
 		// the privacy settings at the time the query was made
-		const char *domain = getDomainString(query->domainID);
+		const char *domain = getDomainString(queryID);
 
 		// Similarly for the client
 		const char *clientIPName = NULL;
@@ -894,7 +897,7 @@ void getRecentBlocked(const char *client_message, int *sock)
 
 			// Ask subroutine for domain. It may return "hidden" depending on
 			// the privacy settings at the time the query was made
-			const char *domain = getDomainString(query->domainID);
+			const char *domain = getDomainString(queryID);
 
 			if(istelnet[*sock])
 				ssend(*sock,"%s\n", domain);

--- a/api.c
+++ b/api.c
@@ -66,7 +66,7 @@ void getStats(int *sock)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(i, true);
+		const clientsData* client = getClient(i, true);
 		if(client->count > 0)
 			activeclients++;
 	}
@@ -209,7 +209,7 @@ void getTopDomains(char *client_message, int *sock)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i, true);
+		const domainsData* domain = getDomain(i, true);
 
 		temparray[i][0] = i;
 		if(blocked)
@@ -270,7 +270,7 @@ void getTopDomains(char *client_message, int *sock)
 		int j = temparray[i][0];
 
 		// Get domain pointer
-		domainsData* domain = getDomain(j, true);
+		const domainsData* domain = getDomain(j, true);
 
 		// Skip this domain if there is a filter on it
 		if(excludedomains != NULL && insetupVarsArray(getstr(domain->domainpos)))
@@ -376,7 +376,7 @@ void getTopClients(char *client_message, int *sock)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(i, true);
+		const clientsData* client = getClient(i, true);
 		temparray[i][0] = i;
 		// Use either blocked or total count based on request string
 		temparray[i][1] = blockedonly ? client->blockedcount : client->count;
@@ -414,7 +414,7 @@ void getTopClients(char *client_message, int *sock)
 		int j = temparray[i][0];
 		int ccount = temparray[i][1];
 		// Get client pointer
-		clientsData* client = getClient(j, true);
+		const clientsData* client = getClient(j, true);
 
 		// Skip this client if there is a filter on it
 		if(excludeclients != NULL &&
@@ -467,7 +467,7 @@ void getForwardDestinations(char *client_message, int *sock)
 		// the values we will use for sorting afterwards
 		if(sort) {
 			// Get forward pointer
-			forwardedData* forward = getForward(i, true);
+			const forwardedData* forward = getForward(i, true);
 
 			temparray[i][0] = i;
 			temparray[i][1] = forward->count;
@@ -519,7 +519,7 @@ void getForwardDestinations(char *client_message, int *sock)
 				j = i;
 
 			// Get forward pointer
-			forwardedData* forward = getForward(j, true);
+			const forwardedData* forward = getForward(j, true);
 
 			// Get IP and host name of forward destination if available
 			ip = getstr(forward->ippos);
@@ -646,7 +646,7 @@ void getAllQueries(char *client_message, int *sock)
 			for(int i = 0; i < counters->forwarded; i++)
 			{
 				// Get forward pointer
-				forwardedData* forward = getForward(i, true);
+				const forwardedData* forward = getForward(i, true);
 				// Try to match the requested string against their IP addresses and
 				// (if available) their host names
 				if(strcmp(getstr(forward->ippos), forwarddest) == 0 ||
@@ -678,7 +678,7 @@ void getAllQueries(char *client_message, int *sock)
 		for(int i = 0; i < counters->domains; i++)
 		{
 			// Get domain pointer
-			domainsData* domain = getDomain(i, true);
+			const domainsData* domain = getDomain(i, true);
 
 			// Try to match the requested string
 			if(strcmp(getstr(domain->domainpos), domainname) == 0)
@@ -708,7 +708,7 @@ void getAllQueries(char *client_message, int *sock)
 		for(int i = 0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsData* client = getClient(i, true);
+			const clientsData* client = getClient(i, true);
 			// Try to match the requested string
 			if(strcmp(getstr(client->ippos), clientname) == 0 ||
 			   (client->namepos != 0 &&
@@ -758,7 +758,7 @@ void getAllQueries(char *client_message, int *sock)
 	int i;
 	for(i=ibeg; i < counters->queries; i++)
 	{
-		queriesData* query = getQuery(i, true);
+		const queriesData* query = getQuery(i, true);
 		// Check if this query has been create while in maximum privacy mode
 		if(query->privacylevel >= PRIVACY_MAXIMUM) continue;
 
@@ -812,7 +812,7 @@ void getAllQueries(char *client_message, int *sock)
 		// Similarly for the client
 		char *clientIPName = NULL;
 		// Get client pointer
-		clientsData* client = getClient(i, true);
+		const clientsData* client = getClient(i, true);
 		if(strlen(getstr(client->namepos)) > 0)
 			clientIPName = getClientNameString(i);
 		else
@@ -870,7 +870,7 @@ void getRecentBlocked(char *client_message, int *sock)
 	int found = 0;
 	for(i = counters->queries - 1; i > 0 ; i--)
 	{
-		queriesData* query = getQuery(i, true);
+		const queriesData* query = getQuery(i, true);
 
 		if(query->status == QUERY_GRAVITY ||
 		   query->status == QUERY_WILDCARD ||
@@ -1071,7 +1071,7 @@ void getClientsOverTime(int *sock)
 		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsData* client = getClient(i, true);
+			const clientsData* client = getClient(i, true);
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1094,7 +1094,7 @@ void getClientsOverTime(int *sock)
 				continue;
 
 			// Get client pointer
-			clientsData* client = getClient(j, true);
+			const clientsData* client = getClient(j, true);
 
 			int thisclient = client->overTime[i];
 
@@ -1136,7 +1136,7 @@ void getClientNames(int *sock)
 		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsData* client = getClient(i, true);
+			const clientsData* client = getClient(i, true);
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1151,7 +1151,7 @@ void getClientNames(int *sock)
 			continue;
 
 		// Get client pointer
-		clientsData* client = getClient(i, true);
+		const clientsData* client = getClient(i, true);
 
 		char *client_ip = getstr(client->ippos);
 		char *client_name = getstr(client->namepos);
@@ -1178,7 +1178,7 @@ void getUnknownQueries(int *sock)
 	int i;
 	for(i=0; i < counters->queries; i++)
 	{
-		queriesData* query = getQuery(i, true);
+		const queriesData* query = getQuery(i, true);
 
 		if(query->status != QUERY_UNKNOWN && query->complete) continue;
 
@@ -1193,9 +1193,9 @@ void getUnknownQueries(int *sock)
 		}
 
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID, true);
+		const domainsData* domain = getDomain(query->domainID, true);
 		// Get client pointer
-		clientsData* client = getClient(query->clientID, true);
+		const clientsData* client = getClient(query->clientID, true);
 
 		char *clientIP = getstr(client->ippos);
 
@@ -1232,7 +1232,7 @@ void getDomainDetails(char *client_message, int *sock)
 	for(int i = 0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i, true);
+		const domainsData* domain = getDomain(i, true);
 
 		if(strcmp(getstr(domain->domainpos), domainString) == 0)
 		{

--- a/api.c
+++ b/api.c
@@ -66,7 +66,7 @@ void getStats(int *sock)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(i);
+		clientsData* client = getClient(i, true);
 		if(client->count > 0)
 			activeclients++;
 	}
@@ -209,7 +209,7 @@ void getTopDomains(char *client_message, int *sock)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i);
+		domainsData* domain = getDomain(i, true);
 
 		temparray[i][0] = i;
 		if(blocked)
@@ -270,7 +270,7 @@ void getTopDomains(char *client_message, int *sock)
 		int j = temparray[i][0];
 
 		// Get domain pointer
-		domainsData* domain = getDomain(j);
+		domainsData* domain = getDomain(j, true);
 
 		// Skip this domain if there is a filter on it
 		if(excludedomains != NULL && insetupVarsArray(getstr(domain->domainpos)))
@@ -376,7 +376,7 @@ void getTopClients(char *client_message, int *sock)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(i);
+		clientsData* client = getClient(i, true);
 		temparray[i][0] = i;
 		// Use either blocked or total count based on request string
 		temparray[i][1] = blockedonly ? client->blockedcount : client->count;
@@ -414,7 +414,7 @@ void getTopClients(char *client_message, int *sock)
 		int j = temparray[i][0];
 		int ccount = temparray[i][1];
 		// Get client pointer
-		clientsData* client = getClient(j);
+		clientsData* client = getClient(j, true);
 
 		// Skip this client if there is a filter on it
 		if(excludeclients != NULL &&
@@ -467,7 +467,7 @@ void getForwardDestinations(char *client_message, int *sock)
 		// the values we will use for sorting afterwards
 		if(sort) {
 			// Get forward pointer
-			forwardedData* forward = getForward(i);
+			forwardedData* forward = getForward(i, true);
 
 			temparray[i][0] = i;
 			temparray[i][1] = forward->count;
@@ -519,7 +519,7 @@ void getForwardDestinations(char *client_message, int *sock)
 				j = i;
 
 			// Get forward pointer
-			forwardedData* forward = getForward(j);
+			forwardedData* forward = getForward(j, true);
 
 			// Get IP and host name of forward destination if available
 			ip = getstr(forward->ippos);
@@ -646,7 +646,7 @@ void getAllQueries(char *client_message, int *sock)
 			for(int i = 0; i < counters->forwarded; i++)
 			{
 				// Get forward pointer
-				forwardedData* forward = getForward(i);
+				forwardedData* forward = getForward(i, true);
 				// Try to match the requested string against their IP addresses and
 				// (if available) their host names
 				if(strcmp(getstr(forward->ippos), forwarddest) == 0 ||
@@ -678,7 +678,7 @@ void getAllQueries(char *client_message, int *sock)
 		for(int i = 0; i < counters->domains; i++)
 		{
 			// Get domain pointer
-			domainsData* domain = getDomain(i);
+			domainsData* domain = getDomain(i, true);
 
 			// Try to match the requested string
 			if(strcmp(getstr(domain->domainpos), domainname) == 0)
@@ -708,7 +708,7 @@ void getAllQueries(char *client_message, int *sock)
 		for(int i = 0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsData* client = getClient(i);
+			clientsData* client = getClient(i, true);
 			// Try to match the requested string
 			if(strcmp(getstr(client->ippos), clientname) == 0 ||
 			   (client->namepos != 0 &&
@@ -758,7 +758,7 @@ void getAllQueries(char *client_message, int *sock)
 	int i;
 	for(i=ibeg; i < counters->queries; i++)
 	{
-		queriesData* query = getQuery(i);
+		queriesData* query = getQuery(i, true);
 		// Check if this query has been create while in maximum privacy mode
 		if(query->privacylevel >= PRIVACY_MAXIMUM) continue;
 
@@ -812,7 +812,7 @@ void getAllQueries(char *client_message, int *sock)
 		// Similarly for the client
 		char *clientIPName = NULL;
 		// Get client pointer
-		clientsData* client = getClient(i);
+		clientsData* client = getClient(i, true);
 		if(strlen(getstr(client->namepos)) > 0)
 			clientIPName = getClientNameString(i);
 		else
@@ -870,7 +870,7 @@ void getRecentBlocked(char *client_message, int *sock)
 	int found = 0;
 	for(i = counters->queries - 1; i > 0 ; i--)
 	{
-		queriesData* query = getQuery(i);
+		queriesData* query = getQuery(i, true);
 
 		if(query->status == QUERY_GRAVITY ||
 		   query->status == QUERY_WILDCARD ||
@@ -1071,7 +1071,7 @@ void getClientsOverTime(int *sock)
 		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsData* client = getClient(i);
+			clientsData* client = getClient(i, true);
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1094,7 +1094,7 @@ void getClientsOverTime(int *sock)
 				continue;
 
 			// Get client pointer
-			clientsData* client = getClient(j);
+			clientsData* client = getClient(j, true);
 
 			int thisclient = client->overTime[i];
 
@@ -1136,7 +1136,7 @@ void getClientNames(int *sock)
 		for(int i=0; i < counters->clients; i++)
 		{
 			// Get client pointer
-			clientsData* client = getClient(i);
+			clientsData* client = getClient(i, true);
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1151,7 +1151,7 @@ void getClientNames(int *sock)
 			continue;
 
 		// Get client pointer
-		clientsData* client = getClient(i);
+		clientsData* client = getClient(i, true);
 
 		char *client_ip = getstr(client->ippos);
 		char *client_name = getstr(client->namepos);
@@ -1178,7 +1178,7 @@ void getUnknownQueries(int *sock)
 	int i;
 	for(i=0; i < counters->queries; i++)
 	{
-		queriesData* query = getQuery(i);
+		queriesData* query = getQuery(i, true);
 
 		if(query->status != QUERY_UNKNOWN && query->complete) continue;
 
@@ -1193,9 +1193,9 @@ void getUnknownQueries(int *sock)
 		}
 
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID, true);
 		// Get client pointer
-		clientsData* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID, true);
 
 		char *clientIP = getstr(client->ippos);
 
@@ -1232,7 +1232,7 @@ void getDomainDetails(char *client_message, int *sock)
 	for(int i = 0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i);
+		domainsData* domain = getDomain(i, true);
 
 		if(strcmp(getstr(domain->domainpos), domainString) == 0)
 		{

--- a/database.c
+++ b/database.c
@@ -456,7 +456,7 @@ void save_to_DB(void)
 	time_t newlasttimestamp = 0;
 	for(i = MAX(0, lastdbindex); i < counters->queries; i++)
 	{
-		queriesData* query = getQuery(i);
+		queriesData* query = getQuery(i, true);
 		if(query->db != 0)
 		{
 			// Skip, already saved in database
@@ -498,7 +498,7 @@ void save_to_DB(void)
 		if(query->status == QUERY_FORWARDED && query->forwardID > -1)
 		{
 			// Get forward pointer
-			forwardedData* forward = getForward(query->forwardID);
+			forwardedData* forward = getForward(query->forwardID, true);
 			sqlite3_bind_text(stmt, 6, getstr(forward->ippos), -1, SQLITE_TRANSIENT);
 		}
 		else
@@ -775,7 +775,7 @@ void read_data_from_DB(void)
 		int queryIndex = counters->queries;
 
 		// Store this query in memory
-		queriesData* query = getQuery(queryIndex);
+		queriesData* query = getQuery(queryIndex, false);
 		query->magic = MAGICBYTE;
 		query->timestamp = queryTimeStamp;
 		query->type = type;
@@ -793,7 +793,7 @@ void read_data_from_DB(void)
 		query->reply = REPLY_UNKNOWN;
 
 		// Set lastQuery timer and add one query for network table
-		clientsData* client = getClient(clientID);
+		clientsData* client = getClient(clientID, true);
 		client->lastQuery = queryTimeStamp;
 		client->numQueriesARP++;
 
@@ -825,7 +825,7 @@ void read_data_from_DB(void)
 			case QUERY_EXTERNAL_BLOCKED: // Blocked by external provider
 				counters->blocked++;
 				// Get domain pointer
-				domainsData* domain = getDomain(domainID);
+				domainsData* domain = getDomain(domainID, true);
 				domain->blockedcount++;
 				client->blockedcount++;
 				// Update overTime data structure

--- a/database.c
+++ b/database.c
@@ -498,7 +498,7 @@ void save_to_DB(void)
 		if(query->status == QUERY_FORWARDED && query->forwardID > -1)
 		{
 			// Get forward pointer
-			forwardedData* forward = getForward(query->forwardID, true);
+			const forwardedData* forward = getForward(query->forwardID, true);
 			sqlite3_bind_text(stmt, 6, getstr(forward->ippos), -1, SQLITE_TRANSIENT);
 		}
 		else

--- a/database.c
+++ b/database.c
@@ -428,7 +428,6 @@ void save_to_DB(void)
 	}
 
 	unsigned int saved = 0, saved_error = 0;
-	long int i;
 	sqlite3_stmt* stmt;
 
 	// Get last ID stored in the database
@@ -454,9 +453,10 @@ void save_to_DB(void)
 	int total = 0, blocked = 0;
 	time_t currenttimestamp = time(NULL);
 	time_t newlasttimestamp = 0;
-	for(i = MAX(0, lastdbindex); i < counters->queries; i++)
+	long int queryID;
+	for(queryID = MAX(0, lastdbindex); queryID < counters->queries; queryID++)
 	{
-		queriesData* query = getQuery(i, true);
+		queriesData* query = getQuery(queryID, true);
 		if(query->db != 0)
 		{
 			// Skip, already saved in database
@@ -487,11 +487,11 @@ void save_to_DB(void)
 		sqlite3_bind_int(stmt, 3, query->status);
 
 		// DOMAIN
-		const char *domain = getDomainString(i);
+		const char *domain = getDomainString(queryID);
 		sqlite3_bind_text(stmt, 4, domain, -1, SQLITE_TRANSIENT);
 
 		// CLIENT
-		const char *client = getClientIPString(i);
+		const char *client = getClientIPString(queryID);
 		sqlite3_bind_text(stmt, 5, client, -1, SQLITE_TRANSIENT);
 
 		// FORWARD
@@ -555,7 +555,7 @@ void save_to_DB(void)
 	// in the database only if all queries have been saved successfully
 	if(saved > 0 && saved_error == 0)
 	{
-		lastdbindex = i;
+		lastdbindex = queryID;
 		db_set_FTL_property(DB_LASTTIMESTAMP, newlasttimestamp);
 	}
 

--- a/database.c
+++ b/database.c
@@ -470,9 +470,6 @@ void save_to_DB(void)
 			break;
 		}
 
-		// Memory checks
-		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);
-
 		if(query->privacylevel >= PRIVACY_MAXIMUM)
 		{
 			// Skip, we never store nor count queries recorded

--- a/database.c
+++ b/database.c
@@ -456,7 +456,7 @@ void save_to_DB(void)
 	time_t newlasttimestamp = 0;
 	for(i = MAX(0, lastdbindex); i < counters->queries; i++)
 	{
-		queriesDataStruct* query = getQuery(i);
+		queriesData* query = getQuery(i);
 		if(query->db != 0)
 		{
 			// Skip, already saved in database
@@ -498,7 +498,7 @@ void save_to_DB(void)
 		if(query->status == QUERY_FORWARDED && query->forwardID > -1)
 		{
 			// Get forward pointer
-			forwardedDataStruct* forward = getForward(query->forwardID);
+			forwardedData* forward = getForward(query->forwardID);
 			sqlite3_bind_text(stmt, 6, getstr(forward->ippos), -1, SQLITE_TRANSIENT);
 		}
 		else
@@ -775,7 +775,7 @@ void read_data_from_DB(void)
 		int queryIndex = counters->queries;
 
 		// Store this query in memory
-		queriesDataStruct* query = getQuery(queryIndex);
+		queriesData* query = getQuery(queryIndex);
 		query->magic = MAGICBYTE;
 		query->timestamp = queryTimeStamp;
 		query->type = type;
@@ -793,7 +793,7 @@ void read_data_from_DB(void)
 		query->reply = REPLY_UNKNOWN;
 
 		// Set lastQuery timer and add one query for network table
-		clientsDataStruct* client = getClient(clientID);
+		clientsData* client = getClient(clientID);
 		client->lastQuery = queryTimeStamp;
 		client->numQueriesARP++;
 
@@ -825,7 +825,7 @@ void read_data_from_DB(void)
 			case QUERY_EXTERNAL_BLOCKED: // Blocked by external provider
 				counters->blocked++;
 				// Get domain pointer
-				domainsDataStruct* domain = getDomain(domainID);
+				domainsData* domain = getDomain(domainID);
 				domain->blockedcount++;
 				client->blockedcount++;
 				// Update overTime data structure

--- a/database.c
+++ b/database.c
@@ -500,8 +500,9 @@ void save_to_DB(void)
 		// FORWARD
 		if(query->status == QUERY_FORWARDED && query->forwardID > -1)
 		{
-			validate_access("forwarded", query->forwardID, true, __LINE__, __FUNCTION__, __FILE__);
-			sqlite3_bind_text(stmt, 6, getstr(forwarded[query->forwardID].ippos), -1, SQLITE_TRANSIENT);
+			// Get forward pointer
+			forwardedDataStruct* forward = getForward(query->forwardID);
+			sqlite3_bind_text(stmt, 6, getstr(forward->ippos), -1, SQLITE_TRANSIENT);
 		}
 		else
 		{

--- a/database.c
+++ b/database.c
@@ -826,7 +826,9 @@ void read_data_from_DB(void)
 			case QUERY_BLACKLIST: // Blocked by black.list
 			case QUERY_EXTERNAL_BLOCKED: // Blocked by external provider
 				counters->blocked++;
-				domains[domainID].blockedcount++;
+				// Get domain pointer
+				domainsDataStruct* domain = getDomain(domainID);
+				domain->blockedcount++;
 				client->blockedcount++;
 				// Update overTime data structure
 				overTime[timeidx].blocked++;

--- a/datastructure.c
+++ b/datastructure.c
@@ -184,10 +184,11 @@ bool isValidIPv6(const char *addr)
 // only when appropriate for the requested query
 char *getDomainString(int queryID)
 {
-	if(queries[queryID].privacylevel < PRIVACY_HIDE_DOMAINS)
+	queriesDataStruct* query = getQuery(queryID);
+	if(query->privacylevel < PRIVACY_HIDE_DOMAINS)
 	{
-		validate_access("domains", queries[queryID].domainID, true, __LINE__, __FUNCTION__, __FILE__);
-		return getstr(domains[queries[queryID].domainID].domainpos);
+		validate_access("domains", query->domainID, true, __LINE__, __FUNCTION__, __FILE__);
+		return getstr(domains[query->domainID].domainpos);
 	}
 	else
 		return HIDDEN_DOMAIN;
@@ -197,10 +198,11 @@ char *getDomainString(int queryID)
 // only when appropriate for the requested query
 char *getClientIPString(int queryID)
 {
-	if(queries[queryID].privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
+	queriesDataStruct* query = getQuery(queryID);
+	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
-		validate_access("clients", queries[queryID].clientID, true, __LINE__, __FUNCTION__, __FILE__);
-		return getstr(clients[queries[queryID].clientID].ippos);
+		validate_access("clients", query->clientID, true, __LINE__, __FUNCTION__, __FILE__);
+		return getstr(clients[query->clientID].ippos);
 	}
 	else
 		return HIDDEN_CLIENT;
@@ -210,10 +212,11 @@ char *getClientIPString(int queryID)
 // only when appropriate for the requested query
 char *getClientNameString(int queryID)
 {
-	if(queries[queryID].privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
+	queriesDataStruct* query = getQuery(queryID);
+	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
-		validate_access("clients", queries[queryID].clientID, true, __LINE__, __FUNCTION__, __FILE__);
-		return getstr(clients[queries[queryID].clientID].namepos);
+		validate_access("clients", query->clientID, true, __LINE__, __FUNCTION__, __FILE__);
+		return getstr(clients[query->clientID].namepos);
 	}
 	else
 		return HIDDEN_CLIENT;

--- a/datastructure.c
+++ b/datastructure.c
@@ -190,11 +190,11 @@ bool isValidIPv6(const char *addr)
 // only when appropriate for the requested query
 char *getDomainString(int queryID)
 {
-	queriesData* query = getQuery(queryID, true);
+	const queriesData* query = getQuery(queryID, true);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID, true);
+		const domainsData* domain = getDomain(query->domainID, true);
 
 		// Return string
 		return getstr(domain->domainpos);
@@ -207,11 +207,11 @@ char *getDomainString(int queryID)
 // only when appropriate for the requested query
 char *getClientIPString(int queryID)
 {
-	queriesData* query = getQuery(queryID, false);
+	const queriesData* query = getQuery(queryID, false);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
-		clientsData* client = getClient(query->clientID, false);
+		const clientsData* client = getClient(query->clientID, false);
 
 		// Return string
 		return getstr(client->ippos);
@@ -224,11 +224,11 @@ char *getClientIPString(int queryID)
 // only when appropriate for the requested query
 char *getClientNameString(int queryID)
 {
-	queriesData* query = getQuery(queryID, true);
+	const queriesData* query = getQuery(queryID, true);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
-		clientsData* client = getClient(query->clientID, true);
+		const clientsData* client = getClient(query->clientID, true);
 
 		// Return string
 		return getstr(client->namepos);

--- a/datastructure.c
+++ b/datastructure.c
@@ -24,7 +24,7 @@ int findForwardID(const char * forwardString, bool count)
 	for(int i=0; i < counters->forwarded; i++)
 	{
 		// Get forward pointer
-		forwardedData* forward = getForward(i);
+		forwardedData* forward = getForward(i, true);
 
 		if(strcmp(getstr(forward->ippos), forwardString) == 0)
 		{
@@ -41,7 +41,7 @@ int findForwardID(const char * forwardString, bool count)
 	memory_check(FORWARDED);
 
 	// Get forward pointer
-	forwardedData* forward = getForward(forwardID);
+	forwardedData* forward = getForward(forwardID, false);
 
 	// Set magic byte
 	forward->magic = MAGICBYTE;
@@ -70,7 +70,7 @@ int findDomainID(const char *domainString)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i);
+		domainsData* domain = getDomain(i, true);
 
 		// Quick test: Does the domain start with the same character?
 		if(getstr(domain->domainpos)[0] != domainString[0])
@@ -92,7 +92,7 @@ int findDomainID(const char *domainString)
 	memory_check(DOMAINS);
 
 	// Get domain pointer
-	domainsData* domain = getDomain(domainID);
+	domainsData* domain = getDomain(domainID, false);
 
 	// Set magic byte
 	domain->magic = MAGICBYTE;
@@ -116,7 +116,7 @@ int findClientID(const char *clientIP, bool count)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(i);
+		clientsData* client = getClient(i, true);
 
 		// Quick test: Does the clients IP start with the same character?
 		if(getstr(client->ippos)[0] != clientIP[0])
@@ -144,7 +144,7 @@ int findClientID(const char *clientIP, bool count)
 	memory_check(CLIENTS);
 
 	// Get client pointer
-	clientsData* client = getClient(clientID);
+	clientsData* client = getClient(clientID, false);
 
 	// Set magic byte
 	client->magic = MAGICBYTE;
@@ -190,11 +190,11 @@ bool isValidIPv6(const char *addr)
 // only when appropriate for the requested query
 char *getDomainString(int queryID)
 {
-	queriesData* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID, true);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID, true);
 
 		// Return string
 		return getstr(domain->domainpos);
@@ -207,11 +207,11 @@ char *getDomainString(int queryID)
 // only when appropriate for the requested query
 char *getClientIPString(int queryID)
 {
-	queriesData* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID, false);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
-		clientsData* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID, false);
 
 		// Return string
 		return getstr(client->ippos);
@@ -224,11 +224,11 @@ char *getClientIPString(int queryID)
 // only when appropriate for the requested query
 char *getClientNameString(int queryID)
 {
-	queriesData* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID, true);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
-		clientsData* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID, true);
 
 		// Return string
 		return getstr(client->namepos);

--- a/datastructure.c
+++ b/datastructure.c
@@ -19,22 +19,21 @@ void strtolower(char *str)
 
 int findForwardID(const char * forwardString, bool count)
 {
-	int forwardID = -1;
 	// Go through already knows forward servers and see if we used one of those
-	for(int i=0; i < counters->forwarded; i++)
+	for(int forwardID=0; forwardID < counters->forwarded; forwardID++)
 	{
 		// Get forward pointer
-		forwardedData* forward = getForward(i, true);
+		forwardedData* forward = getForward(forwardID, true);
 
 		if(strcmp(getstr(forward->ippos), forwardString) == 0)
 		{
 			if(count) forward->count++;
-			return i;
+			return forwardID;
 		}
 	}
 	// This forward server is not known
 	// Store ID
-	forwardID = counters->forwarded;
+	const int forwardID = counters->forwarded;
 	logg("New forward server: %s (%i/%u)", forwardString, forwardID, counters->forwarded_MAX);
 
 	// Check struct size
@@ -67,10 +66,10 @@ int findForwardID(const char * forwardString, bool count)
 
 int findDomainID(const char *domainString)
 {
-	for(int i=0; i < counters->domains; i++)
+	for(int domainID = 0; domainID < counters->domains; domainID++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i, true);
+		domainsData* domain = getDomain(domainID, true);
 
 		// Quick test: Does the domain start with the same character?
 		if(getstr(domain->domainpos)[0] != domainString[0])
@@ -80,13 +79,13 @@ int findDomainID(const char *domainString)
 		if(strcmp(getstr(domain->domainpos), domainString) == 0)
 		{
 			domain->count++;
-			return i;
+			return domainID;
 		}
 	}
 
 	// If we did not return until here, then this domain is not known
 	// Store ID
-	int domainID = counters->domains;
+	const int domainID = counters->domains;
 
 	// Check struct size
 	memory_check(DOMAINS);
@@ -113,10 +112,10 @@ int findDomainID(const char *domainString)
 int findClientID(const char *clientIP, bool count)
 {
 	// Compare content of client against known client IP addresses
-	for(int i=0; i < counters->clients; i++)
+	for(int clientID=0; clientID < counters->clients; clientID++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(i, true);
+		clientsData* client = getClient(clientID, true);
 
 		// Quick test: Does the clients IP start with the same character?
 		if(getstr(client->ippos)[0] != clientIP[0])
@@ -127,7 +126,7 @@ int findClientID(const char *clientIP, bool count)
 		{
 			// Add one if count == true (do not add one, e.g., during ARP table processing)
 			if(count) client->count++;
-			return i;
+			return clientID;
 		}
 	}
 
@@ -138,7 +137,7 @@ int findClientID(const char *clientIP, bool count)
 
 	// If we did not return until here, then this client is definitely new
 	// Store ID
-	int clientID = counters->clients;
+	const int clientID = counters->clients;
 
 	// Check struct size
 	memory_check(CLIENTS);

--- a/datastructure.c
+++ b/datastructure.c
@@ -17,46 +17,48 @@ void strtolower(char *str)
 	while(str[i]){ str[i] = tolower(str[i]); i++; }
 }
 
-int findForwardID(const char * forward, bool count)
+int findForwardID(const char * forwardString, bool count)
 {
-	int i, forwardID = -1;
-	if(counters->forwarded > 0)
-		validate_access("forwarded", counters->forwarded-1, true, __LINE__, __FUNCTION__, __FILE__);
+	int forwardID = -1;
 	// Go through already knows forward servers and see if we used one of those
-	for(i=0; i < counters->forwarded; i++)
+	for(int i=0; i < counters->forwarded; i++)
 	{
-		if(strcmp(getstr(forwarded[i].ippos), forward) == 0)
+		// Get forward pointer
+		forwardedDataStruct* forward = getForward(i);
+
+		if(strcmp(getstr(forward->ippos), forwardString) == 0)
 		{
-			forwardID = i;
-			if(count) forwarded[forwardID].count++;
-			return forwardID;
+			if(count) forward->count++;
+			return i;
 		}
 	}
 	// This forward server is not known
 	// Store ID
 	forwardID = counters->forwarded;
-	logg("New forward server: %s (%i/%u)", forward, forwardID, counters->forwarded_MAX);
+	logg("New forward server: %s (%i/%u)", forwardString, forwardID, counters->forwarded_MAX);
 
 	// Check struct size
 	memory_check(FORWARDED);
 
-	validate_access("forwarded", forwardID, false, __LINE__, __FUNCTION__, __FILE__);
+	// Get forward pointer
+	forwardedDataStruct* forward = getForward(forwardID);
+
 	// Set magic byte
-	forwarded[forwardID].magic = MAGICBYTE;
+	forward->magic = MAGICBYTE;
 	// Initialize its counter
 	if(count)
-		forwarded[forwardID].count = 1;
+		forward->count = 1;
 	else
-		forwarded[forwardID].count = 0;
+		forward->count = 0;
 	// Save forward destination IP address
-	forwarded[forwardID].ippos = addstr(forward);
-	forwarded[forwardID].failed = 0;
+	forward->ippos = addstr(forwardString);
+	forward->failed = 0;
 	// Initialize forward hostname
 	// Due to the nature of us being the resolver,
 	// the actual resolving of the host name has
 	// to be done separately to be non-blocking
-	forwarded[forwardID].new = true;
-	forwarded[forwardID].namepos = 0; // 0 -> string with length zero
+	forward->new = true;
+	forward->namepos = 0; // 0 -> string with length zero
 	// Increase counter by one
 	counters->forwarded++;
 

--- a/datastructure.c
+++ b/datastructure.c
@@ -24,7 +24,7 @@ int findForwardID(const char * forwardString, bool count)
 	for(int i=0; i < counters->forwarded; i++)
 	{
 		// Get forward pointer
-		forwardedDataStruct* forward = getForward(i);
+		forwardedData* forward = getForward(i);
 
 		if(strcmp(getstr(forward->ippos), forwardString) == 0)
 		{
@@ -41,7 +41,7 @@ int findForwardID(const char * forwardString, bool count)
 	memory_check(FORWARDED);
 
 	// Get forward pointer
-	forwardedDataStruct* forward = getForward(forwardID);
+	forwardedData* forward = getForward(forwardID);
 
 	// Set magic byte
 	forward->magic = MAGICBYTE;
@@ -70,7 +70,7 @@ int findDomainID(const char *domainString)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(i);
+		domainsData* domain = getDomain(i);
 
 		// Quick test: Does the domain start with the same character?
 		if(getstr(domain->domainpos)[0] != domainString[0])
@@ -92,7 +92,7 @@ int findDomainID(const char *domainString)
 	memory_check(DOMAINS);
 
 	// Get domain pointer
-	domainsDataStruct* domain = getDomain(domainID);
+	domainsData* domain = getDomain(domainID);
 
 	// Set magic byte
 	domain->magic = MAGICBYTE;
@@ -116,7 +116,7 @@ int findClientID(const char *clientIP, bool count)
 	for(int i=0; i < counters->clients; i++)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(i);
+		clientsData* client = getClient(i);
 
 		// Quick test: Does the clients IP start with the same character?
 		if(getstr(client->ippos)[0] != clientIP[0])
@@ -144,7 +144,7 @@ int findClientID(const char *clientIP, bool count)
 	memory_check(CLIENTS);
 
 	// Get client pointer
-	clientsDataStruct* client = getClient(clientID);
+	clientsData* client = getClient(clientID);
 
 	// Set magic byte
 	client->magic = MAGICBYTE;
@@ -190,11 +190,11 @@ bool isValidIPv6(const char *addr)
 // only when appropriate for the requested query
 char *getDomainString(int queryID)
 {
-	queriesDataStruct* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID);
 
 		// Return string
 		return getstr(domain->domainpos);
@@ -207,11 +207,11 @@ char *getDomainString(int queryID)
 // only when appropriate for the requested query
 char *getClientIPString(int queryID)
 {
-	queriesDataStruct* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID);
 
 		// Return string
 		return getstr(client->ippos);
@@ -224,11 +224,11 @@ char *getClientIPString(int queryID)
 // only when appropriate for the requested query
 char *getClientNameString(int queryID)
 {
-	queriesDataStruct* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID);
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID);
 
 		// Return string
 		return getstr(client->namepos);

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -231,7 +231,7 @@ static int findQueryID(int id)
 	// Check UUIDs of queries
 	for(int i = start; i >= until; i--)
 	{
-		queriesData* query = getQuery(i, true);
+		const queriesData* query = getQuery(i, true);
 		if(query->id == id)
 			return i;
 	}
@@ -603,7 +603,6 @@ static void query_externally_blocked(int i)
 
 	// Get domain pointer
 	domainsData* domain = getDomain(query->domainID, true);
-
 	domain->blockedcount++;
 
 	// Get client pointer
@@ -787,7 +786,7 @@ void _FTL_dnssec(int status, int id, const char* file, const int line)
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID, true);
+		const domainsData* domain = getDomain(query->domainID, true);
 
 		logg("**** got DNSSEC details for %s: %i (ID %i, %s:%i)", getstr(domain->domainpos), status, id, file, line);
 	}
@@ -855,7 +854,7 @@ void _FTL_upstream_error(unsigned int rcode, int id, const char* file, const int
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID, true);
+		const domainsData* domain = getDomain(query->domainID, true);
 
 		logg("**** got error report for %s: %s (ID %i, %s:%i)", getstr(domain->domainpos), rcodestr, id, file, line);
 	}
@@ -897,7 +896,7 @@ void _FTL_header_ADbit(unsigned char header4, unsigned int rcode, int id, const 
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID, true);
+		const domainsData* domain = getDomain(query->domainID, true);
 
 		logg("**** AD bit set for %s (ID %i, RCODE %u, %s:%i)", getstr(domain->domainpos), id, rcode, file, line);
 	}

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -140,7 +140,7 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	int clientID = findClientID(clientIP, true);
 
 	// Save everything
-	queriesDataStruct* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID);
 	query->magic = MAGICBYTE;
 	query->timestamp = querytimestamp;
 	query->type = querytype;
@@ -176,7 +176,7 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	overTime[timeidx].total++;
 
 	// Get client pointer
-	clientsDataStruct* client = getClient(clientID);
+	clientsData* client = getClient(clientID);
 	// Update overTime data structure with the new client
 	client->overTime[timeidx]++;
 
@@ -185,7 +185,7 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	client->numQueriesARP++;
 
 	// Get domain pointer
-	domainsDataStruct* domain = getDomain(domainID);
+	domainsData* domain = getDomain(domainID);
 
 	// Try blocking regex if configured
 	if(domain->regexmatch == REGEX_UNKNOWN && blockingstatus != BLOCKING_DISABLED)
@@ -238,7 +238,7 @@ static int findQueryID(int id)
 	// Check UUIDs of queries
 	for(int i = start; i >= until; i--)
 	{
-		queriesDataStruct* query = getQuery(i);
+		queriesData* query = getQuery(i);
 		if(query->id == id)
 			return i;
 	}
@@ -281,7 +281,7 @@ void _FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int i
 	}
 
 	// Get query pointer
-	queriesDataStruct* query = getQuery(i);
+	queriesData* query = getQuery(i);
 
 	// Proceed only if
 	// - current query has not been marked as replied to so far
@@ -433,7 +433,7 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 	}
 
 	// Get query pointer
-	queriesDataStruct* query = getQuery(i);
+	queriesData* query = getQuery(i);
 
 	if(query->reply != REPLY_UNKNOWN)
 	{
@@ -446,7 +446,7 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 	int domainID = query->domainID;
 
 	// Get domain pointer
-	domainsDataStruct* domain = getDomain(domainID);
+	domainsData* domain = getDomain(domainID);
 
 	// Check if this domain matches exactly
 	bool isExactMatch = (name != NULL && strcmp(getstr(domain->domainpos), name) == 0);
@@ -472,7 +472,7 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 			domain->blockedcount++;
 
 			// Get client pointer
-			clientsDataStruct* client = getClient(query->clientID);
+			clientsData* client = getClient(query->clientID);
 
 			// Update client blocked counter
 			client->blockedcount++;
@@ -588,7 +588,7 @@ static void detect_blocked_IP(unsigned short flags, char* answer, int queryID)
 static void query_externally_blocked(int i)
 {
 	// Get query pointer
-	queriesDataStruct* query = getQuery(i);
+	queriesData* query = getQuery(i);
 
 	// Get time index
 	unsigned int timeidx = query->timeidx;
@@ -600,7 +600,7 @@ static void query_externally_blocked(int i)
 		overTime[timeidx].forwarded--;
 
 		// Get forward pointer
-		forwardedDataStruct* forward = getForward(query->forwardID);
+		forwardedData* forward = getForward(query->forwardID);
 		forward->count--;
 	}
 
@@ -609,12 +609,12 @@ static void query_externally_blocked(int i)
 	overTime[timeidx].blocked++;
 
 	// Get domain pointer
-	domainsDataStruct* domain = getDomain(query->domainID);
+	domainsData* domain = getDomain(query->domainID);
 
 	domain->blockedcount++;
 
 	// Get client pointer
-	clientsDataStruct* client = getClient(query->clientID);
+	clientsData* client = getClient(query->clientID);
 	client->blockedcount++;
 
 	query->status = QUERY_EXTERNAL_BLOCKED;
@@ -708,7 +708,7 @@ void _FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg
 		}
 
 		// Get query pointer
-		queriesDataStruct* query = getQuery(i);
+		queriesData* query = getQuery(i);
 
 		if(query->complete)
 		{
@@ -724,10 +724,10 @@ void _FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg
 		unsigned int timeidx = query->timeidx;
 
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID);
 
 		// Get client pointer
-		clientsDataStruct* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID);
 
 		// Mark this query as blocked if domain was matched by a regex
 		if(domain->regexmatch == REGEX_BLOCKED)
@@ -794,13 +794,13 @@ void _FTL_dnssec(int status, int id, const char* file, const int line)
 	}
 
 	// Get query pointer
-	queriesDataStruct* query = getQuery(i);
+	queriesData* query = getQuery(i);
 
 	// Debug logging
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID);
 
 		logg("**** got DNSSEC details for %s: %i (ID %i, %s:%i)", getstr(domain->domainpos), status, id, file, line);
 	}
@@ -838,7 +838,7 @@ void _FTL_upstream_error(unsigned int rcode, int id, const char* file, const int
 	}
 
 	// Get query pointer
-	queriesDataStruct* query = getQuery(i);
+	queriesData* query = getQuery(i);
 
 	// Translate dnsmasq's rcode into something we can use
 	char *rcodestr = NULL;
@@ -868,7 +868,7 @@ void _FTL_upstream_error(unsigned int rcode, int id, const char* file, const int
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID);
 
 		logg("**** got error report for %s: %s (ID %i, %s:%i)", getstr(domain->domainpos), rcodestr, id, file, line);
 	}
@@ -905,12 +905,12 @@ void _FTL_header_ADbit(unsigned char header4, unsigned int rcode, int id, const 
 	}
 
 	// Get query pointer
-	queriesDataStruct* query = getQuery(i);
+	queriesData* query = getQuery(i);
 
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID);
 
 		logg("**** AD bit set for %s (ID %i, RCODE %u, %s:%i)", getstr(domain->domainpos), id, rcode, file, line);
 	}
@@ -961,7 +961,7 @@ void print_flags(unsigned int flags)
 void save_reply_type(unsigned int flags, int queryID, struct timeval response)
 {
 	// Get query pointer
-	queriesDataStruct* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID);
 
 	// Iterate through possible values
 	if(flags & F_NEG)
@@ -1125,7 +1125,7 @@ void _FTL_forwarding_failed(struct server *server, const char* file, const int l
 	if(config.debug & DEBUG_QUERIES) logg("**** forwarding to %s (ID %i, %s:%i) failed", dest, forwardID, file, line);
 
 	// Get forward pointer
-	forwardedDataStruct* forward = getForward(forwardID);
+	forwardedData* forward = getForward(forwardID);
 
 	// Update counter
 	forward->failed++;

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -140,7 +140,7 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	int clientID = findClientID(clientIP, true);
 
 	// Save everything
-	queriesData* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID, false);
 	query->magic = MAGICBYTE;
 	query->timestamp = querytimestamp;
 	query->type = querytype;
@@ -176,7 +176,7 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	overTime[timeidx].total++;
 
 	// Get client pointer
-	clientsData* client = getClient(clientID);
+	clientsData* client = getClient(clientID, true);
 	// Update overTime data structure with the new client
 	client->overTime[timeidx]++;
 
@@ -185,7 +185,7 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	client->numQueriesARP++;
 
 	// Get domain pointer
-	domainsData* domain = getDomain(domainID);
+	domainsData* domain = getDomain(domainID, true);
 
 	// Try blocking regex if configured
 	if(domain->regexmatch == REGEX_UNKNOWN && blockingstatus != BLOCKING_DISABLED)
@@ -238,7 +238,7 @@ static int findQueryID(int id)
 	// Check UUIDs of queries
 	for(int i = start; i >= until; i--)
 	{
-		queriesData* query = getQuery(i);
+		queriesData* query = getQuery(i, true);
 		if(query->id == id)
 			return i;
 	}
@@ -281,7 +281,7 @@ void _FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int i
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(i);
+	queriesData* query = getQuery(i, true);
 
 	// Proceed only if
 	// - current query has not been marked as replied to so far
@@ -433,7 +433,7 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(i);
+	queriesData* query = getQuery(i, true);
 
 	if(query->reply != REPLY_UNKNOWN)
 	{
@@ -446,7 +446,7 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 	int domainID = query->domainID;
 
 	// Get domain pointer
-	domainsData* domain = getDomain(domainID);
+	domainsData* domain = getDomain(domainID, true);
 
 	// Check if this domain matches exactly
 	bool isExactMatch = (name != NULL && strcmp(getstr(domain->domainpos), name) == 0);
@@ -472,7 +472,7 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 			domain->blockedcount++;
 
 			// Get client pointer
-			clientsData* client = getClient(query->clientID);
+			clientsData* client = getClient(query->clientID, true);
 
 			// Update client blocked counter
 			client->blockedcount++;
@@ -588,7 +588,7 @@ static void detect_blocked_IP(unsigned short flags, char* answer, int queryID)
 static void query_externally_blocked(int i)
 {
 	// Get query pointer
-	queriesData* query = getQuery(i);
+	queriesData* query = getQuery(i, true);
 
 	// Get time index
 	unsigned int timeidx = query->timeidx;
@@ -600,7 +600,7 @@ static void query_externally_blocked(int i)
 		overTime[timeidx].forwarded--;
 
 		// Get forward pointer
-		forwardedData* forward = getForward(query->forwardID);
+		forwardedData* forward = getForward(query->forwardID, true);
 		forward->count--;
 	}
 
@@ -609,12 +609,12 @@ static void query_externally_blocked(int i)
 	overTime[timeidx].blocked++;
 
 	// Get domain pointer
-	domainsData* domain = getDomain(query->domainID);
+	domainsData* domain = getDomain(query->domainID, true);
 
 	domain->blockedcount++;
 
 	// Get client pointer
-	clientsData* client = getClient(query->clientID);
+	clientsData* client = getClient(query->clientID, true);
 	client->blockedcount++;
 
 	query->status = QUERY_EXTERNAL_BLOCKED;
@@ -708,7 +708,7 @@ void _FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg
 		}
 
 		// Get query pointer
-		queriesData* query = getQuery(i);
+		queriesData* query = getQuery(i, true);
 
 		if(query->complete)
 		{
@@ -724,10 +724,10 @@ void _FTL_cache(unsigned int flags, char *name, struct all_addr *addr, char *arg
 		unsigned int timeidx = query->timeidx;
 
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID, true);
 
 		// Get client pointer
-		clientsData* client = getClient(query->clientID);
+		clientsData* client = getClient(query->clientID, true);
 
 		// Mark this query as blocked if domain was matched by a regex
 		if(domain->regexmatch == REGEX_BLOCKED)
@@ -794,13 +794,13 @@ void _FTL_dnssec(int status, int id, const char* file, const int line)
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(i);
+	queriesData* query = getQuery(i, true);
 
 	// Debug logging
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID, true);
 
 		logg("**** got DNSSEC details for %s: %i (ID %i, %s:%i)", getstr(domain->domainpos), status, id, file, line);
 	}
@@ -838,7 +838,7 @@ void _FTL_upstream_error(unsigned int rcode, int id, const char* file, const int
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(i);
+	queriesData* query = getQuery(i, true);
 
 	// Translate dnsmasq's rcode into something we can use
 	char *rcodestr = NULL;
@@ -868,7 +868,7 @@ void _FTL_upstream_error(unsigned int rcode, int id, const char* file, const int
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID, true);
 
 		logg("**** got error report for %s: %s (ID %i, %s:%i)", getstr(domain->domainpos), rcodestr, id, file, line);
 	}
@@ -905,12 +905,12 @@ void _FTL_header_ADbit(unsigned char header4, unsigned int rcode, int id, const 
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(i);
+	queriesData* query = getQuery(i, true);
 
 	if(config.debug & DEBUG_QUERIES)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(query->domainID);
+		domainsData* domain = getDomain(query->domainID, true);
 
 		logg("**** AD bit set for %s (ID %i, RCODE %u, %s:%i)", getstr(domain->domainpos), id, rcode, file, line);
 	}
@@ -961,7 +961,7 @@ void print_flags(unsigned int flags)
 void save_reply_type(unsigned int flags, int queryID, struct timeval response)
 {
 	// Get query pointer
-	queriesData* query = getQuery(queryID);
+	queriesData* query = getQuery(queryID, true);
 
 	// Iterate through possible values
 	if(flags & F_NEG)
@@ -1125,7 +1125,7 @@ void _FTL_forwarding_failed(struct server *server, const char* file, const int l
 	if(config.debug & DEBUG_QUERIES) logg("**** forwarding to %s (ID %i, %s:%i) failed", dest, forwardID, file, line);
 
 	// Get forward pointer
-	forwardedData* forward = getForward(forwardID);
+	forwardedData* forward = getForward(forwardID, true);
 
 	// Update counter
 	forward->failed++;

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -598,8 +598,10 @@ static void query_externally_blocked(int i)
 	{
 		counters->forwardedqueries--;
 		overTime[timeidx].forwarded--;
-		validate_access("forwarded", query->forwardID, true, __LINE__, __FUNCTION__, __FILE__);
-		forwarded[query->forwardID].count--;
+
+		// Get forward pointer
+		forwardedDataStruct* forward = getForward(query->forwardID);
+		forward->count--;
 	}
 
 	// ... but as blocked
@@ -1116,13 +1118,17 @@ void _FTL_forwarding_failed(struct server *server, const char* file, const int l
 		inet_ntop(AF_INET6, &server->addr.in6.sin6_addr, dest, ADDRSTRLEN);
 
 	// Convert forward to lower case
-	char *forward = strdup(dest);
-	strtolower(forward);
-	int forwardID = findForwardID(forward, false);
+	char *forwarddest = strdup(dest);
+	strtolower(forwarddest);
+	int forwardID = findForwardID(forwarddest, false);
 
 	if(config.debug & DEBUG_QUERIES) logg("**** forwarding to %s (ID %i, %s:%i) failed", dest, forwardID, file, line);
 
-	forwarded[forwardID].failed++;
+	// Get forward pointer
+	forwardedDataStruct* forward = getForward(forwardID);
+
+	// Update counter
+	forward->failed++;
 
 	free(forward);
 	unlock_shm();

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -209,8 +209,8 @@ void _FTL_new_query(unsigned int flags, char *name, struct all_addr *addr, char 
 	}
 
 	// Free allocated memory
-	free(client);
-	free(domain);
+	free(domainString);
+	free(clientIP);
 
 	// Release thread lock
 	unlock_shm();
@@ -263,8 +263,8 @@ void _FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int i
 	if(config.debug & DEBUG_QUERIES) logg("**** forwarded %s to %s (ID %i, %s:%i)", name, forward, id, file, line);
 
 	// Save status and forwardID in corresponding query identified by dnsmasq's ID
-	int i = findQueryID(id);
-	if(i < 0)
+	int queryID = findQueryID(id);
+	if(queryID < 0)
 	{
 		// This may happen e.g. if the original query was a PTR query or "pi.hole"
 		// as we ignore them altogether
@@ -274,7 +274,7 @@ void _FTL_forwarded(unsigned int flags, char *name, struct all_addr *addr, int i
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(i, true);
+	queriesData* query = getQuery(queryID, true);
 
 	// Proceed only if
 	// - current query has not been marked as replied to so far

--- a/gc.c
+++ b/gc.c
@@ -70,6 +70,9 @@ void *GC_thread(void *val)
 				domainsDataStruct* domain = getDomain(query->domainID);
 				domain->count--;
 
+				// Get forward pointer
+				forwardedDataStruct* forward = getForward(query->forwardID);
+
 				// Change other counters according to status of this query
 				switch(query->status)
 				{
@@ -79,9 +82,9 @@ void *GC_thread(void *val)
 						break;
 					case QUERY_FORWARDED:
 						// Forwarded to an upstream DNS server
+						// Adjust counters
 						counters->forwardedqueries--;
-						validate_access("forwarded", query->forwardID, true, __LINE__, __FUNCTION__, __FILE__);
-						forwarded[query->forwardID].count--;
+						forward->count--;
 						overTime[timeidx].forwarded--;
 						break;
 					case QUERY_CACHE:

--- a/gc.c
+++ b/gc.c
@@ -67,9 +67,8 @@ void *GC_thread(void *val)
 				client->overTime[timeidx]--;
 
 				// Adjust domain counter (no overTime information)
-				int domainID = query->domainID;
-				validate_access("domains", domainID, true, __LINE__, __FUNCTION__, __FILE__);
-				domains[domainID].count--;
+				domainsDataStruct* domain = getDomain(query->domainID);
+				domain->count--;
 
 				// Change other counters according to status of this query
 				switch(query->status)
@@ -96,7 +95,7 @@ void *GC_thread(void *val)
 					case QUERY_EXTERNAL_BLOCKED: // Blocked by upstream provider (fall through)
 						counters->blocked--;
 						overTime[timeidx].blocked--;
-						domains[domainID].blockedcount--;
+						domain->blockedcount--;
 						client->blockedcount--;
 						break;
 					default:

--- a/gc.c
+++ b/gc.c
@@ -51,13 +51,13 @@ void *GC_thread(void *val)
 			// Process all queries
 			for(i=0; i < counters->queries; i++)
 			{
-				queriesDataStruct* query = getQuery(i);
+				queriesData* query = getQuery(i);
 				// Test if this query is too new
 				if(query->timestamp > mintime)
 					break;
 
 				// Adjust client counter
-				clientsDataStruct* client = getClient(query->clientID);
+				clientsData* client = getClient(query->clientID);
 				client->count--;
 
 				// Adjust total counters and total over time data
@@ -67,11 +67,11 @@ void *GC_thread(void *val)
 				client->overTime[timeidx]--;
 
 				// Adjust domain counter (no overTime information)
-				domainsDataStruct* domain = getDomain(query->domainID);
+				domainsData* domain = getDomain(query->domainID);
 				domain->count--;
 
 				// Get forward pointer
-				forwardedDataStruct* forward = getForward(query->forwardID);
+				forwardedData* forward = getForward(query->forwardID);
 
 				// Change other counters according to status of this query
 				switch(query->status)
@@ -150,7 +150,7 @@ void *GC_thread(void *val)
 			// Example: (I = now invalid, X = still valid queries, F = free space)
 			//   Before: IIIIIIXXXXFF
 			//   After:  XXXXFFFFFFFF
-			memmove(getQuery(0), getQuery(removed), (counters->queries - removed)*sizeof(queriesDataStruct));
+			memmove(getQuery(0), getQuery(removed), (counters->queries - removed)*sizeof(queriesData));
 
 			// Update queries counter
 			counters->queries -= removed;
@@ -158,7 +158,7 @@ void *GC_thread(void *val)
 			lastdbindex -= removed;
 
 			// Zero out remaining memory (marked as "F" in the above example)
-			memset(getQuery(counters->queries), 0, (counters->queries_MAX - counters->queries)*sizeof(queriesDataStruct));
+			memset(getQuery(counters->queries), 0, (counters->queries_MAX - counters->queries)*sizeof(queriesData));
 
 			// Determine if overTime memory needs to get moved
 			moveOverTimeMemory(mintime);

--- a/gc.c
+++ b/gc.c
@@ -57,15 +57,14 @@ void *GC_thread(void *val)
 					break;
 
 				// Adjust client counter
-				int clientID = query->clientID;
-				validate_access("clients", clientID, true, __LINE__, __FUNCTION__, __FILE__);
-				clients[clientID].count--;
+				clientsDataStruct* client = getClient(query->clientID);
+				client->count--;
 
 				// Adjust total counters and total over time data
 				int timeidx = query->timeidx;
 				overTime[timeidx].total--;
 				// Adjust corresponding overTime counters
-				clients[clientID].overTime[timeidx]--;
+				client->overTime[timeidx]--;
 
 				// Adjust domain counter (no overTime information)
 				int domainID = query->domainID;
@@ -98,7 +97,7 @@ void *GC_thread(void *val)
 						counters->blocked--;
 						overTime[timeidx].blocked--;
 						domains[domainID].blockedcount--;
-						clients[clientID].blockedcount--;
+						client->blockedcount--;
 						break;
 					default:
 						/* That cannot happen */

--- a/gc.c
+++ b/gc.c
@@ -145,20 +145,24 @@ void *GC_thread(void *val)
 
 			}
 
-			// Move memory forward to keep only what we want
-			// Note: for overlapping memory blocks, memmove() is a safer approach than memcpy()
-			// Example: (I = now invalid, X = still valid queries, F = free space)
-			//   Before: IIIIIIXXXXFF
-			//   After:  XXXXFFFFFFFF
-			memmove(getQuery(0, true), getQuery(removed, true), (counters->queries - removed)*sizeof(queriesData));
+			// Only perform memory operations when we actually removed queries
+			if(removed > 0)
+			{
+				// Move memory forward to keep only what we want
+				// Note: for overlapping memory blocks, memmove() is a safer approach than memcpy()
+				// Example: (I = now invalid, X = still valid queries, F = free space)
+				//   Before: IIIIIIXXXXFF
+				//   After:  XXXXFFFFFFFF
+				memmove(getQuery(0, true), getQuery(removed, true), (counters->queries - removed)*sizeof(queriesData));
 
-			// Update queries counter
-			counters->queries -= removed;
-			// Update DB index as total number of queries reduced
-			lastdbindex -= removed;
+				// Update queries counter
+				counters->queries -= removed;
+				// Update DB index as total number of queries reduced
+				lastdbindex -= removed;
 
-			// Zero out remaining memory (marked as "F" in the above example)
-			memset(getQuery(counters->queries, true), 0, (counters->queries_MAX - counters->queries)*sizeof(queriesData));
+				// ensure remaining memory is zeroed out (marked as "F" in the above example)
+				memset(getQuery(counters->queries, true), 0, (counters->queries_MAX - counters->queries)*sizeof(queriesData));
+			}
 
 			// Determine if overTime memory needs to get moved
 			moveOverTimeMemory(mintime);

--- a/gc.c
+++ b/gc.c
@@ -51,13 +51,13 @@ void *GC_thread(void *val)
 			// Process all queries
 			for(i=0; i < counters->queries; i++)
 			{
-				queriesData* query = getQuery(i);
+				queriesData* query = getQuery(i, true);
 				// Test if this query is too new
 				if(query->timestamp > mintime)
 					break;
 
 				// Adjust client counter
-				clientsData* client = getClient(query->clientID);
+				clientsData* client = getClient(query->clientID, true);
 				client->count--;
 
 				// Adjust total counters and total over time data
@@ -67,11 +67,11 @@ void *GC_thread(void *val)
 				client->overTime[timeidx]--;
 
 				// Adjust domain counter (no overTime information)
-				domainsData* domain = getDomain(query->domainID);
+				domainsData* domain = getDomain(query->domainID, true);
 				domain->count--;
 
 				// Get forward pointer
-				forwardedData* forward = getForward(query->forwardID);
+				forwardedData* forward = getForward(query->forwardID, true);
 
 				// Change other counters according to status of this query
 				switch(query->status)
@@ -150,7 +150,7 @@ void *GC_thread(void *val)
 			// Example: (I = now invalid, X = still valid queries, F = free space)
 			//   Before: IIIIIIXXXXFF
 			//   After:  XXXXFFFFFFFF
-			memmove(getQuery(0), getQuery(removed), (counters->queries - removed)*sizeof(queriesData));
+			memmove(getQuery(0, true), getQuery(removed, true), (counters->queries - removed)*sizeof(queriesData));
 
 			// Update queries counter
 			counters->queries -= removed;
@@ -158,7 +158,7 @@ void *GC_thread(void *val)
 			lastdbindex -= removed;
 
 			// Zero out remaining memory (marked as "F" in the above example)
-			memset(getQuery(counters->queries), 0, (counters->queries_MAX - counters->queries)*sizeof(queriesData));
+			memset(getQuery(counters->queries, true), 0, (counters->queries_MAX - counters->queries)*sizeof(queriesData));
 
 			// Determine if overTime memory needs to get moved
 			moveOverTimeMemory(mintime);

--- a/memory.c
+++ b/memory.c
@@ -35,10 +35,8 @@ logFileNamesStruct files = {
 
 // Fixed size structs
 countersStruct *counters = NULL;
-ConfigStruct config;
-
-// Variable size array structs
 overTimeDataStruct *overTime = NULL;
+ConfigStruct config;
 
 // The special memory handling routines have to be the last ones in this source file
 // as we restore the original definition of the strdup, free, calloc, and realloc

--- a/memory.c
+++ b/memory.c
@@ -38,33 +38,7 @@ countersStruct *counters = NULL;
 ConfigStruct config;
 
 // Variable size array structs
-forwardedDataStruct *forwarded = NULL;
 overTimeDataStruct *overTime = NULL;
-
-void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file)
-{
-	int limit = 0;
-	if(name[0] == 'f') limit = counters->forwarded_MAX;
-	else { logg("Validator error (range)"); killed = 1; }
-
-	if(pos >= limit || pos < 0)
-	{
-		logg("FATAL ERROR: Trying to access %s[%i], but maximum is %i", name, pos, limit);
-		logg("             found in %s() (%s:%i)", function, file, line);
-	}
-	// Don't test magic byte if detected potential out-of-bounds error
-	else if(testmagic)
-	{
-		unsigned char magic = 0x00;
-		if(name[0] == 'f') magic = forwarded[pos].magic;
-		else { logg("Validator error (magic byte)"); killed = 1; }
-		if(magic != MAGICBYTE)
-		{
-			logg("FATAL ERROR: Trying to access %s[%i], but magic byte is %x", name, pos, magic);
-			logg("             found in %s() (%s:%i)", function, file, line);
-		}
-	}
-}
 
 // The special memory handling routines have to be the last ones in this source file
 // as we restore the original definition of the strdup, free, calloc, and realloc

--- a/memory.c
+++ b/memory.c
@@ -38,78 +38,16 @@ countersStruct *counters = NULL;
 ConfigStruct config;
 
 // Variable size array structs
-queriesDataStruct *queries = NULL;
 forwardedDataStruct *forwarded = NULL;
 clientsDataStruct *clients = NULL;
 domainsDataStruct *domains = NULL;
 overTimeDataStruct *overTime = NULL;
-
-void memory_check(int which)
-{
-	switch(which)
-	{
-		case QUERIES:
-			if(counters->queries >= counters->queries_MAX-1)
-			{
-				// Have to reallocate shared memory
-				queries = enlarge_shmem_struct(QUERIES);
-				if(queries == NULL)
-				{
-					logg("FATAL: Memory allocation failed! Exiting");
-					exit(EXIT_FAILURE);
-				}
-			}
-		break;
-		case FORWARDED:
-			if(counters->forwarded >= counters->forwarded_MAX-1)
-			{
-				// Have to reallocate shared memory
-				forwarded = enlarge_shmem_struct(FORWARDED);
-				if(forwarded == NULL)
-				{
-					logg("FATAL: Memory allocation failed! Exiting");
-					exit(EXIT_FAILURE);
-				}
-			}
-		break;
-		case CLIENTS:
-			if(counters->clients >= counters->clients_MAX-1)
-			{
-				// Have to reallocate shared memory
-				clients = enlarge_shmem_struct(CLIENTS);
-				if(clients == NULL)
-				{
-					logg("FATAL: Memory allocation failed! Exiting");
-					exit(EXIT_FAILURE);
-				}
-			}
-		break;
-		case DOMAINS:
-			if(counters->domains >= counters->domains_MAX-1)
-			{
-				// Have to reallocate shared memory
-				domains = enlarge_shmem_struct(DOMAINS);
-				if(domains == NULL)
-				{
-					logg("FATAL: Memory allocation failed! Exiting");
-					exit(EXIT_FAILURE);
-				}
-			}
-		break;
-		default:
-			/* That cannot happen */
-			logg("Fatal error in memory_check(%i)", which);
-			exit(EXIT_FAILURE);
-		break;
-	}
-}
 
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file)
 {
 	int limit = 0;
 	if(name[0] == 'c') limit = counters->clients_MAX;
 	else if(name[0] == 'd') limit = counters->domains_MAX;
-	else if(name[0] == 'q') limit = counters->queries_MAX;
 	else if(name[0] == 'f') limit = counters->forwarded_MAX;
 	else { logg("Validator error (range)"); killed = 1; }
 
@@ -124,7 +62,6 @@ void validate_access(const char * name, int pos, bool testmagic, int line, const
 		unsigned char magic = 0x00;
 		if(name[0] == 'c') magic = clients[pos].magic;
 		else if(name[0] == 'd') magic = domains[pos].magic;
-		else if(name[0] == 'q') magic = queries[pos].magic;
 		else if(name[0] == 'f') magic = forwarded[pos].magic;
 		else { logg("Validator error (magic byte)"); killed = 1; }
 		if(magic != MAGICBYTE)

--- a/memory.c
+++ b/memory.c
@@ -39,14 +39,12 @@ ConfigStruct config;
 
 // Variable size array structs
 forwardedDataStruct *forwarded = NULL;
-domainsDataStruct *domains = NULL;
 overTimeDataStruct *overTime = NULL;
 
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file)
 {
 	int limit = 0;
-	if(name[0] == 'd') limit = counters->domains_MAX;
-	else if(name[0] == 'f') limit = counters->forwarded_MAX;
+	if(name[0] == 'f') limit = counters->forwarded_MAX;
 	else { logg("Validator error (range)"); killed = 1; }
 
 	if(pos >= limit || pos < 0)
@@ -58,8 +56,7 @@ void validate_access(const char * name, int pos, bool testmagic, int line, const
 	else if(testmagic)
 	{
 		unsigned char magic = 0x00;
-		if(name[0] == 'd') magic = domains[pos].magic;
-		else if(name[0] == 'f') magic = forwarded[pos].magic;
+		if(name[0] == 'f') magic = forwarded[pos].magic;
 		else { logg("Validator error (magic byte)"); killed = 1; }
 		if(magic != MAGICBYTE)
 		{

--- a/memory.c
+++ b/memory.c
@@ -35,7 +35,7 @@ logFileNamesStruct files = {
 
 // Fixed size structs
 countersStruct *counters = NULL;
-overTimeDataStruct *overTime = NULL;
+overTimeData *overTime = NULL;
 ConfigStruct config;
 
 // The special memory handling routines have to be the last ones in this source file

--- a/memory.c
+++ b/memory.c
@@ -39,15 +39,13 @@ ConfigStruct config;
 
 // Variable size array structs
 forwardedDataStruct *forwarded = NULL;
-clientsDataStruct *clients = NULL;
 domainsDataStruct *domains = NULL;
 overTimeDataStruct *overTime = NULL;
 
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file)
 {
 	int limit = 0;
-	if(name[0] == 'c') limit = counters->clients_MAX;
-	else if(name[0] == 'd') limit = counters->domains_MAX;
+	if(name[0] == 'd') limit = counters->domains_MAX;
 	else if(name[0] == 'f') limit = counters->forwarded_MAX;
 	else { logg("Validator error (range)"); killed = 1; }
 
@@ -60,8 +58,7 @@ void validate_access(const char * name, int pos, bool testmagic, int line, const
 	else if(testmagic)
 	{
 		unsigned char magic = 0x00;
-		if(name[0] == 'c') magic = clients[pos].magic;
-		else if(name[0] == 'd') magic = domains[pos].magic;
+		if(name[0] == 'd') magic = domains[pos].magic;
 		else if(name[0] == 'f') magic = forwarded[pos].magic;
 		else { logg("Validator error (magic byte)"); killed = 1; }
 		if(magic != MAGICBYTE)

--- a/networktable.c
+++ b/networktable.c
@@ -125,7 +125,7 @@ void parse_arp_cache(void)
 		// Get hostname of this client if the client is known
 		char *hostname = "";
 		// Get client pointer
-		clientsDataStruct* client = getClient(clientID);
+		clientsData* client = getClient(clientID);
 
 		if(clientKnown)
 		{

--- a/networktable.c
+++ b/networktable.c
@@ -125,7 +125,7 @@ void parse_arp_cache(void)
 		// Get hostname of this client if the client is known
 		char *hostname = "";
 		// Get client pointer
-		clientsData* client = getClient(clientID);
+		clientsData* client = getClient(clientID, true);
 
 		if(clientKnown)
 		{

--- a/overTime.c
+++ b/overTime.c
@@ -125,16 +125,18 @@ void moveOverTimeMemory(time_t mintime)
 		// Correct time indices of queries. This is necessary because we just moved the slot this index points to
 		for(int queryID = 0; queryID < counters->queries; queryID++)
 		{
+			// Get query pointer
+			queriesDataStruct* query = getQuery(queryID);
 			// Check if the index would become negative if we adjusted it
-			if(((int)queries[queryID].timeidx - (int)moveOverTime) < 0)
+			if(((int)query->timeidx - (int)moveOverTime) < 0)
 			{
 				// This should never happen, but we print a warning if it still happens
 				// We don't do anything in this case
-				logg("WARN: moveOverTimeMemory(): overTime time index correction failed (%i: %u / %u)", queryID, queries[queryID].timeidx, moveOverTime);
+				logg("WARN: moveOverTimeMemory(): overTime time index correction failed (%i: %u / %u)", queryID, query->timeidx, moveOverTime);
 			}
 			else
 			{
-				queries[queryID].timeidx -= moveOverTime;
+				query->timeidx -= moveOverTime;
 			}
 		}
 

--- a/overTime.c
+++ b/overTime.c
@@ -37,7 +37,7 @@ static void initSlot(unsigned int index, time_t timestamp)
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(clientID);
+		clientsData* client = getClient(clientID);
 
 		client->overTime[index] = 0;
 	}
@@ -131,7 +131,7 @@ void moveOverTimeMemory(time_t mintime)
 		for(int queryID = 0; queryID < counters->queries; queryID++)
 		{
 			// Get query pointer
-			queriesDataStruct* query = getQuery(queryID);
+			queriesData* query = getQuery(queryID);
 			// Check if the index would become negative if we adjusted it
 			if(((int)query->timeidx - (int)moveOverTime) < 0)
 			{

--- a/overTime.c
+++ b/overTime.c
@@ -37,7 +37,7 @@ static void initSlot(unsigned int index, time_t timestamp)
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(clientID);
+		clientsData* client = getClient(clientID, true);
 
 		client->overTime[index] = 0;
 	}
@@ -131,7 +131,7 @@ void moveOverTimeMemory(time_t mintime)
 		for(int queryID = 0; queryID < counters->queries; queryID++)
 		{
 			// Get query pointer
-			queriesData* query = getQuery(queryID);
+			queriesData* query = getQuery(queryID, true);
 			// Check if the index would become negative if we adjusted it
 			if(((int)query->timeidx - (int)moveOverTime) < 0)
 			{
@@ -148,7 +148,7 @@ void moveOverTimeMemory(time_t mintime)
 		// Move client-specific overTime memory
 		for(int clientID = 0; clientID < counters->clients; clientID++)
 		{
-			memmove(&getClient(clientID)->overTime[0], &getClient(clientID)->overTime[moveOverTime], remainingSlots*sizeof(int));
+			memmove(&(getClient(clientID, true)->overTime[0]), &(getClient(clientID, true)->overTime[moveOverTime]), remainingSlots*sizeof(int));
 		}
 
 		// Iterate over new overTime region and initialize it

--- a/overTime.c
+++ b/overTime.c
@@ -38,7 +38,6 @@ static void initSlot(unsigned int index, time_t timestamp)
 	{
 		// Get client pointer
 		clientsData* client = getClient(clientID, true);
-
 		client->overTime[index] = 0;
 	}
 }

--- a/overTime.c
+++ b/overTime.c
@@ -35,7 +35,12 @@ static void initSlot(unsigned int index, time_t timestamp)
 
 	// Zero overTime counter for all known clients
 	for(int clientID = 0; clientID < counters->clients; clientID++)
-		clients[clientID].overTime[index] = 0;
+	{
+		// Get client pointer
+		clientsDataStruct* client = getClient(clientID);
+
+		client->overTime[index] = 0;
+	}
 }
 
 void initOverTime(void)
@@ -143,7 +148,7 @@ void moveOverTimeMemory(time_t mintime)
 		// Move client-specific overTime memory
 		for(int clientID = 0; clientID < counters->clients; clientID++)
 		{
-			memmove(&clients[clientID].overTime[0], &clients[clientID].overTime[moveOverTime], remainingSlots*sizeof(int));
+			memmove(&getClient(clientID)->overTime[0], &getClient(clientID)->overTime[moveOverTime], remainingSlots*sizeof(int));
 		}
 
 		// Iterate over new overTime region and initialize it

--- a/regex.c
+++ b/regex.c
@@ -156,7 +156,7 @@ void free_regex(void)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsData* domain = getDomain(i);
+		domainsData* domain = getDomain(i, true);
 
 		// Reset regexmatch to unknown
 		domain->regexmatch = REGEX_UNKNOWN;

--- a/regex.c
+++ b/regex.c
@@ -156,7 +156,7 @@ void free_regex(void)
 	for(int i=0; i < counters->domains; i++)
 	{
 		// Get domain pointer
-		domainsDataStruct* domain = getDomain(i);
+		domainsData* domain = getDomain(i);
 
 		// Reset regexmatch to unknown
 		domain->regexmatch = REGEX_UNKNOWN;

--- a/regex.c
+++ b/regex.c
@@ -153,11 +153,13 @@ void free_regex(void)
 
 	// Must reevaluate regex filters after having reread the regex filter
 	// We reset all regex status to unknown to have them being reevaluated
-	if(counters->domains > 0)
-		validate_access("domains", counters->domains-1, false, __LINE__, __FUNCTION__, __FILE__);
 	for(int i=0; i < counters->domains; i++)
 	{
-		domains[i].regexmatch = REGEX_UNKNOWN;
+		// Get domain pointer
+		domainsDataStruct* domain = getDomain(i);
+
+		// Reset regexmatch to unknown
+		domain->regexmatch = REGEX_UNKNOWN;
 	}
 
 	// Also free array of whitelisted domains

--- a/resolve.c
+++ b/resolve.c
@@ -77,7 +77,7 @@ void resolveClients(bool onlynew)
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		// Get client pointer
-		clientsDataStruct* client = getClient(clientID);
+		clientsData* client = getClient(clientID);
 
 		// If onlynew flag is set, we will only resolve new clients
 		// If not, we will try to re-resolve all known clients
@@ -108,7 +108,7 @@ void resolveForwardDestinations(bool onlynew)
 	for(forwardID = 0; forwardID < counters->forwarded; forwardID++)
 	{
 		// Get forward pointer
-		forwardedDataStruct* forward = getForward(forwardID);
+		forwardedData* forward = getForward(forwardID);
 
 		// If onlynew flag is set, we will only resolve new upstream destinations
 		// If not, we will try to re-resolve all known upstream destinations

--- a/resolve.c
+++ b/resolve.c
@@ -74,20 +74,19 @@ char *resolveHostname(const char *addr)
 // Resolve client host names
 void resolveClients(bool onlynew)
 {
-	int clientID;
-	for(clientID = 0; clientID < counters->clients; clientID++)
+	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
-		// Memory validation
-		validate_access("clients", clientID, true, __LINE__, __FUNCTION__, __FILE__);
+		// Get client pointer
+		clientsDataStruct* client = getClient(clientID);
 
 		// If onlynew flag is set, we will only resolve new clients
 		// If not, we will try to re-resolve all known clients
-		if(onlynew && !clients[clientID].new)
+		if(onlynew && !client->new)
 			continue;
 
 		// Lock data when obtaining IP of this client
 		lock_shm();
-		const char* ipaddr = getstr(clients[clientID].ippos);
+		const char* ipaddr = getstr(client->ippos);
 		unlock_shm();
 
 		// Important: Don't hold a lock while resolving as the main thread
@@ -96,8 +95,8 @@ void resolveClients(bool onlynew)
 
 		// Finally, lock data when storing obtained hostname
 		lock_shm();
-		clients[clientID].namepos = addstr(hostname);
-		clients[clientID].new = false;
+		client->namepos = addstr(hostname);
+		client->new = false;
 		unlock_shm();
 	}
 }

--- a/resolve.c
+++ b/resolve.c
@@ -107,17 +107,17 @@ void resolveForwardDestinations(bool onlynew)
 	int forwardID;
 	for(forwardID = 0; forwardID < counters->forwarded; forwardID++)
 	{
-		// Memory validation
-		validate_access("forwarded", forwardID, true, __LINE__, __FUNCTION__, __FILE__);
+		// Get forward pointer
+		forwardedDataStruct* forward = getForward(forwardID);
 
 		// If onlynew flag is set, we will only resolve new upstream destinations
 		// If not, we will try to re-resolve all known upstream destinations
-		if(onlynew && !forwarded[forwardID].new)
+		if(onlynew && !forward->new)
 			continue;
 
 		// Lock data when obtaining IP of this forward destination
 		lock_shm();
-		const char* ipaddr = getstr(forwarded[forwardID].ippos);
+		const char* ipaddr = getstr(forward->ippos);
 		unlock_shm();
 
 
@@ -127,8 +127,8 @@ void resolveForwardDestinations(bool onlynew)
 
 		// Finally, lock data when storing obtained hostname
 		lock_shm();
-		forwarded[forwardID].namepos = addstr(hostname);
-		forwarded[forwardID].new = false;
+		forward->namepos = addstr(hostname);
+		forward->new = false;
 		unlock_shm();
 	}
 }

--- a/resolve.c
+++ b/resolve.c
@@ -77,7 +77,7 @@ void resolveClients(bool onlynew)
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		// Get client pointer
-		clientsData* client = getClient(clientID);
+		clientsData* client = getClient(clientID, true);
 
 		// If onlynew flag is set, we will only resolve new clients
 		// If not, we will try to re-resolve all known clients
@@ -108,7 +108,7 @@ void resolveForwardDestinations(bool onlynew)
 	for(forwardID = 0; forwardID < counters->forwarded; forwardID++)
 	{
 		// Get forward pointer
-		forwardedData* forward = getForward(forwardID);
+		forwardedData* forward = getForward(forwardID, true);
 
 		// If onlynew flag is set, we will only resolve new upstream destinations
 		// If not, we will try to re-resolve all known upstream destinations

--- a/routines.h
+++ b/routines.h
@@ -96,7 +96,6 @@ char *FTLstrdup(const char *src, const char *file, const char *function, int lin
 void *FTLcalloc(size_t nmemb, size_t size, const char *file, const char *function, int line);
 void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *function, int line);
 void FTLfree(void *ptr, const char* file, const char *function, int line);
-void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file);
 
 int main_dnsmasq(int argc, char **argv);
 

--- a/shmem.c
+++ b/shmem.c
@@ -37,10 +37,10 @@ static SharedMemory shm_overTime = { 0 };
 static SharedMemory shm_settings = { 0 };
 
 // Variable size array structs
-static queriesDataStruct *queries = NULL;
-static clientsDataStruct *clients = NULL;
-static domainsDataStruct *domains = NULL;
-static forwardedDataStruct *forwarded = NULL;
+static queriesData *queries = NULL;
+static clientsData *clients = NULL;
+static domainsData *domains = NULL;
+static forwardedData *forwarded = NULL;
 
 typedef struct {
 	pthread_mutex_t lock;
@@ -134,14 +134,14 @@ pthread_mutex_t create_mutex() {
 void remap_shm(void)
 {
 	// Remap shared object pointers which might have changed
-	realloc_shm(&shm_queries, counters->queries_MAX*sizeof(queriesDataStruct), false);
-	queries = (queriesDataStruct*)shm_queries.ptr;
-	realloc_shm(&shm_domains, counters->domains_MAX*sizeof(domainsDataStruct), false);
-	domains = (domainsDataStruct*)shm_domains.ptr;
-	realloc_shm(&shm_clients, counters->clients_MAX*sizeof(clientsDataStruct), false);
-	clients = (clientsDataStruct*)shm_clients.ptr;
-	realloc_shm(&shm_forwarded, counters->forwarded_MAX*sizeof(forwardedDataStruct), false);
-	forwarded = (forwardedDataStruct*)shm_forwarded.ptr;
+	realloc_shm(&shm_queries, counters->queries_MAX*sizeof(queriesData), false);
+	queries = (queriesData*)shm_queries.ptr;
+	realloc_shm(&shm_domains, counters->domains_MAX*sizeof(domainsData), false);
+	domains = (domainsData*)shm_domains.ptr;
+	realloc_shm(&shm_clients, counters->clients_MAX*sizeof(clientsData), false);
+	clients = (clientsData*)shm_clients.ptr;
+	realloc_shm(&shm_forwarded, counters->forwarded_MAX*sizeof(forwardedData), false);
+	forwarded = (forwardedData*)shm_forwarded.ptr;
 	realloc_shm(&shm_strings, counters->strings_MAX, false);
 	// strings are not exposed by a global pointer
 
@@ -230,35 +230,35 @@ bool init_shmem(void)
 
 	/****************************** shared domains struct ******************************/
 	// Try to create shared memory object
-	shm_domains = create_shm(SHARED_DOMAINS_NAME, pagesize*sizeof(domainsDataStruct));
-	domains = (domainsDataStruct*)shm_domains.ptr;
+	shm_domains = create_shm(SHARED_DOMAINS_NAME, pagesize*sizeof(domainsData));
+	domains = (domainsData*)shm_domains.ptr;
 	counters->domains_MAX = pagesize;
 
 	/****************************** shared clients struct ******************************/
-	size_t size = get_optimal_object_size(sizeof(clientsDataStruct), 1);
+	size_t size = get_optimal_object_size(sizeof(clientsData), 1);
 	// Try to create shared memory object
-	shm_clients = create_shm(SHARED_CLIENTS_NAME, size*sizeof(clientsDataStruct));
-	clients = (clientsDataStruct*)shm_clients.ptr;
+	shm_clients = create_shm(SHARED_CLIENTS_NAME, size*sizeof(clientsData));
+	clients = (clientsData*)shm_clients.ptr;
 	counters->clients_MAX = size;
 
 	/****************************** shared forwarded struct ******************************/
-	size = get_optimal_object_size(sizeof(forwardedDataStruct), 1);
+	size = get_optimal_object_size(sizeof(forwardedData), 1);
 	// Try to create shared memory object
-	shm_forwarded = create_shm(SHARED_FORWARDED_NAME, size*sizeof(forwardedDataStruct));
-	forwarded = (forwardedDataStruct*)shm_forwarded.ptr;
+	shm_forwarded = create_shm(SHARED_FORWARDED_NAME, size*sizeof(forwardedData));
+	forwarded = (forwardedData*)shm_forwarded.ptr;
 	counters->forwarded_MAX = size;
 
 	/****************************** shared queries struct ******************************/
 	// Try to create shared memory object
-	shm_queries = create_shm(SHARED_QUERIES_NAME, pagesize*sizeof(queriesDataStruct));
-	queries = (queriesDataStruct*)shm_queries.ptr;
+	shm_queries = create_shm(SHARED_QUERIES_NAME, pagesize*sizeof(queriesData));
+	queries = (queriesData*)shm_queries.ptr;
 	counters->queries_MAX = pagesize;
 
 	/****************************** shared overTime struct ******************************/
-	size = get_optimal_object_size(sizeof(overTimeDataStruct), OVERTIME_SLOTS);
+	size = get_optimal_object_size(sizeof(overTimeData), OVERTIME_SLOTS);
 	// Try to create shared memory object
-	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size*sizeof(overTimeDataStruct));
-	overTime = (overTimeDataStruct*)shm_overTime.ptr;
+	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size*sizeof(overTimeData));
+	overTime = (overTimeData*)shm_overTime.ptr;
 	initOverTime();
 
 	return true;
@@ -354,25 +354,25 @@ void *enlarge_shmem_struct(char type)
 		case QUERIES:
 			sharedMemory = &shm_queries;
 			allocation_step = pagesize;
-			sizeofobj = sizeof(queriesDataStruct);
+			sizeofobj = sizeof(queriesData);
 			counter = &counters->queries_MAX;
 			break;
 		case CLIENTS:
 			sharedMemory = &shm_clients;
-			allocation_step = get_optimal_object_size(sizeof(clientsDataStruct), 1);
-			sizeofobj = sizeof(clientsDataStruct);
+			allocation_step = get_optimal_object_size(sizeof(clientsData), 1);
+			sizeofobj = sizeof(clientsData);
 			counter = &counters->clients_MAX;
 			break;
 		case DOMAINS:
 			sharedMemory = &shm_domains;
 			allocation_step = pagesize;
-			sizeofobj = sizeof(domainsDataStruct);
+			sizeofobj = sizeof(domainsData);
 			counter = &counters->domains_MAX;
 			break;
 		case FORWARDED:
 			sharedMemory = &shm_forwarded;
-			allocation_step = get_optimal_object_size(sizeof(forwardedDataStruct), 1);
-			sizeofobj = sizeof(forwardedDataStruct);
+			allocation_step = get_optimal_object_size(sizeof(forwardedData), 1);
+			sizeofobj = sizeof(forwardedData);
 			counter = &counters->forwarded_MAX;
 			break;
 		default:
@@ -578,7 +578,7 @@ void memory_check(int which)
 	}
 }
 
-queriesDataStruct* _getQuery(int queryID, int line, const char * function, const char * file)
+queriesData* _getQuery(int queryID, int line, const char * function, const char * file)
 {
 	if(queryID < 0 || queryID > counters->queries_MAX)
 	{
@@ -595,7 +595,7 @@ queriesDataStruct* _getQuery(int queryID, int line, const char * function, const
 	return &queries[queryID];
 }
 
-clientsDataStruct* _getClient(int clientID, int line, const char * function, const char * file)
+clientsData* _getClient(int clientID, int line, const char * function, const char * file)
 {
 	if(clientID < 0 || clientID > counters->clients_MAX)
 	{
@@ -612,7 +612,7 @@ clientsDataStruct* _getClient(int clientID, int line, const char * function, con
 	return &clients[clientID];
 }
 
-domainsDataStruct* _getDomain(int domainID, int line, const char * function, const char * file)
+domainsData* _getDomain(int domainID, int line, const char * function, const char * file)
 {
 	if(domainID < 0 || domainID > counters->domains_MAX)
 	{
@@ -629,7 +629,7 @@ domainsDataStruct* _getDomain(int domainID, int line, const char * function, con
 	return &domains[domainID];
 }
 
-forwardedDataStruct* _getForward(int forwardID, int line, const char * function, const char * file)
+forwardedData* _getForward(int forwardID, int line, const char * function, const char * file)
 {
 	if(forwardID < 0 || forwardID > counters->forwarded_MAX)
 	{

--- a/shmem.c
+++ b/shmem.c
@@ -40,6 +40,7 @@ static SharedMemory shm_settings = { 0 };
 static queriesDataStruct *queries = NULL;
 static clientsDataStruct *clients = NULL;
 static domainsDataStruct *domains = NULL;
+static forwardedDataStruct *forwarded = NULL;
 
 typedef struct {
 	pthread_mutex_t lock;
@@ -626,4 +627,21 @@ domainsDataStruct* _getDomain(int domainID, int line, const char * function, con
 		return NULL;
 	}
 	return &domains[domainID];
+}
+
+forwardedDataStruct* _getForward(int forwardID, int line, const char * function, const char * file)
+{
+	if(forwardID < 0 || forwardID > counters->forwarded_MAX)
+	{
+		logg("FATAL: Trying to access forwarded ID %i, but maximum is %i", forwardID, counters->forwarded_MAX);
+		logg("       found in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	if(forwarded[forwardID].magic != MAGICBYTE)
+	{
+		logg("FATAL: Trying to access forwarded ID %i, but magic byte is %x", forwardID, forwarded[forwardID].magic);
+		logg("       found in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	return &forwarded[forwardID];
 }

--- a/shmem.c
+++ b/shmem.c
@@ -578,78 +578,64 @@ void memory_check(int which)
 	}
 }
 
-queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * function, const char * file)
+static inline bool check_range(int ID, int MAXID, const char* type, int line, const char * function, const char * file)
 {
-	if(queryID < 0 || queryID > counters->queries_MAX)
+	if(ID < 0 || ID > MAXID)
 	{
 		// Check bounds
-		logg("FATAL: Trying to access query ID %i, but maximum is %i", queryID, counters->queries_MAX);
+		logg("FATAL: Trying to access %s ID %i, but maximum is %i", type, ID, MAXID);
 		logg("       found in %s() (%s:%i)", function, file, line);
-		return NULL;
+		return false;
 	}
-	if(checkMagic && queries[queryID].magic != MAGICBYTE)
+	// Everything okay
+	return true;
+}
+
+static inline bool check_magic(int ID, bool checkMagic, unsigned char magic, const char* type, int line, const char * function, const char * file)
+{
+	if(checkMagic && magic != MAGICBYTE)
 	{
 		// Check magic only if requested (skipped for new entries which are uninitialized)
-		logg("FATAL: Trying to access query ID %i, but magic byte is %x", queryID, queries[queryID].magic);
+		logg("FATAL: Trying to access %s ID %i, but magic byte is %x", type, ID, magic);
 		logg("       found in %s() (%s:%i)", function, file, line);
-		return NULL;
+		return false;
 	}
-	return &queries[queryID];
+	// Everything okay
+	return true;
+}
+
+queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * function, const char * file)
+{
+	if(check_range(queryID, counters->queries_MAX, "query", line, function, file) &&
+	   check_magic(queryID, checkMagic, queries[queryID].magic, "query", line, function, file))
+		return &queries[queryID];
+	else
+		return NULL;
 }
 
 clientsData* _getClient(int clientID, bool checkMagic, int line, const char * function, const char * file)
 {
-	if(clientID < 0 || clientID > counters->clients_MAX)
-	{
-		// Check bounds
-		logg("FATAL: Trying to access client ID %i, but maximum is %i", clientID, counters->clients_MAX);
-		logg("       found in %s() (%s:%i)", function, file, line);
+	if(check_range(clientID, counters->clients_MAX, "client", line, function, file) &&
+	   check_magic(clientID, checkMagic, clients[clientID].magic, "client", line, function, file))
+		return &clients[clientID];
+	else
 		return NULL;
-	}
-	if(checkMagic && clients[clientID].magic != MAGICBYTE)
-	{
-		// Check magic only if requested (skipped for new entries which are uninitialized)
-		logg("FATAL: Trying to access client ID %i, but magic byte is %x", clientID, clients[clientID].magic);
-		logg("       found in %s() (%s:%i)", function, file, line);
-		return NULL;
-	}
-	return &clients[clientID];
 }
 
 domainsData* _getDomain(int domainID, bool checkMagic, int line, const char * function, const char * file)
 {
-	if(domainID < 0 || domainID > counters->domains_MAX)
-	{
-		// Check bounds
-		logg("FATAL: Trying to access domain ID %i, but maximum is %i", domainID, counters->domains_MAX);
-		logg("       found in %s() (%s:%i)", function, file, line);
+	if(check_range(domainID, counters->domains_MAX, "domain", line, function, file) &&
+	   check_magic(domainID, checkMagic, domains[domainID].magic, "domain", line, function, file))
+		return &domains[domainID];
+	else
 		return NULL;
-	}
-	if(checkMagic && domains[domainID].magic != MAGICBYTE)
-	{
-		// Check magic only if requested (skipped for new entries which are uninitialized)
-		logg("FATAL: Trying to access domain ID %i, but magic byte is %x", domainID, domains[domainID].magic);
-		logg("       found in %s() (%s:%i)", function, file, line);
-		return NULL;
-	}
-	return &domains[domainID];
 }
 
 forwardedData* _getForward(int forwardID, bool checkMagic, int line, const char * function, const char * file)
 {
-	if(forwardID < 0 || forwardID > counters->forwarded_MAX)
-	{
-		// Check bounds
-		logg("FATAL: Trying to access forwarded ID %i, but maximum is %i", forwardID, counters->forwarded_MAX);
-		logg("       found in %s() (%s:%i)", function, file, line);
+	if(check_range(forwardID, counters->forwarded_MAX, "forward", line, function, file) &&
+	   check_magic(forwardID, checkMagic, forwarded[forwardID].magic, "forward", line, function, file))
+		return &forwarded[forwardID];
+	else
 		return NULL;
-	}
-	if(checkMagic && forwarded[forwardID].magic != MAGICBYTE)
-	{
-		// Check magic only if requested (skipped for new entries which are uninitialized)
-		logg("FATAL: Trying to access forwarded ID %i, but magic byte is %x", forwardID, forwarded[forwardID].magic);
-		logg("       found in %s() (%s:%i)", function, file, line);
-		return NULL;
-	}
-	return &forwarded[forwardID];
 }

--- a/shmem.c
+++ b/shmem.c
@@ -578,16 +578,18 @@ void memory_check(int which)
 	}
 }
 
-queriesData* _getQuery(int queryID, int line, const char * function, const char * file)
+queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * function, const char * file)
 {
 	if(queryID < 0 || queryID > counters->queries_MAX)
 	{
+		// Check bounds
 		logg("FATAL: Trying to access query ID %i, but maximum is %i", queryID, counters->queries_MAX);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
 	}
-	if(queries[queryID].magic != MAGICBYTE)
+	if(checkMagic && queries[queryID].magic != MAGICBYTE)
 	{
+		// Check magic only if requested (skipped for new entries which are uninitialized)
 		logg("FATAL: Trying to access query ID %i, but magic byte is %x", queryID, queries[queryID].magic);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
@@ -595,16 +597,18 @@ queriesData* _getQuery(int queryID, int line, const char * function, const char 
 	return &queries[queryID];
 }
 
-clientsData* _getClient(int clientID, int line, const char * function, const char * file)
+clientsData* _getClient(int clientID, bool checkMagic, int line, const char * function, const char * file)
 {
 	if(clientID < 0 || clientID > counters->clients_MAX)
 	{
+		// Check bounds
 		logg("FATAL: Trying to access client ID %i, but maximum is %i", clientID, counters->clients_MAX);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
 	}
-	if(clients[clientID].magic != MAGICBYTE)
+	if(checkMagic && clients[clientID].magic != MAGICBYTE)
 	{
+		// Check magic only if requested (skipped for new entries which are uninitialized)
 		logg("FATAL: Trying to access client ID %i, but magic byte is %x", clientID, clients[clientID].magic);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
@@ -612,16 +616,18 @@ clientsData* _getClient(int clientID, int line, const char * function, const cha
 	return &clients[clientID];
 }
 
-domainsData* _getDomain(int domainID, int line, const char * function, const char * file)
+domainsData* _getDomain(int domainID, bool checkMagic, int line, const char * function, const char * file)
 {
 	if(domainID < 0 || domainID > counters->domains_MAX)
 	{
+		// Check bounds
 		logg("FATAL: Trying to access domain ID %i, but maximum is %i", domainID, counters->domains_MAX);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
 	}
-	if(domains[domainID].magic != MAGICBYTE)
+	if(checkMagic && domains[domainID].magic != MAGICBYTE)
 	{
+		// Check magic only if requested (skipped for new entries which are uninitialized)
 		logg("FATAL: Trying to access domain ID %i, but magic byte is %x", domainID, domains[domainID].magic);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
@@ -629,16 +635,18 @@ domainsData* _getDomain(int domainID, int line, const char * function, const cha
 	return &domains[domainID];
 }
 
-forwardedData* _getForward(int forwardID, int line, const char * function, const char * file)
+forwardedData* _getForward(int forwardID, bool checkMagic, int line, const char * function, const char * file)
 {
 	if(forwardID < 0 || forwardID > counters->forwarded_MAX)
 	{
+		// Check bounds
 		logg("FATAL: Trying to access forwarded ID %i, but maximum is %i", forwardID, counters->forwarded_MAX);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;
 	}
-	if(forwarded[forwardID].magic != MAGICBYTE)
+	if(checkMagic && forwarded[forwardID].magic != MAGICBYTE)
 	{
+		// Check magic only if requested (skipped for new entries which are uninitialized)
 		logg("FATAL: Trying to access forwarded ID %i, but magic byte is %x", forwardID, forwarded[forwardID].magic);
 		logg("       found in %s() (%s:%i)", function, file, line);
 		return NULL;

--- a/shmem.c
+++ b/shmem.c
@@ -38,6 +38,7 @@ static SharedMemory shm_settings = { 0 };
 
 // Variable size array structs
 static queriesDataStruct *queries = NULL;
+static clientsDataStruct *clients = NULL;
 
 typedef struct {
 	pthread_mutex_t lock;
@@ -590,4 +591,21 @@ queriesDataStruct* _getQuery(int queryID, int line, const char * function, const
 		return NULL;
 	}
 	return &queries[queryID];
+}
+
+clientsDataStruct* _getClient(int clientID, int line, const char * function, const char * file)
+{
+	if(clientID < 0 || clientID > counters->clients_MAX)
+	{
+		logg("FATAL: Trying to access client ID %i, but maximum is %i", clientID, counters->clients_MAX);
+		logg("       found in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	if(clients[clientID].magic != MAGICBYTE)
+	{
+		logg("FATAL: Trying to access client ID %i, but magic byte is %x", clientID, clients[clientID].magic);
+		logg("       found in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	return &clients[clientID];
 }

--- a/shmem.c
+++ b/shmem.c
@@ -39,6 +39,7 @@ static SharedMemory shm_settings = { 0 };
 // Variable size array structs
 static queriesDataStruct *queries = NULL;
 static clientsDataStruct *clients = NULL;
+static domainsDataStruct *domains = NULL;
 
 typedef struct {
 	pthread_mutex_t lock;
@@ -608,4 +609,21 @@ clientsDataStruct* _getClient(int clientID, int line, const char * function, con
 		return NULL;
 	}
 	return &clients[clientID];
+}
+
+domainsDataStruct* _getDomain(int domainID, int line, const char * function, const char * file)
+{
+	if(domainID < 0 || domainID > counters->domains_MAX)
+	{
+		logg("FATAL: Trying to access domain ID %i, but maximum is %i", domainID, counters->domains_MAX);
+		logg("       found in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	if(domains[domainID].magic != MAGICBYTE)
+	{
+		logg("FATAL: Trying to access domain ID %i, but magic byte is %x", domainID, domains[domainID].magic);
+		logg("       found in %s() (%s:%i)", function, file, line);
+		return NULL;
+	}
+	return &domains[domainID];
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This change removes the global objects:
- `queries`
- `clients`
- `domains`
- `forwarded`

They are now all only be available through corresponding getter functions that will return a pointer to exactly one specific entry. Each cal to a pointer getter is accompanied by corresponding boundary checks. We will have to evaluate if - and if how much - effect this has on FTL's performance.

This change does not affect the shared memory the API uses.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
