### PR TITLE
Fix internal DNS cache twist

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -106,7 +106,10 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 				logg("%s is known as %s", domainstr, *blockingreason);
 			}
 
-			return true;
+			// Do not block if the entire query is to be permitted
+			// as sometving along the CNAME path hit the whitelist
+			if(!query->whitelisted)
+				return true;
 			break;
 
 		case GRAVITY_BLOCKED:
@@ -122,7 +125,10 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 				logg("%s is known as %s", domainstr, *blockingreason);
 			}
 
-			return true;
+			// Do not block if the entire query is to be permitted
+			// as sometving along the CNAME path hit the whitelist
+			if(!query->whitelisted)
+				return true;
 			break;
 
 		case REGEX_BLOCKED:
@@ -138,7 +144,10 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 				logg("%s is known as %s", domainstr, *blockingreason);
 			}
 
-			return true;
+			// Do not block if the entire query is to be permitted
+			// as sometving along the CNAME path hit the whitelist
+			if(!query->whitelisted)
+				return true;
 			break;
 
 		case WHITELISTED:

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -97,10 +97,7 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 			// Known as exactly blacklistes, we
 			// return this result early, skipping
 			// all the lengthy tests below
-			query_blocked(query, domain, client);
-			query->status = QUERY_BLACKLIST;
 			*blockingreason = "exactly blacklisted";
-
 			if(config.debug & DEBUG_QUERIES)
 			{
 				logg("%s is known as %s", domainstr, *blockingreason);
@@ -109,17 +106,18 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 			// Do not block if the entire query is to be permitted
 			// as sometving along the CNAME path hit the whitelist
 			if(!query->whitelisted)
+			{
+				query_blocked(query, domain, client);
+				query->status = QUERY_BLACKLIST;
 				return true;
+			}
 			break;
 
 		case GRAVITY_BLOCKED:
 			// Known as gravity blocked, we
 			// return this result early, skipping
 			// all the lengthy tests below
-			query_blocked(query, domain, client);
-			query->status = QUERY_GRAVITY;
 			*blockingreason = "gravity blocked";
-
 			if(config.debug & DEBUG_QUERIES)
 			{
 				logg("%s is known as %s", domainstr, *blockingreason);
@@ -128,17 +126,18 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 			// Do not block if the entire query is to be permitted
 			// as sometving along the CNAME path hit the whitelist
 			if(!query->whitelisted)
+			{
+				query_blocked(query, domain, client);
+				query->status = QUERY_GRAVITY;
 				return true;
+			}
 			break;
 
 		case REGEX_BLOCKED:
 			// Known as regex blacklisted, we
 			// return this result early, skipping
 			// all the lengthy tests below
-			query_blocked(query, domain, client);
-			query->status = QUERY_WILDCARD;
 			*blockingreason = "regex blacklisted";
-
 			if(config.debug & DEBUG_QUERIES)
 			{
 				logg("%s is known as %s", domainstr, *blockingreason);
@@ -147,7 +146,11 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 			// Do not block if the entire query is to be permitted
 			// as sometving along the CNAME path hit the whitelist
 			if(!query->whitelisted)
+			{
+				query_blocked(query, domain, client);
+				query->status = QUERY_WILDCARD;
 				return true;
+			}
 			break;
 
 		case WHITELISTED:


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Do not block queries when a domain is known to be blocked, however, the entire CNAME chain is to be permitted.

This should fix a bug reported on [Discourse](https://discourse.pi-hole.net/t/some-domains-are-intermittently-blocked-even-though-they-are-on-the-whitelist/27477/10), waiting on conformation it fixes the issue before switching this PR to live.