### PR TITLE
Fix compilation errors in development

### DIFF
--- a/src/dnsmasq/crypto.c
+++ b/src/dnsmasq/crypto.c
@@ -275,6 +275,10 @@ static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len
   static struct ecc_point *key_256 = NULL, *key_384 = NULL;
   static mpz_t x, y;
   static struct dsa_signature *sig_struct;
+#if NETTLE_VERSION_MAJOR == 3 && NETTLE_VERSION_MINOR < 4
+#define nettle_get_secp_256r1() (&nettle_secp_256r1)
+#define nettle_get_secp_384r1() (&nettle_secp_384r1)
+#endif
   
   if (!sig_struct)
     {
@@ -294,7 +298,7 @@ static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len
 	  if (!(key_256 = whine_malloc(sizeof(struct ecc_point))))
 	    return 0;
 	  
-	  nettle_ecc_point_init(key_256, &nettle_secp_256r1);
+	  nettle_ecc_point_init(key_256, nettle_get_secp_256r1());
 	}
       
       key = key_256;
@@ -307,7 +311,7 @@ static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len
 	  if (!(key_384 = whine_malloc(sizeof(struct ecc_point))))
 	    return 0;
 	  
-	  nettle_ecc_point_init(key_384, &nettle_secp_384r1);
+	  nettle_ecc_point_init(key_384, nettle_get_secp_384r1());
 	}
       
       key = key_384;

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -141,6 +141,7 @@ typedef unsigned long long u64;
 #endif
 
 #if defined(HAVE_LINUX_NETWORK)
+#include <linux/sockios.h>
 #include <linux/capability.h>
 /* There doesn't seem to be a universally-available 
    userspace header for these. */


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes two compilation issues with FTL.

1. Fixes #603 - we currently compile against libnettle3.4 on the CI. We cherry-pick this commit from the official `dnsmasq` repository to resolve this issue already now.

2. Recent versions of GCC (tested on `gcc version 9.1.1 20190503 (Red Hat 9.1.1-1) (GCC)`) are currently unable to compile `dnsmasq` resp. `pihole-FTL` because of
    ```
    src/dnsmasq/dhcp.c: In function ‘dhcp_packet’:
    src/dnsmasq/dhcp.c:182:17: error: ‘SIOCGSTAMP’ undeclared (first use in this function); did you mean ‘SIOCGARP’?
      182 |   if (ioctl(fd, SIOCGSTAMP, &tv) == 0)
          |                 ^~~~~~~~~~
          |                 SIOCGARP
    src/dnsmasq/dhcp.c:182:17: note: each undeclared identifier is reported only once for each function it appears in
    make: *** [Makefile:138: build/dnsmasq/dhcp.o] Error 1
    ```
    For solving this, we cherry-pick a small (one line change) commit from the official repository.