### PR TITLE
Use whitelist table in gravity.db directly

### DIFF
--- a/dnsmasq_interface.c
+++ b/dnsmasq_interface.c
@@ -382,22 +382,23 @@ void FTL_dnsmasq_reload(void)
 	// its own behalf (on initial reading, the config file is already opened)
 	get_blocking_mode(NULL);
 
-	// Reread regex.list
-	// Free regex list and array of whitelisted domains
+	// Reread pihole-FTL.conf to see which debugging flags are set
+	read_debuging_settings(NULL);
+
+	// Free regex list
 	free_regex();
-	free_whitelist_domains();
+
+	// (Re-)open gravity database connection
+	gravityDB_close();
+	gravityDB_open();
 
 	// Start timer for regex compilation analysis
 	timer_start(REGEX_TIMER);
 	// Read and compile possible regex filters
+	// only after having called gravityDB_open()
 	read_regex_from_database();
-	// Read whitelisted domains from database
-	read_whitelist_from_database();
 	// Log result
-	log_regex_whitelist(timer_elapsed_msec(REGEX_TIMER));
-
-	// Reread pihole-FTL.conf to see which debugging flags are set
-	read_debuging_settings(NULL);
+	log_regex(timer_elapsed_msec(REGEX_TIMER));
 
 	// Print current set of capabilities if requested via debug flag
 	if(config.debug & DEBUG_CAPS)

--- a/gravity.c
+++ b/gravity.c
@@ -32,7 +32,8 @@ bool gravityDB_open(void)
 	}
 
 	int rc = sqlite3_open_v2(FTLfiles.gravitydb, &gravitydb, SQLITE_OPEN_READONLY, NULL);
