### PR TITLE
Improvements for hostname resolving routines

### DIFF
--- a/FTL.h
+++ b/FTL.h
@@ -80,6 +80,14 @@
 // can be 24 hours + 59 minutes
 #define OVERTIME_SLOTS ((MAXLOGAGE+1)*3600/OVERTIME_INTERVAL)
 
+// Interval for resolving NEW client and upstream server host names [seconds]
+// Default: 60 (once every minute)
+#define RESOLVE_INTERVAL 60
+
+// Interval for re-resolving ALL known host names [seconds]
+// Default: 3600 (once every hour)
+#define RERESOLVE_INTERVAL 3600
+
 // FTLDNS enums
 enum { DATABASE_WRITE_TIMER, EXIT_TIMER, GC_TIMER, LISTS_TIMER, REGEX_TIMER, ARP_TIMER, LAST_TIMER };
 enum { QUERIES, FORWARDED, CLIENTS, DOMAINS, OVERTIME, WILDCARD };

--- a/resolve.c
+++ b/resolve.c
@@ -67,8 +67,10 @@ static char *resolveHostname(const char *addr)
 static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 {
 	// Get IP and host name strings
+	lock_shm();
 	const char* ipaddr = getstr(ippos);
 	const char* oldname = getstr(oldnamepos);
+	unlock_shm();
 
 	// Important: Don't hold a lock while resolving as the main thread
 	// (dnsmasq) needs to be operable during the call to resolveHostname()
@@ -79,7 +81,9 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 	{
 		// We do not need to check for name == NULL as name is
 		// always initialized with an empty string at position 0
+		lock_shm();
 		size_t newnamepos = addstr(newname);
+		unlock_shm();
 		if(newname != NULL)
 			free(newname);
 		return newnamepos;

--- a/resolve.c
+++ b/resolve.c
@@ -99,10 +99,10 @@ void resolveClients(bool onlynew)
 		lock_shm();
 
 		// Only store new hostname if it changed
+		// We do not need to check for name == NULL as name is
+		// always initialized with an empty string at position 0
 		if(hostname != NULL && strcmp(name, hostname) != 0)
 		{
-			// We do not need to check for name == NULL as name is
-			// always initialized with an empty string at position 0
 			clients[clientID].namepos = addstr(hostname);
 		}
 		else if(config.debug & DEBUG_SHMEM)
@@ -112,7 +112,8 @@ void resolveClients(bool onlynew)
 		}
 
 		// Release allocated memory
-		free(hostname);
+		if(hostname != NULL)
+			free(hostname);
 
 		// Mark entry as not new
 		clients[clientID].new = false;
@@ -150,10 +151,10 @@ void resolveForwardDestinations(bool onlynew)
 		// Finally, lock data when storing obtained hostname
 		lock_shm();
 		// Only store new hostname if it changed
+		// We do not need to check for name == NULL as name is
+		// always initialized with an empty string at position 0
 		if(hostname != NULL && strcmp(name, hostname) != 0)
 		{
-			// We do not need to check for name == NULL as name is
-			// always initialized with an empty string at position 0
 			forwarded[forwardID].namepos = addstr(hostname);
 		}
 		else if(config.debug & DEBUG_SHMEM)
@@ -163,7 +164,8 @@ void resolveForwardDestinations(bool onlynew)
 		}
 
 		// Release allocated memory
-		free(hostname);
+		if(hostname != NULL)
+			free(hostname);
 
 		// Mark entry as not new
 		forwarded[forwardID].new = false;

--- a/resolve.c
+++ b/resolve.c
@@ -110,12 +110,18 @@ void resolveClients(bool onlynew)
 
 		// If onlynew flag is set, we will only resolve new clients
 		// If not, we will try to re-resolve all known clients
-		if(onlynew && !clients[clientID].new)
+		lock_shm();
+		bool newlock = clients[clientID].new;
+		unlock_shm();
+		if(onlynew && !newlock)
 			continue;
 
 		// Obtain/update hostname of this client
+		lock_shm();
 		size_t oldnamepos = clients[clientID].namepos;
