### PR TITLE
Fix trying to free the wrong variable

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -1182,7 +1182,7 @@ void _FTL_forwarding_failed(const struct server *server, const char* file, const
 	// Update counter
 	forward->failed++;
 
-	free(forward);
+	free(forwarddest);
 	unlock_shm();
 	return;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes a bug introduced in #529 which applied some major changes in how we access memory objects. This bug is only present in the `development` branch, neither any release nor the current release branch `release/v4.3` are affected.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
