### PR TITLE
Ensure blocking also works when the long-term database is not used

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -214,13 +214,6 @@ void db_init(void)
 		exit(EXIT_FAILURE);
 	}
 
-	if(!use_database())
-	{
-		logg("Not using the long-term database");
-		database = false;
-		return;
-	}
-
 	// Lock database thread
 	pthread_mutex_lock(&dblock);
 
@@ -232,6 +225,15 @@ void db_init(void)
 
 	// Register Pi-hole provided SQLite3 extensions (see sqlite3-ext.c)
 	sqlite3_auto_extension((void (*)(void))sqlite3_pihole_extensions_init);
+
+	// Only exit early if we already finished the SQLite3 library initialization
+	if(!use_database())
+	{
+		logg("Not using the long-term database");
+		pthread_mutex_unlock(&dblock);
+		database = false;
+		return;
+	}
 
 	// Check if database exists, if not create empty database
 	if(!file_exists(FTLfiles.FTL_db))


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This was broken before as we returned too early (the SQLite3 engine was not yet fully initialized) when the long-term database was disabled.