### PR TITLE
Use memcpy instead of strncpy where advised

### DIFF
--- a/api.c
+++ b/api.c
@@ -972,7 +972,7 @@ void getVersion(const int *sock)
 
 	// Extract first 7 characters of the hash
 	char hash[8];
-	strncpy(hash, commit, 7); hash[7] = 0;
+	memcpy(hash, commit, 7); hash[7] = 0;
 
 	if(strlen(tag) > 1) {
 		if(istelnet[*sock])

--- a/args.c
+++ b/args.c
@@ -62,7 +62,7 @@ void parse_args(int argc, char* argv[])
 				const char * commit = GIT_HASH;
 				char hash[8];
 				// Extract first 7 characters of the hash
-				strncpy(hash, commit, 7); hash[7] = 0;
+				memcpy(hash, commit, 7); hash[7] = 0;
 				printf("vDev-%s\n", hash);
 			}
 			exit(EXIT_SUCCESS);

--- a/shmem.c
+++ b/shmem.c
@@ -86,8 +86,8 @@ size_t addstr(const char *str)
 	counters->strings_MAX = shm_strings.size;
 
 	// Copy the C string pointed by str into the shared string buffer
-	strncpy(&((char*)shm_strings.ptr)[shmSettings->next_str_pos], str, len);
-	((char*)shm_strings.ptr)[shmSettings->next_str_pos + len] = '\0';
+	// the length (len+1) ensures that we copy the terminator as well
+	strncpy(&((char*)shm_strings.ptr)[shmSettings->next_str_pos], str, len + 1);
 
 	// Increment string length counter
 	shmSettings->next_str_pos += len+1;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---


Use `memcpy()` instead of `strncpy()` in cases where we want to use only parts of strings. GCC 8.1 and higher warns about using `strncpy()` when it detects a truncation of the string to be copied already at compile time.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
