### PR TITLE
Add support for DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,5 +157,6 @@ prefix=/usr
 # other requirements (correct ownership of files, etc.) is managed by
 # the service script on sudo service pihole-FTL (re)start
 install: pihole-FTL
-	install -m 0755 pihole-FTL $(prefix)/bin
-	/sbin/setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip $(prefix)/bin/pihole-FTL
+	mkdir -p $(DESTDIR)$(prefix)/bin
+	install -m 0755 pihole-FTL $(DESTDIR)$(prefix)/bin
+	/sbin/setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip $(DESTDIR)$(prefix)/bin/pihole-FTL

--- a/Makefile
+++ b/Makefile
@@ -151,12 +151,12 @@ version.h: version~
 	@echo '#endif // VERSION_H' >> "$@"
 	@echo "Making FTL version on branch $(GIT_BRANCH) - $(GIT_VERSION) ($(GIT_DATE))"
 
-prefix=/usr
+PREFIX=/usr
 
 # install target just installs the executable
 # other requirements (correct ownership of files, etc.) is managed by
 # the service script on sudo service pihole-FTL (re)start
 install: pihole-FTL
-	mkdir -p $(DESTDIR)$(prefix)/bin
-	install -m 0755 pihole-FTL $(DESTDIR)$(prefix)/bin
-	/sbin/setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip $(DESTDIR)$(prefix)/bin/pihole-FTL
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	install -m 0755 pihole-FTL $(DESTDIR)$(PREFIX)/bin
+	/sbin/setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip $(DESTDIR)$(PREFIX)/bin/pihole-FTL


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The `DESTDIR` variable is specified by the user on the make command line as an absolute file name. For example:
```
sudo make DESTDIR=/tmp/stage install
```
Where the installation step would normally install `/usr/bin/pihole-FTL`, then an installation invoked as in the example above would install `/tmp/stage/usr/bin/pihole-FTL` instead. The `DESTDIR` path is created, if necessary. Note that `root` capabilities are nonetheless required for the `install` step as only `root` can add the required capabilities to the `pihole-FTL` binary.

This PR fixes #558

Prepending the variable `DESTDIR` to each target in this way provides for staged installs, where the installed files are not placed directly into their expected location but are instead copied into a temporary location (the `DESTDIR`). However, installed files maintain their relative directory structure and any embedded file names will not be modified following https://www.gnu.org/prep/standards/html_node/DESTDIR.html.