### PR TITLE
Add CNAME_DEEP_INSPECT config option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -345,6 +345,19 @@ void read_FTLconf(void)
 	else
 		logg("   REGEX_IGNORECASE: Disabled. Regex is case sensitive");
 
+	// CNAME_DEEP_INSPECT
+	// defaults to: true
+	config.cname_inspection = true;
+	buffer = parse_FTLconf(fp, "CNAME_DEEP_INSPECT");
+
+	if(buffer != NULL && strcasecmp(buffer, "false") == 0)
+		config.cname_inspection = false;
+
+	if(config.cname_inspection)
+		logg("   CNAME_DEEP_INSPECT: Active");
+	else
+		logg("   CNAME_DEEP_INSPECT: Inactive");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,7 @@ typedef struct {
 	bool DBimport;
 	bool parse_arp_cache;
 	bool regex_ignorecase;
+	bool cname_inspection;
 } ConfigStruct;
 
 typedef struct {

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -226,6 +226,12 @@ bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const 
 	if(config.privacylevel >= PRIVACY_NOSTATS)
 		return false;
 
+	// Does the user want to skip deep CNAME inspection?
+	if(!config.cname_inspection)
+	{
+		return false;
+	}
+
 	// Lock shared memory
 	lock_shm();
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add `CNAME_DEEP_INSPECT` config option (default: true).

It can be used to disable deep CNAME inspection.
This might be beneficial for very low-end devices.