### PR TITLE
Top lists fix for deeply blocked CNAME chains

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -275,6 +275,21 @@ bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const 
 	const char *blockingreason = NULL;
 	bool block = FTL_check_blocking(queryID, domainID, clientID, &blockingreason);
 
+	// If we find during a CNAME inspection that we want to block the entire chain,
+	// the originally queried domain itself was not counted as blocked (but as
+	// (permitted). Later in the chain, when we find that this is a bad guy, we
+	// short-circuit it. We need to correct the domain counter of the domain at the
+	// head of the chain, otherwise, the data for the top lists is misleading.
+	// For this, we go back the entire path and change the original request to blocked
+	// by increasing the blocked count of this domain by one. Fortunately, each CNAME
+	// path can easily be tracked back to the original head in FTL's data so we do not
+	// need to search it. This makes the change able to happen without causing any delay.
+	if(block)
+	{
+		domainsData* head_domain = getDomain(query->domainID, true);
+		head_domain->blockedcount++;
+	}
+
 	if(config.debug & DEBUG_QUERIES)
 	{
 		if(src == NULL)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

If we find during a deep `CNAME` inspection that we want to block the entire chain, the originally queried domain itself was not counted as blocked (but as permitted). Later in the chain, when we find that this is a bad guy, we short-circuit it. We need to correct the domain counter of the domain at the head of the chain, otherwise, the data for the top lists is misleading.

For this, we go back the entire path and change the original request to blocked by increasing the blocked count of this domain.
We do this, because the value for the permitted list is computed as `permitted = total - blocked` so it doesn't change when we increase both, the subtrahend and the minuend by one.
Fortunately, each `CNAME` path can easily be tracked back to the original head in FTL's data so we do not need to search it.

This makes the change able to happen without causing any additional delay.

This bug exists only in `development`.
Many thanks @Wally3k for reporting this!