### PR TITLE
Fix string reference held across locks

### DIFF
--- a/shmem.h
+++ b/shmem.h
@@ -43,11 +43,11 @@ bool realloc_shm(SharedMemory *sharedMemory, const size_t size, const bool resiz
 void delete_shm(SharedMemory *sharedMemory);
 
 /// Block until a lock can be obtained
-#define lock_shm() _lock_shm(__FUNCTION__, __LINE__, __FILE__);
+#define lock_shm() _lock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _lock_shm(const char* func, const int line, const char* file);
 
 /// Unlock the lock. Only call this if there is an active lock.
-#define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__);
+#define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _unlock_shm(const char* func, const int line, const char* file);
 
 #endif //SHARED_MEMORY_SERVER_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Fixes #567 

A reference to shared memory was used after unlocking shared memory, which caused a crash when shared memory was resized.

This PR also removes some extra semicolons in the macro definition of `lock_shm` and `unlock_shm`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
