### PR TITLE
Print architecture FTL was compiled for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: 2
         name: "Build"
         command: |
           BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
-          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" STATIC="${STATIC}"
+          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" STATIC="${STATIC}" CI_JOB="${CIRCLE_JOB}"
           file pihole-FTL
     - run:
         name: "Upload"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: 2
         name: "Build"
         command: |
           BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
-          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" STATIC="${STATIC}" CI_JOB="${CIRCLE_JOB}"
+          make GIT_BRANCH="${BRANCH}" GIT_TAG="${CIRCLE_TAG}" STATIC="${STATIC}"
           file pihole-FTL
     - run:
         name: "Upload"

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,15 @@ pihole-FTL: $(_FTL_OBJ) $(_DNSMASQ_OBJ) $(DB_OBJ_DIR)/sqlite3.o
 clean:
 	rm -rf $(ODIR) pihole-FTL
 
+# If CI_JOB is unset (local compilation), ask uname -m and add locally compiled comment)
+ifeq ($(strip $(CI_JOB)),)
+FTL_ARCH := $(shell uname -m) (compiled locally)
+else
+FTL_ARCH := $(ARCH) (compiled on CI)
+endif
+# Get compiler version
+FTL_CC := $(shell $(CC) --version | head -n 1)
+
 # # recreate version.h when GIT_VERSION changes, uses temporary file version~
 $(IDIR)/version~: force
 	@echo '$(GIT_BRANCH) $(GIT_VERSION) $(GIT_DATE) $(GIT_TAG)' | cmp -s - $@ || echo '$(GIT_BRANCH) $(GIT_VERSION) $(GIT_DATE) $(GIT_TAG)' > $@
@@ -171,6 +180,8 @@ $(IDIR)/version.h: $(IDIR)/version~
 	@echo '#define GIT_BRANCH "$(GIT_BRANCH)"' >> "$@"
 	@echo '#define GIT_TAG "$(GIT_TAG)"' >> "$@"
 	@echo '#define GIT_HASH "$(GIT_HASH)"' >> "$@"
+	@echo '#define FTL_ARCH "$(FTL_ARCH)"' >> "$@"
+	@echo '#define FTL_CC "$(FTL_CC)"' >> "$@"
 	@echo '#endif // VERSION_H' >> "$@"
 	@echo "Making FTL version on branch $(GIT_BRANCH) - $(GIT_VERSION) / $(GIT_TAG) / $(GIT_HASH) ($(GIT_DATE))"
 

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ pihole-FTL: $(_FTL_OBJ) $(_DNSMASQ_OBJ) $(DB_OBJ_DIR)/sqlite3.o
 clean:
 	rm -rf $(ODIR) pihole-FTL
 
-# If CIRCLE_JOB is unset (local compilation), ask uname -m and add locally compiled comment)
+# If CIRCLE_JOB is unset (local compilation), ask uname -m and add locally compiled comment
 ifeq ($(strip $(CIRCLE_JOB)),)
 FTL_ARCH := $(shell uname -m) (compiled locally)
 else

--- a/Makefile
+++ b/Makefile
@@ -160,11 +160,11 @@ pihole-FTL: $(_FTL_OBJ) $(_DNSMASQ_OBJ) $(DB_OBJ_DIR)/sqlite3.o
 clean:
 	rm -rf $(ODIR) pihole-FTL
 
-# If CI_JOB is unset (local compilation), ask uname -m and add locally compiled comment)
-ifeq ($(strip $(CI_JOB)),)
+# If CIRCLE_JOB is unset (local compilation), ask uname -m and add locally compiled comment)
+ifeq ($(strip $(CIRCLE_JOB)),)
 FTL_ARCH := $(shell uname -m) (compiled locally)
 else
-FTL_ARCH := $(ARCH) (compiled on CI)
+FTL_ARCH := $(CIRCLE_JOB) (compiled on CI)
 endif
 # Get compiler version
 FTL_CC := $(shell $(CC) --version | head -n 1)

