### PR TITLE
Add -Wshadow to extra warning flags

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -267,31 +267,23 @@ extern clientsDataStruct *clients;
 extern domainsDataStruct *domains;
 extern overTimeDataStruct *overTime;
 
-/// Indexed by client ID, then time index (like `overTime`).
-/// This gets automatically updated whenever a new client or overTime slot is added.
-extern int **overTimeClientData;
-
-extern FILE *logfile;
+// Used in gc.c, memory.c, resolve.c, signals.c, and socket.c
 extern volatile sig_atomic_t killed;
-
-extern char ** setupVarsArray;
-extern int setupVarsElements;
-
-extern bool initialscan;
-extern bool threadwritelock;
-extern bool threadreadlock;
+// Used in api.c, grep.c, and dnsmasq_interface.c
 extern unsigned char blockingstatus;
-
+// Used in main.c, log.c, and others
 extern char * username;
-extern bool flush;
-extern bool needGC;
+// Used in main.c, args.c, log.c, and others
 extern bool daemonmode;
+// Used in main.c, database.c, and others
 extern bool database;
+// Used in database.c and gc.c
 extern long int lastdbindex;
-extern bool travis;
+// Used in database.c and gc.c
 extern bool DBdeleteoldqueries;
-extern bool rereadgravity;
+// Used in main.c, socket.c, and dnsmasq_interface.c
 extern bool ipv4telnet, ipv6telnet;
+// Used in api.c, and socket.c
 extern bool istelnet[MAXCONNS];
 
 // Use out own memory handling functions that will detect possible errors

--- a/FTL.h
+++ b/FTL.h
@@ -283,7 +283,6 @@ extern bool threadreadlock;
 extern unsigned char blockingstatus;
 
 extern char * username;
-extern char timestamp[16];
 extern bool flush;
 extern bool needGC;
 extern bool daemonmode;

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLA
 # for dnsmasq we need the nettle crypto library and the gmp maths library
 # We link the two libraries statically. Although this increases the binary file size by about 1 MB, it saves about 5 MB of shared libraries and makes deployment easier
 #LIBS=-pthread -lnettle -lgmp -lhogweed
-LIBS=-pthread -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle -Wl,-Bdynamic -lrt -lcap
+LIBS=-pthread -lrt -lcap -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle -Wl,-Bdynamic
 # Flags for compiling with libidn : -lidn
 # Flags for compiling with libidn2: -lidn2
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ WARNFLAGS=-Wall -Wextra -Wno-unused-parameter
 # -Wformat-nonliteral: If -Wformat is specified, also warn if the format string is not a string literal and so cannot be checked, unless the format function takes its format arguments as a va_list.
 # -Wuninitialized: Warn if an automatic variable is used without first being initialized
 # -Wswitch-enum: Warn whenever a switch statement has an index of enumerated type and lacks a case for one or more of the named codes of that enumeration.
-EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum
+# -Wshadow: Warn whenever a local variable or type declaration shadows another variable, parameter, type, class member, or whenever a built-in function is shadowed.
+EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library

--- a/daemon.c
+++ b/daemon.c
@@ -140,20 +140,20 @@ void removepid(void)
 
 char *getUserName(void)
 {
-	char * username;
+	char * name;
 	// the getpwuid() function shall search the user database for an entry with a matching uid
 	// the geteuid() function shall return the effective user ID of the calling process - this is used as the search criteria for the getpwuid() function
 	uid_t euid = geteuid();
 	struct passwd *pw = getpwuid(euid);
 	if(pw)
 	{
-		username = strdup(pw->pw_name);
+		name = strdup(pw->pw_name);
 	}
 	else
 	{
-		if(asprintf(&username, "%u", euid) < 0)
+		if(asprintf(&name, "%u", euid) < 0)
 			return NULL;
 	}
 
-	return username;
+	return name;
 }

--- a/datastructure.c
+++ b/datastructure.c
@@ -108,11 +108,10 @@ int findDomainID(const char *domain)
 
 int findClientID(const char *client, bool count)
 {
-	int i;
 	// Compare content of client against known client IP addresses
 	if(counters->clients > 0)
 		validate_access("clients", counters->clients-1, true, __LINE__, __FUNCTION__, __FILE__);
-	for(i=0; i < counters->clients; i++)
+	for(int i=0; i < counters->clients; i++)
 	{
 		// Quick test: Does the clients IP start with the same character?
 		if(getstr(clients[i].ippos)[0] != client[0])

--- a/networktable.c
+++ b/networktable.c
@@ -283,10 +283,10 @@ void updateMACVendorRecords()
 	}
 
 	sqlite3_stmt* stmt;
-	const char* querystr = "SELECT id,hwaddr FROM network;";
-	rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
+	const char* selectstr = "SELECT id,hwaddr FROM network;";
+	rc = sqlite3_prepare_v2(db, selectstr, -1, &stmt, NULL);
 	if( rc ){
-		logg("updateMACVendorRecords() - SQL error prepare (%s, %i): %s", querystr, rc, sqlite3_errmsg(db));
+		logg("updateMACVendorRecords() - SQL error prepare (%s, %i): %s", selectstr, rc, sqlite3_errmsg(db));
 		sqlite3_close(db);
 		return;
 	}
@@ -302,8 +302,8 @@ void updateMACVendorRecords()
 		hwaddr = NULL;
 
 		// Prepare UPDATE statement
-		char *querystr = NULL;
-		if(asprintf(&querystr, "UPDATE network SET macVendor = \'%s\' WHERE id = %i", vendor, id) < 1)
+		char *updatestr = NULL;
+		if(asprintf(&updatestr, "UPDATE network SET macVendor = \'%s\' WHERE id = %i", vendor, id) < 1)
 		{
 			logg("updateMACVendorRecords() - Allocation error 2");
 			free(vendor);
@@ -312,17 +312,17 @@ void updateMACVendorRecords()
 
 		// Execute prepared statement
 		char *zErrMsg = NULL;
-		rc = sqlite3_exec(db, querystr, NULL, NULL, &zErrMsg);
+		rc = sqlite3_exec(db, updatestr, NULL, NULL, &zErrMsg);
 		if( rc != SQLITE_OK ){
-			logg("updateMACVendorRecords() - SQL exec error: %s (%i): %s", querystr, rc, zErrMsg);
+			logg("updateMACVendorRecords() - SQL exec error: %s (%i): %s", updatestr, rc, zErrMsg);
 			sqlite3_free(zErrMsg);
-			free(querystr);
+			free(updatestr);
 			free(vendor);
 			break;
 		}
 
 		// Free allocated memory
-		free(querystr);
+		free(updatestr);
 		free(vendor);
 	}
 	if(rc != SQLITE_DONE)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Add `-Wshadow` to extra warning flags. `-Wshadow` defaults to `-Wshadow=global` and implies `-Wshadow=local`. Apply corresponding changes due to shadowing of variables in the current codebase.

`man gcc` excerpt:
> ```
> -Wshadow: Warn whenever a local variable or type declaration shadows
> another variable, parameter, type, class member, or whenever a
> built-in function is shadowed.
> ```


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
