### PR TITLE
Fix for blocking modes

### DIFF
--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1645,7 +1645,8 @@ void receive_query(struct listener *listen, time_t now)
 	{
 	  size_t plen = n;
 	  struct all_addr *addrp = NULL;
-	  unsigned int flags = (listen->family == AF_INET) ? F_IPV4 : F_IPV6;
+	  // DNS resource record type for AAAA is 28 (decimal) following RFC 3596, section 2.1
+	  unsigned int flags = (type == 28u) ? F_IPV6 : F_IPV4;
 	  FTL_get_blocking_metadata(&addrp, &flags);
 	  log_query(flags, daemon->namebuff, addrp, (char*)blockingreason);
 	  plen = setup_reply(header, n, addrp, flags, daemon->local_ttl);
@@ -2021,7 +2022,8 @@ unsigned char *tcp_request(int confd, time_t now,
 	  if(piholeblocked)
 	    {
 	      struct all_addr *addrp = NULL;
-	      unsigned int flags = (peer_addr.sa.sa_family == AF_INET) ? F_IPV4 : F_IPV6;
+	      // DNS resource record type for AAAA is 28 (decimal) following RFC 3596, section 2.1
+	      unsigned int flags = (qtype == 28u) ? F_IPV6 : F_IPV4;
 	      FTL_get_blocking_metadata(&addrp, &flags);
 	      log_query(flags, daemon->namebuff, addrp, (char*)blockingreason);
 	      m = setup_reply(header, size, addrp, flags, daemon->local_ttl);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes two bugs in FTL. One was the detection of the address which should be used to reply to a request, the other was the correct synthesis of the DNS header response codes and the requirement of the absence of answer section records for `NODATA` and `NXDOMAIN` blocking modes.

Both issues are fixed by the PR and only appeared when using a different blocking mode than `NULL` (which is Pi-hole's default).