### PR TITLE
Use network table as secondary source for client host names

### DIFF
--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -496,3 +496,60 @@ void updateMACVendorRecords(void)
 	sqlite3_finalize(stmt);
 	dbclose();
 }
+
+char* getDatabaseHostname(const char* ipaddr)
+{
+	// Open pihole-FTL.db database file
+	if(!dbopen())
+	{
+		logg("getDatabaseHostname(%s) - Failed to open DB", ipaddr);
+		return strdup("");
+	}
+
+	// Prepare SQLite statement
+	sqlite3_stmt* stmt = NULL;
+	const char *querystr = "SELECT name FROM network WHERE id = (SELECT network_id FROM network_addresses WHERE ip = ?);";
+	int rc = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
+	if( rc != SQLITE_OK ){
+		logg("getDatabaseHostname(%s) - SQL error prepare (%i): %s",
+		     ipaddr, rc, sqlite3_errmsg(FTL_db));
+		return strdup("");
+	}
+
+	// Bind domain to prepared statement
+	// SQLITE_STATIC: Use the string without first duplicating it internally.
+	// We can do this as domain has dynamic scope that exceeds that of the binding.
+	if((rc = sqlite3_bind_text(stmt, 1, ipaddr, -1, SQLITE_STATIC)) != SQLITE_OK)
+	{
+		logg("getDatabaseHostname(%s): Failed to bind domain (error %d) - %s",
+		     ipaddr, rc, sqlite3_errmsg(FTL_db));
+		sqlite3_reset(stmt);
+		sqlite3_finalize(stmt);
+		return strdup("");
+	}
+
+	char *hostname = NULL;
+	rc = sqlite3_step(stmt);
+	if(rc == SQLITE_ROW)
+	{
+		// Database record found (result might be empty)
+		hostname = strdup((char*)sqlite3_column_text(stmt, 0));
+	}
+	else
+	{
+		// Not found
+		hostname = strdup("");
+	}
+
+	if(rc != SQLITE_DONE && rc != SQLITE_ROW)
+	{
+		// Error
+		logg("getDatabaseHostname(%s) - SQL error step (%i): %s", ipaddr, rc, sqlite3_errmsg(FTL_db));
+	}
+
+	// Finalize statement and close database handle
+	sqlite3_finalize(stmt);
+	dbclose();
+
+	return hostname;
+}

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -516,9 +516,7 @@ char* getDatabaseHostname(const char* ipaddr)
 		return strdup("");
 	}
 
-	// Bind domain to prepared statement
-	// SQLITE_STATIC: Use the string without first duplicating it internally.
-	// We can do this as domain has dynamic scope that exceeds that of the binding.
+	// Bind ipaddr to prepared statement
 	if((rc = sqlite3_bind_text(stmt, 1, ipaddr, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
 		logg("getDatabaseHostname(%s): Failed to bind domain (error %d) - %s",
@@ -537,17 +535,12 @@ char* getDatabaseHostname(const char* ipaddr)
 	}
 	else
 	{
-		// Not found
+		// Not found or error (will be logged automatically through our SQLite3 hook)
 		hostname = strdup("");
 	}
 
-	if(rc != SQLITE_DONE && rc != SQLITE_ROW)
-	{
-		// Error
-		logg("getDatabaseHostname(%s) - SQL error step (%i): %s", ipaddr, rc, sqlite3_errmsg(FTL_db));
-	}
-
 	// Finalize statement and close database handle
+	sqlite3_reset(stmt);
 	sqlite3_finalize(stmt);
 	dbclose();
 

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -15,5 +15,6 @@ bool create_network_addresses_table(void);
 void parse_neighbor_cache(void);
 void updateMACVendorRecords(void);
 bool unify_hwaddr(void);
+char* getDatabaseHostname(const char* ipaddr);
 
 #endif //NETWORKTABLE_H

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -18,6 +18,8 @@
 #include "log.h"
 // global variable killed
 #include "signals.h"
+// getDatabaseHostname()
+#include "database/network-table.h"
 
 static char *resolveHostname(const char *addr)
 {
@@ -84,6 +86,13 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 	// Important: Don't hold a lock while resolving as the main thread
 	// (dnsmasq) needs to be operable during the call to resolveHostname()
 	char* newname = resolveHostname(ipaddr);
+
+	// If no hostname was found, try to obtain hostname from the network table
+	if(strlen(newname) == 0)
+	{
+		free(newname);
+		newname = getDatabaseHostname(ipaddr);
+	}
 
 	// Only store new newname if it is valid and differs from oldname
 	// We do not need to check for oldname == NULL as names are


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR implements a [feature requested on Discourse](https://discourse.pi-hole.net/t/show-name-in-top-clients-lists-rather-than-ipv6-addresses/23893/).

With this PR we add the `network` table as secondary data source for client host names. This ensures that devices with multiple IPs (on the same network interface) can all be identified by the host name of the machine even if a only one IP address <-> host name association is available.

Especially concerning IPv6 addresses, this will enhance the user experience as host names are now "automatically learned" by FTL.

The principle is the following:
1. For each known client with at least one query to `pihole-FTL`, we query the upstream server (possibly configured using conditional forwarding) for a host name. If such a host name is found, we do not only use it for displaying but we also store it **correlated to the network interface's hardware address** in the `network` table.
2. In case we found no host name for a given IP address (this is commonly the case for IPv6 addresses), we query the `network` table for a host name. Through the path `IP address -> hardware address -> host name` we might be able to find the correct host name even if there is (and maybe was never) a host name correlated to the given IP address.

We implement this lookup in the `network` table intentionally as secondary source of truth to allow users to continue assigning different host names to different IP addresses on the same network interface. It is unclear if anyone used this, however as this was possible before, we think it should still be possible now.

The effect of this PR should be immediately visible to users as FTL should be able to use this new strategy to determine host names for clients it didn't find one for before.