### PR TITLE
Improve debug flag handling in config file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -516,6 +516,22 @@ void get_blocking_mode(FILE *fp)
 		fclose(fp);
 }
 
+// Routine for setting the debug flags in the config struct
+static void setDebugOption(FILE* fp, const char* option, int16_t bitmask)
+{
+	const char* buffer = parse_FTLconf(fp, option);
+
+	// Return early if the key has not been found in FTL's config file
+	if(buffer == NULL)
+		return;
+
+	// Set bit if value equals "true", clear bit otherwise
+	if(strcasecmp(buffer, "true") == 0)
+		config.debug |= bitmask;
+	else
+		config.debug &= ~bitmask;
+}
+
 void read_debuging_settings(FILE *fp)
 {
 	// Set default (no debug instructions set)
@@ -532,92 +548,63 @@ void read_debuging_settings(FILE *fp)
 		opened = true;
 	}
 
+	// DEBUG_ALL
+	// defaults to: false
+	// ~0 is a shortcut for "all bits set"
+	setDebugOption(fp, "DEBUG_ALL", ~(int16_t)0);
+
 	// DEBUG_DATABASE
 	// defaults to: false
-	char* buffer = parse_FTLconf(fp, "DEBUG_DATABASE");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_DATABASE;
+	setDebugOption(fp, "DEBUG_DATABASE", DEBUG_DATABASE);
 
 	// DEBUG_NETWORKING
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_NETWORKING");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_NETWORKING;
+	setDebugOption(fp, "DEBUG_NETWORKING", DEBUG_NETWORKING);
 
 	// DEBUG_LOCKS
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_LOCKS");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_LOCKS;
+	setDebugOption(fp, "DEBUG_LOCKS", DEBUG_LOCKS);
 
 	// DEBUG_QUERIES
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_QUERIES");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_QUERIES;
+	setDebugOption(fp, "DEBUG_QUERIES", DEBUG_QUERIES);
 
 	// DEBUG_FLAGS
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_FLAGS");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_FLAGS;
+	setDebugOption(fp, "DEBUG_FLAGS", DEBUG_FLAGS);
 
 	// DEBUG_SHMEM
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_SHMEM");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_SHMEM;
+	setDebugOption(fp, "DEBUG_SHMEM", DEBUG_SHMEM);
 
 	// DEBUG_GC
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_GC");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_GC;
+	setDebugOption(fp, "DEBUG_GC", DEBUG_GC);
 
 	// DEBUG_ARP
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_ARP");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_ARP;
+	setDebugOption(fp, "DEBUG_ARP", DEBUG_ARP);
 
 	// DEBUG_REGEX or REGEX_DEBUGMODE (legacy config option)
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_REGEX");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_REGEX;
-	buffer = parse_FTLconf(fp, "REGEX_DEBUGMODE");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_REGEX;
+	setDebugOption(fp, "REGEX_DEBUGMODE", DEBUG_REGEX);
+	setDebugOption(fp, "DEBUG_REGEX", DEBUG_REGEX);
 
 	// DEBUG_API
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_API");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_API;
+	setDebugOption(fp, "DEBUG_API", DEBUG_API);
 
 	// DEBUG_OVERTIME
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_OVERTIME");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_OVERTIME;
+	setDebugOption(fp, "DEBUG_OVERTIME", DEBUG_OVERTIME);
 
 	// DEBUG_EXTBLOCKED
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_EXTBLOCKED");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_EXTBLOCKED;
+	setDebugOption(fp, "DEBUG_EXTBLOCKED", DEBUG_EXTBLOCKED);
 
 	// DEBUG_CAPS
 	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_CAPS");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug |= DEBUG_CAPS;
-
-	// DEBUG_ALL
-	// defaults to: false
-	buffer = parse_FTLconf(fp, "DEBUG_ALL");
-	if(buffer != NULL && strcasecmp(buffer, "true") == 0)
-		config.debug = ~0;
+	setDebugOption(fp, "DEBUG_CAPS", DEBUG_CAPS);
 
 	if(config.debug)
 	{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Currently, setting `DEBUG_ALL` to `true` forces all debugging options to be enabled. If one would want to enable all *but* a single debug option, they had to manually add all except the one they don't want.

With this change, debug options can now selectively be removed even when `DEBUG_ALL` is set to `true`.

Possible use cases:
- `DEBUG_ALL` is unset or set to `false`: No change to previous behavior, all flags need to be enabled individually
- `DEBUG_ALL` is set to `true`: No change to previous behavior, all debug flags are enabled
    - However, flags can now be selectively disabled. This was not possible before.

Example:

Config file:
```
DEBUG_ALL=true
DEBUG_REGEX=false
```

Startup message of FTL
```
[2019-07-09 21:57:21.939 7925] ************************
[2019-07-09 21:57:21.939 7925] * Debugging enabled    *
[2019-07-09 21:57:21.940 7925] * DEBUG_DATABASE   YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_NETWORKING YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_LOCKS      YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_QUERIES    YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_FLAGS      YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_SHMEM      YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_GC         YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_ARP        YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_REGEX      NO  *
[2019-07-09 21:57:21.940 7925] * DEBUG_API        YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_OVERTIME   YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_EXTBLOCKED YES *
[2019-07-09 21:57:21.940 7925] * DEBUG_CAPS       YES *
[2019-07-09 21:57:21.940 7925] ************************
```

Especially with the new whitelist regex filters, one might want to selectively remove the `DEBUG_REGEX` flag as it would otherwise log each match. This might be very verbose for general filters matching, e.g., TLDs.

---

Note that the order in the config file doesn't matter,
```
DEBUG_ALL=true
DEBUG_REGEX=false
```
is identical to
```
DEBUG_REGEX=false
DEBUG_ALL=true
```