### PR TITLE
Do not print errors when we create the database for the first time

### DIFF
--- a/database.c
+++ b/database.c
@@ -62,6 +62,12 @@ static double get_db_filesize(void)
 	return 1e-6*st.st_size;
 }
 
+static bool file_exists(const char *filename)
+{
+	struct stat st;
+	return (stat(filename, &st) != 0);
+}
+
 bool dbopen(void)
 {
 	pthread_mutex_lock(&dblock);
@@ -199,19 +205,20 @@ void db_init(void)
 	// explicitly check for failures to have happened
 	sqlite3_config(SQLITE_CONFIG_LOG, SQLite3LogCallback, NULL);
 
-	int rc = sqlite3_open_v2(FTLfiles.db, &db, SQLITE_OPEN_READWRITE, NULL);
-	if( rc == SQLITE_CANTOPEN )
+	// Check if database exists, if not create empty database
+	if(!file_exists(FTLfiles.db))
 	{
-		logg("Database not found, creating new (empty) database");
+		logg("No database file found, creating new (empty) database");
 		if (!db_create())
 		{
-			logg("Database not available");
+			logg("Creation of database failed, database is not available");
 			database = false;
 			return;
 		}
-
 	}
-	else if( rc ){
+
+	int rc = sqlite3_open_v2(FTLfiles.db, &db, SQLITE_OPEN_READWRITE, NULL);
+	if( rc ){
 		logg("db_init() - Cannot open database (%i): %s", rc, sqlite3_errmsg(db));
 		dbclose();
 

--- a/database.c
+++ b/database.c
@@ -65,7 +65,7 @@ static double get_db_filesize(void)
 static bool file_exists(const char *filename)
 {
 	struct stat st;
-	return (stat(filename, &st) != 0);
+	return stat(filename, &st) == 0;
 }
 
 bool dbopen(void)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

An unnecessarily high amount of messages was printed when the database file did not exist. This is, however, not an unlikely case (new installs, database file was corrupted, ...) and hence we should handle it better.

Previously:
```
[2019-05-25 16:17:16.610 1252] SQLite3 message: cannot open file at line 38565 of [884b4b7e50] (14)
[2019-05-25 16:17:16.610 1252] SQLite3 message: os_unix.c:38565: (2) open(/etc/pihole/pihole-FTL.db) -  (14)
[2019-05-25 16:17:16.610 1252] db_init() - Cannot open database (14): unable to open database file
[2019-05-25 16:17:16.610 1252] check_database(14): Disabling database connection due to error
[2019-05-25 16:17:16.610 1252] Creating new (empty) database
```

Now:
```
[2019-05-25 16:27:13.620 1262] No database file found, creating new (empty) database
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
