### PR TITLE
Change ownership of all shared memory objects before switching user

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1531,6 +1531,7 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 		if(database && chown(FTLfiles.FTL_db, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
 			logg("Setting ownership (%i:%i) of %s failed: %s (%i)",
 			     ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.FTL_db, strerror(errno), errno);
+		chown_all_shmem(ent_pw);
 	}
 }
 

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -74,4 +74,7 @@ void newOverTimeClient(const int clientID);
  */
 void addOverTimeClientSlot(void);
 
+// Change ownership of shared memory objects
+void chown_all_shmem(struct passwd *ent_pw);
+
 #endif //SHARED_MEMORY_SERVER_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Change ownership of all shared memory objects to the user/group configured in `/etc/dnsmasq.d/01-pihole.conf`. We already do this for `pihole-FTL.log` and `pihole-FTL.db` but forgot to do this for the shm objects.