### PR TITLE
Prevent possible memory corruption in addstr()

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -62,12 +62,20 @@ size_t addstr(const char *str)
 		return 0;
 	}
 
-	// Get string length
-	size_t len = strlen(str);
+	// Get string length, add terminating character
+	size_t len = strlen(str) + 1;
 
-	// If this is an empty string, use the one at position zero
-	if(len == 0) {
+	// If this is an empty string (only the terminating character is present),
+	// use the shared memory string at position zero instead of creating a new
+	// entry here. We also ensure that the given string is not too long to
+	// prevent possible memory corruption caused by strncpy() further down
+	if(len == 1) {
 		return 0;
+	}
+	else if(len > (size_t)(pagesize-1))
+	{
+		logg("WARN: Shortening too long string (len %zu)", len);
+		len = pagesize;
 	}
 
 	// Debugging output
@@ -75,9 +83,7 @@ size_t addstr(const char *str)
 		logg("Adding \"%s\" (len %zu) to buffer. next_str_pos is %u", str, len, shmSettings->next_str_pos);
 
 	// Reserve additional memory if necessary
-	size_t required_size = shmSettings->next_str_pos + len + 1;
-	// Need to cast to long long because size_t calculations cannot be negative
-	if((long long)required_size-(long long)shm_strings.size > 0 &&
+	if(shmSettings->next_str_pos + len > shm_strings.size &&
 	   !realloc_shm(&shm_strings, shm_strings.size + pagesize, true))
 		return 0;
 
@@ -87,13 +93,12 @@ size_t addstr(const char *str)
 
 	// Copy the C string pointed by str into the shared string buffer
 	strncpy(&((char*)shm_strings.ptr)[shmSettings->next_str_pos], str, len);
-	((char*)shm_strings.ptr)[shmSettings->next_str_pos + len] = '\0';
 
 	// Increment string length counter
-	shmSettings->next_str_pos += len+1;
+	shmSettings->next_str_pos += len;
 
 	// Return start of stored string
-	return (shmSettings->next_str_pos - (len + 1));
+	return (shmSettings->next_str_pos - len);
 }
 
 const char *getstr(const size_t pos)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Several micro-optimizations for the shmem `addstr()` subroutine mostly targeted at reducing the overall complexity. This PR contains a fix for a possible memory corruption issue when a string exceeding the `pagesize` is given to `addstr()`. Note that this might be no real issue as strings we handle are size limited (typically less than 250 bytes).


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
