### PR TITLE
Add DEBUG_DNSMASQ_LINES debug flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ WARN_FLAGS=-Wall -Wextra -Wno-unused-parameter
 # -Wswitch-enum: Warn whenever a switch statement has an index of enumerated type and lacks a case for one or more of the named codes of that enumeration.
 # -Wshadow: Warn whenever a local variable or type declaration shadows another variable, parameter, type, class member, or whenever a built-in function is shadowed.
 # -Wfloat-equal: Warn if floating-point values are used in equality comparisons
-# -Wunsafe-loop-optimizations -funsafe-loop-optimizations: Warn if the loop cannot be optimized because the compiler cannot assume anything on the bounds of the loop indices
 # -Wpointer-arith: Warn about anything that depends on the "size of" a function type or of "void".  GNU C assigns these types a size of 1
 # -Wundef: Warn if an undefined identifier is evaluated in an "#if" directive
 # -Wbad-function-cast: Warn when a function call is cast to a non-matching type
@@ -96,7 +95,7 @@ else
   EXTRAWARN_GCC8=
 endif
 EXTRAWARN=-Werror -Waddress -Wlogical-op -Wmissing-field-initializers -Woverlength-strings -Wformat -Wformat-nonliteral -Wuninitialized -Wswitch-enum -Wshadow \
--Wfloat-equal -Wunsafe-loop-optimizations -funsafe-loop-optimizations -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARN_GCC8)
+-Wfloat-equal -Wbad-function-cast -Wwrite-strings -Wparentheses -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Winline $(EXTRAWARN_GCC8)
 
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 CCFLAGS=-std=gnu11 -I$(IDIR) $(WARN_FLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FLAGS) $(DEBUG_FLAGS) $(CFLAGS) $(SQLITE_FLAGS)

--- a/src/config.c
+++ b/src/config.c
@@ -616,24 +616,30 @@ void read_debuging_settings(FILE *fp)
 	// defaults to: false
 	setDebugOption(fp, "DEBUG_CAPS", DEBUG_CAPS);
 
+	// DEBUG_DNSMASQ_LINES
+	setDebugOption(fp, "DEBUG_DNSMASQ_LINES", DEBUG_DNSMASQ_LINES);
+	extern char debug_dnsmasq_lines;
+	debug_dnsmasq_lines = config.debug & DEBUG_DNSMASQ_LINES ? 1 : 0;
+
 	if(config.debug)
 	{
-		logg("************************");
-		logg("* Debugging enabled    *");
-		logg("* DEBUG_DATABASE   %s *", (config.debug & DEBUG_DATABASE)? "YES":"NO ");
-		logg("* DEBUG_NETWORKING %s *", (config.debug & DEBUG_NETWORKING)? "YES":"NO ");
-		logg("* DEBUG_LOCKS      %s *", (config.debug & DEBUG_LOCKS)? "YES":"NO ");
-		logg("* DEBUG_QUERIES    %s *", (config.debug & DEBUG_QUERIES)? "YES":"NO ");
-		logg("* DEBUG_FLAGS      %s *", (config.debug & DEBUG_FLAGS)? "YES":"NO ");
-		logg("* DEBUG_SHMEM      %s *", (config.debug & DEBUG_SHMEM)? "YES":"NO ");
-		logg("* DEBUG_GC         %s *", (config.debug & DEBUG_GC)? "YES":"NO ");
-		logg("* DEBUG_ARP        %s *", (config.debug & DEBUG_ARP)? "YES":"NO ");
-		logg("* DEBUG_REGEX      %s *", (config.debug & DEBUG_REGEX)? "YES":"NO ");
-		logg("* DEBUG_API        %s *", (config.debug & DEBUG_API)? "YES":"NO ");
-		logg("* DEBUG_OVERTIME   %s *", (config.debug & DEBUG_OVERTIME)? "YES":"NO ");
-		logg("* DEBUG_EXTBLOCKED %s *", (config.debug & DEBUG_EXTBLOCKED)? "YES":"NO ");
-		logg("* DEBUG_CAPS       %s *", (config.debug & DEBUG_CAPS)? "YES":"NO ");
-		logg("************************");
+		logg("*****************************");
+		logg("* Debugging enabled         *");
+		logg("* DEBUG_DATABASE        %s *", (config.debug & DEBUG_DATABASE)? "YES":"NO ");
+		logg("* DEBUG_NETWORKING      %s *", (config.debug & DEBUG_NETWORKING)? "YES":"NO ");
+		logg("* DEBUG_LOCKS           %s *", (config.debug & DEBUG_LOCKS)? "YES":"NO ");
+		logg("* DEBUG_QUERIES         %s *", (config.debug & DEBUG_QUERIES)? "YES":"NO ");
+		logg("* DEBUG_FLAGS           %s *", (config.debug & DEBUG_FLAGS)? "YES":"NO ");
+		logg("* DEBUG_SHMEM           %s *", (config.debug & DEBUG_SHMEM)? "YES":"NO ");
+		logg("* DEBUG_GC              %s *", (config.debug & DEBUG_GC)? "YES":"NO ");
+		logg("* DEBUG_ARP             %s *", (config.debug & DEBUG_ARP)? "YES":"NO ");
+		logg("* DEBUG_REGEX           %s *", (config.debug & DEBUG_REGEX)? "YES":"NO ");
+		logg("* DEBUG_API             %s *", (config.debug & DEBUG_API)? "YES":"NO ");
+		logg("* DEBUG_OVERTIME        %s *", (config.debug & DEBUG_OVERTIME)? "YES":"NO ");
+		logg("* DEBUG_EXTBLOCKED      %s *", (config.debug & DEBUG_EXTBLOCKED)? "YES":"NO ");
+		logg("* DEBUG_CAPS            %s *", (config.debug & DEBUG_CAPS)? "YES":"NO ");
+		logg("* DEBUG_DNSMASQ_LINES   %s *", (config.debug & DEBUG_DNSMASQ_LINES)? "YES":"NO ");
+		logg("*****************************");
 	}
 
 	// Have to close the config file if we opened it

