### PR TITLE
Fix failure during parse_neighbor_cache not unlocking shared memory

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -82,7 +82,7 @@ bool dbopen(void)
 	return true;
 }
 
-bool dbquery(const char *format, ...)
+int dbquery_ret(const char *format, ...)
 {
 	va_list args;
 	va_start(args, format);
@@ -92,7 +92,7 @@ bool dbquery(const char *format, ...)
 	if(query == NULL)
 	{
 		logg("Memory allocation failed in dbquery()");
-		return false;
+		return SQLITE_ERROR;
 	}
 
 	// Log generated SQL string when dbquery() is called
@@ -101,7 +101,7 @@ bool dbquery(const char *format, ...)
 	{
 		logg("dbquery(\"%s\") called but database is not available!", query);
 		sqlite3_free(query);
-		return false;
+		return SQLITE_ERROR;
 	}
 
 	if(config.debug & DEBUG_DATABASE)
@@ -114,12 +114,12 @@ bool dbquery(const char *format, ...)
 	if( rc != SQLITE_OK ){
 		logg("ERROR: SQL query failed with code %d: %s", rc, query);
 		check_database(rc);
-		return false;
+		return rc;
 	}
 	// Free allocated memory for query string
 	sqlite3_free(query);
 	// Return success
-	return true;
+	return SQLITE_OK;
 }
 
 static bool create_counter_table(void)

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -112,6 +112,7 @@ bool dbquery(const char *format, ...)
 	int rc = sqlite3_exec(FTL_db, query, NULL, NULL, NULL);
 
 	if( rc != SQLITE_OK ){
+		logg("ERROR: SQL query failed with code %d: %s", rc, query);
 		check_database(rc);
 		return false;
 	}

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -155,8 +155,7 @@ static bool db_create(void)
 		return false;
 	}
 	// Create Queries table in the database
-	SQL_bool(
-			"CREATE TABLE queries ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain TEXT NOT NULL, client TEXT NOT NULL, forward TEXT );");
+	SQL_bool("CREATE TABLE queries ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain TEXT NOT NULL, client TEXT NOT NULL, forward TEXT );");
 
 	// Add an index on the timestamps (not a unique index!)
 	SQL_bool("CREATE INDEX idx_queries_timestamps ON queries (timestamp);");

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -35,14 +35,14 @@ extern bool DBdeleteoldqueries;
 // Database macros
 #define SQL_bool(sql) {\
 	if(!dbquery(sql)) {\
-		logg("ERROR: %s() failed! SQL = %s", __FUNCTION__, sql);\
+		logg("ERROR: %s() failed!", __FUNCTION__);\
 		return false;\
 	}\
 }
 
 #define SQL_void(sql) {\
 	if(!dbquery(sql)) {\
-		logg("ERROR: %s() failed! SQL = %s", __FUNCTION__, sql);\
+		logg("ERROR: %s() failed!", __FUNCTION__);\
 		return;\
 	}\
 }

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -16,7 +16,10 @@ bool check_database(int rc);
 void db_init(void);
 int db_get_FTL_property(const unsigned int ID);
 bool db_set_FTL_property(const unsigned int ID, const int value);
-bool dbquery(const char *format, ...);
+
+/// Execute a formatted SQL query and get the return code
+int dbquery_ret(const char *format, ...);
+
 bool dbopen(void);
 void dbclose(void);
 int db_query_int(const char*);
@@ -33,6 +36,11 @@ extern long int lastdbindex;
 extern bool DBdeleteoldqueries;
 
 // Database macros
+
+/// Execute a formatted SQL query. The returned boolean indicates if it was
+/// successful or not
+#define dbquery(format, ...) (dbquery_ret(format, ## __VA_ARGS__) == SQLITE_OK)
+
 #define SQL_bool(sql) {\
 	if(!dbquery(sql)) {\
 		logg("ERROR: %s() failed!", __FUNCTION__);\

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -18,7 +18,7 @@ int db_get_FTL_property(const unsigned int ID);
 bool db_set_FTL_property(const unsigned int ID, const int value);
 
 /// Execute a formatted SQL query and get the return code
-int dbquery_ret(const char *format, ...);
+int dbquery(const char *format, ...);
 
 bool dbopen(void);
 void dbclose(void);
@@ -36,20 +36,15 @@ extern long int lastdbindex;
 extern bool DBdeleteoldqueries;
 
 // Database macros
-
-/// Execute a formatted SQL query. The returned boolean indicates if it was
-/// successful or not
-#define dbquery(format, ...) (dbquery_ret(format, ## __VA_ARGS__) == SQLITE_OK)
-
 #define SQL_bool(sql) {\
-	if(!dbquery(sql)) {\
+	if(dbquery(sql) != SQLITE_OK) {\
 		logg("ERROR: %s() failed!", __FUNCTION__);\
 		return false;\
 	}\
 }
 
 #define SQL_void(sql) {\
-	if(!dbquery(sql)) {\
+	if(dbquery(sql) != SQLITE_OK) {\
 		logg("ERROR: %s() failed!", __FUNCTION__);\
 		return;\
 	}\

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -35,14 +35,14 @@ extern bool DBdeleteoldqueries;
 // Database macros
 #define SQL_bool(sql) {\
 	if(!dbquery(sql)) {\
-		logg("ERROR: %s() failed!", __FUNCTION__);\
+		logg("ERROR: %s() failed! SQL = %s", __FUNCTION__, sql);\
 		return false;\
 	}\
 }
 
 #define SQL_void(sql) {\
 	if(!dbquery(sql)) {\
-		logg("ERROR: %s() failed!", __FUNCTION__);\
+		logg("ERROR: %s() failed! SQL = %s", __FUNCTION__, sql);\
 		return;\
 	}\
 }

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -137,8 +137,14 @@ void parse_neighbor_cache(void)
 	// Start collecting database commands
 	lock_shm();
 
