### PR TITLE
Fix FTL crashes in ARP table parsing

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -33,6 +33,7 @@ FTLFileNamesStruct FTLfiles = {
 
 // Private global variables
 static char *conflinebuffer = NULL;
+static size_t size = 0;
 
 // Private prototypes
 static char *parse_FTLconf(FILE *fp, const char * key);
@@ -434,7 +435,6 @@ static char *parse_FTLconf(FILE *fp, const char * key)
 	// Go to beginning of file
 	fseek(fp, 0L, SEEK_SET);
 
-	size_t size = 0;
 	errno = 0;
 	while(getline(&conflinebuffer, &size, fp) != -1)
 	{

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -201,7 +201,7 @@ static int update_netDB_hostname(const int dbID, const char *hostname)
 	if(rc != SQLITE_OK)
 	{
 		logg("update_netDB_hostname(%i, \"%s\") - SQL error prepare (%i): %s",
-		dbID, hostname, rc, sqlite3_errmsg(FTL_db));
+		     dbID, hostname, rc, sqlite3_errmsg(FTL_db));
 		return rc;
 	}
 
@@ -359,6 +359,12 @@ void parse_neighbor_cache(void)
 
 		int num = sscanf(linebuffer, "%99s dev %99s lladdr %99s",
 		                 ip, iface, hwaddr);
+
+		// Ensure strings are null-terminated in case we hit the max.
+		// length limitation
+		ip[sizeof(ip)-1] = '\0';
+		iface[sizeof(iface)-1] = '\0';
+		hwaddr[sizeof(hwaddr)-1] = '\0';
 
 		// Check if we want to process the line we just read
 		if(num != 3)

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -344,9 +344,8 @@ void parse_neighbor_cache(void)
 	// Initialize array of status for individual clients used to
 	// remember the status of a client already seen in the neigh cache
 	enum arp_status { CLIENT_NOT_HANDLED, CLIENT_ARP_COMPLETE, CLIENT_ARP_INCOMPLETE };
-	int clients_array_size = counters->clients;
-	enum arp_status client_status[clients_array_size];
-	for(int i = 0; i < clients_array_size; i++)
+	enum arp_status client_status[counters->clients];
+	for(int i = 0; i < counters->clients; i++)
 	{
 		client_status[i] = CLIENT_NOT_HANDLED;
 	}
@@ -421,7 +420,7 @@ void parse_neighbor_cache(void)
 
 		// This client is known (by its IP address) to pihole-FTL if
 		// findClientID() returned a non-negative index
-		if(clientID >= 0 && clientID < clients_array_size)
+		if(clientID >= 0)
 		{
 			client_status[clientID] = CLIENT_ARP_COMPLETE;
 			client = getClient(clientID, true);
@@ -552,9 +551,7 @@ void parse_neighbor_cache(void)
 		}
 		// Skip if already handled above (first check against clients_array_size as we might have added
 		// more clients to FTL's memory herein (those known only from the database))
-		else if((clientID < clients_array_size &&
-		         client_status[clientID] != CLIENT_NOT_HANDLED) ||
-			clientID >= clients_array_size)
+		else if(client_status[clientID] != CLIENT_NOT_HANDLED)
 		{
 			if(config.debug & DEBUG_ARP)
 				logg("Network table: Client %s known through ARP/neigh cache",

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -421,7 +421,7 @@ void parse_neighbor_cache(void)
 
 		// This client is known (by its IP address) to pihole-FTL if
 		// findClientID() returned a non-negative index
-		if(clientID >= 0)
+		if(clientID >= 0 && clientID < clients_array_size)
 		{
 			client_status[clientID] = CLIENT_ARP_COMPLETE;
 			client = getClient(clientID, true);
@@ -552,8 +552,9 @@ void parse_neighbor_cache(void)
 		}
 		// Skip if already handled above (first check against clients_array_size as we might have added
 		// more clients to FTL's memory herein (those known only from the database))
-		else if(clientID < clients_array_size && 
-		        client_status[clientID] != CLIENT_NOT_HANDLED)
+		else if((clientID < clients_array_size &&
+		         client_status[clientID] != CLIENT_NOT_HANDLED) ||
+			clientID >= clients_array_size)
 		{
 			if(config.debug & DEBUG_ARP)
 				logg("Network table: Client %s known through ARP/neigh cache",

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -517,8 +517,10 @@ void parse_neighbor_cache(void)
 		entries++;
 	}
 
-	// Close file handle
+	// Close pipe handle and free allocated memory
 	pclose(arpfp);
+	if(linebuffer != NULL)
+		free(linebuffer);
 
 	// Finally, loop over all clients known to FTL and ensure we add them
 	// all to the database

--- a/src/database/sqlite3-ext.c
+++ b/src/database/sqlite3-ext.c
@@ -36,8 +36,8 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 	}
 
 	// Return NO MATCH if invoked with non-TEXT arguments
-	if (sqlite3_value_type(argv[0]) == SQLITE_TEXT ||
-	    sqlite3_value_type(argv[1]) == SQLITE_TEXT)
+	if (sqlite3_value_type(argv[0]) != SQLITE_TEXT ||
+	    sqlite3_value_type(argv[1]) != SQLITE_TEXT)
 	{
 		logg("Invoked subnet_match() with non-text arguments: %d, %d",
 		     sqlite3_value_type(argv[0]), sqlite3_value_type(argv[1]));

--- a/src/database/sqlite3-ext.c
+++ b/src/database/sqlite3-ext.c
@@ -139,5 +139,11 @@ int sqlite3_pihole_extensions_init(sqlite3 *db, char **pzErrMsg, const sqlite3_a
 	int rc = sqlite3_create_function(db, "subnet_match", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
 	                                 subnet_match_impl, NULL, NULL);
 
+	if(rc != SQLITE_OK)
+	{
+		logg("Error while initializing the SQLite3 extension subnet_match: %s",
+		     sqlite3_errstr(rc));
+	}
+
 	return rc;
 }

--- a/src/database/sqlite3-ext.c
+++ b/src/database/sqlite3-ext.c
@@ -35,10 +35,13 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 		return;
 	}
 
-	// Return if invoked with NULL argument
-	if (sqlite3_value_type(argv[0]) == SQLITE_NULL ||
-	    sqlite3_value_type(argv[1]) == SQLITE_NULL)
+	// Return NO MATCH if invoked with non-TEXT arguments
+	if (sqlite3_value_type(argv[0]) == SQLITE_TEXT ||
+	    sqlite3_value_type(argv[1]) == SQLITE_TEXT)
 	{
+		logg("Invoked subnet_match() with non-text arguments: %d, %d",
+		     sqlite3_value_type(argv[0]), sqlite3_value_type(argv[1]));
+		sqlite3_result_int(context, 0);
 		return;
 	}
 
@@ -74,8 +77,8 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 		//sqlite3_result_error(context, "Passed a malformed IP address (database)", -1);
 		// Return non-fatal "NO MATCH" if address is invalid
 		logg("Passed a malformed DB IP address: %s/%i (%s)", addrDB, cidr, addrDBcidr);
-		sqlite3_result_int(context, 0);
 		free(addrDB);
+		sqlite3_result_int(context, 0);
 		return;
 	}
 
@@ -103,7 +106,7 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 	// Apply bitmask to both IP addresses
 	// Note: the upper 12 byte of IPv4 addresses are zero
 	int match = 1;
-	for(int i = 0; i < 16; i++)
+	for(unsigned int i = 0u; i < 16u; i++)
 	{
 		saddrDB.s6_addr[i] &= bitmask[i];
 		saddrFTL.s6_addr[i] &= bitmask[i];
@@ -116,10 +119,6 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 		}
 	}
 
-	// Return if we found a match between the two addresses
-	// given a possibly specified mask
-	sqlite3_result_int(context, match);
-
 	// Possible debug logging
 	if(config.debug & DEBUG_DATABASE)
 	{
@@ -127,9 +126,13 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 		     addrFTL, addrDBcidr,
 			 match == 1 ? "!! MATCH !!" : "NO MATCH");
 	}
