### PR TITLE
Hotfix v4.3.1

### DIFF
--- a/networktable.c
+++ b/networktable.c
@@ -116,7 +116,6 @@ void parse_arp_cache(void)
 		//         unknown (only DNS requesting clients do this)
 		lock_shm();
 		int clientID = findClientID(ip, false);
-		unlock_shm();
 
 		// This client is known (by its IP address) to pihole-FTL if
 		// findClientID() returned a non-negative index
@@ -176,6 +175,8 @@ void parse_arp_cache(void)
 		}
 		// else:
 		// Device in database but not known to Pi-hole: No action required
+
+		unlock_shm();
 
 		// Count number of processed ARP cache entries
 		entries++;


### PR DESCRIPTION
Fixes the following bugs:
- Crash when resolving clients, caused by holding a reference to shared memory after unlocking it. #567
- Possible crash when updating the network table, caused by accessing shared memory without a lock