--- a/src/log.c
+++ b/src/log.c
@@ -155,6 +155,7 @@ void log_FTL_version(const bool crashreport)
 		logg("FTL user: started as %s, ended as %s", username, getUserName());
 	else
 		logg("FTL user: %s", username);
+	logg("Compiled for %s using %s", FTL_ARCH, FTL_CC);
 }
 
 static char *FTLversion = NULL;

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -339,3 +339,23 @@
   [[ "${STATIC}" != "true" && "${lines[@]}" == *"interpreter"* ]] || \
   [[ "${STATIC}" == "true" && "${lines[@]}" != *"interpreter"* ]]
 }
+
+@test "Architecture is correctly reported on startup" {
+  run bash -c 'grep "Compiled for" /var/log/pihole-FTL.log'
+  printf "Output: %s\n\$CIRCLE_JOB: %s\nuname -m: %s\n" "${lines[@]:-not set}" "${CIRCLE_JOB:-not set}" "$(uname -m)"
+  [[ ${lines[0]} == *"Compiled for ${CIRCLE_JOB:-$(uname -m)}"* ]]
+}
+
+@test "Building machine (CI) is reported on startup" {
+  [[ ${CIRCLE_JOB} != "" ]] && compiled_str="on CI" || compiled_str="locally" && export compiled_str
+  run bash -c 'grep "Compiled for" /var/log/pihole-FTL.log'
+  printf "Output: %s\n\$CIRCLE_JOB: %s\n" "${lines[@]:-not set}" "${CIRCLE_JOB:-not set}"
+  [[ ${lines[0]} == *"(compiled ${compiled_str})"* ]]
+}
+
+@test "Compiler version is correctly reported on startup" {
+  compiler_version="$(${CC} --version | head -n1)" && export compiler_version
+  run bash -c 'grep "Compiled for" /var/log/pihole-FTL.log'
+  printf "Output: %s\n\$CC: %s\nVersion: %s\n" "${lines[@]:-not set}" "${CC:-not set}" "${compiler_version:-not set}"
+  [[ ${lines[0]} == *"using ${compiler_version}"* ]]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Print architecture and compiler (incl. version) used to compile the `pihole-FTL` binary. This information will be logged and will also be contained in each crash log.

Example for a pre-compiled binary:
```
[2019-07-15 14:52:37.279 20967] ########## FTL started! ##########
[2019-07-15 14:52:37.279 20967] FTL branch: development
[2019-07-15 14:52:37.279 20967] FTL version: v4.3-303-g5e85489-dirty
[2019-07-15 14:52:37.279 20967] FTL commit: 5e85489-dirty
[2019-07-15 14:52:37.279 20967] FTL date: 2019-07-08 23:09:45 -0400
[2019-07-15 14:52:37.279 20967] FTL user: pihole
[2019-07-15 14:52:37.279 20967] Compiled for x86_64 (compiled on CI) using gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
```

Example for a locally compiled binary:
```
[2019-07-15 15:17:23.348 14046] ########## FTL started! ##########
[2019-07-15 15:17:23.348 14046] FTL branch: development
[2019-07-15 15:17:23.348 14046] FTL version: v4.3-303-g5e85489-dirty
[2019-07-15 15:17:23.348 14046] FTL commit: 5e85489-dirty
[2019-07-15 15:17:23.348 14046] FTL date: 2019-07-08 23:09:45 -0400
[2019-07-15 15:17:23.349 14046] FTL user: pihole
[2019-07-15 15:17:23.349 14046] Compiled for x86_64 (compiled locally) using gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
```

I also added three tests for the reported architecture, build machine (local or CI), and compiler version reporting. The tests are adaptive as in that they dynamically detect whether the current build is happening in the CI (detected using the `$CIRCLE_JOB` variable) and checking accordingly.