### PR TITLE
Further general improvements

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -298,7 +298,7 @@ extern bool istelnet[MAXCONNS];
 #define realloc(p1,p2) FTLrealloc(p1,p2, __FILE__,  __FUNCTION__,  __LINE__)
 
 extern int argc_dnsmasq;
-extern char **argv_dnsmasq;
+extern const char ** argv_dnsmasq;
 
 extern pthread_t telnet_listenthreadv4;
 extern pthread_t telnet_listenthreadv6;

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,12 @@ EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverleng
 # -Wbad-function-cast: Warn when a function call is cast to a non-matching type
 # -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
 # -Wwrite-strings: When compiling C, give string constants the type "const char[length]" so that copying the address of one into a non-"const" "char *" pointer produces a warning
-EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings -Wconversion -Wparentheses
+# -Wparentheses: Warn if parentheses are omitted in certain contexts, such as when there is an assignment in a context where a truth value is expected, or when operators are nested whose precedence people often get confused about
+# -Wlogical-op: Warn about suspicious uses of logical operators in expressions
+# -Wlogical-not-parentheses: Warn about logical not used on the left hand side operand of a comparison
+# -Wstrict-prototypes: Warn if a function is declared or defined without specifying the argument types
+# -Wmissing-prototypes: Warn if a global function is defined without a previous prototype declaration
+EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings -Wparentheses -Wlogical-op -Wlogical-not-parentheses -Wstrict-prototypes -Wmissing-prototypes
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverleng
 # -Wlogical-not-parentheses: Warn about logical not used on the left hand side operand of a comparison
 # -Wstrict-prototypes: Warn if a function is declared or defined without specifying the argument types
 # -Wmissing-prototypes: Warn if a global function is defined without a previous prototype declaration
-EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings -Wparentheses -Wlogical-op -Wlogical-not-parentheses -Wstrict-prototypes -Wmissing-prototypes
+# -Wredundant-decls: Warn if anything is declared more than once in the same scope
+# -Winline: Warn if a function that is declared as inline cannot be inlined
+EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings -Wparentheses -Wlogical-op -Wlogical-not-parentheses -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,16 @@ else
   ATTRIBUTEWARNINGS=
 endif
 EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow $(ATTRIBUTEWARNINGS)
+# -Wduplicated-branches: Warn when an if-else has identical branches
+# -Wduplicated-cond: Warn about duplicated conditions in an if-else-if chain
+# -Wfloat-equal: Warn if floating-point values are used in equality comparisons
+# -Wunsafe-loop-optimizations -funsafe-loop-optimizations: Warn if the loop cannot be optimized because the compiler cannot assume anything on the bounds of the loop indices
+# -Wpointer-arith: Warn about anything that depends on the "size of" a function type or of "void".  GNU C assigns these types a size of 1
+# -Wundef: Warn if an undefined identifier is evaluated in an "#if" directive
+# -Wbad-function-cast: Warn when a function call is cast to a non-matching type
+# -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
+# -Wwrite-strings: When compiling C, give string constants the type "const char[length]" so that copying the address of one into a non-"const" "char *" pointer produces a warning
+EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library
@@ -93,7 +103,7 @@ _DNSMASQOBJ = $(patsubst %,$(DNSMASQODIR)/%,$(DNSMASQOBJ))
 
 all: pihole-FTL
 $(ODIR)/%.o: %.c $(_FTLDEPS) | $(ODIR)
-	$(CC) -c -o $@ $< -g3 $(CCFLAGS) $(EXTRAWARN)
+	$(CC) -c -o $@ $< -g3 $(CCFLAGS) $(EXTRAWARN) $(EXTRAWARN2)
 
 $(DNSMASQODIR)/%.o: $(DNSMASQDIR)/%.c $(_DNSMASQDEPS) | $(DNSMASQODIR)
 	$(CC) -c -o $@ $< -g3 $(CCFLAGS) -DVERSION=\"$(DNSMASQVERSION)\" $(DNSMASQOPTS)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverleng
 # -Wbad-function-cast: Warn when a function call is cast to a non-matching type
 # -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
 # -Wwrite-strings: When compiling C, give string constants the type "const char[length]" so that copying the address of one into a non-"const" "char *" pointer produces a warning
-EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings
+EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings -Wconversion -Wparentheses
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library

--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,18 @@ else
 endif
 EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow $(ATTRIBUTEWARNINGS)
 # -Wduplicated-branches: Warn when an if-else has identical branches
+# -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
+ifeq "$(GCCVERSION8)" "1"
+  EXTRAWARNGCC8=-Wduplicated-branches -Wcast-align=strict
+else
+  EXTRAWARNGCC8=
+endif
 # -Wduplicated-cond: Warn about duplicated conditions in an if-else-if chain
 # -Wfloat-equal: Warn if floating-point values are used in equality comparisons
 # -Wunsafe-loop-optimizations -funsafe-loop-optimizations: Warn if the loop cannot be optimized because the compiler cannot assume anything on the bounds of the loop indices
 # -Wpointer-arith: Warn about anything that depends on the "size of" a function type or of "void".  GNU C assigns these types a size of 1
 # -Wundef: Warn if an undefined identifier is evaluated in an "#if" directive
 # -Wbad-function-cast: Warn when a function call is cast to a non-matching type
-# -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
 # -Wwrite-strings: When compiling C, give string constants the type "const char[length]" so that copying the address of one into a non-"const" "char *" pointer produces a warning
 # -Wparentheses: Warn if parentheses are omitted in certain contexts, such as when there is an assignment in a context where a truth value is expected, or when operators are nested whose precedence people often get confused about
 # -Wlogical-op: Warn about suspicious uses of logical operators in expressions
@@ -86,7 +91,7 @@ EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverleng
 # -Wmissing-prototypes: Warn if a global function is defined without a previous prototype declaration
 # -Wredundant-decls: Warn if anything is declared more than once in the same scope
 # -Winline: Warn if a function that is declared as inline cannot be inlined
-EXTRAWARN2=-Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wcast-align=strict -Wwrite-strings -Wparentheses -Wlogical-op -Wlogical-not-parentheses -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline
+EXTRAWARN2=-Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wlogical-not-parentheses -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARNGCC8)
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library

--- a/Makefile
+++ b/Makefile
@@ -63,22 +63,6 @@ WARNFLAGS=-Wall -Wextra -Wno-unused-parameter
 # -Wuninitialized: Warn if an automatic variable is used without first being initialized
 # -Wswitch-enum: Warn whenever a switch statement has an index of enumerated type and lacks a case for one or more of the named codes of that enumeration.
 # -Wshadow: Warn whenever a local variable or type declaration shadows another variable, parameter, type, class member, or whenever a built-in function is shadowed.