+
+	// Return if we found a match between the two addresses
+	// given a possibly specified mask
+	sqlite3_result_int(context, match);
 }
 
-int sqlite3_pihole_extensions_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi)
+int sqlite3_pihole_extensions_init(sqlite3 *db, const char **pzErrMsg, const struct sqlite3_api_routines *pApi)
 {
 	(void)pzErrMsg;  /* Unused parameter */
 

--- a/src/database/sqlite3-ext.h
+++ b/src/database/sqlite3-ext.h
@@ -9,4 +9,4 @@
 *  Please see LICENSE file for your rights under this license. */
 
 // Initialization point for SQLite3 extensions
-extern int sqlite3_pihole_extensions_init(sqlite3 *db, char **pzErrMsg, const struct sqlite3_api_routines *pApi);
+extern int sqlite3_pihole_extensions_init(sqlite3 *db, const char **pzErrMsg, const struct sqlite3_api_routines *pApi);

--- a/src/database/sqlite3-ext.h
+++ b/src/database/sqlite3-ext.h
@@ -1,1 +1,12 @@
-extern int sqlite3_pihole_extensions_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2020 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  SQLite3 database engine extension prototypes
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+// Initialization point for SQLite3 extensions
+extern int sqlite3_pihole_extensions_init(sqlite3 *db, char **pzErrMsg, const struct sqlite3_api_routines *pApi);

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -159,7 +159,9 @@ int findClientID(const char *clientIP, const bool count)
 		}
 	}
 
