### PR TITLE
Allow for graceful filtering of AAAA record requests.

### DIFF
--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -266,7 +266,8 @@ struct event_desc {
 #define OPT_TFTP_APREF_MAC 56
 #define OPT_RAPID_COMMIT   57
 #define OPT_UBUS           58
-#define OPT_LAST           59
+#define OPT_FILTER_AAAA    59
+#define OPT_LAST           60
 
 /* extra flags for my_syslog, we use a couple of facilities since they are known 
    not to occupy the same bits as priorities, no matter how syslog.h is set up. */

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -170,6 +170,7 @@ struct myoption {
 #define LOPT_UBUS          354
 #define LOPT_NAME_MATCH    355
 #define LOPT_CAA           356
+#define LOPT_FILTER_AAAA   357
  
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -341,6 +342,7 @@ static const struct myoption opts[] =
     { "dhcp-rapid-commit", 0, 0, LOPT_RAPID_COMMIT },
     { "dumpfile", 1, 0, LOPT_DUMPFILE },
     { "dumpmask", 1, 0, LOPT_DUMPMASK },
+    { "filter-aaaa", 0, 0, LOPT_FILTER_AAAA },
     { NULL, 0, 0, 0 }
   };
 
@@ -519,6 +521,7 @@ static struct {
   { LOPT_RAPID_COMMIT, OPT_RAPID_COMMIT, NULL, gettext_noop("Enables DHCPv4 Rapid Commit option."), NULL },
   { LOPT_DUMPFILE, ARG_ONE, "<path>", gettext_noop("Path to debug packet dump file"), NULL },
   { LOPT_DUMPMASK, ARG_ONE, "<hex>", gettext_noop("Mask which packets to dump"), NULL },
+  { LOPT_FILTER_AAAA, OPT_FILTER_AAAA, NULL, gettext_noop("Gracefully filter AAAA requests."), NULL },
   { 0, 0, NULL, NULL, NULL }
 }; 
 

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1931,6 +1931,12 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 	    }
 	}
 
+      if (qtype == T_AAAA && option_bool(OPT_FILTER_AAAA) ){
+        ans = 1;
+        if (!dryrun) log_query(F_CONFIG | F_IPV6 | F_NEG, name, &addr, NULL);
+        break;
+      }
+
       if (!ans)
 	return 0; /* failed to answer a question */
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 2

---

This is a little unusual to do on most home networks, but on some networks the DNS resolvers can't handle AAAA queries properly (Lookin at you F5 Wide IP Resolvers....) in the case of those of us who are cursed with GTM Wide IP resolvers doing our DNS Resolution, if we send a query then it takes a full 10 seconds for every resolution. F5 have a KB about it here - https://support.f5.com/csp/article/K7308

While I've just been maintaining this for a while now as a patch I apply to FTL releases I was asked by someone if there was any way to block AAAA queries, having recommended that they use pi-hole on their home network, and it occured to me that there may be other use cases where it is desirable for someone to apply this sort of control to their network, I don't know, I don't know everyone's requirements

It does seem to _kind of_ fit within the purview of pi-hole as the entire project is largely about being able to control what happens on _your_ network. And in the case where it's not necessarily _your_ network, but one managed by people who have definitely kept up to date on their networking knowledge and try and fix the 10s problem by disabling IPv6 everywhere 🤦‍♂ because obviously you can query AAAA records over ipv4... it's also kinda handy.

The dnsmasq upstream don't appear to be overly sympathetic to this problem, as they have stated a number of times, but this feels like a useful "provide flexibility on your network" kind of feature that _sort of_ fits in the purview of pi-hole given that it let's you better control what is going in and out of your network.

And given the minuscule size of the change (and that I know that an almost identical patch to dnsmasq is running in production in multiple extremely large organisations across literally tens of thousands of servers) it feels like it's not likely to do any harm stabilitywise so if it's desirable by the maintainers - here you go 🙂 