### PR TITLE
Follow-up on #527

### DIFF
--- a/main.c
+++ b/main.c
@@ -36,6 +36,13 @@ int main (int argc, char* argv[])
 	logg("########## FTL started! ##########");
 	log_FTL_version(false);
 
+	// Catch signals like SIGTERM and SIGINT
+	// Other signals like SIGHUP, SIGUSR1 are handled by the resolver part
+	handle_signals();
+
+	// Process pihole-FTL.conf
+	read_FTLconf();
+
 	// Initialize shared memory
 	if(!init_shmem())
 	{
@@ -47,13 +54,6 @@ int main (int argc, char* argv[])
 	// print warning otherwise
 	if(strcmp(username, "pihole") != 0)
 		logg("WARNING: Starting pihole-FTL as user %s is not recommended", username);
-
-	// Process pihole-FTL.conf
-	read_FTLconf();
-
-	// Catch signals like SIGTERM and SIGINT
-	// Other signals like SIGHUP, SIGUSR1 are handled by the resolver part
-	handle_signals();
 
 	// Initialize database
 	if(config.maxDBdays != 0)

--- a/shmem.c
+++ b/shmem.c
@@ -516,7 +516,7 @@ static unsigned int get_optimal_object_size(unsigned int objsize, unsigned int m
 	{
 		if(config.debug & DEBUG_SHMEM)
 		{
-			logg("DEBUG: LCM(%i, %zu) == %zu >= %zu",
+			logg("DEBUG: LCM(%i, %u) == %u >= %u",
 			     pagesize, objsize,
 			     optsize*objsize,
 			     minsize*objsize);

--- a/shmem.c
+++ b/shmem.c
@@ -46,7 +46,7 @@ static ShmSettings *shmSettings = NULL;
 static int pagesize;
 static unsigned int local_shm_counter = 0;
 
-static unsigned int get_optimal_object_size(unsigned int objsize, unsigned int minsize);
+static size_t get_optimal_object_size(size_t objsize, size_t minsize);
 
 unsigned long long addstr(const char *str)
 {
@@ -457,11 +457,11 @@ void delete_shm(SharedMemory *sharedMemory)
 }
 
 // Euclidean algorithm to return greatest common divisor of the numbers
-static unsigned int gcd(unsigned int a, unsigned int b)
+static size_t gcd(size_t a, size_t b)
 {
 	while(b != 0)
 	{
-		unsigned int temp = b;
+		size_t temp = b;
 		b = a % b;
 		a = temp;
 	}
@@ -472,14 +472,14 @@ static unsigned int gcd(unsigned int a, unsigned int b)
 // shared memory objects. This routine works by computing the LCM
 // of two numbers, the pagesize and the size of a single element
 // in the shared memory object
-static unsigned int get_optimal_object_size(unsigned int objsize, unsigned int minsize)
+static size_t get_optimal_object_size(size_t objsize, size_t minsize)
 {
-	unsigned int optsize = pagesize / gcd(pagesize, objsize);
+	size_t optsize = pagesize / gcd(pagesize, objsize);
 	if(optsize < minsize)
 	{
 		if(config.debug & DEBUG_SHMEM)
 		{
-			logg("DEBUG: LCM(%i, %u) == %u < %u",
+			logg("DEBUG: LCM(%i, %zu) == %zu < %zu",
 			     pagesize, objsize,
 			     optsize*objsize,
 			     minsize*objsize);
@@ -490,10 +490,10 @@ static unsigned int get_optimal_object_size(unsigned int objsize, unsigned int m
 		// First part: Integer division, may cause clipping, e.g., 5/3 = 1
 		// Second part: Catch a possibly happened clipping event by adding
 		//              one to the number: (5 % 3 != 0) is 1
-		unsigned int multiplier = (minsize/optsize) + ((minsize % optsize != 0) ? 1u : 0u);
+		size_t multiplier = (minsize/optsize) + ((minsize % optsize != 0) ? 1u : 0u);
 		if(config.debug & DEBUG_SHMEM)
 		{
-			logg("DEBUG: Using %u*%u == %u >= %zu",
+			logg("DEBUG: Using %zu*%zu == %zu >= %zu",
 			     multiplier, optsize*objsize,
 			     multiplier*optsize*objsize,
 			     minsize*objsize);
@@ -506,7 +506,7 @@ static unsigned int get_optimal_object_size(unsigned int objsize, unsigned int m
 	{
 		if(config.debug & DEBUG_SHMEM)
 		{
-			logg("DEBUG: LCM(%i, %u) == %u >= %u",
+			logg("DEBUG: LCM(%i, %zu) == %zu >= %zu",
 			     pagesize, objsize,
 			     optsize*objsize,
 			     minsize*objsize);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

---

This PR is a follow-up on #527 and adds:

- Output result of optimum size calculation when `DEBUG_SHMEM` is enabled
- Ensure `pihole-FTL.conf` and crash handler are set up before we create shared memory objects (so that the `DEBUG_*` values are already known early on during initialization)
- Log which size has been used we used the multiplier

This PR fixes a bug that is only present in branch `development`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
