### PR TITLE
Pin build image to specific version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ version: 2
 
 .docker_template: &docker_template
   docker:
-    - image: pihole/ftl-build:$CIRCLE_JOB
+    - image: pihole/ftl-build:v1.0-$CIRCLE_JOB
   <<: *job_steps
 
 jobs:


### PR DESCRIPTION
Don't use the `latest` tag, use the specific version.

Fixes #683 