### PR TITLE
Add malloc attribute to getDatabaseHostname()

### DIFF
--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -503,7 +503,7 @@ void updateMACVendorRecords(void)
 	dbclose();
 }
 
-char* getDatabaseHostname(const char* ipaddr)
+char* __attribute__((malloc)) getDatabaseHostname(const char* ipaddr)
 {
 	// Open pihole-FTL.db database file
 	if(!dbopen())

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -15,6 +15,6 @@ bool create_network_addresses_table(void);
 void parse_neighbor_cache(void);
 void updateMACVendorRecords(void);
 bool unify_hwaddr(void);
-char* getDatabaseHostname(const char* ipaddr);
+char* getDatabaseHostname(const char* ipaddr) __attribute__((malloc));
 
 #endif //NETWORKTABLE_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

The subroutine `getDatabaseHostname()` is guaranteed to allocate "fresh" memory not pointing to any existing objects. Hence, it should be given the attribute `((malloc))`.