### PR TITLE
Do not try to resolve client host names during the tests

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -32,7 +32,7 @@ sqlite3 /etc/pihole/gravity.db < test/gravity.db.sql
 echo "BLOCKING_ENABLED=true" > /etc/pihole/setupVars.conf
 
 # Prepare pihole-FTL.conf
-echo "DEBUG_ALL=true" > /etc/pihole/pihole-FTL.conf
+echo "DEBUG_ALL=true\nRESOLVE_IPV4=no\nRESOLVE_IPV6=no" > /etc/pihole/pihole-FTL.conf
 
 # Prepare dnsmasq.conf
 echo -e "log-queries\nlog-facility=/var/log/pihole.log" > /etc/dnsmasq.conf


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10
---

The CI cannot always resolve the host names so the tests are written to test for IP addresses.
However, when it can occasionally resolve host names this leads to false-negatives during the CI testing. This PR enables already existing config settings of FTL that prevent it from trying to resolve client host names during the tests.