-		size_t newnamepos = resolveAndAddHostname(clients[clientID].ippos, oldnamepos);
+		size_t ippos = clients[clientID].ippos;
+		unlock_shm();
+		size_t newnamepos = resolveAndAddHostname(ippos, oldnamepos);
 
 		if(newnamepos != oldnamepos)
 		{
@@ -143,12 +149,18 @@ void resolveForwardDestinations(bool onlynew)
 
 		// If onlynew flag is set, we will only resolve new upstream destinations
 		// If not, we will try to re-resolve all known upstream destinations
-		if(onlynew && !forwarded[forwardID].new)
+		lock_shm();
+		bool newflag = forwarded[forwardID].new;
+		unlock_shm();
+		if(onlynew && !newflag)
 			continue;
 
 		// Obtain/update hostname of this client
+		lock_shm();
 		size_t oldnamepos = forwarded[forwardID].namepos;
-		size_t newnamepos = resolveAndAddHostname(forwarded[forwardID].ippos, oldnamepos);
+		size_t ippos = forwarded[forwardID].ippos;
+		unlock_shm();
+		size_t newnamepos = resolveAndAddHostname(ippos, oldnamepos);
 
 		if(newnamepos != oldnamepos)
 		{

--- a/resolve.c
+++ b/resolve.c
@@ -113,14 +113,14 @@ void resolveClients(bool onlynew)
 
 		// Memory access needs to get locked
 		lock_shm();
-		bool newlock = clients[clientID].new;
+		bool newflag = clients[clientID].new;
 		size_t ippos = clients[clientID].ippos;
 		size_t oldnamepos = clients[clientID].namepos;
 		unlock_shm();
 
 		// If onlynew flag is set, we will only resolve new clients
 		// If not, we will try to re-resolve all known clients
-		if(onlynew && !newlock)
+		if(onlynew && !newflag)
 			continue;
 
 		// Obtain/update hostname of this client
@@ -132,11 +132,12 @@ void resolveClients(bool onlynew)
 			lock_shm();
 			clients[clientID].namepos = newnamepos;
 			clients[clientID].new = false;
+			newflag = false;
 			unlock_shm();
 		}
 
 		// Mark entry as not new even when we don't have a new host name
-		if(clients[clientID].new)
+		if(newflag)
 		{
 			lock_shm();
 			clients[clientID].new = false;
@@ -178,11 +179,12 @@ void resolveForwardDestinations(bool onlynew)
 			lock_shm();
 			forwarded[forwardID].namepos = newnamepos;
 			forwarded[forwardID].new = false;
+			newflag = false;
 			unlock_shm();
 		}
 
 		// Mark entry as not new
-		if(forwarded[forwardID].new)
+		if(newflag)
 		{
 			lock_shm();
 			forwarded[forwardID].new = false;

--- a/resolve.c
+++ b/resolve.c
@@ -88,6 +88,7 @@ void resolveClients(bool onlynew)
 		// Lock data when obtaining IP of this client
 		lock_shm();
 		const char* ipaddr = getstr(clients[clientID].ippos);
+		const char* name = getstr(clients[clientID].namepos);
 		unlock_shm();
 
 		// Important: Don't hold a lock while resolving as the main thread
@@ -96,7 +97,13 @@ void resolveClients(bool onlynew)
 
 		// Finally, lock data when storing obtained hostname
 		lock_shm();
-		clients[clientID].namepos = addstr(hostname);
+		// Only store new hostname if it changed
+		if(hostname != NULL && strcmp(name, hostname) != 0)
+		{
+			// We do not need to check for name == NULL as name is
+			// always initialized with an empty string at position 0
+			clients[clientID].namepos = addstr(hostname);
+		}
 		clients[clientID].new = false;
 		unlock_shm();
 	}
@@ -119,6 +126,7 @@ void resolveForwardDestinations(bool onlynew)
 		// Lock data when obtaining IP of this forward destination
 		lock_shm();
 		const char* ipaddr = getstr(forwarded[forwardID].ippos);
+		const char* name = getstr(forwarded[forwardID].namepos);
 		unlock_shm();
 
 
@@ -128,7 +136,13 @@ void resolveForwardDestinations(bool onlynew)
 
 		// Finally, lock data when storing obtained hostname
 		lock_shm();
-		forwarded[forwardID].namepos = addstr(hostname);
+		// Only store new hostname if it changed
+		if(hostname != NULL && strcmp(name, hostname) != 0)
+		{
+			// We do not need to check for name == NULL as name is
+			// always initialized with an empty string at position 0
+			forwarded[forwardID].namepos = addstr(hostname);
+		}
 		forwarded[forwardID].new = false;
 		unlock_shm();
 	}

--- a/resolve.c
+++ b/resolve.c
@@ -126,23 +126,13 @@ void resolveClients(bool onlynew)
 		// Obtain/update hostname of this client
 		size_t newnamepos = resolveAndAddHostname(ippos, oldnamepos);
 
-		if(newnamepos != oldnamepos)
-		{
-			// Need lock when storing obtained hostname
-			lock_shm();
-			clients[clientID].namepos = newnamepos;
-			clients[clientID].new = false;
-			newflag = false;
-			unlock_shm();
-		}
+		lock_shm();
+		// Store obtained host name (may be unchanged)
+		clients[clientID].namepos = newnamepos;
 
-		// Mark entry as not new even when we don't have a new host name
-		if(newflag)
-		{
-			lock_shm();
-			clients[clientID].new = false;
-			unlock_shm();
-		}
+		// Mark entry as not new
+		clients[clientID].new = false;
+		unlock_shm();
 	}
 }
 