-	if( rc ){
+	if( rc )
+	{
 		logg("gravityDB_open() - SQL error (%i): %s", rc, sqlite3_errmsg(gravitydb));
 		gravityDB_close();
 		return false;
@@ -42,7 +43,8 @@ bool gravityDB_open(void)
 	// temporary tables, indices, and views.
 	char *zErrMsg = NULL;
 	rc = sqlite3_exec(gravitydb, "PRAGMA temp_store = MEMORY", NULL, NULL, &zErrMsg);
-	if( rc != SQLITE_OK ){
+	if( rc != SQLITE_OK )
+	{
 		logg("gravityDB_open(PRAGMA temp_store) - SQL error (%i): %s", rc, zErrMsg);
 		sqlite3_free(zErrMsg);
 		gravityDB_close();
@@ -56,7 +58,8 @@ bool gravityDB_open(void)
 	// returns true as soon as it sees the first row from the query inside
 	// of EXISTS().
 	rc = sqlite3_prepare_v2(gravitydb, "SELECT EXISTS(SELECT domain from vw_whitelist WHERE domain = ?);", -1, &whitelist_stmt, NULL);
-	if( rc ){
+	if( rc )
+	{
 		logg("gravityDB_open(\"SELECT EXISTS(...)\") - SQL error prepare (%i): %s", rc, sqlite3_errmsg(gravitydb));
 		gravityDB_close();
 		return false;
@@ -72,6 +75,10 @@ bool gravityDB_open(void)
 
 void gravityDB_close(void)
 {
+	// Return early if gravity database is not available
+	if(!gravity_database_avail)
+		return;
+
 	// Finalize whitelist scanning statement
 	sqlite3_finalize(whitelist_stmt);
 
@@ -86,7 +93,10 @@ void gravityDB_close(void)
 bool gravityDB_getTable(const unsigned char list)
 {
 	if(!gravity_database_avail)
+	{
+		logg("gravityDB_getTable(%d): Gravity database not available", list);
 		return false;
+	}
 
 	// Select correct query string to be used depending on list to be read
 	const char *querystr = NULL;
@@ -108,7 +118,8 @@ bool gravityDB_getTable(const unsigned char list)
 
 	// Prepare SQLite3 statement
 	int rc = sqlite3_prepare_v2(gravitydb, querystr, -1, &stmt, NULL);
-	if( rc ){
+	if( rc )
+	{
 		logg("readGravity(%s) - SQL error prepare (%i): %s", querystr, rc, sqlite3_errmsg(gravitydb));
 		gravityDB_close();
 		return false;
@@ -167,7 +178,10 @@ void gravityDB_finalizeTable(void)
 int gravityDB_count(const unsigned char list)
 {
 	if(!gravity_database_avail)
+	{
+		logg("gravityDB_count(%d): Gravity database not available", list);
 		return DB_FAILED;
+	}
 
 	// Select correct query string to be used depending on list to be read
 	const char* querystr = NULL;

--- a/main.c
+++ b/main.c
@@ -90,10 +90,12 @@ int main (int argc, char* argv[])
 
 	// Free regex list and array of whitelisted domains
 	free_regex();
-	free_whitelist_domains();
 
 	// Remove shared memory objects
 	destroy_shmem();
+
+	// Close gravity database connection
+	gravityDB_close();
 
 	//Remove PID file
 	removepid();

--- a/request.c
+++ b/request.c
@@ -167,15 +167,12 @@ void process_request(const char *client_message, int *sock)
 		// Reread regex.list
 		// Free regex list and array of whitelisted domains
 		free_regex();
-		free_whitelist_domains();
 		// Start timer for regex compilation analysis
 		timer_start(REGEX_TIMER);
 		// Read and compile possible regex filters
 		read_regex_from_database();
-		// Read whitelisted domains from database
-		read_whitelist_from_database();
 		// Log result
-		log_regex_whitelist(timer_elapsed_msec(REGEX_TIMER));
+		log_regex(timer_elapsed_msec(REGEX_TIMER));
 		unlock_shm();
 	}
 	else if(command(client_message, ">update-mac-vendor"))

--- a/routines.h
+++ b/routines.h
@@ -118,11 +118,8 @@ void resolveForwardDestinations(const bool onlynew);
 // regex.c
 bool match_regex(const char *input);
 void free_regex(void);
-void free_whitelist_domains(void);
 void read_regex_from_database(void);
-void read_whitelist_from_database(void);
-bool in_whitelist(const char *domain) __attribute__((pure));
-void log_regex_whitelist(const double time);
+void log_regex(const double time);
 
 // shmem.c
 bool init_shmem(void);
@@ -164,8 +161,12 @@ void parse_arp_cache(void);
 void updateMACVendorRecords(void);
 
 // gravity.c
+bool gravityDB_open(void);
+void gravityDB_close(void);
 bool gravityDB_getTable(unsigned char list);
 const char* gravityDB_getDomain(void);
 void gravityDB_finalizeTable(void);
 int gravityDB_count(unsigned char list);
+bool in_whitelist(const char *domain);
+
 #endif // ROUTINES_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

Use `vw_whitelist` view of table `whitelist` when checking if a domain is contained in the whitelist instead of copying whitelisted domains on receipt of `SIGHUP` into FTL's memory.
This change will not only decrease FTL's memory footprint but also allow a much better scaling to very large / huge whitelists (looking into the 100k+ domains regime).

---

To achieve good performance, we constantly keep the database connection to `gravity.db` open to have a prepared (= precompiled to SQLite byte code) statement ready for querying the whitelist.

In vivo tests on a Raspberry Pi with a whitelist containing 100.000 whitelisted domains combined with the regex `.` (matches any character) confirms that checking the whitelist should not take longer than typically 2 milliseconds, even for very large whitelists. The fast reaction is achieved by using `SELECT EXISTS(...)` which is highly optimized:
```sql
SELECT EXISTS(SELECT domain from vw_whitelist WHERE domain = ?);
```

Note that querying strategies like
```sql
SELECT COUNT(*) FROM vw_whitelist WHERE domain = ?;
```
are less performant as they will almost always result in an iterating co-routine (even when the column in the `WHERE` clause is `UNIQUE`!)
In contrast, `SELECT EXISTS(...)` immediately returns when it finds the first occurrence of the contained `SELECT` statement. The domain itself will be bound at lookup time using SQLite bindings (placeholder `?`).

---

A drawback of relying on the always-open connection to the whitelist view is that when the database is locked (e.g., `pihole -g` is currently storing the blocked domains), we cannot check whether a domain in contained in the whitelist or not. To avoid blocking the DNS service until gravity is eventually done, we immediately return and assume that the domain was **not** on the whitelist. In this case, we log like
```
[2019-06-23 18:41:18.419 22527] in_whitelist("badbad.de"): Database is busy, assuming domain is NOT whitelisted",

```
As gravity will send `SIGHUP` at the end, this possibly wrong cache entry will be removed soon after the query was made. On the next query of this domain, the database should not be locked any more and the query to the database can succeed.

---

Overall, the benefits seem to outweigh the drawbacks but this PR may serve as a discussion platform.

This PR fixes #596 (at least partially).