-	// Proceed with adding a new client entry
+	// Return -1 (= not found) if count is false because we do not want to create a new client here
+	if(!count)
+		return -1;
 
 	// If we did not return until here, then this client is definitely new
 	// Store ID
@@ -179,7 +181,7 @@ int findClientID(const char *clientIP, const bool count)
 	// Set magic byte
 	client->magic = MAGICBYTE;
 	// Set its counter to 1
-	client->count = count ? 1 : 0;
+	client->count = 1;
 	// Initialize blocked count to zero
 	client->blockedcount = 0;
 	// Store client IP - no need to check for NULL here as it doesn't harm

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -173,6 +173,7 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 		logg("Not adding \"%s\" to buffer (unchanged)", oldname);
 	}
 
+	free(newname);
 	free(ipaddr);
 	free(oldname);
 

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -99,12 +99,14 @@ static char *resolveHostname(const char *addr)
 	{
 		struct in6_addr ipaddr;
 		inet_pton(AF_INET6, addr, &ipaddr);
+		// Known to leak some tiny amounts of memory under certain conditions
 		he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET6);
 	}
 	else if(!IPv6 && config.resolveIPv4) // Resolve IPv4 address only if requested
 	{
 		struct in_addr ipaddr;
 		inet_pton(AF_INET, addr, &ipaddr);
+		// Known to leak some tiny amounts of memory under certain conditions
 		he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET);
 	}
 

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -23,6 +23,8 @@
 // struct _res
 #include <resolv.h>
 
+static bool res_initialized = false;
+
 // Validate given hostname
 static bool valid_hostname(char* name, const char* clientip)
 {
@@ -80,6 +82,16 @@ static char *resolveHostname(const char *addr)
 		hostname = strdup("hidden");
 		//if(hostname == NULL) return NULL;
 		return hostname;
+	}
+
+	// Initialize resolver subroutines if trying to resolve for the first time
+	// res_init() reads resolv.conf to get the default domain name and name server
+	// address(es). If no server is given, the local host is tried. If no domain
+	// is given, that associated with the local host is used.
+	if(!res_initialized)
+	{
+		res_init();
+		res_initialized = true;
 	}
 
 	// Force last available (MAXNS-1) server used for lookups to 127.0.0.1 (FTL itself)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes a bug in `release/v5.0` reported in #718.

The underlying heap memory access violation occurred only when there are both, multiple addresses for the same devices in the ARP table, and only some of these addresses are already known to FTL (i.e., they sent DNS queries to the Pi-hole before).
If either all addresses of a device (or likely none) were already known to FTL because they made requests in the past, this bug doesn’t show up.
This is likely because users with IPv6 are much more likely to see this bug as there is a high likelihood that an interface has at least one address that has never been used to ask Pi-hole any questions. Multiple addresses on the same interface are rather seldom in the IPv4-world.

As a side-effect of my code review, I also found two small memory leaks which are now fixed. There is a small remaining leak in the system-provided function `gethostbyaddr()` but we cannot do anything about it. The worst seems to be leaking 110 bytes *once* during the first name resolution. This sounds perfectly acceptable.