### PR TITLE
Correctly handle REFUSED and SERVFAIL responses

### DIFF
--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -479,12 +479,12 @@ struct crec *cache_insert(char *name, struct all_addr *addr,
   if (flags & (F_IPV4 | F_IPV6 | F_CNAME))
     {
       log_query(flags | F_UPSTREAM, name, addr, NULL);
+      FTL_reply(flags, name, addr, daemon->log_display_id);
       /* Don't mess with TTL for DNSSEC records. */
       if (daemon->max_cache_ttl != 0 && daemon->max_cache_ttl < ttl)
 	ttl = daemon->max_cache_ttl;
       if (daemon->min_cache_ttl != 0 && daemon->min_cache_ttl > ttl)
 	ttl = daemon->min_cache_ttl;
-      FTL_reply(flags, name, addr, daemon->log_display_id);
     }
 
   /* if previous insertion failed give up now. */

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -964,6 +964,7 @@ size_t setup_reply(struct dns_header *header, size_t qlen,
       struct all_addr a;
       a.addr.rcode.rcode = SERVFAIL;
       log_query(F_CONFIG | F_RCODE, "error", &a, NULL);
+      FTL_reply(flags, "error", &a, daemon->log_display_id);
       SET_RCODE(header, SERVFAIL);
     }
   else if (flags & ( F_IPV4 | F_IPV6))
@@ -991,6 +992,7 @@ size_t setup_reply(struct dns_header *header, size_t qlen,
       struct all_addr a;
       a.addr.rcode.rcode = REFUSED;
       log_query(F_CONFIG | F_RCODE, "error", &a, NULL);
+      FTL_reply(flags, "error", &a, daemon->log_display_id);
       SET_RCODE(header, REFUSED);
     }
   


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Correctly handle `REFUSED` responses. There are mainly two possibilities for such replies:
- **Forwarding failed because no forward destinations are known.**
  This happens when `/etc/resolv.conf` is empty and there are no upstream servers specified in `/etc/dnsmasq.d/01-pihole.conf`. `dnsmasq` rejects such queries with response code `REFUSED`.
- **Forwarding cannot happen as we ran out of resources.**
  `dnsmasq` limits how many concurrent queries can be made. Once this number is reached, it will reject further queries until the backlog has been cleared.

This PR also makes sure to correctly process received `SERVFAIL` replies sent from forward destinations.