### PR TITLE
Restored asterisk match for auditlog

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -72,7 +72,7 @@ bool gravityDB_open(void)
 	}
 
 	// Prepare audit statement
-	rc = sqlite3_prepare_v2(gravity_db, "SELECT EXISTS(SELECT domain from domain_audit WHERE domain = ?);", -1, &auditlist_stmt, NULL);
+	rc = sqlite3_prepare_v2(gravity_db, "SELECT EXISTS(SELECT domain, CASE WHEN substr(domain, 1, 1) = '*' THEN '*' || substr(?, - length(domain) + 1) else  substr(?, - length(domain)) END matcher FROM domain_audit WHERE matcher = domain);", -1, &auditlist_stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
 		logg("gravityDB_open(\"SELECT EXISTS(... domain_audit ...)\") - SQL error prepare (%i): %s", rc, sqlite3_errmsg(gravity_db));


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _3_


---

My auditlog includes things like `*.domain.local` and `*.arpa` and as those entries were converted to the databse while testing the v5.0 branch I noticed that my auditlog show'd up with tons of 'wrong' entries and I decided to put some research into the new database based version of the auditlog:

The current stable version has an asterisk matching for the first char of an auditlog.list line: If the line starts with * a substring from the linevalue will be used to check if the current domain contains the entry. This feature wasn't there anymore as the sqlversion strictly uses 'domain = ?' for the where-clause...

To avoid changes in 'domain_in_list' I decided to replace the auditlist_stmt: 

`SELECT EXISTS(SELECT domain, CASE WHEN substr(domain, 1, 1) = '*' THEN '*' || SUBSTR(?, - length(domain) + 1) ELSE SUBSTR(?, - length(domain)) END matcher FROM domain_audit WHERE matcher = domain);`

I'm open for a better solution (or query) - Please feel free to improve my solution.

---

*hope it's all at the right branch/place now as I noticed my earlier request was done against release/v5.0 and also I now used my local branch to commit my change as the github web gui wasn't the best way... - sorry for the trouble - first timer with pull request via github...*
