### PR TITLE
Do not mark cached PTR queries as externally blocked even if NXDOMAIN

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -103,6 +103,7 @@ enum {
   DEBUG_REGEX      = (1 << 8),  /* 00000001 00000000 */
   DEBUG_API        = (1 << 9),  /* 00000010 00000000 */
   DEBUG_OVERTIME   = (1 << 10), /* 00000100 00000000 */
+  DEBUG_EXTBLOCKED = (1 << 11), /* 00001000 00000000 */
 };
 
 // Database table "ftl"

--- a/config.c
+++ b/config.c
@@ -588,6 +588,12 @@ void read_debuging_settings(FILE *fp)
 	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
 		config.debug |= DEBUG_OVERTIME;
 
+	// DEBUG_EXTBLOCKED
+	// defaults to: false
+	buffer = parse_FTLconf(fp, "DEBUG_EXTBLOCKED");
+	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
+		config.debug |= DEBUG_EXTBLOCKED;
+
 	// DEBUG_ALL
 	// defaults to: false
 	buffer = parse_FTLconf(fp, "DEBUG_ALL");
@@ -609,6 +615,7 @@ void read_debuging_settings(FILE *fp)
 		logg("* DEBUG_REGEX      %s *", (config.debug & DEBUG_REGEX)? "YES":"NO ");
 		logg("* DEBUG_API        %s *", (config.debug & DEBUG_API)? "YES":"NO ");
 		logg("* DEBUG_OVERTIME   %s *", (config.debug & DEBUG_OVERTIME)? "YES":"NO ");
+		logg("* DEBUG_EXTBLOCKED %s *", (config.debug & DEBUG_EXTBLOCKED)? "YES":"NO ");
 		logg("************************");
 	}
 

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -521,13 +521,22 @@ void _FTL_reply(unsigned short flags, char *name, struct all_addr *addr, int id,
 
 static void detect_blocked_IP(unsigned short flags, const char* answer, int queryID)
 {
-	// Skip replies which originated locally. Otherwise, we would count
-	// gravity.list blocked queries as externally blocked.
 	if(flags & F_HOSTS)
 	{
-		if(config.debug & DEBUG_QUERIES)
+		// Skip replies which originated locally. Otherwise, we would
+		// count gravity.list blocked queries as externally blocked.
+		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Skipping detection of external blocking IP for query ID %i as origin is HOSTS", queryID);
+		}
+		return;
+	}
+	else if(flags & F_REVERSE)
+	{
+		// Do not mark responses of PTR requests as externally blocked.
+		if(config.debug & DEBUG_EXTBLOCKED)
+		{
+			logg("Skipping detection of external blocking IP for query ID %i as query is PTR", queryID);
 		}
 		return;
 	}
@@ -545,7 +554,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		 strcmp("146.112.61.109", answer) == 0 ||
 		 strcmp("146.112.61.110", answer) == 0 ))
 	{
-		if(config.debug & DEBUG_QUERIES)
+		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with known blocking page IPv6 for query ID %i:\n\t\"%s\"", queryID, answer);
 		}
@@ -563,7 +572,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		 strcmp("::ffff:146.112.61.109", answer) == 0 ||
 		 strcmp("::ffff:146.112.61.110", answer) == 0 ))
 	{
-		if(config.debug & DEBUG_QUERIES)
+		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with known blocking page IPv6 for query ID %i:\n\t\"%s\"", queryID, answer);
 		}
@@ -578,7 +587,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	else if(flags & F_IPV4 && answer != NULL &&
 		strcmp("0.0.0.0", answer) == 0)
 	{
-		if(config.debug & DEBUG_QUERIES)
+		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with 0.0.0.0 for query ID %i\nDomain: \"%s\"",
 			     queryID, getstr(domains[queryID].domainpos));
@@ -591,7 +600,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	else if(flags & F_IPV6 && answer != NULL &&
 		strcmp("::", answer) == 0)
 	{
-		if(config.debug & DEBUG_QUERIES)
+		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with :: for query ID %i\nDomain: \"%s\"",
 			     queryID, getstr(domains[queryID].domainpos));

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -527,7 +527,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		// count gravity.list blocked queries as externally blocked.
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
-			logg("Skipping detection of external blocking IP for query ID %i as origin is HOSTS", queryID);
+			logg("Skipping detection of external blocking IP for ID %i as origin is HOSTS", queryID);
 		}
 		return;
 	}