-ifeq "$(GCCVERSION8)" "1"
-  # ATTRIBUTEWARNINGS: Warn for cases where adding an attribute may be beneficial.
-  ATTRIBUTEWARNINGS=-Wsuggest-attribute=pure -Wsuggest-attribute=const -Wsuggest-attribute=noreturn -Wmissing-noreturn -Wsuggest-attribute=malloc -Wsuggest-attribute=format -Wmissing-format-attribute -Wsuggest-attribute=cold
-else
-  ATTRIBUTEWARNINGS=
-endif
-EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow $(ATTRIBUTEWARNINGS)
-# -Wduplicated-cond: Warn about duplicated conditions in an if-else-if chain
-# -Wduplicated-branches: Warn when an if-else has identical branches
-# -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
-# -Wlogical-not-parentheses: Warn about logical not used on the left hand side operand of a comparison
-ifeq "$(GCCVERSION8)" "1"
-  EXTRAWARNGCC8=-Wduplicated-cond -Wduplicated-branches -Wcast-align=strict -Wlogical-not-parentheses
-else
-  EXTRAWARNGCC8=
-endif
 # -Wfloat-equal: Warn if floating-point values are used in equality comparisons
 # -Wunsafe-loop-optimizations -funsafe-loop-optimizations: Warn if the loop cannot be optimized because the compiler cannot assume anything on the bounds of the loop indices
 # -Wpointer-arith: Warn about anything that depends on the "size of" a function type or of "void".  GNU C assigns these types a size of 1
@@ -91,7 +75,17 @@ endif
 # -Wmissing-prototypes: Warn if a global function is defined without a previous prototype declaration
 # -Wredundant-decls: Warn if anything is declared more than once in the same scope
 # -Winline: Warn if a function that is declared as inline cannot be inlined
-EXTRAWARN2=-Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARNGCC8)
+ifeq "$(GCCVERSION8)" "1"
+  EXTRAWARNGCC8=-Wduplicated-cond -Wduplicated-branches -Wcast-align=strict -Wlogical-not-parentheses -Wsuggest-attribute=pure -Wsuggest-attribute=const -Wsuggest-attribute=noreturn -Wsuggest-attribute=malloc -Wsuggest-attribute=format -Wsuggest-attribute=cold
+else
+  EXTRAWARNGCC8=
+endif
+# -Wduplicated-cond: Warn about duplicated conditions in an if-else-if chain
+# -Wduplicated-branches: Warn when an if-else has identical branches
+# -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
+# -Wlogical-not-parentheses: Warn about logical not used on the left hand side operand of a comparison
+EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow \
+-Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARNGCC8)
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library
@@ -115,7 +109,7 @@ _DNSMASQOBJ = $(patsubst %,$(DNSMASQODIR)/%,$(DNSMASQOBJ))
 
 all: pihole-FTL
 $(ODIR)/%.o: %.c $(_FTLDEPS) | $(ODIR)
-	$(CC) -c -o $@ $< -g3 $(CCFLAGS) $(EXTRAWARN) $(EXTRAWARN2)
+	$(CC) -c -o $@ $< -g3 $(CCFLAGS) $(EXTRAWARN)
 
 $(DNSMASQODIR)/%.o: $(DNSMASQDIR)/%.c $(_DNSMASQDEPS) | $(DNSMASQODIR)
 	$(CC) -c -o $@ $< -g3 $(CCFLAGS) -DVERSION=\"$(DNSMASQVERSION)\" $(DNSMASQOPTS)

--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,15 @@ else
   ATTRIBUTEWARNINGS=
 endif
 EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow $(ATTRIBUTEWARNINGS)
+# -Wduplicated-cond: Warn about duplicated conditions in an if-else-if chain
 # -Wduplicated-branches: Warn when an if-else has identical branches
 # -Wcast-align=strict: Warn whenever a pointer is cast such that the required alignment of the target is increased. For example, warn if a "char *" is cast to an "int *" regardless of the target machine.
+# -Wlogical-not-parentheses: Warn about logical not used on the left hand side operand of a comparison
 ifeq "$(GCCVERSION8)" "1"
-  EXTRAWARNGCC8=-Wduplicated-branches -Wcast-align=strict
+  EXTRAWARNGCC8=-Wduplicated-cond -Wduplicated-branches -Wcast-align=strict -Wlogical-not-parentheses
 else
   EXTRAWARNGCC8=
 endif
-# -Wduplicated-cond: Warn about duplicated conditions in an if-else-if chain
 # -Wfloat-equal: Warn if floating-point values are used in equality comparisons
 # -Wunsafe-loop-optimizations -funsafe-loop-optimizations: Warn if the loop cannot be optimized because the compiler cannot assume anything on the bounds of the loop indices
 # -Wpointer-arith: Warn about anything that depends on the "size of" a function type or of "void".  GNU C assigns these types a size of 1
@@ -86,12 +87,11 @@ endif
 # -Wwrite-strings: When compiling C, give string constants the type "const char[length]" so that copying the address of one into a non-"const" "char *" pointer produces a warning
 # -Wparentheses: Warn if parentheses are omitted in certain contexts, such as when there is an assignment in a context where a truth value is expected, or when operators are nested whose precedence people often get confused about
 # -Wlogical-op: Warn about suspicious uses of logical operators in expressions
-# -Wlogical-not-parentheses: Warn about logical not used on the left hand side operand of a comparison
 # -Wstrict-prototypes: Warn if a function is declared or defined without specifying the argument types
 # -Wmissing-prototypes: Warn if a global function is defined without a previous prototype declaration
 # -Wredundant-decls: Warn if anything is declared more than once in the same scope
 # -Winline: Warn if a function that is declared as inline cannot be inlined
-EXTRAWARN2=-Wduplicated-cond -Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wlogical-not-parentheses -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARNGCC8)
+EXTRAWARN2=-Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARNGCC8)
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITEFLAGS)
 # for FTL we need the pthread library

--- a/api.c
+++ b/api.c
@@ -574,7 +574,7 @@ void getQueryTypes(int *sock)
 	}
 }
 