--- a/src/config.h
+++ b/src/config.h
@@ -53,19 +53,20 @@ extern ConfigStruct config;
 extern FTLFileNamesStruct FTLfiles;
 
 enum {
-  DEBUG_DATABASE   = (1 << 0),  /* 00000000 00000001 */
-  DEBUG_NETWORKING = (1 << 1),  /* 00000000 00000010 */
-  DEBUG_LOCKS      = (1 << 2),  /* 00000000 00000100 */
-  DEBUG_QUERIES    = (1 << 3),  /* 00000000 00001000 */
-  DEBUG_FLAGS      = (1 << 4),  /* 00000000 00010000 */
-  DEBUG_SHMEM      = (1 << 5),  /* 00000000 00100000 */
-  DEBUG_GC         = (1 << 6),  /* 00000000 01000000 */
-  DEBUG_ARP        = (1 << 7),  /* 00000000 10000000 */
-  DEBUG_REGEX      = (1 << 8),  /* 00000001 00000000 */
-  DEBUG_API        = (1 << 9),  /* 00000010 00000000 */
-  DEBUG_OVERTIME   = (1 << 10), /* 00000100 00000000 */
-  DEBUG_EXTBLOCKED = (1 << 11), /* 00001000 00000000 */
-  DEBUG_CAPS       = (1 << 12), /* 00010000 00000000 */
+  DEBUG_DATABASE      = (1 << 0),  /* 00000000 00000001 */
+  DEBUG_NETWORKING    = (1 << 1),  /* 00000000 00000010 */
+  DEBUG_LOCKS         = (1 << 2),  /* 00000000 00000100 */
+  DEBUG_QUERIES       = (1 << 3),  /* 00000000 00001000 */
+  DEBUG_FLAGS         = (1 << 4),  /* 00000000 00010000 */
+  DEBUG_SHMEM         = (1 << 5),  /* 00000000 00100000 */
+  DEBUG_GC            = (1 << 6),  /* 00000000 01000000 */
+  DEBUG_ARP           = (1 << 7),  /* 00000000 10000000 */
+  DEBUG_REGEX         = (1 << 8),  /* 00000001 00000000 */
+  DEBUG_API           = (1 << 9),  /* 00000010 00000000 */
+  DEBUG_OVERTIME      = (1 << 10), /* 00000100 00000000 */
+  DEBUG_EXTBLOCKED    = (1 << 11), /* 00001000 00000000 */
+  DEBUG_CAPS          = (1 << 12), /* 00010000 00000000 */
+  DEBUG_DNSMASQ_LINES = (1 << 13), /* 00100000 00000000 */
 };
 
 #endif //CONFIG_H

--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -1764,7 +1764,8 @@ char *querystr(char *desc, unsigned short type)
   return buff ? buff : "";
 }
 
