### PR TITLE
Use thread-safe alternatives of ctime and localtime

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -45,7 +45,8 @@ void *GC_thread(void *val)
 			if(config.debug & DEBUG_GC) timer_start(GC_TIMER);
 
 			int removed = 0;
-			if(config.debug & DEBUG_GC) logg("GC starting, mintime: %lu %s", mintime, ctime(&mintime));
+			char ctimebuffer[32]; // need at least 26 bytes according to ctime_r man page
+			if(config.debug & DEBUG_GC) logg("GC starting, mintime: %lu %s", mintime, ctime_r(&mintime, ctimebuffer));
 
 			// Process all queries
 			for(long int i=0; i < counters->queries; i++)

--- a/gc.c
+++ b/gc.c
@@ -42,13 +42,16 @@ void *GC_thread(void *val)
 			mintime -= mintime % 3600;
 			mintime += 3600;
 
-			if(config.debug & DEBUG_GC) timer_start(GC_TIMER);
-
-			int removed = 0;
-			char ctimebuffer[32]; // need at least 26 bytes according to ctime_r man page
-			if(config.debug & DEBUG_GC) logg("GC starting, mintime: %lu %s", mintime, ctime_r(&mintime, ctimebuffer));
+			if(config.debug & DEBUG_GC)
+			{
+				timer_start(GC_TIMER);
+				char timestring[84] = "";
+				get_timestr(timestring, mintime);
+				logg("GC starting, mintime: %s (%lu)", timestring, mintime);
+			}
 
 			// Process all queries
+			int removed = 0;
 			for(long int i=0; i < counters->queries; i++)
 			{
 				queriesData* query = getQuery(i, true);

--- a/log.c
+++ b/log.c
@@ -53,7 +53,9 @@ void open_FTL_log(const bool test)
 static void get_timestr(char *timestring)
 {
 	const time_t t = time(NULL);
-	const struct tm tm = *localtime(&t);
+	struct tm tm;
+	localtime_r(&t, &tm);
+
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
 	const int millisec = tv.tv_usec/1000;

--- a/log.c
+++ b/log.c
@@ -50,11 +50,10 @@ void open_FTL_log(const bool test)
 	}
 }
 
-static void get_timestr(char *timestring)
+void get_timestr(char *timestring, const time_t timein)
 {
-	const time_t t = time(NULL);
 	struct tm tm;
-	localtime_r(&t, &tm);
+	localtime_r(&timein, &tm);
 
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
@@ -70,7 +69,7 @@ void __attribute__ ((format (gnu_printf, 1, 2))) logg(const char *format, ...)
 
 	pthread_mutex_lock(&lock);
 
-	get_timestr(timestring);
+	get_timestr(timestring, time(NULL));
 
 	// Get and log PID of current process to avoid ambiguities when more than one
 	// pihole-FTL instance is logging into the same file

--- a/routines.h
+++ b/routines.h
@@ -21,6 +21,7 @@ void logg(const char* format, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 void log_counter_info(void);
 void format_memory_size(char *prefix, unsigned long int bytes, double *formated);
 void log_FTL_version(bool crashreport);
+void get_timestr(char *timestring, const time_t timein);
 
 // datastructure.c
 void strtolower(char *str);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Use thread-safe alternatives of `ctime()` and `localtime()`. 

`ctime()` and `localtime()` fill data into a `char` array resp. `tm` struct in global memory and then return a pointer to that memory. If the function is called from multiple places in the same program, and especially if it is called from multiple threads in the same program, then the calls will overwrite each other's data which we want to avoid.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
