### PR TITLE
Identify clients by hardware address not hardware + IP address

### DIFF
--- a/database.c
+++ b/database.c
@@ -269,10 +269,10 @@ void db_init(void)
 		dbversion = db_get_FTL_property(DB_VERSION);
 	}
 
-	//Update to version 4 if lower
+	// Update to version 4 if lower
 	if(dbversion < 4)
 	{
-		// Update to version 3: Create network table
+		// Update to version 4: Unify clients in network table
 		logg("Updating long-term database to version 4");
 		unify_hwaddr(db);
 		// Get updated version

--- a/database.c
+++ b/database.c
@@ -22,6 +22,9 @@ static pthread_mutex_t dblock;
 static bool db_set_counter(const unsigned int ID, const int value);
 static int db_get_FTL_property(const unsigned int ID);
 
+// defined in networktable.c
+extern bool unify_hwaddr(sqlite3 *db);
+
 static bool check_database(int rc)
 {
 	// We will retry if the database is busy at the moment
@@ -235,6 +238,7 @@ void db_init(void)
 		database = false;
 		return;
 	}
+
 	// Update to version 2 if lower
 	if(dbversion < 2)
 	{
@@ -249,6 +253,7 @@ void db_init(void)
 		// Get updated version
 		dbversion = db_get_FTL_property(DB_VERSION);
 	}
+
 	// Update to version 3 if lower
 	if(dbversion < 3)
 	{
@@ -260,6 +265,16 @@ void db_init(void)
 			database = false;
 			return;
 		}
+		// Get updated version
+		dbversion = db_get_FTL_property(DB_VERSION);
+	}
+
+	//Update to version 4 if lower
+	if(dbversion < 4)
+	{
+		// Update to version 3: Create network table
+		logg("Updating long-term database to version 4");
+		unify_hwaddr(db);
 		// Get updated version
 		dbversion = db_get_FTL_property(DB_VERSION);
 	}

--- a/networktable.c
+++ b/networktable.c
@@ -15,6 +15,7 @@
 
 // Private prototypes
 static char* getMACVendor(const char* hwaddr);
+bool unify_hwaddr(sqlite3 *db);
 
 bool create_network_table(void)
 {
@@ -169,7 +170,7 @@ void parse_arp_cache(void)
 			client->numQueriesARP = 0;
 
 			// Update IP address in case it changed. This might happen with
-			// sequential  DHCP servers as found in many commercial routers
+			// sequential DHCP servers as found in many commercial routers
 			dbquery("UPDATE network "\
 			        "SET ip = \'%s\' "\
 			        "WHERE id = %i;",\
@@ -205,6 +206,82 @@ void parse_arp_cache(void)
 
 	// Close database connection
 	dbclose();
+}
+
+// Loop over all entries in network table and unify entries by their hardware addresses
+// If we find duplicates, we keep the most recent entry, while
+// - we replace the first-seen date by the smallest one
+// - we sum up the number of queries of all rows
+// Note: The database handle is already active when this subroutine is called
+bool unify_hwaddr(sqlite3 *db)
+{
+	char* querystr = NULL;
+	// We request sets of (id,hwaddr). They are GROUPed BY hwaddr to make
+	// the set unique in hwaddr, while the grouping is constrained by the
+	// HAVING clause which is evaluated once across all rows of a group to
+	// ensure the returned set represents the most recent entry for a given
+	// hwaddr
+	int ret = asprintf(&querystr, "SELECT id,hwaddr FROM network GROUP BY hwaddr HAVING MAX(lastQuery)");
+	if(querystr == NULL || ret < 0)
+	{
+		logg("Memory allocation failed in unify_hwaddr (%i)", ret);
+		dbclose();
+		return false;
+	}
+
+	// Perform SQL query
+	sqlite3_stmt* stmt;
+	ret = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
+	if( ret ){
+		logg("unify_hwaddr(%s) - SQL error prepare (%i): %s", querystr, ret, sqlite3_errmsg(db));
+		dbclose();
+		return false;
+	}
+
+	// Loop until no further rows are read
+	while((ret = sqlite3_step(stmt)) != SQLITE_DONE)
+	{
+		// Check if we ran into an error
+		if(ret != SQLITE_ROW)
+		{
+			logg("unify_hwaddr(%s) - SQL error step (%i): %s", querystr, ret, sqlite3_errmsg(db));
+			dbclose();
+			return false;
+		}
+
+		const int id = sqlite3_column_int(stmt, 0);
+		const char *hwaddr = (const char *)sqlite3_column_text(stmt, 1);
+
+		// Update firstSeen with lowest value
+		dbquery("UPDATE network "\
+		        "SET firstSeen = (SELECT MIN(firstSeen) FROM network WHERE hwaddr = \'%s\') "\
+		        "WHERE id = %i;",\
+		        hwaddr, id);
+
+		// Update numQueries with sum of all rows
+		dbquery("UPDATE network "\
+		        "SET numQueries = (SELECT SUM(numQueries) FROM network WHERE hwaddr = \'%s\') "\
+		        "WHERE id = %i;",\
+		        hwaddr, id);
+
+		// Remove all other lines with the same hwaddr
+		dbquery("DELETE FROM network "\
+		        "WHERE hwaddr = \'%s\' "\
+		        "AND id != %i;",\
+		        hwaddr, id);
+	}
+
+	sqlite3_finalize(stmt);
+	free(querystr);
+
+	// Update database version to 4
+	if(!db_set_FTL_property(DB_VERSION, 4))
+	{
+		dbclose();
+		return false;
+	}
+
+	return true;
 }
 
 static char* getMACVendor(const char* hwaddr)

--- a/networktable.c
+++ b/networktable.c
@@ -88,7 +88,7 @@ void parse_arp_cache(void)
 			continue;
 
 		// Get ID of this device in our network database. If it cannot be
-		// found, then this is a new device We only use the hardware address
+		// found, then this is a new device. We only use the hardware address
 		// to uniquely identify clients and only use the first returned ID.
 		//
 		// Same MAC, two IPs: Non-deterministic (sequential) DHCP server, we
@@ -283,7 +283,7 @@ bool unify_hwaddr(sqlite3 *db)
 	// See https://www.sqlite.org/lang_createtable.html#constraints:
 	// >>> In most cases, UNIQUE and PRIMARY KEY constraints are
 	// >>> implemented by creating a unique index in the database.
-	dbquery("CREATE UNIQUE INDEX hwaddr_idx ON network(hwaddr)");
+	dbquery("CREATE UNIQUE INDEX network_hwaddr_idx ON network(hwaddr)");
 
 	// Update database version to 4
 	if(!db_set_FTL_property(DB_VERSION, 4))


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes #576. Further details can be found therein.

If multiple clients (with the same `hwaddr` but different IP addresses) have been added in the past, they will be fused to unique entries.

This PR bumps the database version to 4 without changing the structure. The version update is merely to signal that the unification of clients in the `network` table has been done on the given database.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
