### PR TITLE
Improve inner-struct alignments

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -160,69 +160,69 @@ typedef struct {
 } countersStruct;
 
 typedef struct {
-	bool socket_listenlocal;
-	bool analyze_AAAA;
 	int maxDBdays;
-	bool resolveIPv6;
-	bool resolveIPv4;
 	int DBinterval;
 	int port;
 	int maxlogage;
+	int16_t debug;
 	unsigned char privacylevel;
-	bool ignore_localhost;
 	unsigned char blockingmode;
+	bool socket_listenlocal;
+	bool analyze_AAAA;
+	bool resolveIPv6;
+	bool resolveIPv4;
+	bool ignore_localhost;
 	bool analyze_only_A_AAAA;
 	bool DBimport;
 	bool parse_arp_cache;
-	int16_t debug;
 } ConfigStruct;
 
 // Dynamic structs
 typedef struct {
 	unsigned char magic;
-	time_t timestamp;
-	unsigned int timeidx;
 	unsigned char type;
 	unsigned char status;
+	unsigned char privacylevel;
+	unsigned char reply;
+	unsigned char dnssec;
+	time_t timestamp;
 	int domainID;
 	int clientID;
 	int forwardID;
-	int64_t db;
 	int id; // the ID is a (signed) int in dnsmasq, so no need for a long int here
-	bool complete;
-	unsigned char privacylevel;
 	unsigned long response; // saved in units of 1/10 milliseconds (1 = 0.1ms, 2 = 0.2ms, 2500 = 250.0ms, etc.)
-	unsigned char reply;
-	unsigned char dnssec;
+	int64_t db;
+	unsigned int timeidx;
+	bool complete;
 } queriesDataStruct;
 
 typedef struct {
 	unsigned char magic;
+	size_t ippos;
+	size_t namepos;
 	int count;
 	int failed;
-	unsigned long long ippos;
-	unsigned long long namepos;
 	bool new;
 } forwardedDataStruct;
 
 typedef struct {
 	unsigned char magic;
+	size_t ippos;
+	size_t namepos;
+	time_t lastQuery;
 	int count;
 	int blockedcount;
-	unsigned long long ippos;
-	unsigned long long namepos;
-	bool new;
 	int overTime[OVERTIME_SLOTS];
-	time_t lastQuery;
 	unsigned int numQueriesARP;
+	bool new;
 } clientsDataStruct;
 
 typedef struct {
 	unsigned char magic;
+	unsigned char regexmatch;
+	size_t domainpos;
 	int count;
 	int blockedcount;
-	unsigned long long domainpos;
-	unsigned char regexmatch;
 } domainsDataStruct;
 
 typedef struct {
@@ -236,8 +236,8 @@ typedef struct {
 } overTimeDataStruct;
 
 typedef struct {
-	int count;
 	char **domains;
+	int count;
 } whitelistStruct;
 
 typedef struct {

--- a/regex.c
+++ b/regex.c
@@ -15,7 +15,7 @@ static int num_regex;
 static regex_t *regex = NULL;
 static bool *regexconfigured = NULL;
 static char **regexbuffer = NULL;
-static whitelistStruct whitelist = { 0, NULL };
+static whitelistStruct whitelist = { NULL, 0 };
 
 static void log_regex_error(const char *where, int errcode, int index)
 {

--- a/routines.h
+++ b/routines.h
@@ -118,8 +118,8 @@ bool in_whitelist(char *domain) __attribute__((pure));
 // shmem.c
 bool init_shmem(void);
 void destroy_shmem(void);
-unsigned long long addstr(const char *str);
-const char *getstr(unsigned long long pos);
+size_t addstr(const char *str);
+const char *getstr(size_t pos);
 void *enlarge_shmem_struct(char type);
 
 /**

--- a/shmem.c
+++ b/shmem.c
@@ -48,7 +48,7 @@ static unsigned int local_shm_counter = 0;
 
 static size_t get_optimal_object_size(size_t objsize, size_t minsize);
 
-unsigned long long addstr(const char *str)
+size_t addstr(const char *str)
 {
 	if(str == NULL)
 	{
@@ -90,14 +90,14 @@ unsigned long long addstr(const char *str)
 	return (shmSettings->next_str_pos - (len + 1));
 }
 
-const char *getstr(unsigned long long pos)
+const char *getstr(size_t pos)
 {
 	// Only access the string memory if this memory region has already been set
 	if(pos < shmSettings->next_str_pos)
 		return &((const char*)shm_strings.ptr)[pos];
 	else
 	{
-		logg("WARN: Tried to access %llu but next_str_pos is %u", pos, shmSettings->next_str_pos);
+		logg("WARN: Tried to access %zu but next_str_pos is %u", pos, shmSettings->next_str_pos);
 		return "";
 	}
 }

--- a/shmem.c
+++ b/shmem.c
@@ -12,7 +12,7 @@
 #include "shmem.h"
 
 /// The version of shared memory used
-#define SHARED_MEMORY_VERSION 5
+#define SHARED_MEMORY_VERSION 6
 
 /// The name of the shared memory. Use this when connecting to the shared memory.
 #define SHARED_LOCK_NAME "/FTL-lock"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR improves on the inner-struct alignments. While this does not change any functionality, it results in reduced padding and, due to this, we save a lot of space. This will immediately reduce `pihole-FTL`'s memory footprint.

| struct | before | after | reduction |
| --- | --- | --- | --- |
`queriesDataStruct` | 72 | 56 | **22 %** |
`domainsDataStruct` | 32 | 24 | **25 %** |
`clientsDataStruct` | 656 | 648 | 1 % |
`ConfigStruct` | 32 | 28 | 12.5 % |
`whitelistStruct` | 16  | 16 | 0 % |

(numbers above correspond to `x86_64` architecture)

While there is no immediate benefit for the `whitelistStruct`, the padding is shifted to the end of the struct. This space can possibly be used in future additions without enlarging the struct.

Also, change the type of `ippos` and `namepos` from `u long long` to `size_t` to always use the most suitable type for the current architecture.

This updates the shared memory version to 6

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
