### PR TITLE
Database error checking

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -3,7 +3,7 @@
 *  Network-wide ad blocking via your own hardware.
 *
 *  FTL Engine
-*  Common database routines
+*  Common database routines for pihole-FTL.db
 *
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
@@ -203,9 +203,11 @@ void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg)
 
 void db_init(void)
 {
-	// First check if the user doesn't want to use the database and set an
-	// empty string as file name in FTL's config file
-	if(FTLfiles.FTL_db == NULL || strlen(FTLfiles.FTL_db) == 0)
+	// First check if the user doesn't want to use the database and set
+	// an empty string as file name in FTL's config file or configured
+	// a maximum history of zero days
+	if(FTLfiles.FTL_db == NULL || strlen(FTLfiles.FTL_db) == 0 ||
+	   config.maxDBdays == 0)
 	{
 		database = false;
 		return;

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -81,9 +81,7 @@ bool dbopen(void)
 
 bool dbquery(const char *format, ...)
 {
-	char *zErrMsg = NULL;
 	va_list args;
-
 	va_start(args, format);
 	char *query = sqlite3_vmprintf(format, args);
 	va_end(args);
@@ -108,11 +106,9 @@ bool dbquery(const char *format, ...)
 		logg("dbquery: \"%s\"", query);
 	}
 
-	int rc = sqlite3_exec(FTL_db, query, NULL, NULL, &zErrMsg);
+	int rc = sqlite3_exec(FTL_db, query, NULL, NULL, NULL);
 
 	if( rc != SQLITE_OK ){
-		logg("dbquery(%s) - SQL error (%i): %s", query, rc, zErrMsg);
-		sqlite3_free(zErrMsg);
 		check_database(rc);
 		return false;
 	}

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -19,7 +19,10 @@
 #include "files.h"
 
 sqlite3 *FTL_db;
-bool database = false;
+// This boolean is set to false once we hit the
+// first database error to prevent further access
+// to the pihole-FTL.db database
+bool database = true;
 bool DBdeleteoldqueries = false;
 long int lastdbindex = 0;
 
@@ -235,9 +238,6 @@ void db_init(void)
 		return;
 	}
 
-	// Database connection is not open
-	database = true;
-
 	// Test FTL_db version and see if we need to upgrade the database file
 	int dbversion = db_get_FTL_property(DB_VERSION);
 	logg("Database version is %i", dbversion);
@@ -320,7 +320,6 @@ void db_init(void)
 	}
 
 	logg("Database successfully initialized");
-	database = true;
 }
 
 int db_get_FTL_property(const unsigned int ID)

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -35,14 +35,14 @@ extern bool DBdeleteoldqueries;
 // Database macros
 #define SQL_bool(sql) {\
 	if(!dbquery(sql)) {\
-		logg("%s(): \"%s\" failed!", __FUNCTION__, sql);\
+		logg("ERROR: %s() failed!", __FUNCTION__);\
 		return false;\
 	}\
 }
 
 #define SQL_void(sql) {\
 	if(!dbquery(sql)) {\
-		logg("%s(): \"%s\" failed!", __FUNCTION__, sql);\
+		logg("ERROR: %s() failed!", __FUNCTION__);\
 		return;\
 	}\
 }

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -284,18 +284,11 @@ bool unify_hwaddr(void)
 	// The grouping is constrained by the HAVING clause which is
 	// evaluated once across all rows of a group to ensure the returned
 	// set represents the most recent entry for a given hwaddr
-	char* querystr = NULL;
-	int ret = asprintf(&querystr, "SELECT id,hwaddr FROM network GROUP BY hwaddr HAVING MAX(lastQuery)");
-	if(querystr == NULL || ret < 0)
-	{
-		logg("Memory allocation failed in unify_hwaddr (%i)", ret);
-		dbclose();
-		return false;
-	}
+	const char* querystr = "SELECT id,hwaddr FROM network GROUP BY hwaddr HAVING MAX(lastQuery)";
 
 	// Perform SQL query
 	sqlite3_stmt* stmt;
-	ret = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
+	int ret = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
 	if( ret != SQLITE_OK ){
 		logg("unify_hwaddr(%s) - SQL error prepare (%i): %s", querystr, ret, sqlite3_errmsg(FTL_db));
 		check_database(ret);
@@ -338,7 +331,6 @@ bool unify_hwaddr(void)
 
 	// Finalize statement and free query string
 	sqlite3_finalize(stmt);
-	free(querystr);
 
 	// Ensure hwaddr is a unique field
 	// Unfortunately, SQLite's ALTER TABLE does not support adding

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -232,9 +232,6 @@ void delete_old_queries_in_DB(void)
 
 	// Close database
 	dbclose();
-
-	// Re-enable database actions
-	database = true;
 }
 
 // Get most recent 24 hours data from long-term database

--- a/src/main.c
+++ b/src/main.c
@@ -68,8 +68,7 @@ int main (int argc, char* argv[])
 		logg("WARNING: Starting pihole-FTL as user %s is not recommended", username);
 
 	// Initialize database
-	if(config.maxDBdays != 0)
-		db_init();
+	db_init();
 
 	// Try to import queries from long-term database if available
 	if(database && config.DBimport)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Improve error checking in the database routines to cover all actions that can fail, e.g., due to readonly database errors.

- Check if the `pihole-FTL.db` database is still available at the beginning of all database routines in `database/common.c`
- Log if we failed to update the database from version 3 -> 4 and return early if this is the case.
- Simplify logging in case of an error.
    Previously:
    ```
    [2019-07-06 17:00:55.526 32339] SQLite3 message: statement aborts at 36: [CREATE UNIQUE INDEX network_hwaddr_idx ON network(hwaddr)] attempt to write a readonly database (8)
    [2019-07-06 17:00:55.526 32339] dbquery(CREATE UNIQUE INDEX network_hwaddr_idx ON network(hwaddr)) - SQL error (8): attempt to write a readonly database
    [2019-07-06 17:00:55.526 32339] check_database(8): Disabling database connection due to error
    [2019-07-06 17:00:55.526 32339] unify_hwaddr(): "CREATE UNIQUE INDEX network_hwaddr_idx ON network(hwaddr)" failed!
    ```
    Now:
    ```
    [2019-07-06 17:00:55.526 32339] SQLite3 message: statement aborts at 36: [CREATE UNIQUE INDEX network_hwaddr_idx ON network(hwaddr)] attempt to write a readonly database (8)
    [2019-07-06 17:00:55.526 32339] check_database(8): Disabling database connection due to error
    [2019-07-06 17:00:55.526 32339] ERROR: unify_hwaddr() failed!
    ```