### PR TITLE
Use precomputed gravity count from database

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -432,7 +432,15 @@ int gravityDB_count(const unsigned char list)
 
 	char *querystr = NULL;
 	// Build correct query string to be used depending on list to be read
-	if(asprintf(&querystr, "SELECT count(DISTINCT domain) FROM %s", tablename[list]) < 18)
+	if(list != GRAVITY_TABLE && asprintf(&querystr, "SELECT COUNT(DISTINCT domain) FROM %s", tablename[list]) < 18)
+	{
+		logg("readGravity(%u) - asprintf() error", list);
+		return false;
+	}
+	// We get the number of unique gravity domains as counted and stored by gravity. Counting the number
+	// of distinct domains in vw_gravity may take up to several minutes for very large blocking lists on
+	// very low-end devices such as the Raspierry Pi Zero
+	else if(list == GRAVITY_TABLE && asprintf(&querystr, "SELECT value FROM info WHERE property = 'gravity_count';") < 18)
 	{
 		logg("readGravity(%u) - asprintf() error", list);
 		return false;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -453,7 +453,7 @@ int gravityDB_count(const unsigned char list)
 	int rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &table_stmt, NULL);
 	if(rc != SQLITE_OK){
 		logg("gravityDB_count(%s) - SQL error prepare (%i): %s", querystr, rc, sqlite3_errmsg(gravity_db));
-		sqlite3_finalize(table_stmt);
+		gravityDB_finalizeTable();
 		gravityDB_close();
 		free(querystr);
 		return DB_FAILED;
@@ -463,8 +463,11 @@ int gravityDB_count(const unsigned char list)
 	rc = sqlite3_step(table_stmt);
 	if(rc != SQLITE_ROW){
 		logg("gravityDB_count(%s) - SQL error step (%i): %s", querystr, rc, sqlite3_errmsg(gravity_db));
-		sqlite3_finalize(table_stmt);
-		gravityDB_close();
+		if(list == GRAVITY_TABLE)
+		{
+			logg("Count of gravity domains not available. Please run pihole -g");
+		}
+		gravityDB_finalizeTable();
 		free(querystr);
 		return DB_FAILED;
 	}

--- a/test/gravity.db.sql
+++ b/test/gravity.db.sql
@@ -169,6 +169,7 @@ INSERT INTO adlist VALUES(1,'https://hosts-file.net/ad_servers.txt',1,1559928803
 INSERT INTO gravity VALUES('whitelisted.test.pi-hole.net',1);
 INSERT INTO gravity VALUES('gravity-blocked.test.pi-hole.net',1);
 INSERT INTO gravity VALUES('discourse.pi-hole.net',1);
+INSERT INTO info VALUES("gravity_count",3);
 
 INSERT INTO "group" VALUES(1,0,'Test group',1559928803,1559928803,'A disabled test group');
 INSERT INTO domainlist VALUES(7,1,'blacklisted-group-disabled.com',1,1559928803,1559928803,'Entry disabled by a group');


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This speeds up FTL start and reload actions. See discussion [here](https://discourse.pi-hole.net/t/disabling-pi-hole-breaks-dns-for-1-min/274929).