### PR TITLE
Change SQLITE_TRANSIENT to SQLITE_STATIC

### DIFF
--- a/database.c
+++ b/database.c
@@ -526,18 +526,18 @@ void save_to_DB(void)
 
 		// DOMAIN
 		const char *domain = getDomainString(queryID);
-		sqlite3_bind_text(stmt, 4, domain, -1, SQLITE_TRANSIENT);
+		sqlite3_bind_text(stmt, 4, domain, -1, SQLITE_STATIC);
 
 		// CLIENT
 		const char *client = getClientIPString(queryID);
-		sqlite3_bind_text(stmt, 5, client, -1, SQLITE_TRANSIENT);
+		sqlite3_bind_text(stmt, 5, client, -1, SQLITE_STATIC);
 
 		// FORWARD
 		if(query->status == QUERY_FORWARDED && query->forwardID > -1)
 		{
 			// Get forward pointer
 			const forwardedData* forward = getForward(query->forwardID, true);
-			sqlite3_bind_text(stmt, 6, getstr(forward->ippos), -1, SQLITE_TRANSIENT);
+			sqlite3_bind_text(stmt, 6, getstr(forward->ippos), -1, SQLITE_STATIC);
 		}
 		else
 		{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

If the fifth argument of `sqlite3_bind_text()` has the value `SQLITE_TRANSIENT`, then SQLite makes its own private copy of the data immediately, before the routine returns. If, however, the argument is `SQLITE_STATIC`, then SQLite assumes that the information is in static, unmanaged space and does not need to be freed.

As the scope of all strings we pass to the binding routines is larger/longer than the scope of the entire transaction, we can safely use `SQLITE_STATIC` here to avoid unnecessary and possibly time-consuming memory duplication.