### PR TITLE
Fix possible crash if database is locked on startup

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -221,6 +221,14 @@ void db_init(void)
 		return;
 	}
 
+	// Initialize database lock mutex
+	if (pthread_mutex_init(&dblock, NULL) != 0)
+	{
+		logg("FATAL: FTL_db mutex init failed\n");
+		// Return failure
+		exit(EXIT_FAILURE);
+	}
+
 	// Initialize SQLite3 logging callback
 	// This ensures SQLite3 errors and warnings are logged to pihole-FTL.log
 	// We use this to possibly catch even more errors in places we do not
@@ -321,13 +329,6 @@ void db_init(void)
 	// Close database to prevent having it opened all time
 	// we already closed the database when we returned earlier
 	sqlite3_close(FTL_db);
-
-	if (pthread_mutex_init(&dblock, NULL) != 0)
-	{
-		logg("FATAL: FTL_db mutex init failed\n");
-		// Return failure
-		exit(EXIT_FAILURE);
-	}
 
 	logg("Database successfully initialized");
 }

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -222,9 +222,10 @@ void db_init(void)
 	}
 
 	// Initialize database lock mutex
-	if (pthread_mutex_init(&dblock, NULL) != 0)
+	int rc;
+	if((rc = pthread_mutex_init(&dblock, NULL)) != 0)
 	{
-		logg("FATAL: FTL_db mutex init failed\n");
+		logg("FATAL: FTL_db mutex init failed (%s, %i)\n", strerror(rc), rc);
 		// Return failure
 		exit(EXIT_FAILURE);
 	}
@@ -253,7 +254,7 @@ void db_init(void)
 	}
 
 	// Try to open the database connection
-	int rc = sqlite3_open_v2(FTLfiles.FTL_db, &FTL_db, SQLITE_OPEN_READWRITE, NULL);
+	rc = sqlite3_open_v2(FTLfiles.FTL_db, &FTL_db, SQLITE_OPEN_READWRITE, NULL);
 	if( rc != SQLITE_OK ){
 		logg("db_init() - Cannot open database (%i): %s", rc, sqlite3_errmsg(FTL_db));
 		dbclose();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Ensure we always initialize the database lock mutex even if an error causes us to return early in `db_init()`.

This PR fixes #625 (at least I assume this given the limited information available there so far).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
