### PR TITLE
Security: Ensure print_flags() cannot overflow

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1055,9 +1055,9 @@ void print_flags(const unsigned int flags)
 	if(!(config.debug & DEBUG_FLAGS))
 		return;
 
-	char *flagstr = calloc(256,sizeof(char));
-	for(unsigned int i = 0; i < sizeof(flags)*8; i++)
-		if(flags & (1u << i))
+	char *flagstr = calloc(sizeof(flagnames) + 1, sizeof(char));
+	for (unsigned int i = 0; i < (sizeof(flagnames) / sizeof(*flagnames)); i++)
+		if (flags & (1u << i))
 			strcat(flagstr, flagnames[i]);
 	logg("     Flags: %s", flagstr);
 	free(flagstr);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Ensure that `print_flags()` cannot overflow. Note that this is a mere code improvement and not really a security fix as current code cannot be exploited. Only a small (and fixed!) subset of flags can be set at once, none of the configured configurations can come even close to the available 256 bytes.
Nevertheless, this PR changes the code to go from hard-coded string limits to fully adaptive limits ensuring we do not accidentally introduce bugs in the future when more flags get added to `dnsmasq` without remembering to modify the `print_flags()` routine.