### PR TITLE
Try to reopen gravity database when not available

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -294,12 +294,20 @@ inline void gravityDB_finalize_client_statements(clientsData* client)
 
 void gravityDB_reload_client_statements(void)
 {
+	// Set SQLite3 busy timeout to a user-defined value (defaults to 1 second)
+	// to avoid immediate failures when the gravity database is still busy
+	// writing the changes to disk
+	sqlite3_busy_timeout(gravity_db, DATABASE_BUSY_TIMEOUT);
+
 	for(int i=0; i < counters->clients; i++)
 	{
 		clientsData* client = getClient(i, true);
 		if(client != NULL)
 			gravityDB_prepare_client_statements(client);
 	}
+
+	// Reset SQLite3 busy timeout to zero
+	sqlite3_busy_timeout(gravity_db, 0);
 }
 
 void gravityDB_close(void)

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -112,7 +112,7 @@ static bool get_client_groupids(const clientsData* client, char **groups)
 	*groups = NULL;
 
 	// Do not proceed when database is not available
-	if(!gravity_database_avail)
+	if(!gravity_database_avail && !gravityDB_open())
 	{
 		logg("get_client_groupids(): Gravity database not available");
 		return false;
@@ -134,7 +134,6 @@ static bool get_client_groupids(const clientsData* client, char **groups)
 		logg("get_client_groupids(%s) - SQL error prepare (%i): %s",
 		     querystr, rc, sqlite3_errmsg(gravity_db));
 		sqlite3_finalize(table_stmt);
-		gravityDB_close();
 		free(querystr);
 		return false;
 	}
@@ -162,7 +161,6 @@ static bool get_client_groupids(const clientsData* client, char **groups)
 		logg("get_client_groupids(%s) - SQL error step (%i): %s",
 		     querystr, rc, sqlite3_errmsg(gravity_db));
 		sqlite3_finalize(table_stmt);
-		gravityDB_close();
 		free(querystr);
 		return false;
 	}
@@ -191,7 +189,6 @@ static bool get_client_groupids(const clientsData* client, char **groups)
 		logg("get_client_groupids(%s) - SQL error prepare (%i): %s",
 		     querystr, rc, sqlite3_errmsg(gravity_db));
 		sqlite3_finalize(table_stmt);
-		gravityDB_close();
 		free(querystr);
 		return false;
 	}
@@ -218,12 +215,12 @@ static bool get_client_groupids(const clientsData* client, char **groups)
 		logg("get_client_groupids(%s) - SQL error step (%i): %s",
 		     querystr, rc, sqlite3_errmsg(gravity_db));
 		sqlite3_finalize(table_stmt);
-		gravityDB_close();
 		free(querystr);
 		return false;
 	}
 	// Finalize statement
 	gravityDB_finalizeTable();
+
 	// Free allocated memory and return result
 	free(querystr);
 	return true;
@@ -232,7 +229,7 @@ static bool get_client_groupids(const clientsData* client, char **groups)
 bool gravityDB_prepare_client_statements(clientsData* client)
 {
 	// Return early if gravity database is not available
-	if(!gravity_database_avail)
+	if(!gravity_database_avail && !gravityDB_open())
 		return false;
 
 	if(config.debug & DEBUG_DATABASE)
@@ -308,7 +305,7 @@ void gravityDB_reload_client_statements(void)
 void gravityDB_close(void)
 {
 	// Return early if gravity database is not available
-	if(!gravity_database_avail)
+	if(!gravity_database_avail && !gravityDB_open())
 		return;
 
 	// Finalize list statements
@@ -330,7 +327,7 @@ void gravityDB_close(void)
 // a table which is specified when calling this function
 bool gravityDB_getTable(const unsigned char list)
 {
-	if(!gravity_database_avail)
+	if(!gravity_database_avail && !gravityDB_open())
 	{
 		logg("gravityDB_getTable(%u): Gravity database not available", list);
 		return false;
@@ -419,7 +416,7 @@ void gravityDB_finalizeTable(void)
 // encounter any error
 int gravityDB_count(const unsigned char list)
 {
-	if(!gravity_database_avail)
+	if(!gravity_database_avail && !gravityDB_open())
 	{
 		logg("gravityDB_count(%d): Gravity database not available", list);
 		return DB_FAILED;
@@ -488,7 +485,7 @@ int gravityDB_count(const unsigned char list)
 static bool domain_in_list(const char *domain, sqlite3_stmt* stmt, const char* listname)
 {
 	// Do not try to bind text to statement when database is not available
-	if(!gravity_database_avail)
+	if(!gravity_database_avail && !gravityDB_open())
 	{
 		logg("domain_in_list(%s): Gravity database not available", domain);
 		return false;
@@ -617,16 +614,18 @@ bool gravityDB_get_regex_client_groups(clientsData* client, const int numregex, 
 	while((rc = sqlite3_step(query_stmt)) == SQLITE_ROW)
 	{
 		const int result = sqlite3_column_int(query_stmt, 0);
-		for(int i = 0; i < numregex; i++)
+		for(int regexID = 0; regexID < numregex; regexID++)
 		{
-			if(regexid[i] == result)
+			if(regexid[regexID] == result)
 			{
-				unsigned int regexID = i;
 				if(type == REGEX_WHITELIST)
 					regexID += counters->num_regex[REGEX_BLACKLIST];
+
 				set_per_client_regex(clientID, regexID, true);
+
 				if(config.debug & DEBUG_REGEX)
-					logg("Regex %s: Enabling regex with DB ID %i for client %s", regextype[type], regexid[i], getstr(client->ippos));
+					logg("Regex %s: Enabling regex with DB ID %i for client %s", regextype[type], regexid[regexID], getstr(client->ippos));
+
 				break;
 			}
 		}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Access to the gravity database is essential for correct working of `pihole-FTL`. Try to reopen the gravity database when it was not available due to an existing lock.