### PR TITLE
Propagate ID of responsible regex up in CNAME inspection

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -341,7 +341,21 @@ bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const 
 		if(query->status == QUERY_GRAVITY)
 			query->status = QUERY_GRAVITY_CNAME;
 		else if(query->status == QUERY_REGEX)
+		{
+			// Get parent DNS cache entry
+			unsigned int parent_cacheID = findCacheID(domainID, query->clientID);
+			DNSCacheData *parent_dns_cache = getDNSCache(parent_cacheID, true);
+
+			// Get child DNS cache entry
+			unsigned int child_cacheID = findCacheID(query->domainID, query->clientID);
+			DNSCacheData *child_dns_cache = getDNSCache(child_cacheID, true);
+
+			// Propagate ID of responsible regex up from the child to the parent domain
+			if(parent_dns_cache != NULL && child_dns_cache != NULL)
+				child_dns_cache->black_regex_idx = parent_dns_cache->black_regex_idx;
+
 			query->status = QUERY_REGEX_CNAME;
+		}
 		else if(query->status == QUERY_BLACKLIST)
 			query->status = QUERY_BLACKLIST_CNAME;
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Propagate ID of responsible regex up from the child to the parent domain if blocking happened during CNAME inspection.

Related Discourse discussion: https://discourse.pi-hole.net/t/request-show-regex-responsible-for-blocking/27656