### PR TITLE
Check pointers before accessing content

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -81,6 +81,9 @@ void getStats(const int *sock)
 	{
 		// Get client pointer
 		const clientsData* client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
+
 		if(client->count > 0)
 			activeclients++;
 	}
@@ -227,6 +230,8 @@ void getTopDomains(const char *client_message, const int *sock)
 	{
 		// Get domain pointer
 		const domainsData* domain = getDomain(domainID, true);
+		if(domain == NULL)
+			continue;
 
 		temparray[domainID][0] = domainID;
 		if(blocked)
@@ -287,6 +292,8 @@ void getTopDomains(const char *client_message, const int *sock)
 		const int domainID = temparray[i][0];
 		// Get domain pointer
 		const domainsData* domain = getDomain(domainID, true);
+		if(domain == NULL)
+			continue;
 
 		// Skip this domain if there is a filter on it
 		if(excludedomains != NULL && insetupVarsArray(getstr(domain->domainpos)))
@@ -397,6 +404,8 @@ void getTopClients(const char *client_message, const int *sock)
 	{
 		// Get client pointer
 		const clientsData* client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
 		temparray[clientID][0] = clientID;
 		// Use either blocked or total count based on request string
 		temparray[clientID][1] = blockedonly ? client->blockedcount : client->count;
@@ -435,6 +444,8 @@ void getTopClients(const char *client_message, const int *sock)
 		const int ccount = temparray[i][1];
 		// Get client pointer
 		const clientsData* client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
 
 		// Skip this client if there is a filter on it
 		if(excludeclients != NULL &&
@@ -490,6 +501,8 @@ void getForwardDestinations(const char *client_message, const int *sock)
 		if(sort) {
 			// Get forward pointer
 			const forwardedData* forward = getForward(forwardID, true);
+			if(forward == NULL)
+				continue;
 
 			temparray[forwardID][0] = forwardID;
 			temparray[forwardID][1] = forward->count;
@@ -542,6 +555,8 @@ void getForwardDestinations(const char *client_message, const int *sock)
 
 			// Get forward pointer
 			const forwardedData* forward = getForward(forwardID, true);
+			if(forward == NULL)
+				continue;
 
 			// Get IP and host name of forward destination if available
 			ip = getstr(forward->ippos);
@@ -675,6 +690,9 @@ void getAllQueries(const char *client_message, const int *sock)
 			{
 				// Get forward pointer
 				const forwardedData* forward = getForward(i, true);
+				if(forward == NULL)
+					continue;
+
 				// Try to match the requested string against their IP addresses and
 				// (if available) their host names
 				if(strcmp(getstr(forward->ippos), forwarddest) == 0 ||
@@ -707,6 +725,8 @@ void getAllQueries(const char *client_message, const int *sock)
 		{
 			// Get domain pointer
 			const domainsData* domain = getDomain(domainID, true);
+			if(domain == NULL)
+				continue;
 
 			// Try to match the requested string
 			if(strcmp(getstr(domain->domainpos), domainname) == 0)
@@ -737,6 +757,9 @@ void getAllQueries(const char *client_message, const int *sock)
 		{
 			// Get client pointer
 			const clientsData* client = getClient(i, true);
+			if(client == NULL)
+				continue;
+
 			// Try to match the requested string
 			if(strcmp(getstr(client->ippos), clientname) == 0 ||
 			   (client->namepos != 0 &&
@@ -787,7 +810,8 @@ void getAllQueries(const char *client_message, const int *sock)
 	{
 		const queriesData* query = getQuery(queryID, true);
 		// Check if this query has been create while in maximum privacy mode
-		if(query->privacylevel >= PRIVACY_MAXIMUM) continue;
+		if(query == NULL || query->privacylevel >= PRIVACY_MAXIMUM)
+			continue;
 
 		// Verify query type
 		if(query->type > TYPE_MAX-1)
@@ -844,6 +868,9 @@ void getAllQueries(const char *client_message, const int *sock)
 		const char *clientIPName = NULL;
 		// Get client pointer
 		const clientsData* client = getClient(query->clientID, true);
+		if(domain == NULL || client == NULL)
+			continue;
+
 		if(strlen(getstr(client->namepos)) > 0)
 			clientIPName = getClientNameString(queryID);
 		else
@@ -905,6 +932,8 @@ void getRecentBlocked(const char *client_message, const int *sock)
 	for(int queryID = counters->queries - 1; queryID > 0 ; queryID--)
 	{
 		const queriesData* query = getQuery(queryID, true);
+		if(query == NULL)
+			continue;
 
 		if(query->status == QUERY_GRAVITY ||
 		   query->status == QUERY_WILDCARD ||
@@ -915,6 +944,8 @@ void getRecentBlocked(const char *client_message, const int *sock)
 			// Ask subroutine for domain. It may return "hidden" depending on
 			// the privacy settings at the time the query was made
 			const char *domain = getDomainString(queryID);
+			if(domain == NULL)
+				continue;
 
 			if(istelnet[*sock])
 				ssend(*sock,"%s\n", domain);
@@ -1102,6 +1133,8 @@ void getClientsOverTime(const int *sock)
 		{
 			// Get client pointer
 			const clientsData* client = getClient(clientID, true);
+			if(client == NULL)
+				continue;
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1125,6 +1158,8 @@ void getClientsOverTime(const int *sock)
 
 			// Get client pointer
 			const clientsData* client = getClient(clientID, true);
+			if(client == NULL)
+				continue;
 			const int thisclient = client->overTime[slot];
 
 			if(istelnet[*sock])
@@ -1166,6 +1201,9 @@ void getClientNames(const int *sock)
 		{
 			// Get client pointer
 			const clientsData* client = getClient(clientID, true);
+			if(client == NULL)
+				continue;
+
 			// Check if this client should be skipped
 			if(insetupVarsArray(getstr(client->ippos)) ||
 			   insetupVarsArray(getstr(client->namepos)))
@@ -1181,6 +1219,9 @@ void getClientNames(const int *sock)
 
 		// Get client pointer
 		const clientsData* client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
+
 		const char *client_ip = getstr(client->ippos);
 		const char *client_name = getstr(client->namepos);
 
@@ -1207,7 +1248,9 @@ void getUnknownQueries(const int *sock)
 	{
 		const queriesData* query = getQuery(queryID, true);
 
-		if(query->status != QUERY_UNKNOWN && query->complete) continue;
+		if(query == NULL ||
+		  (query->status != QUERY_UNKNOWN && query->complete))
+			continue;
 
 		char type[5];
 		if(query->type == TYPE_A)
@@ -1223,6 +1266,9 @@ void getUnknownQueries(const int *sock)
 		const domainsData* domain = getDomain(query->domainID, true);
 		// Get client pointer
 		const clientsData* client = getClient(query->clientID, true);
+
+		if(domain == NULL || client == NULL)
+			continue;
 
 		// Get client IP string
 		const char *clientIP = getstr(client->ippos);
@@ -1261,6 +1307,8 @@ void getDomainDetails(const char *client_message, const int *sock)
 	{
 		// Get domain pointer
 		const domainsData* domain = getDomain(domainID, true);
+		if(domain == NULL)
+			continue;
 
 		if(strcmp(getstr(domain->domainpos), domainString) == 0)
 		{

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -31,6 +31,10 @@ int findForwardID(const char * forwardString, const bool count)
 		// Get forward pointer
 		forwardedData* forward = getForward(forwardID, true);
 
+		// Check if the returned pointer is valid before trying to access it
+		if(forward == NULL)
+			continue;
+
 		if(strcmp(getstr(forward->ippos), forwardString) == 0)
 		{
 			if(count) forward->count++;
@@ -77,6 +81,10 @@ int findDomainID(const char *domainString)
 		// Get domain pointer
 		domainsData* domain = getDomain(domainID, true);
 
+		// Check if the returned pointer is valid before trying to access it
+		if(domain == NULL)
+			continue;
+
 		// Quick test: Does the domain start with the same character?
 		if(getstr(domain->domainpos)[0] != domainString[0])
 			continue;
@@ -122,6 +130,10 @@ int findClientID(const char *clientIP, const bool count)
 	{
 		// Get client pointer
 		clientsData* client = getClient(clientID, true);
+
+		// Check if the returned pointer is valid before trying to access it
+		if(client == NULL)
+			continue;
 
 		// Quick test: Does the clients IP start with the same character?
 		if(getstr(client->ippos)[0] != clientIP[0])
@@ -196,6 +208,11 @@ bool isValidIPv6(const char *addr)
 const char *getDomainString(const int queryID)
 {
 	const queriesData* query = getQuery(queryID, true);
+
+	// Check if the returned pointer is valid before trying to access it
+	if(query == NULL)
+		return "";
+
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS)
 	{
 		// Get domain pointer
@@ -213,6 +230,11 @@ const char *getDomainString(const int queryID)
 const char *getClientIPString(const int queryID)
 {
 	const queriesData* query = getQuery(queryID, false);
+
+	// Check if the returned pointer is valid before trying to access it
+	if(query == NULL)
+		return "";
+
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer
@@ -230,6 +252,11 @@ const char *getClientIPString(const int queryID)
 const char *getClientNameString(const int queryID)
 {
 	const queriesData* query = getQuery(queryID, true);
+
+	// Check if the returned pointer is valid before trying to access it
+	if(query == NULL)
+		return "";
+
 	if(query->privacylevel < PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Get client pointer

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -51,6 +51,11 @@ int findForwardID(const char * forwardString, const bool count)
 
 	// Get forward pointer
 	forwardedData* forward = getForward(forwardID, false);
+	if(forward == NULL)
+	{
+		logg("ERROR: Encountered serious memory error in findForwardID()");
+		return -1;
+	}
 
 	// Set magic byte
 	forward->magic = MAGICBYTE;
@@ -106,6 +111,11 @@ int findDomainID(const char *domainString)
 
 	// Get domain pointer
 	domainsData* domain = getDomain(domainID, false);
+	if(domain == NULL)
+	{
+		logg("ERROR: Encountered serious memory error in findDomainID()");
+		return -1;
+	}
 
 	// Set magic byte
 	domain->magic = MAGICBYTE;
@@ -162,6 +172,11 @@ int findClientID(const char *clientIP, const bool count)
 
 	// Get client pointer
 	clientsData* client = getClient(clientID, false);
+	if(client == NULL)
+	{
+		logg("ERROR: Encountered serious memory error in findClientID()");
+		return -1;
+	}
 
 	// Set magic byte
 	client->magic = MAGICBYTE;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -263,6 +263,11 @@ static int findQueryID(const int id)
 	for(int i = start; i >= until; i--)
 	{
 		const queriesData* query = getQuery(i, true);
+
+		// Check if the returned pointer is valid before trying to access it
+		if(query == NULL)
+			continue;
+
 		if(query->id == id)
 			return i;
 	}

--- a/src/gc.c
+++ b/src/gc.c
@@ -67,23 +67,28 @@ void *GC_thread(void *val)
 			for(long int i=0; i < counters->queries; i++)
 			{
 				queriesData* query = getQuery(i, true);
+				if(query == NULL)
+					continue;
+
 				// Test if this query is too new
 				if(query->timestamp > mintime)
 					break;
 
 				// Adjust client counter
 				clientsData* client = getClient(query->clientID, true);
-				client->count--;
+				if(client != NULL)
+					client->count--;
 
 				// Adjust total counters and total over time data
 				const int timeidx = query->timeidx;
 				overTime[timeidx].total--;
-				// Adjust corresponding overTime counters
-				client->overTime[timeidx]--;
+				if(client != NULL)
+					client->overTime[timeidx]--;
 
 				// Adjust domain counter (no overTime information)
 				domainsData* domain = getDomain(query->domainID, true);
-				domain->count--;
+				if(domain != NULL)
+					domain->count--;
 
 				// Get forward pointer
 				forwardedData* forward = getForward(query->forwardID, true);
@@ -99,7 +104,8 @@ void *GC_thread(void *val)
 						// Forwarded to an upstream DNS server
 						// Adjust counters
 						counters->forwardedqueries--;
-						forward->count--;
+						if(forward != NULL)
+							forward->count--;
 						overTime[timeidx].forwarded--;
 						break;
 					case QUERY_CACHE:
@@ -115,8 +121,10 @@ void *GC_thread(void *val)
 					case QUERY_EXTERNAL_BLOCKED_NULL: // Blocked by upstream provider (fall through)
 						counters->blocked--;
 						overTime[timeidx].blocked--;
-						domain->blockedcount--;
-						client->blockedcount--;
+						if(domain != NULL)
+							domain->blockedcount--;
+						if(client != NULL)
+							client->blockedcount--;
 						break;
 					default:
 						/* That cannot happen */

--- a/src/overTime.c
+++ b/src/overTime.c
@@ -53,8 +53,11 @@ static void initSlot(const unsigned int index, const time_t timestamp)
 	{
 		// Get client pointer
 		clientsData* client = getClient(clientID, true);
-		// Set overTime data to zero
-		client->overTime[index] = 0;
+		if(client != NULL)
+		{
+			// Set overTime data to zero
+			client->overTime[index] = 0;
+		}
 	}
 }
 
@@ -160,6 +163,9 @@ void moveOverTimeMemory(const time_t mintime)
 		{
 			// Get query pointer
 			queriesData* query = getQuery(queryID, true);
+			if(query == NULL)
+				continue;
+
 			// Check if the index would become negative if we adjusted it
 			if(((int)query->timeidx - (int)moveOverTime) < 0)
 			{

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -124,6 +124,8 @@ void resolveClients(const bool onlynew)
 	{
 		// Get client pointer
 		clientsData* client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
 
 		// Memory access needs to get locked
 		lock_shm();
@@ -160,6 +162,8 @@ void resolveForwardDestinations(const bool onlynew)
 	{
 		// Get forward pointer
 		forwardedData* forward = getForward(forwardID, true);
+		if(forward == NULL)
+			continue;
 
 		// Memory access needs to get locked
 		lock_shm();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

 In case requested object is out of range (`ID < 0` or `ID > maximum`) or has an incorrect magic byte, get getter functions in `shmem.c` return `NULL`. We have check against such `NULL`s before accessing the objects to avoid memory issues and segmentation faults.

Unfortunately, there are many getters and, hence, we have to add many guards. In a more high-level language, something like this will probably done by the language/compiler for us, but as C is a rather low-level language (you may want to call it "Comfort-Assembler"), we have to so this checking ourselves. This freedom opens a few possibilities, like we can skip updating only parts of the information if only some pointers are not available.

Finally, I should note that none of the checks added in this PR are expected to be triggered. However, I have once seen one failed magic byte (in several years looking almost daily at the logs) so there is a certain necessity for the checks to ensure the absence of SEGFAULTs in the crucial service a DNS server offers.

---

Footnote: The failing tests will be fixed when #634 is merged into this branch.