@@ -536,7 +536,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		// Do not mark responses of PTR requests as externally blocked.
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
-			logg("Skipping detection of external blocking IP for query ID %i as query is PTR", queryID);
+			logg("Skipping detection of external blocking IP for ID %i as query is PTR", queryID);
 		}
 		return;
 	}
@@ -556,7 +556,8 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
-			logg("Upstream responded with known blocking page IPv6 for query ID %i:\n\t\"%s\"", queryID, answer);
+			logg("Upstream responded with known blocking page (IPv4), ID %i:\n\t\"%s\" -> \"%s\"",
+			     queryID, answer, getstr(domains[queryID].domainpos));
 		}
 
 		// Update status
@@ -574,7 +575,8 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
-			logg("Upstream responded with known blocking page IPv6 for query ID %i:\n\t\"%s\"", queryID, answer);
+			logg("Upstream responded with known blocking page (IPv6), ID %i:\n\t\"%s\" -> \"%s\"",
+			     queryID, answer, getstr(domains[queryID].domainpos));
 		}
 
 		// Update status
@@ -589,8 +591,8 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
-			logg("Upstream responded with 0.0.0.0 for query ID %i\nDomain: \"%s\"",
-			     queryID, getstr(domains[queryID].domainpos));
+			logg("Upstream responded with 0.0.0.0, ID %i:\n\t\"%s\" -> \"%s\"",
+			     queryID, answer, getstr(domains[queryID].domainpos));
 		}
 
 		// Update status
@@ -602,8 +604,8 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
-			logg("Upstream responded with :: for query ID %i\nDomain: \"%s\"",
-			     queryID, getstr(domains[queryID].domainpos));
+			logg("Upstream responded with ::, ID %i:\n\t\"%s\" -> \"%s\"",
+			     queryID, answer, getstr(domains[queryID].domainpos));
 		}
 
 		// Update status

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -557,7 +557,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with known blocking page (IPv4), ID %i:\n\t\"%s\" -> \"%s\"",
-			     queryID, answer, getstr(domains[queryID].domainpos));
+			     queryID, getstr(domains[queryID].domainpos), answer);
 		}
 
 		// Update status
@@ -576,7 +576,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with known blocking page (IPv6), ID %i:\n\t\"%s\" -> \"%s\"",
-			     queryID, answer, getstr(domains[queryID].domainpos));
+			     queryID, getstr(domains[queryID].domainpos), answer);
 		}
 
 		// Update status
@@ -592,7 +592,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with 0.0.0.0, ID %i:\n\t\"%s\" -> \"%s\"",
-			     queryID, answer, getstr(domains[queryID].domainpos));
+			     queryID, getstr(domains[queryID].domainpos), answer);
 		}
 
 		// Update status
@@ -605,7 +605,7 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
 			logg("Upstream responded with ::, ID %i:\n\t\"%s\" -> \"%s\"",
-			     queryID, answer, getstr(domains[queryID].domainpos));
+			     queryID, getstr(domains[queryID].domainpos), answer);
 		}
 
 		// Update status

--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -580,7 +580,8 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	{
 		if(config.debug & DEBUG_QUERIES)
 		{
-			logg("Upstream responded with 0.0.0.0 for query ID %i:\n\t\"%s\"", queryID, answer);
+			logg("Upstream responded with 0.0.0.0 for query ID %i\nDomain: \"%s\"",
+			     queryID, getstr(domains[queryID].domainpos));
 		}
 
 		// Update status
@@ -592,7 +593,8 @@ static void detect_blocked_IP(unsigned short flags, const char* answer, int quer
 	{
 		if(config.debug & DEBUG_QUERIES)
 		{
-			logg("Upstream responded with :: for query ID %i:\n\t\"%s\"", queryID, answer);
+			logg("Upstream responded with :: for query ID %i\nDomain: \"%s\"",
+			     queryID, getstr(domains[queryID].domainpos));
 		}
 
 		// Update status


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _

## 10

---

Do not mark `PTR` requests as `externally blocked (NULL)` when we serve an entry from cache. This bug exists in the `development` branch only.

Also add new `DEBUG_EXTBLOCKED` property for `pihole-FTL.conf` that logs reasons for why FTL decided a query was externally blocked.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