-void log_query(unsigned int flags, char *name, struct all_addr *addr, char *arg)
+// Modified by Pi-hole
+void _log_query(unsigned int flags, char *name, struct all_addr *addr, char *arg, const char* file, const int line)
 {
   char *source, *dest = daemon->addrbuff;
   char *verb = "is";
@@ -1868,7 +1869,10 @@ void log_query(unsigned int flags, char *name, struct all_addr *addr, char *arg)
   
   if (strlen(name) == 0)
     name = ".";
-
+/************************************************************** Pi-hole modification  **************************************************************/
+if(debug_dnsmasq_lines == 0)
+{
+/***************************************************************************************************************************************************/
   if (option_bool(OPT_EXTRALOG))
     {
       int port = prettyprint_addr(daemon->log_source_addr, daemon->addrbuff2);
@@ -1879,6 +1883,22 @@ void log_query(unsigned int flags, char *name, struct all_addr *addr, char *arg)
     }
   else
     my_syslog(LOG_INFO, "%s %s %s %s", source, name, verb, dest);
+/************************************************************** Pi-hole modification  **************************************************************/
+}
+else
+{
+  if (option_bool(OPT_EXTRALOG))
+    {
+      int port = prettyprint_addr(daemon->log_source_addr, daemon->addrbuff2);
+      if (flags & F_NOEXTRA)
+	my_syslog(LOG_INFO, "* %s/%u %s %s %s %s (%s:%d)", daemon->addrbuff2, port, source, name, verb, dest, file, line);
+      else
+	my_syslog(LOG_INFO, "%u %s/%u %s %s %s %s (%s:%d)", daemon->log_display_id, daemon->addrbuff2, port, source, name, verb, dest, file, line);
+    }
+  else
+    my_syslog(LOG_INFO, "%s %s %s %s (%s:%d)", source, name, verb, dest, file, line);
+}
+/***************************************************************************************************************************************************/
 }
 
  

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1159,7 +1159,10 @@ extern struct daemon {
 /* cache.c */
 void cache_init(void);
 void next_uid(struct crec *crecp);
-void log_query(unsigned int flags, char *name, struct all_addr *addr, char *arg); 
+/********************************************* Pi-hole modification ***********************************************/
+#define log_query(flags,name,addr,arg) _log_query(flags, name, addr, arg, __FILE__, __LINE__)
+void _log_query(unsigned int flags, char *name, struct all_addr *addr, char *arg, const char* file, const int line);
+/******************************************************************************************************************/
 char *record_source(unsigned int index);
 char *querystr(char *desc, unsigned short type);
 int cache_find_non_terminal(char *name, time_t now);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -44,6 +44,9 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 static void query_externally_blocked(const int queryID, const unsigned char status);
 static int findQueryID(const int id);
 
+// Adds debug information to the regular pihole.log file
+char debug_dnsmasq_lines = 0;
+
 unsigned char* pihole_privacylevel = &config.privacylevel;
 const char flagnames[28][12] = {"F_IMMORTAL ", "F_NAMEP ", "F_REVERSE ", "F_FORWARD ", "F_DHCP ", "F_NEG ", "F_HOSTS ", "F_IPV4 ", "F_IPV6 ", "F_BIGNAME ", "F_NXDOMAIN ", "F_CNAME ", "F_DNSKEY ", "F_CONFIG ", "F_DS ", "F_DNSSECOK ", "F_UPSTREAM ", "F_RRNAME ", "F_SERVER ", "F_QUERY ", "F_NOERR ", "F_AUTH ", "F_DNSSEC ", "F_KEYTAG ", "F_SECSTAT ", "F_NO_RR ", "F_IPSET ", "F_NOEXTRA "};
 

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -42,4 +42,6 @@ void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
 int FTL_database_import(int cache_size, struct crec **rhash, int hashsz);
 
+extern char debug_dnsmasq_lines;
+
 #endif // DNSMASQ_INTERFACE_H


### PR DESCRIPTION
Signed-off-by: DL6ER <dl6er@dl6er.de>

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This PR adds a new debug option. Then enabled, the embedded `dnsmasq` will append `file:line` information for each line (see example below).

`DEBUG_DNSMASQ_LINES=false` (standard):
```
Dec 10 10:53:31 dnsmasq[21723]: query[A] team.pi-hole.net from 192.168.2.223
Dec 10 10:53:31 dnsmasq[21723]: forwarded team.pi-hole.net to 8.8.8.8
Dec 10 10:53:31 dnsmasq[21723]: query[AAAA] team.pi-hole.net from 192.168.2.223
Dec 10 10:53:31 dnsmasq[21723]: forwarded team.pi-hole.net to 8.8.8.8
Dec 10 10:53:31 dnsmasq[21723]: reply team.pi-hole.net is 46.4.71.158
Dec 10 10:53:31 dnsmasq[21723]: reply team.pi-hole.net is 2a01:4f8:140:329e::1:4
```

`DEBUG_DNSMASQ_LINES=true`:
```
Dec 10 10:55:12 dnsmasq[21723]: query[A] team.pi-hole.net from 192.168.2.223 (src/dnsmasq/forward.c:1558)
Dec 10 10:55:12 dnsmasq[21723]: forwarded team.pi-hole.net to 8.8.8.8 (src/dnsmasq/forward.c:556)
Dec 10 10:55:12 dnsmasq[21723]: query[AAAA] team.pi-hole.net from 192.168.2.223 (src/dnsmasq/forward.c:1558)
Dec 10 10:55:12 dnsmasq[21723]: forwarded team.pi-hole.net to 8.8.8.8 (src/dnsmasq/forward.c:556)
Dec 10 10:55:12 dnsmasq[21723]: reply team.pi-hole.net is 46.4.71.158 (src/dnsmasq/cache.c:481)
Dec 10 10:55:12 dnsmasq[21723]: reply team.pi-hole.net is 2a01:4f8:140:329e::1:4 (src/dnsmasq/cache.c:481)
```