### PR TITLE
Ensure sockaddr_un.sun_path does not overflow

### DIFF
--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -175,9 +175,9 @@ static void bind_to_unix_socket(int *socketdescriptor)
 
 	struct sockaddr_un address;
 	address.sun_family = AF_LOCAL;
-	strcpy(address.sun_path, FTLfiles.socketfile);
+	strncpy(address.sun_path, FTLfiles.socketfile, sizeof(address.sun_path));
 
-	// Bild to Unix socket handle
+	// Bind to Unix socket handle
 	errno = 0;
 	if(bind(*socketdescriptor, (struct sockaddr *) &address, sizeof (address)) != 0)
 	{

--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -175,7 +175,13 @@ static void bind_to_unix_socket(int *socketdescriptor)
 
 	struct sockaddr_un address;
 	address.sun_family = AF_LOCAL;
+	// The sockaddr_un.sum_path may be shorter than the size of the FTLfiles.socketfile
+	// buffer. Ensure that the string is null-terminated even when the string is too large.
+	// In case strlen(FTLfiles.socketfile) < sizeof(address.sun_path) [this will virtually
+	// always be the case], the explicit setting of the last byte to zero is a no-op as
+	// strncpy() writes additional null bytes to ensure that a total of n bytes are written.
 	strncpy(address.sun_path, FTLfiles.socketfile, sizeof(address.sun_path));
+	address.sun_path[sizeof(address.sun_path)-1] = '\0';
 
 	// Bind to Unix socket handle
 	errno = 0;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Ensure `sockaddr_un.sun_path` does not overflow even for articially large `FTLfiles.socketfile` buffers. This bug has never been observed in the wild and does not seem to be exploitable.