### PR TITLE
Fix tests: regexa.com is now registered

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -495,7 +495,7 @@ void _FTL_reply(const unsigned short flags, const char *name, const struct all_a
 	domainsData* domain = getDomain(domainID, true);
 
 	// Check if this domain matches exactly
-	const bool isExactMatch = (name != NULL && strcmp(getstr(domain->domainpos), name) == 0);
+	const bool isExactMatch = (name != NULL && strcasecmp(getstr(domain->domainpos), name) == 0);
 
 	if((flags & F_CONFIG) && isExactMatch && !query->complete)
 	{

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -135,7 +135,7 @@
   [[ ${lines[11]} == "reply_NODATA 0" ]]
   [[ ${lines[12]} == "reply_NXDOMAIN 2" ]]
   [[ ${lines[13]} == "reply_CNAME 0" ]]
-  [[ ${lines[14]} == "reply_IP 8" ]]
+  [[ ${lines[14]} == "reply_IP 9" ]]
   [[ ${lines[15]} == "privacy_level 0" ]]
   [[ ${lines[16]} == "status enabled" ]]
   [[ ${lines[17]} == "" ]]

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -81,7 +81,6 @@
   run bash -c "dig regexA.com @127.0.0.1 +short"
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} != "0.0.0.0" ]]
-  [[ ${lines[1]} == "" ]]
 }
 
 @test "Regex blacklist match + whitelist exact match is not blocked" {

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -259,7 +259,7 @@
   [[ ${lines[5]} == *"A whitelisted.com "?*" 2 0 4"* ]]
   [[ ${lines[6]} == *"A 01tse443.se "?*" 2 0 2"* ]]
   [[ ${lines[7]} == *"A regex5.com "?*" 4 0 4"* ]]
-  [[ ${lines[8]} == *"A regexa.com "?*" 2 0 7"* ]]
+  [[ ${lines[8]} == *"A regexa.com "?*" 2 0 4"* ]]
   [[ ${lines[9]} == *"A regex1.com "?*" 2 0 4"* ]]
   [[ ${lines[10]} == *"A regex2.com "?*" 2 0 2"* ]]
   [[ ${lines[11]} == *"A google.com "?*" 2 0 4"* ]]
@@ -271,14 +271,14 @@
 @test "Get all queries (domain filtered)" {
   run bash -c 'echo ">getallqueries-domain regexa.com >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == *"A regexa.com "?*" 2 0 7"* ]]
+  [[ ${lines[1]} == *"A regexa.com "?*" 2 0 4"* ]]
   [[ ${lines[2]} == "" ]]
 }
 
 @test "Get all queries (domain + number filtered)" {
   run bash -c 'echo ">getallqueries-domain regexa.com (6) >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == *"A regexa.com "?*" 2 0 7"* ]]
+  [[ ${lines[1]} == *"A regexa.com "?*" 2 0 4"* ]]
   [[ ${lines[2]} == "" ]]
 }
 
@@ -292,7 +292,7 @@
   [[ ${lines[5]} == *"A whitelisted.com "?*" 2 0 4"* ]]
   [[ ${lines[6]} == *"A 01tse443.se "?*" 2 0 2"* ]]
   [[ ${lines[7]} == *"A regex5.com "?*" 4 0 4"* ]]
-  [[ ${lines[8]} == *"A regexa.com "?*" 2 0 7"* ]]
+  [[ ${lines[8]} == *"A regexa.com "?*" 2 0 4"* ]]
   [[ ${lines[9]} == *"A regex1.com "?*" 2 0 4"* ]]
   [[ ${lines[10]} == *"A regex2.com "?*" 2 0 2"* ]]
   [[ ${lines[11]} == *"A google.com "?*" 2 0 4"* ]]


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Our tests currently rely on `regexa.com` to not exist. However, this domain recently became available and is now causing our tests to fail. This PR fixes this by not assuming that `regexa.com` does not exist.

This PR also fixes a small bug as domain equivalence checks should be case-**in**sensitive (which wasn't the case before).