### PR TITLE
Add database busy timeouts

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -99,6 +99,10 @@
 #define DB_FAILED -2
 #define DB_NODATA -1
 
+// Add a timeout for the pihole-FTL.db database connection.
+// This prevents immediate failures when the database is busy for a short time.
+#define DATABASE_BUSY_TIMEOUT 1000
+
 // FTLDNS enums
 enum { QUERIES, FORWARDED, CLIENTS, DOMAINS, OVERTIME, WILDCARD };
 enum { DNSSEC_UNSPECIFIED, DNSSEC_SECURE, DNSSEC_INSECURE, DNSSEC_BOGUS, DNSSEC_ABANDONED, DNSSEC_UNKNOWN };

--- a/src/FTL.h
+++ b/src/FTL.h
@@ -99,8 +99,9 @@
 #define DB_FAILED -2
 #define DB_NODATA -1
 
-// Add a timeout for the pihole-FTL.db database connection.
+// Add a timeout for the pihole-FTL.db database connection [milliseconds]
 // This prevents immediate failures when the database is busy for a short time.
+// Default: 1000 (one second)
 #define DATABASE_BUSY_TIMEOUT 1000
 
 // FTLDNS enums

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -79,6 +79,13 @@ bool dbopen(void)
 		return false;
 	}
 
+	// Explicitly set busy handler to value defined in FTL.h
+	rc = sqlite3_busy_timeout(FTL_db, DATABASE_BUSY_TIMEOUT);
+	if(rc != SQLITE_OK)
+	{
+		logg("dbopen() - Cannot set busy handler (%i): %s", rc, sqlite3_errmsg(FTL_db));
+	}
+
 	return true;
 }
 

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -45,6 +45,13 @@ bool gravityDB_open(void)
 		return false;
 	}
 
+	// Explicitly set busy handler to zero milliseconds
+	rc = sqlite3_busy_timeout(gravity_db, 0);
+	if(rc != SQLITE_OK)
+	{
+		logg("gravityDB_open() - Cannot set busy handler (%i): %s", rc, sqlite3_errmsg(gravity_db));
+	}
+
 	// Tell SQLite3 to store temporary tables in memory. This speeds up read operations on
 	// temporary tables, indices, and views.
 	char *zErrMsg = NULL;

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -339,3 +339,9 @@
   [[ "${STATIC}" != "true" && "${lines[@]}" == *"interpreter"* ]] || \
   [[ "${STATIC}" == "true" && "${lines[@]}" != *"interpreter"* ]]
 }
+
+@test "No errors on setting busy handlers for the databases" {
+  run bash -c 'grep -c "Cannot set busy handler" /var/log/pihole-FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0" ]]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Adding an explicitly allowed timeout of 1000 milliseconds to `pihole-FTL.db` will allow short intervals of busyness to be tolerated by FTL. As `pihole-FTL.db` is only used by threads surrounding the DNS server, this should have no implications on the performance of `pihole-FTL`.

Note that we explicitly set zero timeout for `gravity.db` as timeout might have an influence on DNS resolution due to lookups in the whitelist tables.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
