### PR TITLE
Fix unlocking shared memory lock outside of networktable loop

### DIFF
--- a/networktable.c
+++ b/networktable.c
@@ -177,8 +177,6 @@ void parse_arp_cache(void)
 		// else:
 		// Device in database but not known to Pi-hole: No action required
 
-		unlock_shm();
-
 		// Count number of processed ARP cache entries
 		entries++;
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix unlocking shared memory lock outside of the networktable loop, we want to lock during the entire loop to avoid interruption of the transaction.

This error has been introduced in #571 