### PR TITLE
Add support for IDNs in HOSTS files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ IDIR = src
 ODIR = build
 
 DNSMASQ_VERSION = "pi-hole-2.80"
-DNSMASQ_OPTS = -DHAVE_DNSSEC -DHAVE_DNSSEC_STATIC
-# Flags for compiling with libidn : -DHAVE_IDN
-# Flags for compiling with libidn2: -DHAVE_LIBIDN2 -DIDN2_VERSION_NUMBER=0x02000003
+DNSMASQ_OPTS = -DHAVE_DNSSEC -DHAVE_DNSSEC_STATIC -DHAVE_IDN
 
 FTL_DEPS = *.h database/*.h api/*.h version.h
 FTL_DB_OBJ = database/common.o database/query-table.o database/network-table.o database/gravity-db.o database/database-thread.o
@@ -106,9 +104,7 @@ CCFLAGS=-std=gnu11 -I$(IDIR) $(WARN_FLAGS) -D_FILE_OFFSET_BITS=64 $(HARDENING_FL
 # for FTL we need the pthread library
 # for dnsmasq we need the nettle crypto library and the gmp maths library
 # We link the two libraries statically. Although this increases the binary file size by about 1 MB, it saves about 5 MB of shared libraries and makes deployment easier
-LIBS=-pthread -lrt -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle
-# Flags for compiling with libidn : -lidn
-# Flags for compiling with libidn2: -lidn2
+LIBS=-pthread -lrt -Wl,-Bstatic -L/usr/local/lib -lhogweed -lgmp -lnettle -lidn
 
 # Do we want to compile a statically linked musl executable?
 ifeq "$(STATIC)" "true"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Use `libidn`. This will improve support for internationalized domain names (IDNs) by adding an automated conversion from locale's encoding to a legit ASCII domain name string. We do not use `libidn2` as there are some [bug reports](https://redmine.pfsense.org/issues/7820) and we found issues trying to compile statically against `libidn2`. Additionally, there seems to be no clear advantage compared to using `libidn`.

For this to work, we need to add `libidn11-dev`  to our CI containers. Until then, this PR stays marked as `[WIP]`. Note that we have not added this before v5.0 as we were still loading the domains from HOSTS files. The automated conversion would have slowed down the initial startup of FTL by about one order of magnitude which would have been unacceptable on low-end hardware (one minute or more). It was always possible to enable IDN when compiling FTL from source as we described what needs to be done in the Makefile.