### PR TITLE
Tests: Test against WARNING and ERROR messages

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -16,8 +16,8 @@ fi
 
 # Create necessary directories and files
 mkdir -p /etc/pihole /var/run/pihole /var/log
-touch /var/log/pihole-FTL.log
-chown pihole:pihole /etc/pihole /var/run/pihole /var/log/pihole-FTL.log
+touch /var/log/pihole-FTL.log /var/run/pihole-FTL.pid /var/run/pihole-FTL.port
+chown pihole:pihole /etc/pihole /var/run/pihole /var/log/pihole-FTL.log /var/run/pihole-FTL.pid /var/run/pihole-FTL.port
 
 # Copy binary into a location the new user pihole can access
 cp ./pihole-FTL /home/pihole

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -263,7 +263,7 @@
 }
 
 @test "No WARNING messages in pihole-FTL.log (besides known capability issues)" {
-  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|(Starting pihole-FTL as user root is not recommended)"'
+  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -263,7 +263,7 @@
 }
 
 @test "No WARNING messages in pihole-FTL.log (besides known capability issues)" {
-  run bash -c 'grep "WARNING" /var/log/pihole-FTL.log' | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW"
+  run bash -c 'grep "WARNING" /var/log/pihole-FTL.log' | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|(Starting pihole-FTL as user root is not recommended)"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -263,19 +263,19 @@
 }
 
 @test "No WARNING messages in pihole-FTL.log (besides known capability issues)" {
-  run bash -c 'grep "WARNING" /var/log/pihole-FTL.log' | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|(Starting pihole-FTL as user root is not recommended)"'
+  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log' | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|(Starting pihole-FTL as user root is not recommended)"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }
 
 @test "No ERROR messages in pihole-FTL.log" {
-  run bash -c 'grep -c "ERROR" /var/log/pihole-FTL.log'
+  run bash -c 'grep -c "ERROR:" /var/log/pihole-FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }
 
 @test "No FATAL messages in pihole-FTL.log" {
-  run bash -c 'grep -c "FATAL" /var/log/pihole-FTL.log'
+  run bash -c 'grep -c "FATAL:" /var/log/pihole-FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -263,7 +263,7 @@
 }
 
 @test "No WARNING messages in pihole-FTL.log (besides known capability issues)" {
-  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log' | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|(Starting pihole-FTL as user root is not recommended)"'
+  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|(Starting pihole-FTL as user root is not recommended)"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -262,6 +262,18 @@
   [[ ${lines[3]} == "Available arguments:" ]]
 }
 
+@test "No WARNING messages in pihole-FTL.log (besides known capability issues)" {
+  run bash -c 'grep "WARNING" /var/log/pihole-FTL.log' | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0" ]]
+}
+
+@test "No ERROR messages in pihole-FTL.log" {
+  run bash -c 'grep -c "ERROR" /var/log/pihole-FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0" ]]
+}
+
 @test "No FATAL messages in pihole-FTL.log" {
   run bash -c 'grep -c "FATAL" /var/log/pihole-FTL.log'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Tests: Test against `WARNING` and `ERROR` messages in `pihole-FTL.log`. We explicitly ignore the two warnings complaining about missing capabilities. They are unavoidable on the testing machine.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
