### PR TITLE
Generate self-contained musl binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ version: 2
         name: "Build"
         command: |
           BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
-
-          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}"
+          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" CIRCLE_JOB="${CIRCLE_JOB}"
           file pihole-FTL
     - run:
         name: "Upload"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: 2
         name: "Build"
         command: |
           BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
-          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" CIRCLE_JOB="${CIRCLE_JOB}"
+          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" STATIC="${STATIC}"
           file pihole-FTL
     - run:
         name: "Upload"

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ LIBS=-pthread -lrt -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle
 # Flags for compiling with libidn2: -lidn2
 
 # Do we want to compile a statically linked musl executable?
-ifeq "$(CIRCLE_JOB)" "x86_64-musl"
+ifeq "$(STATIC)" "true"
   CC := $(CC) -Wl,-Bstatic -static-libgcc -static-pie
 else
   LIBS := $(LIBS) -Wl,-Bdynamic

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ GCCVERSION8 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 8)
 # -Wp,-D_FORTIFY_SOURCE=2 and -O1 or higher: This causes certain unsafe glibc functions to be replaced with their safer counterparts
 # -Wl,-z,relro: reduces the possible areas of memory in a program that can be used by an attacker that performs a successful memory corruption exploit
 # -Wl,-z,now: When combined with RELRO above, this further reduces the regions of memory available to memory corruption attacks
-# -pie -fPIE: For ASLR (address space layout randomization)
 # -g3: More debugging information
 # -fno-omit-frame-pointer: get nicer stacktraces
 # -funwind-tables: Generate static data for unwinding
@@ -43,7 +42,7 @@ GCCVERSION8 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 8)
 # -Wl,-z,defs: Detect and reject underlinking (phenomenon caused by missing shared library arguments when invoking the linked editor to produce another shared library)
 # -Wl,-z,now: Disable lazy binding
 # -Wl,-z,relro: Read-only segments after relocation
-HARDENING_FLAGS=-fstack-protector-strong -Wp,-D_FORTIFY_SOURCE=2 -O3 -Wl,-z,relro,-z,now -pie -fPIE -fexceptions -funwind-tables -fasynchronous-unwind-tables -Wl,-z,defs -Wl,-z,now -Wl,-z,relro
+HARDENING_FLAGS=-fstack-protector-strong -Wp,-D_FORTIFY_SOURCE=2 -O3 -Wl,-z,relro,-z,now -fexceptions -funwind-tables -fasynchronous-unwind-tables -Wl,-z,defs -Wl,-z,now -Wl,-z,relro
 DEBUG_FLAGS=-rdynamic -fno-omit-frame-pointer
 
 # -DSQLITE_OMIT_LOAD_EXTENSION: This option omits the entire extension loading mechanism from SQLite, including sqlite3_enable_load_extension() and sqlite3_load_extension() interfaces. (needs -ldl linking option, otherwise)
@@ -107,6 +106,8 @@ ifeq "$(CIRCLE_JOB)" "x86_64-musl"
   CC := $(CC) -Wl,-Bstatic -static-libgcc -static-pie
 else
   LIBS := $(LIBS) -Wl,-Bdynamic
+  # -pie -fPIE: (Dynamic) position independent executable
+  HARDENING_FLAGS := $(HARDENING_FLAGS) -pie -fPIE
 endif
 
 IDIR = .

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,16 @@ CCFLAGS=-std=gnu11 -I$(IDIR) $(WARNFLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLA
 # for FTL we need the pthread library
 # for dnsmasq we need the nettle crypto library and the gmp maths library
 # We link the two libraries statically. Although this increases the binary file size by about 1 MB, it saves about 5 MB of shared libraries and makes deployment easier
-#LIBS=-pthread -lnettle -lgmp -lhogweed
-LIBS=-pthread -lrt -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle -Wl,-Bdynamic
+LIBS=-pthread -lrt -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle
 # Flags for compiling with libidn : -lidn
 # Flags for compiling with libidn2: -lidn2
+
+# Do we want to compile a statically linked musl executable?
+ifeq "$(CIRCLE_JOB)" "x86_64-musl"
+  CC := $(CC) -Wl,-Bstatic -static-libgcc -static-pie
+else
+  LIBS := $(LIBS) -Wl,-Bdynamic
+endif
 
 IDIR = .
 ODIR = obj

--- a/docker/x86_64-musl/Dockerfile
+++ b/docker/x86_64-musl/Dockerfile
@@ -13,3 +13,4 @@ RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_lin
     mv ghr_*_linux_amd64/ghr /usr/bin/ghr
 
 ENV CC gcc
+ENV STATIC true

--- a/log.c
+++ b/log.c
@@ -140,7 +140,7 @@ void log_counter_info(void)
 void log_FTL_version(const bool crashreport)
 {
 	logg("FTL branch: %s", GIT_BRANCH);
-	logg("FTL version: %s", GIT_TAG);
+	logg("FTL version: %s", GIT_VERSION);
 	logg("FTL commit: %s", GIT_HASH);
 	logg("FTL date: %s", GIT_DATE);
 	if(crashreport)

--- a/log.c
+++ b/log.c
@@ -140,7 +140,7 @@ void log_counter_info(void)
 void log_FTL_version(const bool crashreport)
 {
 	logg("FTL branch: %s", GIT_BRANCH);
-	logg("FTL version: %s", GIT_VERSION);
+	logg("FTL version: %s", GIT_TAG);
 	logg("FTL commit: %s", GIT_HASH);
 	logg("FTL date: %s", GIT_DATE);
 	if(crashreport)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---


Compile x86_64-musl binary as static position independent executable. A static position independent executable is similar to static executable, but can be loaded at any address without a dynamic linker.

As a test, I downloaded the generated `pihole-FTL-musl-linux-x86_64` binary into a Debian-based `x86_64` container and made it executable. Thereafter, ran our test suite* using this binary and all tests succeeded.

---
*) For running the tests, 
- cloned the `FTL` repository, 
- checked out the current `development` branch,
- copied the previously downloaded binary into the cloned directory, and
- ran `test/run.sh`.

I did *not* build the binary in the cloned repository.