### PR TITLE
Unify version determination mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ version.h: version~
 	@echo '#define GIT_TAG "$(GIT_TAG)"' >> "$@"
 	@echo '#define GIT_HASH "$(GIT_HASH)"' >> "$@"
 	@echo '#endif // VERSION_H' >> "$@"
-	@echo "Making FTL version on branch $(GIT_BRANCH) - $(GIT_VERSION) ($(GIT_DATE))"
+	@echo "Making FTL version on branch $(GIT_BRANCH) - $(GIT_VERSION) / $(GIT_TAG) / $(GIT_HASH) ($(GIT_DATE))"
 
 PREFIX=/usr
 SETCAP = $(shell which setcap)

--- a/api.c
+++ b/api.c
@@ -967,8 +967,9 @@ void getQueryTypesOverTime(const int *sock)
 
 void getVersion(const int *sock)
 {
-	const char * commit = GIT_HASH;
-	const char * tag = GIT_TAG;
+	const char *commit = GIT_HASH;
+	const char *tag = GIT_TAG;
+	const char *version = get_FTL_version();
 
 	// Extract first 7 characters of the hash
 	char hash[8];
@@ -979,10 +980,10 @@ void getVersion(const int *sock)
 			ssend(
 					*sock,
 					"version %s\ntag %s\nbranch %s\nhash %s\ndate %s\n",
-					GIT_VERSION, tag, GIT_BRANCH, hash, GIT_DATE
+					version, tag, GIT_BRANCH, hash, GIT_DATE
 			);
 		else {
-			if(!pack_str32(*sock, GIT_VERSION) ||
+			if(!pack_str32(*sock, version) ||
 					!pack_str32(*sock, (char *) tag) ||
 					!pack_str32(*sock, GIT_BRANCH) ||
 					!pack_str32(*sock, hash) ||

--- a/args.c
+++ b/args.c
@@ -51,19 +51,7 @@ void parse_args(int argc, char* argv[])
 		   strcmp(argv[i], "version") == 0 ||
 		   strcmp(argv[i], "--version") == 0)
 		{
-			const char * tag = GIT_TAG;
-			if(strlen(tag) > 1)
-			{
-				printf("%s\n",GIT_VERSION);
-			}
-			else
-			{
-				const char * commit = GIT_HASH;
-				char hash[8];
-				// Extract first 7 characters of the hash
-				memcpy(hash, commit, 7); hash[7] = 0;
-				printf("vDev-%s\n", hash);
-			}
+			printf("%s\n", get_FTL_version());
 			exit(EXIT_SUCCESS);
 		}
 

--- a/dnsmasq/option.c
+++ b/dnsmasq/option.c
@@ -20,7 +20,7 @@
 #include <setjmp.h>
 
 /* Pi-hole modification */
-#include "../version.h"
+extern char *get_FTL_version(void);
 /************************/
 
 static volatile int mem_recover = 0;
@@ -4777,7 +4777,7 @@ void read_opts(int argc, char **argv, char *compile_opts)
   /************************/
 #endif
   /******** Pi-hole modification ********/
-  add_txt("version.FTL", GIT_VERSION, 0 );
+  add_txt("version.FTL", get_FTL_version(), 0 );
   /**************************************/
 
   while (1)

--- a/log.c
+++ b/log.c
@@ -140,11 +140,37 @@ void log_counter_info(void)
 void log_FTL_version(const bool crashreport)
 {
 	logg("FTL branch: %s", GIT_BRANCH);
-	logg("FTL version: %s", GIT_TAG);
+	logg("FTL version: %s", get_FTL_version());
 	logg("FTL commit: %s", GIT_HASH);
 	logg("FTL date: %s", GIT_DATE);
 	if(crashreport)
 		logg("FTL user: started as %s, ended as %s", username, getUserName());
 	else
 		logg("FTL user: %s", username);
+}
+
+static char *FTLversion = NULL;
+const char __attribute__ ((malloc)) *get_FTL_version(void)
+{
+	// Obtain FTL version if not already determined
+	if(FTLversion == NULL)
+	{
+		const char *tag = GIT_TAG;
+		if(strlen(tag) > 1)
+		{
+			FTLversion = strdup(GIT_VERSION);
+		}
+		else
+		{
+			const char *commit = GIT_HASH;
+			FTLversion = calloc(13, sizeof(char));
+			// Build version by appending 7 characters of the hash to "vDev-"
+			memcpy(FTLversion, "vDev-", 5);
+			memcpy(FTLversion+5, commit, 7);
+			// Zero-terminate string
+			FTLversion[12] = 0;
+		}
+	}
+
+	return FTLversion;
 }

--- a/log.c
+++ b/log.c
@@ -155,20 +155,15 @@ const char __attribute__ ((malloc)) *get_FTL_version(void)
 	// Obtain FTL version if not already determined
 	if(FTLversion == NULL)
 	{
-		const char *tag = GIT_TAG;
-		if(strlen(tag) > 1)
+		if(strlen(GIT_TAG) > 1)
 		{
 			FTLversion = strdup(GIT_VERSION);
 		}
 		else
 		{
-			const char *commit = GIT_HASH;
 			FTLversion = calloc(13, sizeof(char));
 			// Build version by appending 7 characters of the hash to "vDev-"
-			memcpy(FTLversion, "vDev-", 5);
-			memcpy(FTLversion+5, commit, 7);
-			// Zero-terminate string
-			FTLversion[12] = 0;
+			snprintf(FTLversion, 13, "vDev-%.7s", GIT_HASH);
 		}
 	}
 

--- a/routines.h
+++ b/routines.h
@@ -24,6 +24,7 @@ void open_FTL_log(const bool test);
 void logg(const char* format, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 void log_counter_info(void);
 void format_memory_size(char *prefix, unsigned long int bytes, double *formated);
+const char *get_FTL_version(void) __attribute__ ((malloc));
 void log_FTL_version(bool crashreport);
 void get_timestr(char *timestring, const time_t timein);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

So far we used a different algorithm to determine the version in `pihole -v` and other places. This is inconsistent and, hence, a potential bug.

This PR fixes this by providing a common function based on the command line result.

---

Exemplary output in the log file:
```
[2019-06-18 20:18:52.296 365] FTL branch: fix/versions
[2019-06-18 20:18:52.296 365] FTL version: vDev-e0c3577
[2019-06-18 20:18:52.296 365] FTL commit: e0c3577
[2019-06-18 20:18:52.296 365] FTL date: 2019-06-18 22:16:16 +0200
[2019-06-18 20:18:52.296 365] FTL user: pihole
```

Exemplary output of `pihole-FTL -v`:
```
vDev-e0c3577
```

Exemplary output through API:
```
version vDev-e0c3577
tag 
branch fix/versions
hash e0c3577
date 2019-06-18 22:16:16 +0200
```