-char *querytypes[8] = {"A","AAAA","ANY","SRV","SOA","PTR","TXT","UNKN"};
+const char *querytypes[8] = {"A","AAAA","ANY","SRV","SOA","PTR","TXT","UNKN"};
 
 void getAllQueries(const char *client_message, int *sock)
 {
@@ -752,7 +752,7 @@ void getAllQueries(const char *client_message, int *sock)
 		validate_access("domains", queries[i].domainID, true, __LINE__, __FUNCTION__, __FILE__);
 		validate_access("clients", queries[i].clientID, true, __LINE__, __FUNCTION__, __FILE__);
 
-		char *qtype = querytypes[queries[i].type - TYPE_A];
+		const char *qtype = querytypes[queries[i].type - TYPE_A];
 
 		// 1 = gravity.list, 4 = wildcard, 5 = black.list
 		if((queries[i].status == QUERY_GRAVITY ||
@@ -1218,7 +1218,7 @@ void getDomainDetails(const char *client_message, int *sock)
 			ssend(*sock,"Domain \"%s\", ID: %i\n", domain, i);
 			ssend(*sock,"Total: %i\n", domains[i].count);
 			ssend(*sock,"Blocked: %i\n", domains[i].blockedcount);
-			char *regexstatus;
+			const char *regexstatus;
 			if(domains[i].regexmatch == REGEX_BLOCKED)
 				regexstatus = "blocked";
 			if(domains[i].regexmatch == REGEX_NOTBLOCKED)

--- a/api.c
+++ b/api.c
@@ -418,8 +418,8 @@ void getTopClients(char *client_message, int *sock)
 		if(strcmp(getstr(clients[j].ippos), HIDDEN_CLIENT) == 0)
 			continue;
 
-		char *client_ip = getstr(clients[j].ippos);
-		char *client_name = getstr(clients[j].namepos);
+		const char *client_ip = getstr(clients[j].ippos);
+		const char *client_name = getstr(clients[j].namepos);
 
 		// Return this client if either
 		// - "withzero" option is set, and/or
@@ -450,12 +450,12 @@ void getTopClients(char *client_message, int *sock)
 void getForwardDestinations(char *client_message, int *sock)
 {
 	bool sort = true;
-	int i, temparray[counters->forwarded][2], totalqueries = 0;
+	int temparray[counters->forwarded][2], totalqueries = 0;
 
 	if(command(client_message, "unsorted"))
 		sort = false;
 
-	for(i=0; i < counters->forwarded; i++) {
+	for(int i = 0; i < counters->forwarded; i++) {
 		validate_access("forwarded", i, true, __LINE__, __FUNCTION__, __FILE__);
 		// If we want to print a sorted output, we fill the temporary array with
 		// the values we will use for sorting afterwards
@@ -474,10 +474,10 @@ void getForwardDestinations(char *client_message, int *sock)
 	totalqueries = counters->forwardedqueries + counters->cached + counters->blocked;
 
 	// Loop over available forward destinations
-	for(i=-2; i < min(counters->forwarded, 8); i++)
+	for(int i = -2; i < min(counters->forwarded, 8); i++)
 	{
-		char *ip, *name;
 		float percentage = 0.0f;
+		const char* ip, *name;
 
 		if(i == -2)
 		{
@@ -797,9 +797,9 @@ void getAllQueries(char *client_message, int *sock)
 
 		// Ask subroutine for domain. It may return "hidden" depending on
 		// the privacy settings at the time the query was made
-		char *domain = getDomainString(i);
+		const char *domain = getDomainString(i);
 		// Similarly for the client
-		char *client;
+		const char *client;
 		if(strlen(getstr(clients[queries[i].clientID].namepos)) > 0)
 			client = getClientNameString(i);
 		else
@@ -844,7 +844,7 @@ void getAllQueries(char *client_message, int *sock)
 
 void getRecentBlocked(char *client_message, int *sock)
 {
-	int i, num=1;
+	int num=1;
 
 	// Test for integer that specifies number of entries to be shown
 	if(sscanf(client_message, "%*[^(](%i)", &num) > 0) {
@@ -855,7 +855,7 @@ void getRecentBlocked(char *client_message, int *sock)
 
 	// Find most recently blocked query
 	int found = 0;
-	for(i = counters->queries - 1; i > 0 ; i--)
+	for(int i = counters->queries - 1; i > 0 ; i--)
 	{
 		validate_access("queries", i, true, __LINE__, __FUNCTION__, __FILE__);
 
@@ -867,7 +867,7 @@ void getRecentBlocked(char *client_message, int *sock)
 
 			// Ask subroutine for domain. It may return "hidden" depending on
 			// the privacy settings at the time the query was made
-			char *domain = getDomainString(i);
+			const char *domain = getDomainString(i);
 
 			if(istelnet[*sock])
 				ssend(*sock,"%s\n", domain);
@@ -1135,8 +1135,8 @@ void getClientNames(int *sock)
 		if(skipclient[i])
 			continue;
 
-		char *client_ip = getstr(clients[i].ippos);
-		char *client_name = getstr(clients[i].namepos);
+		const char *client_ip = getstr(clients[i].ippos);
+		const char *client_name = getstr(clients[i].namepos);
 
 		if(istelnet[*sock])
 			ssend(*sock, "%s %s\n", client_name, client_ip);
@@ -1177,7 +1177,7 @@ void getUnknownQueries(int *sock)
 		validate_access("clients", queries[i].clientID, true, __LINE__, __FUNCTION__, __FILE__);
 
 
-		char *client = getstr(clients[queries[i].clientID].ippos);
+		const char *client = getstr(clients[queries[i].clientID].ippos);
 
 		if(istelnet[*sock])
 			ssend(*sock, "%li %i %i %s %s %s %i %s\n", queries[i].timestamp, i, queries[i].id, type, getstr(domains[queries[i].domainID].domainpos), client, queries[i].status, queries[i].complete ? "true" : "false");

--- a/api.c
+++ b/api.c
@@ -171,7 +171,7 @@ void getOverTime(int *sock)
 	}
 }
 
-void getTopDomains(char *client_message, int *sock)
+void getTopDomains(const char *client_message, int *sock)
 {
 	int i, temparray[counters->domains][2], count=10, num;
 	bool blocked, audit = false, asc = false;
@@ -333,7 +333,7 @@ void getTopDomains(char *client_message, int *sock)
 		clearSetupVarsArray();
 }
 
-void getTopClients(char *client_message, int *sock)
+void getTopClients(const char *client_message, int *sock)
 {
 	int i, temparray[counters->clients][2], count=10, num;
 
@@ -447,7 +447,7 @@ void getTopClients(char *client_message, int *sock)
 }
 
 
-void getForwardDestinations(char *client_message, int *sock)
+void getForwardDestinations(const char *client_message, int *sock)
 {
 	bool sort = true;
 	int temparray[counters->forwarded][2], totalqueries = 0;
@@ -576,7 +576,7 @@ void getQueryTypes(int *sock)
 
 char *querytypes[8] = {"A","AAAA","ANY","SRV","SOA","PTR","TXT","UNKN"};
 
-void getAllQueries(char *client_message, int *sock)
+void getAllQueries(const char *client_message, int *sock)
 {
 	// Exit before processing any data if requested via config setting
 	get_privacy_level(NULL);
@@ -842,7 +842,7 @@ void getAllQueries(char *client_message, int *sock)
 		free(forwarddest);
 }
 
-void getRecentBlocked(char *client_message, int *sock)
+void getRecentBlocked(const char *client_message, int *sock)
 {
 	int num=1;
 
@@ -1199,7 +1199,7 @@ void getUnknownQueries(int *sock)
 	}
 }
 
-void getDomainDetails(char *client_message, int *sock)
+void getDomainDetails(const char *client_message, int *sock)
 {
 	// Get domain name
 	char domain[128];

--- a/api.h
+++ b/api.h
@@ -11,16 +11,16 @@
 // Statistic methods
 void getStats(int *sock);
 void getOverTime(int *sock);
-void getTopDomains(char *client_message, int *sock);
-void getTopClients(char *client_message, int *sock);
-void getForwardDestinations(char *client_message, int *sock);
+void getTopDomains(const char *client_message, int *sock);
+void getTopClients(const char *client_message, int *sock);
+void getForwardDestinations(const char *client_message, int *sock);
 void getQueryTypes(int *sock);
-void getAllQueries(char *client_message, int *sock);
-void getRecentBlocked(char *client_message, int *sock);
+void getAllQueries(const char *client_message, int *sock);
+void getRecentBlocked(const char *client_message, int *sock);
 void getQueryTypesOverTime(int *sock);
 void getClientsOverTime(int *sock);
 void getClientNames(int *sock);
-void getDomainDetails(char *client_message, int *sock);
+void getDomainDetails(const char *client_message, int *sock);
 
 // FTL methods
 void getClientID(int *sock);

--- a/api.h
+++ b/api.h
@@ -39,6 +39,6 @@ void pack_uint64(int sock, uint64_t value);
 void pack_int32(int sock, int32_t value);
 void pack_int64(int sock, int64_t value);
 void pack_float(int sock, float value);
-bool pack_fixstr(int sock, char *string);
-bool pack_str32(int sock, char *string);
+bool pack_fixstr(int sock, const char *string);
+bool pack_str32(int sock, const char *string);
 void pack_map16_start(int sock, uint16_t length);

--- a/args.c
+++ b/args.c
@@ -15,7 +15,7 @@ static bool debug = false;
 bool daemonmode = true;
 bool travis = false;
 int argc_dnsmasq = 0;
-char **argv_dnsmasq = NULL;
+const char** argv_dnsmasq = NULL;
 
 void parse_args(int argc, char* argv[])
 {
@@ -24,8 +24,8 @@ void parse_args(int argc, char* argv[])
 	// Regardless of any arguments, we always pass "-k" (nofork) to dnsmasq
 	argc_dnsmasq = 2;
 	argv_dnsmasq = calloc(argc_dnsmasq, sizeof(char*));
-	argv_dnsmasq[0] = (char*)"";
-	argv_dnsmasq[1] = (char*)"-k";
+	argv_dnsmasq[0] = "";
+	argv_dnsmasq[1] = "-k";
 
 	// start from 1, as argv[0] is the executable name "pihole-FTL"
 	for(i=1; i < argc; i++)
@@ -39,7 +39,7 @@ void parse_args(int argc, char* argv[])
 			ok = true;
 
 			// Replace "-k" by "-d" (debug mode implies nofork)
-			argv_dnsmasq[1] = (char*)"-d";
+			argv_dnsmasq[1] = "-d";
 		}
 
 		if(strcmp(argv[i], "test") == 0)
@@ -100,9 +100,9 @@ void parse_args(int argc, char* argv[])
 		// Implement dnsmasq's test function
 		if(strcmp(argv[i], "dnsmasq-test") == 0)
 		{
-			char *arg[2];
-			arg[0] = (char*)"";
-			arg[1] = (char*)"--test";
+			const char *arg[2];
+			arg[0] = "";
+			arg[1] = "--test";
 			main_dnsmasq(2, arg);
 			ok = true;
 		}
@@ -113,10 +113,10 @@ void parse_args(int argc, char* argv[])
 			int j;
 			argc_dnsmasq = argc - i + 1;
 			if(argv_dnsmasq != NULL) free(argv_dnsmasq);
-			argv_dnsmasq = calloc(argc_dnsmasq + 2,sizeof(char*));
-			argv_dnsmasq[0] = (char*)"";
-			if(debug) argv_dnsmasq[1] = (char*)"-d";
-			else      argv_dnsmasq[1] = (char*)"-k";
+			argv_dnsmasq = calloc(argc_dnsmasq + 2,sizeof(const char*));
+			argv_dnsmasq[0] = "";
+			if(debug) argv_dnsmasq[1] = "-d";
+			else      argv_dnsmasq[1] = "-k";
 
 			for(j=2; j < argc_dnsmasq; j++)
 			{

--- a/args.c
+++ b/args.c
@@ -24,8 +24,8 @@ void parse_args(int argc, char* argv[])
 	// Regardless of any arguments, we always pass "-k" (nofork) to dnsmasq
 	argc_dnsmasq = 2;
 	argv_dnsmasq = calloc(argc_dnsmasq, sizeof(char*));
-	argv_dnsmasq[0] = "";
-	argv_dnsmasq[1] = "-k";
+	argv_dnsmasq[0] = (char*)"";
+	argv_dnsmasq[1] = (char*)"-k";
 
 	// start from 1, as argv[0] is the executable name "pihole-FTL"
 	for(i=1; i < argc; i++)
@@ -39,7 +39,7 @@ void parse_args(int argc, char* argv[])
 			ok = true;
 
 			// Replace "-k" by "-d" (debug mode implies nofork)
-			argv_dnsmasq[1] = "-d";
+			argv_dnsmasq[1] = (char*)"-d";
 		}
 
 		if(strcmp(argv[i], "test") == 0)
@@ -101,9 +101,9 @@ void parse_args(int argc, char* argv[])
 		if(strcmp(argv[i], "dnsmasq-test") == 0)
 		{
 			char *arg[2];
-			arg[0] = "";
-			arg[1] = "--test";
-			main_dnsmasq(2,arg);
+			arg[0] = (char*)"";
+			arg[1] = (char*)"--test";
+			main_dnsmasq(2, arg);
 			ok = true;
 		}
 
@@ -114,9 +114,9 @@ void parse_args(int argc, char* argv[])
 			argc_dnsmasq = argc - i + 1;
 			if(argv_dnsmasq != NULL) free(argv_dnsmasq);
 			argv_dnsmasq = calloc(argc_dnsmasq + 2,sizeof(char*));
-			argv_dnsmasq[0] = "";
-			if(debug) argv_dnsmasq[1] = "-d";
-			else      argv_dnsmasq[1] = "-k";
+			argv_dnsmasq[0] = (char*)"";
+			if(debug) argv_dnsmasq[1] = (char*)"-d";
+			else      argv_dnsmasq[1] = (char*)"-k";
 
 			for(j=2; j < argc_dnsmasq; j++)
 			{

--- a/database.c
+++ b/database.c
@@ -490,11 +490,11 @@ void save_to_DB(void)
 		sqlite3_bind_int(stmt, 3, queries[i].status);
 
 		// DOMAIN
-		char *domain = getDomainString(i);
+		const char *domain = getDomainString(i);
 		sqlite3_bind_text(stmt, 4, domain, -1, SQLITE_TRANSIENT);
 
 		// CLIENT
-		char *client = getClientIPString(i);
+		const char *client = getClientIPString(i);
 		sqlite3_bind_text(stmt, 5, client, -1, SQLITE_TRANSIENT);
 
 		// FORWARD

--- a/database.c
+++ b/database.c
@@ -22,7 +22,7 @@ static pthread_mutex_t dblock;
 bool db_set_counter(unsigned int ID, int value);
 int db_get_FTL_property(unsigned int ID);
 
-void check_database(int rc)
+static void check_database(int rc)
 {
 	// We will retry if the database is busy at the moment
 	// However, we won't retry if any other error happened
@@ -49,7 +49,7 @@ void dbclose(void)
 	pthread_mutex_unlock(&dblock);
 }
 
-double get_db_filesize(void)
+static double get_db_filesize(void)
 {
 	struct stat st;
 	if(stat(FTLfiles.db, &st) != 0)
@@ -106,7 +106,7 @@ bool dbquery(const char *format, ...)
 
 }
 
-bool create_counter_table(void)
+static bool create_counter_table(void)
 {
 	bool ret;
 	// Create FTL table in the database (holds properties like database version, etc.)
@@ -132,7 +132,7 @@ bool create_counter_table(void)
 	return true;
 }
 
-bool db_create(void)
+static bool db_create(void)
 {
 	bool ret;
 	int rc = sqlite3_open_v2(FTLfiles.db, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
@@ -293,7 +293,7 @@ bool db_set_counter(unsigned int ID, int value)
 	return dbquery("INSERT OR REPLACE INTO counters (id, value) VALUES ( %u, %i );", ID, value);
 }
 
-bool db_update_counters(int total, int blocked)
+static bool db_update_counters(int total, int blocked)
 {
 	if(!dbquery("UPDATE counters SET value = value + %i WHERE id = %i;", total, DB_TOTALQUERIES))
 		return false;
@@ -338,7 +338,7 @@ int db_query_int(const char* querystr)
 	return result;
 }
 
-int number_of_queries_in_DB(void)
+static int number_of_queries_in_DB(void)
 {
 	sqlite3_stmt* stmt;
 
@@ -577,7 +577,7 @@ void save_to_DB(void)
 	}
 }
 
-void delete_old_queries_in_DB(void)
+static void delete_old_queries_in_DB(void)
 {
 	// Open database
 	if(!dbopen())

--- a/datastructure.c
+++ b/datastructure.c
@@ -181,7 +181,7 @@ bool isValidIPv6(const char *addr)
 
 // Privacy-level sensitive subroutine that returns the domain name
 // only when appropriate for the requested query
-char *getDomainString(int queryID)
+const char *getDomainString(int queryID)
 {
 	if(queries[queryID].privacylevel < PRIVACY_HIDE_DOMAINS)
 	{
@@ -194,7 +194,7 @@ char *getDomainString(int queryID)
 
 // Privacy-level sensitive subroutine that returns the client IP
 // only when appropriate for the requested query
-char *getClientIPString(int queryID)
+const char *getClientIPString(int queryID)
 {
 	if(queries[queryID].privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
@@ -207,7 +207,7 @@ char *getClientIPString(int queryID)
 
 // Privacy-level sensitive subroutine that returns the client host name
 // only when appropriate for the requested query
-char *getClientNameString(int queryID)
+const char *getClientNameString(int queryID)
 {
 	if(queries[queryID].privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{

--- a/dnsmasq/dnsmasq.h
+++ b/dnsmasq/dnsmasq.h
@@ -1220,9 +1220,6 @@ size_t resize_packet(struct dns_header *header, size_t plen,
 int add_resource_record(struct dns_header *header, char *limit, int *truncp,
 			int nameoffset, unsigned char **pp, unsigned long ttl,
 			int *offset, unsigned short type, unsigned short class, char *format, ...);
-unsigned char *skip_questions(struct dns_header *header, size_t plen);
-int extract_name(struct dns_header *header, size_t plen, unsigned char **pp,
-		 char *name, int isExtract, int extrabytes);
 int in_arpa_name_2_addr(char *namein, struct all_addr *addrp);
 int private_net(struct in_addr addr, int ban_localhost);
 
@@ -1575,8 +1572,6 @@ void dhcp_update_configs(struct dhcp_config *configs);
 void display_opts(void);
 int lookup_dhcp_opt(int prot, char *name);
 int lookup_dhcp_len(int prot, int val);
-char *option_string(int prot, unsigned int opt, unsigned char *val,
-		    int opt_len, char *buf, int buf_len);
 struct dhcp_config *find_config(struct dhcp_config *configs,
 				struct dhcp_context *context,
 				unsigned char *clid, int clid_len,

--- a/dnsmasq/dnsmasq.h
+++ b/dnsmasq/dnsmasq.h
@@ -1463,7 +1463,18 @@ void route_sock(void);
 #endif
 
 /* bpf.c or netlink.c */
+/************ Pi-hole modification ************/
+// We need to skip this function declaration
+// when compiling FTLDNS code as it is not
+// a valid prototype such that this line
+// would throw an error when compiling
+// dnsmasq_interface.c
+#if !defined(FTLDNS)
+/**********************************************/
 int iface_enumerate(int family, void *parm, int (callback)());
+/************ Pi-hole modification ************/
+#endif
+/**********************************************/
 
 /* dbus.c */
 #ifdef HAVE_DBUS

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -8,11 +8,14 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
+#define FTLDNS
 #include "dnsmasq/dnsmasq.h"
 #undef __USE_XOPEN
 #include "FTL.h"
 #include "dnsmasq_interface.h"
 #include "shmem.h"
+// Prototype of getCacheInformation()
+#include "api.h"
 
 void print_flags(unsigned int flags);
 void save_reply_type(unsigned int flags, int queryID, struct timeval response);

--- a/grep.c
+++ b/grep.c
@@ -125,7 +125,7 @@ int countlineswith(const char* str, const char* fname)
 void check_blocking_status(void)
 {
 	char* blocking = read_setupVarsconf("BLOCKING_ENABLED");
-	char* message;
+	const char* message;
 
 	if(blocking == NULL || getSetupVarsBool(blocking))
 	{

--- a/grep.c
+++ b/grep.c
@@ -45,25 +45,6 @@ int countlines(const char* fname)
 	return lines;
 }
 
-int readnumberfromfile(const char* fname)
-{
-	FILE *fp;
-	int num;
-
-	if((fp = fopen(fname, "r")) == NULL)
-	{
-		return -1;
-	}
-
-	if(fscanf(fp,"%i",&num) != 1)
-	{
-		num = -1;
-	}
-
-	fclose(fp);
-	return num;
-}
-
 int countlineswith(const char* str, const char* fname)
 {
 	FILE *fp;

--- a/log.c
+++ b/log.c
@@ -14,7 +14,7 @@
 pthread_mutex_t lock;
 FILE *logfile = NULL;
 
-void close_FTL_log(void)
+static void close_FTL_log(void)
 {
 	if(logfile != NULL)
 		fclose(logfile);
@@ -50,7 +50,7 @@ void open_FTL_log(bool test)
 	}
 }
 
-void get_timestr(char *timestring)
+static void get_timestr(char *timestring)
 {
 	time_t t = time(NULL);
 	struct tm tm = *localtime(&t);
@@ -63,7 +63,7 @@ void get_timestr(char *timestring)
 
 void __attribute__ ((format (gnu_printf, 1, 2))) logg(const char *format, ...)
 {
-	char timestring[32] = "";
+	char timestring[84] = "";
 	va_list args;
 
 	pthread_mutex_lock(&lock);

--- a/main.c
+++ b/main.c
@@ -14,9 +14,6 @@ char * username;
 bool needGC = false;
 bool needDBGC = false;
 
-// Prototype
-int main_dnsmasq(int argc, char **argv);
-
 int main (int argc, char* argv[])
 {
 	// Get user pihole-FTL is running as

--- a/memory.c
+++ b/memory.c
@@ -166,7 +166,7 @@ char* __attribute__((malloc)) FTLstrdup(const char *src, const char * file, cons
 }
 
 #undef calloc
-void* __attribute__((malloc)) FTLcalloc(size_t nmemb, size_t size, const char * file, const char * function, int line)
+void* __attribute__((malloc)) __attribute__((alloc_size(1,2))) FTLcalloc(size_t nmemb, size_t size, const char * file, const char * function, int line)
 {
 	// The FTLcalloc() function allocates memory for an array of nmemb elements
 	// of size bytes each and returns a pointer to the allocated memory. The
@@ -182,7 +182,7 @@ void* __attribute__((malloc)) FTLcalloc(size_t nmemb, size_t size, const char * 
 }
 
 #undef realloc
-void *FTLrealloc(void *ptr_in, size_t size, const char * file, const char * function, int line)
+void __attribute__((alloc_size(2))) *FTLrealloc(void *ptr_in, size_t size, const char * file, const char * function, int line)
 {
 	// The FTLrealloc() function changes the size of the memory block pointed to
 	// by ptr to size bytes. The contents will be unchanged in the range from

--- a/msgpack.c
+++ b/msgpack.c
@@ -17,7 +17,7 @@ void pack_eom(int sock) {
 	swrite(sock, &eom, sizeof(eom));
 }
 
-void pack_basic(int sock, uint8_t format, void *value, size_t size) {
+static void pack_basic(int sock, uint8_t format, void *value, size_t size) {
 	swrite(sock, &format, sizeof(format));
 	swrite(sock, value, size);
 }

--- a/msgpack.c
+++ b/msgpack.c
@@ -86,7 +86,7 @@ bool pack_fixstr(int sock, const char *string) {
 
 	uint8_t format = (uint8_t) (0xA0 | length);
 	swrite(sock, &format, sizeof(format));
-	swrite(sock, (char*)string, length);
+	swrite(sock, string, length);
 
 	return true;
 }
@@ -105,7 +105,7 @@ bool pack_str32(int sock, const char *string) {
 	swrite(sock, &format, sizeof(format));
 	uint32_t bigELength = htonl((uint32_t) length);
 	swrite(sock, &bigELength, sizeof(bigELength));
-	swrite(sock, (char*)string, length);
+	swrite(sock, string, length);
 
 	return true;
 }

--- a/msgpack.c
+++ b/msgpack.c
@@ -75,7 +75,7 @@ void pack_float(int sock, float value) {
 }
 
 // Return true if successful
-bool pack_fixstr(int sock, char *string) {
+bool pack_fixstr(int sock, const char *string) {
 	// Make sure that the length is less than 32
 	size_t length = strlen(string);
 
@@ -86,13 +86,13 @@ bool pack_fixstr(int sock, char *string) {
 
 	uint8_t format = (uint8_t) (0xA0 | length);
 	swrite(sock, &format, sizeof(format));
-	swrite(sock, string, length);
+	swrite(sock, (char*)string, length);
 
 	return true;
 }
 
 // Return true if successful
-bool pack_str32(int sock, char *string) {
+bool pack_str32(int sock, const char *string) {
 	// Make sure that the length is less than 4294967296
 	size_t length = strlen(string);
 
@@ -105,7 +105,7 @@ bool pack_str32(int sock, char *string) {
 	swrite(sock, &format, sizeof(format));
 	uint32_t bigELength = htonl((uint32_t) length);
 	swrite(sock, &bigELength, sizeof(bigELength));
-	swrite(sock, string, length);
+	swrite(sock, (char*)string, length);
 
 	return true;
 }

--- a/networktable.c
+++ b/networktable.c
@@ -123,7 +123,7 @@ void parse_arp_cache(void)
 		bool clientKnown = clientID >= 0;
 
 		// Get hostname of this client if the client is known
-		char *hostname = "";
+		const char *hostname = "";
 		if(clientKnown)
 		{
 			validate_access("clients", clientID, true, __LINE__, __FUNCTION__, __FILE__);

--- a/regex.c
+++ b/regex.c
@@ -17,7 +17,7 @@ static bool *regexconfigured = NULL;
 static char **regexbuffer = NULL;
 static whitelistStruct whitelist = { 0, NULL };
 
-static void log_regex_error(char *where, int errcode, int index)
+static void log_regex_error(const char *where, int errcode, int index)
 {
 	// Regex failed for some reason (probably user syntax error)
 	// Get error string and log it

--- a/request.c
+++ b/request.c
@@ -12,11 +12,11 @@
 #include "api.h"
 #include "shmem.h"
 
-bool __attribute__((pure)) command(char *client_message, const char* cmd) {
+bool __attribute__((pure)) command(const char *client_message, const char* cmd) {
 	return strstr(client_message, cmd) != NULL;
 }
 
-void process_request(char *client_message, int *sock)
+void process_request(const char *client_message, int *sock)
 {
 	char EOT[2];
 	EOT[0] = 0x04;

--- a/resolve.c
+++ b/resolve.c
@@ -19,7 +19,7 @@
 // once every hour
 #define RERESOLVE_INTERVAL 3600
 
-char *resolveHostname(const char *addr)
+static const char *resolveHostname(const char *addr)
 {
 	// Get host name
 	struct hostent *he = NULL;

--- a/routines.h
+++ b/routines.h
@@ -89,6 +89,7 @@ bool dbquery(const char *format, ...);
 bool dbopen(void);
 void dbclose(void);
 int db_query_int(const char*);
+void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg);
 
 // memory.c
 void memory_check(int which);
@@ -131,7 +132,7 @@ void newOverTimeClient(int clientID);
  * Add a new overTime slot to each overTime client shared memory block.
  * This also updates `overTimeClientData`.
  */
-void addOverTimeClientSlot();
+void addOverTimeClientSlot(void);
 
 // overTime.c
 void initOverTime(void);

--- a/routines.h
+++ b/routines.h
@@ -94,8 +94,8 @@ void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg);
 // memory.c
 void memory_check(int which);
 char *FTLstrdup(const char *src, const char *file, const char *function, int line) __attribute__((malloc));
-void *FTLcalloc(size_t nmemb, size_t size, const char *file, const char *function, int line) __attribute__((malloc));
-void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *function, int line);
+void *FTLcalloc(size_t nmemb, size_t size, const char *file, const char *function, int line) __attribute__((malloc)) __attribute__((alloc_size(1,2)));
+void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *function, int line) __attribute__((alloc_size(2)));
 void FTLfree(void *ptr, const char* file, const char *function, int line);
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file);
 

--- a/routines.h
+++ b/routines.h
@@ -38,7 +38,7 @@ void close_telnet_socket(void);
 void close_unix_socket(void);
 void seom(int sock);
 void ssend(int sock, const char *format, ...) __attribute__ ((format (gnu_printf, 2, 3)));
-void swrite(int sock, void *value, size_t size);
+void swrite(int sock, const void* value, size_t size);
 void *telnet_listening_thread_IPv4(void *args);
 void *telnet_listening_thread_IPv6(void *args);
 

--- a/routines.h
+++ b/routines.h
@@ -30,9 +30,9 @@ int findDomainID(const char *domain);
 int findClientID(const char *client, bool addNew);
 bool isValidIPv4(const char *addr);
 bool isValidIPv6(const char *addr);
-char *getDomainString(int queryID);
-char *getClientIPString(int queryID);
-char *getClientNameString(int queryID);
+const char *getDomainString(int queryID);
+const char *getClientIPString(int queryID);
+const char *getClientNameString(int queryID);
 
 void close_telnet_socket(void);
 void close_unix_socket(void);
@@ -57,10 +57,10 @@ void check_blocking_status(void);
 
 void check_setupVarsconf(void);
 char * read_setupVarsconf(const char * key);
-void getSetupVarsArray(char * input);
+void getSetupVarsArray(const char * input);
 void clearSetupVarsArray(void);
-bool insetupVarsArray(char * str);
-bool getSetupVarsBool(char * input) __attribute__((pure));
+bool insetupVarsArray(const char * str);
+bool getSetupVarsBool(const char * input) __attribute__((pure));
 
 void parse_args(int argc, char* argv[]);
 
@@ -118,7 +118,7 @@ bool in_whitelist(char *domain) __attribute__((pure));
 bool init_shmem(void);
 void destroy_shmem(void);
 unsigned long long addstr(const char *str);
-char *getstr(unsigned long long pos);
+const char *getstr(unsigned long long pos);
 void *enlarge_shmem_struct(char type);
 
 /**

--- a/routines.h
+++ b/routines.h
@@ -46,8 +46,8 @@ void *socket_listening_thread(void *args);
 bool ipv6_available(void);
 void bind_sockets(void);
 
-void process_request(char *client_message, int *sock);
-bool command(char *client_message, const char* cmd) __attribute__((pure));
+void process_request(const char *client_message, int *sock);
+bool command(const char *client_message, const char* cmd) __attribute__((pure));
 bool matchesEndpoint(char *client_message, const char *cmd);
 
 // grep.c

--- a/routines.h
+++ b/routines.h
@@ -99,7 +99,7 @@ void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *functi
 void FTLfree(void *ptr, const char* file, const char *function, int line);
 void validate_access(const char * name, int pos, bool testmagic, int line, const char * function, const char * file);
 
-int main_dnsmasq(int argc, char **argv);
+int main_dnsmasq(int argc, const char ** argv);
 
 // signals.c
 void handle_signals(void);

--- a/setupVars.c
+++ b/setupVars.c
@@ -133,9 +133,9 @@ char * read_setupVarsconf(const char * key)
 // setupVarsArray[1] = def
 // setupVarsArray[2] = ghi
 // setupVarsArray[3] = NULL
-void getSetupVarsArray(char * input)
+void getSetupVarsArray(const char * input)
 {
-	char * p = strtok(input, ",");
+	char * p = strtok((char*)input, ",");
 
 	/* split string and append tokens to 'res' */
 
@@ -182,16 +182,15 @@ void clearSetupVarsArray(void)
 	clearSetupVarsArray();
 */
 
-bool insetupVarsArray(char * str)
+bool insetupVarsArray(const char * str)
 {
-	int i;
 	// Check for possible NULL pointer
 	// (this is valid input, e.g. if clients[i].name is unspecified)
 	if(str == NULL)
 		return false;
 
 	// Loop over all entries in setupVarsArray
-	for (i = 0; i < setupVarsElements; ++i)
+	for (int i = 0; i < setupVarsElements; ++i)
 		if(setupVarsArray[i][0] == '*')
 		{
 			// Copying strlen-1 chars into buffer of size strlen: OK
@@ -221,7 +220,7 @@ bool insetupVarsArray(char * str)
 	return false;
 }
 
-bool __attribute__((pure)) getSetupVarsBool(char * input)
+bool __attribute__((pure)) getSetupVarsBool(const char * input)
 {
 	if((strcmp(input, "true")) == 0)
 		return true;

--- a/shmem.c
+++ b/shmem.c
@@ -274,7 +274,7 @@ void destroy_shmem(void)
 	delete_shm(&shm_settings);
 }
 
-SharedMemory create_shm(char *name, size_t size)
+SharedMemory create_shm(const char *name, size_t size)
 {
 	if(config.debug & DEBUG_SHMEM)
 		logg("Creating shared memory with name \"%s\" and size %zu", name, size);

--- a/shmem.c
+++ b/shmem.c
@@ -90,11 +90,11 @@ unsigned long long addstr(const char *str)
 	return (shmSettings->next_str_pos - (len + 1));
 }
 
-char *getstr(unsigned long long pos)
+const char *getstr(unsigned long long pos)
 {
 	// Only access the string memory if this memory region has already been set
 	if(pos < shmSettings->next_str_pos)
-		return &((char*)shm_strings.ptr)[pos];
+		return &((const char*)shm_strings.ptr)[pos];
 	else
 	{
 		logg("WARN: Tried to access %llu but next_str_pos is %u", pos, shmSettings->next_str_pos);

--- a/shmem.c
+++ b/shmem.c
@@ -103,7 +103,7 @@ const char *getstr(unsigned long long pos)
 }
 
 /// Create a mutex for shared memory
-pthread_mutex_t create_mutex() {
+static pthread_mutex_t create_mutex(void) {
 	pthread_mutexattr_t lock_attr = {};
 	pthread_mutex_t lock = {};
 
@@ -125,7 +125,7 @@ pthread_mutex_t create_mutex() {
 	return lock;
 }
 
-void remap_shm(void)
+static void remap_shm(void)
 {
 	// Remap shared object pointers which might have changed
 	realloc_shm(&shm_queries, counters->queries_MAX*sizeof(queriesDataStruct), false);

--- a/shmem.h
+++ b/shmem.h
@@ -16,7 +16,7 @@
 #include <stdbool.h>
 
 typedef struct {
-    char *name;
+    const char *name;
     size_t size;
     void *ptr;
 } SharedMemory;
@@ -27,7 +27,7 @@ typedef struct {
 /// \param size the size to allocate
 /// \return a structure with a pointer to the mounted shared memory. The pointer
 /// will always be valid, because if it failed FTL will have exited.
-SharedMemory create_shm(char *name, size_t size);
+SharedMemory create_shm(const char *name, size_t size);
 
 /// Reallocate shared memory
 ///

--- a/socket.c
+++ b/socket.c
@@ -28,7 +28,7 @@ bool dualstack = false;
 bool ipv4telnet = false, ipv6telnet = false;
 bool istelnet[MAXCONNS];
 
-void saveport(void)
+static void saveport(void)
 {
 	FILE *f;
 	if((f = fopen(FTLfiles.port, "w+")) == NULL)
@@ -43,7 +43,7 @@ void saveport(void)
 	}
 }
 
-bool bind_to_telnet_port_IPv4(int *socketdescriptor)
+static bool bind_to_telnet_port_IPv4(int *socketdescriptor)
 {
 	// IPv4 socket
 	*socketdescriptor = socket(AF_INET, SOCK_STREAM, 0);
@@ -92,7 +92,7 @@ bool bind_to_telnet_port_IPv4(int *socketdescriptor)
 	return true;
 }
 
-bool bind_to_telnet_port_IPv6(int *socketdescriptor)
+static bool bind_to_telnet_port_IPv6(int *socketdescriptor)
 {
 	// IPv6 socket
 	*socketdescriptor = socket(AF_INET6, SOCK_STREAM, 0);
@@ -154,7 +154,7 @@ bool bind_to_telnet_port_IPv6(int *socketdescriptor)
 	return true;
 }
 
-void bind_to_unix_socket(int *socketdescriptor)
+static void bind_to_unix_socket(int *socketdescriptor)
 {
 	*socketdescriptor = socket(AF_LOCAL, SOCK_STREAM, 0);
 
@@ -190,7 +190,7 @@ void bind_to_unix_socket(int *socketdescriptor)
 }
 
 // Called from main() at graceful shutdown
-void removeport(void)
+static void removeport(void)
 {
 	FILE *f;
 	if((f = fopen(FTLfiles.port, "w+")) == NULL)
@@ -229,7 +229,7 @@ void swrite(int sock, void *value, size_t size) {
 		logg("WARNING: Socket write returned error code %i", errno);
 }
 
-int checkClientLimit(int socket) {
+static inline int checkClientLimit(int socket) {
 	if(socket < MAXCONNS)
 	{
 		return socket;
@@ -243,7 +243,7 @@ int checkClientLimit(int socket) {
 	}
 }
 
-int listener(int sockfd, char type)
+static int listener(int sockfd, char type)
 {
 	struct sockaddr_un un_addr;
 	struct sockaddr_in in4_addr;
@@ -294,7 +294,7 @@ void close_unix_socket(void)
 	close(socketfd);
 }
 
-void *telnet_connection_handler_thread(void *socket_desc)
+static void *telnet_connection_handler_thread(void *socket_desc)
 {
 	//Get the socket descriptor
 	int sock = *(int*)socket_desc;
@@ -345,7 +345,7 @@ void *telnet_connection_handler_thread(void *socket_desc)
 }
 
 
-void *socket_connection_handler_thread(void *socket_desc)
+static void *socket_connection_handler_thread(void *socket_desc)
 {
 	//Get the socket descriptor
 	int sock = *(int*)socket_desc;

--- a/socket.c
+++ b/socket.c
@@ -224,7 +224,7 @@ void __attribute__ ((format (gnu_printf, 2, 3))) ssend(int sock, const char *for
 	}
 }
 
-void swrite(int sock, void *value, size_t size) {
+void swrite(int sock, const void *value, size_t size) {
 	if(write(sock, value, size) == -1)
 		logg("WARNING: Socket write returned error code %i", errno);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR adds further general improvements for our code base.

Highlights:
- Added many additional warning flags that are useful and are neither included by `-Wall` and `-Wextra`
- Declare many `char*` which should not be changeable in the corresponding subroutines as `const char*` to have the compiler enforce their immutability.
- Enforce strict prototyping for FTL routines. This ensures that functions have to be *either* made explicitly global (by adding a prototype to the suitable header file), or they have to be made explicitly local (by adding the `static` keyword). Furthermore, strict prototyping requires that functions with zero arguments need to be written explicitly as `function(void)`. Non-strict prototype such as `function()` are permitted by regular `C`, however they in fact allow an arbitrary amount of parameters (they are a function declaration and not a prototype).
- As before, we split the warnings into a `gcc` version 8 and higher and a CI-compatible section which is automatically selected. This will be helpful for users with sufficiently recent `gcc` to get better hints whereas compilation is still possible on the CI.

Additional note: There are changes to `dnsmasq` code in this PR which are necessary to be able to compile *FTL*DNS with the added warning flags. The changes are meaningful and will be submitted to `dnsmasq` separately to be already part of the next release of `dnsmasq`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