@@ -173,23 +163,12 @@ void resolveForwardDestinations(bool onlynew)
 		// Obtain/update hostname of this client
 		size_t newnamepos = resolveAndAddHostname(ippos, oldnamepos);
 
-		if(newnamepos != oldnamepos)
-		{
-			// Need lock when storing obtained hostname
-			lock_shm();
-			forwarded[forwardID].namepos = newnamepos;
-			forwarded[forwardID].new = false;
-			newflag = false;
-			unlock_shm();
-		}
-
+		lock_shm();
+		// Store obtained host name (may be unchanged)
+		forwarded[forwardID].namepos = newnamepos;
 		// Mark entry as not new
-		if(newflag)
-		{
-			lock_shm();
-			forwarded[forwardID].new = false;
-			unlock_shm();
-		}
+		forwarded[forwardID].new = false;
+		unlock_shm();
 	}
 }
 

--- a/resolve.c
+++ b/resolve.c
@@ -126,7 +126,9 @@ void resolveClients(bool onlynew)
 		}
 
 		// Mark entry as not new
+		lock_shm();
 		clients[clientID].new = false;
+		unlock_shm();
 	}
 }
 
@@ -157,7 +159,9 @@ void resolveForwardDestinations(bool onlynew)
 		}
 
 		// Mark entry as not new
+		lock_shm();
 		forwarded[forwardID].new = false;
+		unlock_shm();
 	}
 }
 

--- a/resolve.c
+++ b/resolve.c
@@ -108,7 +108,7 @@ void resolveClients(bool onlynew)
 		else if(config.debug & DEBUG_SHMEM)
 		{
 			// Debugging output
-			logg("Not adding \"%s\" (unchanged)", name);
+			logg("Not adding \"%s\" to buffer (unchanged)", name);
 		}
 
 		// Release allocated memory
@@ -159,7 +159,7 @@ void resolveForwardDestinations(bool onlynew)
 		else if(config.debug & DEBUG_SHMEM)
 		{
 			// Debugging output
-			logg("Not adding \"%s\" (unchanged)", name);
+			logg("Not adding \"%s\" to buffer (unchanged)", name);
 		}
 
 		// Release allocated memory

--- a/resolve.c
+++ b/resolve.c
@@ -11,14 +11,6 @@
 #include "FTL.h"
 #include "shmem.h"
 
-// Resolve new client and upstream server host names
-// once every minute
-#define RESOLVE_INTERVAL 60
-
-// Re-resolve client names
-// once every hour
-#define RERESOLVE_INTERVAL 3600
-
 static char *resolveHostname(const char *addr)
 {
 	// Get host name

--- a/resolve.c
+++ b/resolve.c
@@ -76,16 +76,17 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 	// (dnsmasq) needs to be operable during the call to resolveHostname()
 	char* newname = resolveHostname(ipaddr);
 
-	// Only store new newname if it changed
+	// Only store new newname if it is valid and differs from oldname
+	// We do not need to check for oldname == NULL as names are
+	// always initialized with an empty string at position 0
 	if(newname != NULL && strcmp(oldname, newname) != 0)
 	{
-		// We do not need to check for name == NULL as name is
-		// always initialized with an empty string at position 0
 		lock_shm();
 		size_t newnamepos = addstr(newname);
+		// newname has already been checked against NULL
+		// so we can safely free it
+		free(newname);
 		unlock_shm();
-		if(newname != NULL)
-			free(newname);
 		return newnamepos;
 	}
 	else if(config.debug & DEBUG_SHMEM)

--- a/resolve.c
+++ b/resolve.c
@@ -104,6 +104,12 @@ void resolveClients(bool onlynew)
 			// always initialized with an empty string at position 0
 			clients[clientID].namepos = addstr(hostname);
 		}
+		else if(config.debug & DEBUG_SHMEM)
+		{
+			// Debug output
+			logg("Not adding \"%s\" (unchanged)", name);
+		}
+		// Mark entry as not new
 		clients[clientID].new = false;
 		unlock_shm();
 	}
@@ -143,6 +149,12 @@ void resolveForwardDestinations(bool onlynew)
 			// always initialized with an empty string at position 0
 			forwarded[forwardID].namepos = addstr(hostname);
 		}
+		else if(config.debug & DEBUG_SHMEM)
+		{
+			// Debug output
+			logg("Not adding \"%s\" (unchanged)", name);
+		}
+		// Mark entry as not new
 		forwarded[forwardID].new = false;
 		unlock_shm();
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR adds a few micro-optimizations and a bug fix for the host name resolving routines.

Improvement:
- Do not add host names of clients and upstream servers if they haven't changed.

Bug fix:
- Any determined host name was allocated using `strdup()`. However, as a consecutive `free()` was missing, some memory got lost.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