-	if(!dbquery("BEGIN TRANSACTION")) {
-		logg("ERROR: parse_neighbor_cache() failed! SQL = \"BEGIN TRANSACTION\"");
+	int ret = dbquery_ret("BEGIN TRANSACTION");
+
+	if(ret == SQLITE_BUSY) {
+		logg("WARN: parse_neighbor_cache(), database is busy, skipping");
+		unlock_shm();
+		return;
+	} else if(ret != SQLITE_OK) {
+		logg("ERROR: parse_neighbor_cache() failed!");
 		unlock_shm();
 		return;
 	}
@@ -265,7 +271,7 @@ void parse_neighbor_cache(void)
 
 	// Actually update the database
 	if(!dbquery("COMMIT")) {
-		logg("ERROR: parse_neighbor_cache() failed! SQL = \"COMMIT\"");
+		logg("ERROR: parse_neighbor_cache() failed!");
 		unlock_shm();
 		return;
 	}

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -137,7 +137,7 @@ void parse_neighbor_cache(void)
 	// Start collecting database commands
 	lock_shm();
 
-	int ret = dbquery_ret("BEGIN TRANSACTION");
+	int ret = dbquery("BEGIN TRANSACTION");
 
 	if(ret == SQLITE_BUSY) {
 		logg("WARN: parse_neighbor_cache(), database is busy, skipping");
@@ -171,7 +171,7 @@ void parse_neighbor_cache(void)
 		// commitment. Read-only access such as this SELECT command will be
 		// executed immediately on the database.
 		char* querystr = NULL;
-		int ret = asprintf(&querystr, "SELECT id FROM network WHERE hwaddr = \'%s\';", hwaddr);
+		ret = asprintf(&querystr, "SELECT id FROM network WHERE hwaddr = \'%s\';", hwaddr);
 		if(querystr == NULL || ret < 0)
 		{
 			logg("Memory allocation failed in parse_arp_cache(): %i", ret);
@@ -270,7 +270,7 @@ void parse_neighbor_cache(void)
 	}
 
 	// Actually update the database
-	if(!dbquery("COMMIT")) {
+	if(dbquery("COMMIT") != SQLITE_OK) {
 		logg("ERROR: parse_neighbor_cache() failed!");
 		unlock_shm();
 		return;

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -136,7 +136,12 @@ void parse_neighbor_cache(void)
 
 	// Start collecting database commands
 	lock_shm();
-	SQL_void("BEGIN TRANSACTION");
+
+	if(!dbquery("BEGIN TRANSACTION")) {
+		logg("ERROR: parse_neighbor_cache() failed! SQL = \"BEGIN TRANSACTION\"");
+		unlock_shm();
+		return;
+	}
 
 	// Read ARP cache line by line
 	while(getline(&linebuffer, &linebuffersize, arpfp) != -1)
@@ -259,7 +264,12 @@ void parse_neighbor_cache(void)
 	}
 
 	// Actually update the database
-	SQL_void("COMMIT");
+	if(!dbquery("COMMIT")) {
+		logg("ERROR: parse_neighbor_cache() failed! SQL = \"COMMIT\"");
+		unlock_shm();
+		return;
+	}
+
 	unlock_shm();
 
 	// Debug logging

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -217,7 +217,7 @@ void delete_old_queries_in_DB(void)
 
 	int timestamp = time(NULL) - config.maxDBdays * 86400;
 
-	if(!dbquery("DELETE FROM queries WHERE timestamp <= %i", timestamp))
+	if(dbquery("DELETE FROM queries WHERE timestamp <= %i", timestamp) != SQLITE_OK)
 	{
 		logg("delete_old_queries_in_DB(): Deleting queries due to age of entries failed!");
 		return;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

If the transaction fails to open or commit, the shared memory would not be unlocked. This change ensures that shared memory is unlocked in the SQL error case. Also, the SQL statement that failed in the macro is logged.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
