### PR TITLE
Add DELAY_STARTUP setting to delay startup of the embedded dnsmasq

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -358,6 +358,19 @@ void read_FTLconf(void)
 	else
 		logg("   CNAME_DEEP_INSPECT: Inactive");
 
+	// DELAY_STARTUP
+	// defaults to: zero (seconds)
+	buffer = parse_FTLconf(fp, "DELAY_STARTUP");
+
+	config.delay_startup = 0;
+	if(buffer != NULL && sscanf(buffer, "%u", &config.delay_startup) &&
+	   (config.delay_startup > 0 && config.delay_startup <= 300))
+	{
+		logg("   DELAY_STARTUP: Requested to wait %u seconds during startup.", config.delay_startup);
+	}
+	else
+		logg("   DELAY_STARTUP: No delay requested.");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -21,6 +21,7 @@ typedef struct {
 	int DBinterval;
 	int port;
 	int maxlogage;
+	unsigned int delay_startup;
 	int16_t debug;
 	unsigned char privacylevel;
 	unsigned char blockingmode;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -13,6 +13,8 @@
 #include "memory.h"
 #include "config.h"
 #include "log.h"
+// sleepms()
+#include "timers.h"
 
 void go_daemon(void)
 {
@@ -125,4 +127,17 @@ char *getUserName(void)
 	}
 
 	return name;
+}
+
+void delay_startup(void)
+{
+	// Exit early if not sleeping
+	if(config.delay_startup == 0u)
+		return;
+
+	// Sleep if requested by DELAY_STARTUP
+	logg("Sleeping for %d seconds as requested by configuration ...",
+	     config.delay_startup);
+	sleep(config.delay_startup);
+	logg("Done sleeping, continuing startup of resolver...\n");
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -14,5 +14,6 @@ void go_daemon(void);
 void savepid(void);
 char * getUserName(void);
 void removepid(void);
+void delay_startup(void);
 
 #endif //DAEMON_H

--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,8 @@ int main (int argc, char* argv[])
 	// immediately before starting the resolver.
 	check_capabilities();
 
-	// Start the resolver
+	// Start the resolver, delay startup if requested
+	delay_startup();
 	startup = false;
 	main_dnsmasq(argc_dnsmasq, argv_dnsmasq);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Adding a supported way of delaying the startup of the embedded `dnsmasq`. Even though it would be good to solve this otherwise, it is still better to do this in a supported way instead of hacking `cron` jobs or modify the `init.d` files which makes debugging much harder.