### PR TITLE
Bugfix for tools/macvendor.py

### DIFF
--- a/tools/macvendor.py
+++ b/tools/macvendor.py
@@ -29,7 +29,7 @@ for line in manuf:
 	line = line.strip()
 
 	# Skip comments and empty lines
-	if line[1] == "#" or line == "":
+	if line == "" or line[0] == "#":
 		continue
 
 	# Remove quotation marks as these might interfere with later INSERT / UPDATE commands


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix using wrong index when looking for comments in the downloaded file causing the following error:
```
$ python3 macvendor.py 
Downloading...
...done
Processing...
Traceback (most recent call last):
  File "macvendor.py", line 32, in <module>
    if line[0] == "#" or line == "":
IndexError: string index out of range
```

This bugfix changes two things:
1. Check *first* if the string is empty (short-circuit evaluation)
2. Check the first (instead of the second) character against `#`

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
