### PR TITLE
Restore fork-safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ FTL_DEPS = *.h database/*.h api/*.h version.h
 FTL_DB_OBJ = database/common.o database/query-table.o database/network-table.o database/gravity-db.o database/database-thread.o database/sqlite3-ext.o
 FTL_API_OBJ = api/socket.o api/request.o api/msgpack.o api/api.o
 FTL_OBJ = $(FTL_DB_OBJ) $(FTL_API_OBJ) main.o memory.o log.o daemon.o datastructure.o signals.o files.o setupVars.o args.o gc.o config.o \
-          dnsmasq_interface.o resolve.o regex.o shmem.o capabilities.o overTime.o timers.o
+          dnsmasq_interface.o resolve.o regex.o shmem.o capabilities.o overTime.o timers.o vector.o
 
 DNSMASQ_DEPS = config.h dhcp-protocol.h dns-protocol.h radv-protocol.h dhcp6-protocol.h dnsmasq.h ip6addr.h metrics.h ../dnsmasq_interface.h
 DNSMASQ_OBJ = arp.o dbus.o domain.o lease.o outpacket.o rrfilter.o auth.o dhcp6.o edns0.o log.o poll.o slaac.o blockdata.o dhcp.o forward.o \

--- a/src/config.c
+++ b/src/config.c
@@ -647,6 +647,10 @@ void read_debuging_settings(FILE *fp)
 	extern char debug_dnsmasq_lines;
 	debug_dnsmasq_lines = config.debug & DEBUG_DNSMASQ_LINES ? 1 : 0;
 
+	// DEBUG_VECTORS
+	// defaults to: false
+	setDebugOption(fp, "DEBUG_VECTORS", DEBUG_VECTORS);
+
 	if(config.debug)
 	{
 		logg("*****************************");
@@ -665,6 +669,7 @@ void read_debuging_settings(FILE *fp)
 		logg("* DEBUG_EXTBLOCKED      %s *", (config.debug & DEBUG_EXTBLOCKED)? "YES":"NO ");
 		logg("* DEBUG_CAPS            %s *", (config.debug & DEBUG_CAPS)? "YES":"NO ");
 		logg("* DEBUG_DNSMASQ_LINES   %s *", (config.debug & DEBUG_DNSMASQ_LINES)? "YES":"NO ");
+		logg("* DEBUG_VECTORS         %s *", (config.debug & DEBUG_VECTORS)? "YES":"NO ");
 		logg("*****************************");
 	}
 

--- a/src/config.h
+++ b/src/config.h
@@ -69,6 +69,7 @@ enum {
   DEBUG_EXTBLOCKED    = (1 << 11), /* 00001000 00000000 */
   DEBUG_CAPS          = (1 << 12), /* 00010000 00000000 */
   DEBUG_DNSMASQ_LINES = (1 << 13), /* 00100000 00000000 */
+  DEBUG_VECTORS       = (1 << 14), /* 01000000 00000000 */
 };
 
 #endif //CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,9 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+// typedef int16_t
+#include <sys/types.h>
+
 void getLogFilePath(void);
 void read_FTLconf(void);
 void get_privacy_level(FILE *fp);

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -26,8 +26,7 @@ static sqlite3 *gravity_db = NULL;
 static sqlite3_stmt* table_stmt = NULL;
 static sqlite3_stmt* auditlist_stmt = NULL;
 bool gravityDB_opened = false;
-static pid_t main_process = 0;
-static pid_t this_process = 0;
+static pid_t main_process = 0, this_process = 0;
 
 // Table names corresponding to the enum defined in gravity-db.h
 static const char* tablename[] = { "vw_gravity", "vw_blacklist", "vw_whitelist", "vw_regex_blacklist", "vw_regex_whitelist" , ""};
@@ -47,7 +46,7 @@ static void gravityDB_check_fork(void)
 		this_process = main_process;
 	}
 
-	if(main_process == getpid())
+	if(this_process == getpid())
 		return;
 
 	// If we reach this point, FTL forked to handle
@@ -57,6 +56,10 @@ static void gravityDB_check_fork(void)
 	// of locking problems as SQLite3 was not intended
 	// to work under such circumstances. Doing so may
 	// easily lead to ending up with a corrupted database.
+
+	// Memorize PID of this thread to avoid re-opening the
+	// gravity database connection multiple times for the
+	// same fork
 	this_process = getpid();
 
 	// Pretend that we did not open the database so far

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -29,5 +29,4 @@ bool in_blacklist(const char *domain, const int clientID, clientsData* client);
 bool gravityDB_get_regex_client_groups(clientsData* client, const int numregex, const int *regexid,
                                        const unsigned char type, const char* table, const int clientID);
 
-
 #endif //GRAVITY_H

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -14,9 +14,7 @@
 enum { GRAVITY_TABLE, EXACT_BLACKLIST_TABLE, EXACT_WHITELIST_TABLE, REGEX_BLACKLIST_TABLE, REGEX_WHITELIST_TABLE, UNKNOWN_TABLE };
 
 bool gravityDB_open(void);
-bool gravityDB_prepare_client_statements(clientsData* client);
-void gravityDB_finalize_client_statements(clientsData* client);
-void gravityDB_reload_client_statements(void);
+bool gravityDB_prepare_client_statements(const int clientID, clientsData* client);
 void gravityDB_close(void);
 bool gravityDB_getTable(unsigned char list);
 const char* gravityDB_getDomain(int *rowid);
@@ -24,9 +22,9 @@ void gravityDB_finalizeTable(void);
 int gravityDB_count(unsigned char list);
 bool in_auditlist(const char *domain);
 
-bool in_gravity(const char *domain, clientsData* client);
-bool in_whitelist(const char *domain, clientsData* client, const int clientID);
-bool in_blacklist(const char *domain, clientsData* client);
+bool in_gravity(const char *domain, const int clientID, clientsData* client);
+bool in_whitelist(const char *domain, const int clientID, clientsData* client);
+bool in_blacklist(const char *domain, const int clientID, clientsData* client);
 
 bool gravityDB_get_regex_client_groups(clientsData* client, const int numregex, const int *regexid,
                                        const unsigned char type, const char* table, const int clientID);

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -203,11 +203,6 @@ int findClientID(const char *clientIP, const bool count)
 	// Increase counter by one
 	counters->clients++;
 
-	// NULL-initialize database client statements
-	client->gravity_stmt = NULL;
-	client->whitelist_stmt = NULL;
-	client->blacklist_stmt = NULL;
-
 	// Allocate regex substructure
 	allocate_regex_client_enabled(client, clientID);
 

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -63,9 +63,6 @@ typedef struct {
 	size_t ippos;
 	size_t namepos;
 	time_t lastQuery;
-	sqlite3_stmt* whitelist_stmt;
-	sqlite3_stmt* gravity_stmt;
-	sqlite3_stmt* blacklist_stmt;
 } clientsData;
 
 typedef struct {

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -16,7 +16,7 @@
 
 #define FTABSIZ 150 /* max number of outstanding requests (default) */
 #define MAX_PROCS 20 /* max no children for TCP requests */
-#define CHILD_LIFETIME 150 /* secs 'till terminated (RFC1035 suggests > 120s) */
+#define CHILD_LIFETIME 5 /* secs 'till terminated (RFC1035 suggests > 120s) */
 #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
 #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
 #define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -16,7 +16,7 @@
 
 #define FTABSIZ 150 /* max number of outstanding requests (default) */
 #define MAX_PROCS 20 /* max no children for TCP requests */
-#define CHILD_LIFETIME 5 /* secs 'till terminated (RFC1035 suggests > 120s) */
+#define CHILD_LIFETIME 150 /* secs 'till terminated (RFC1035 suggests > 120s) */
 #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
 #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
 #define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1484,8 +1484,10 @@ static void async_event(int pipe, time_t now)
 	
 	my_syslog(LOG_INFO, _("exiting on receipt of SIGTERM"));
 	flush_log();
+	/*** Pi-hole modification ***/
 //	exit(EC_GOOD);
 	terminate = 1;
+	/*** Pi-hole modification ***/
       }
 }
 
@@ -1822,6 +1824,10 @@ static void check_dns_listeners(time_t now)
 #ifndef NO_FORK		   
 	      if (!option_bool(OPT_DEBUG))
 		{
+		  /*** Pi-hole modification ***/
+		  // TCP workers ignore all signals except SIGALRM
+		  FTL_TCP_worker_terminating();
+		  /*** Pi-hole modification ***/
 		  flush_log();
 		  _exit(0);
 		}

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1151,7 +1151,13 @@ static void sig_handler(int sig)
     {
       /* alarm is used to kill TCP children after a fixed time. */
       if (sig == SIGALRM)
-	_exit(0);
+        {
+	  /*** Pi-hole modification ***/
+	  // TCP workers ignore all signals except SIGALRM
+	  FTL_TCP_worker_terminating();
+	  /*** Pi-hole modification ***/
+	  _exit(0);
+        }
     }
   else
     {

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -189,14 +189,14 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 
 	// Check whitelist (exact + regex) for match
 	const char *domainString = getstr(domain->domainpos);
-	query->whitelisted = in_whitelist(domainString, client, clientID);
+	query->whitelisted = in_whitelist(domainString, clientID, client);
 
 	// Check domains against exact blacklist
 	// Skipped when the domain is whitelisted
 	bool blockDomain = false;
 	unsigned char new_status = QUERY_UNKNOWN;
 	if(!query->whitelisted &&
-	   in_blacklist(domainString, client))
+	   in_blacklist(domainString, clientID, client))
 	{
 		// We block this domain
 		blockDomain = true;
@@ -210,7 +210,7 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 	// Check domains against gravity domains
 	// Skipped when the domain is whitelisted or blocked by exact blacklist
 	if(!query->whitelisted && !blockDomain &&
-	   in_gravity(domainString, client))
+	   in_gravity(domainString, clientID, client))
 	{
 		// We block this domain
 		blockDomain = true;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1726,3 +1726,18 @@ static void prepare_blocking_metadata(void)
 	// Free IPv6addr
 	clearSetupVarsArray();
 }
+
+// Called when a (forked) TCP worker is terminated by receiving SIGALRM
+// We close the dedicated database connection this client had opened
+// to avoid dangling database locks
+void FTL_TCP_worker_terminating(void)
+{
+	if(config.debug & DEBUG_DATABASE)
+	{
+		logg("TCP worker terminating, "
+		     "closing gravity database connection");
+	}
+
+	// Close dedicated database connection of this fork
+	gravityDB_close();
+}

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -51,6 +51,7 @@ bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const 
 
 void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
+void FTL_TCP_worker_terminating(void);
 
 void set_debug_dnsmasq_lines(char enabled);
 extern char debug_dnsmasq_lines;

--- a/src/main.c
+++ b/src/main.c
@@ -85,6 +85,11 @@ int main (int argc, char* argv[])
 	// Start the resolver, delay startup if requested
 	delay_startup();
 	startup = false;
+	if(config.debug != 0)
+	{
+		for(int i = 0; i < argc_dnsmasq; i++)
+			logg("DEBUG: argv[%i] = \"%s\"", i, argv_dnsmasq[i]);
+	}
 	main_dnsmasq(argc_dnsmasq, argv_dnsmasq);
 
 	logg("Shutting down...");

--- a/src/main.c
+++ b/src/main.c
@@ -121,6 +121,6 @@ int main (int argc, char* argv[])
 
 	//Remove PID file
 	removepid();
-	logg("########## FTL terminated after %.1f ms! ##########", timer_elapsed_msec(EXIT_TIMER));
+	logg("########## FTL terminated after %e s! ##########", 1e-3*timer_elapsed_msec(EXIT_TIMER));
 	return EXIT_SUCCESS;
 }

--- a/src/signals.c
+++ b/src/signals.c
@@ -77,7 +77,7 @@ static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, vo
 
 	// Print message and abort
 	logg("FTL terminated!");
-	abort();
+	exit(EXIT_FAILURE);
 }
 
 static void SIGRT_handler(int signum, siginfo_t *si, void *unused)

--- a/src/vector.c
+++ b/src/vector.c
@@ -43,7 +43,7 @@ static void resize_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int capacity)
 	// equivalent to malloc(size) so we can use it also for
 	// initializing a vector for the first time.
 	sqlite3_stmt **items = realloc(v->items, sizeof(sqlite3_stmt *) * capacity);
-	if (!items)
+	if(!items)
 	{
 		logg("ERROR: Memory allocation failed in resize_sqlite3_stmt_vec(%p, %u)",
 		       v, capacity);
@@ -73,7 +73,7 @@ void append_sqlite3_stmt_vec(sqlite3_stmt_vec *v, sqlite3_stmt *item)
 	}
 
 	// Check if vector needs to be resized
-	if (v->capacity == v->size)
+	if(v->capacity == v->size)
 	{
 		resize_sqlite3_stmt_vec(v, v->capacity + VEC_ALLOC_STEP);
 	}
@@ -95,7 +95,7 @@ void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt 
 		return;
 	}
 
-	if (index >= v->size)
+	if(index >= v->size)
 	{
 		// Allocate more memory when trying to set a statement vector entry with
 		// an index larger than the current array size (this makes set an equivalent
@@ -119,11 +119,10 @@ sqlite3_stmt * __attribute__((pure)) get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, u
 		return 0;
 	}
 
-	if (index >= v->size)
+	if(index >= v->size)
 	{
-		logg("ERROR: Boundary violation in get_sqlite3_stmt_vec(%p, %u)",
-		       v, index);
-		return 0;
+		// Silently increase size of vector if trying to read out-of-bounds
+		resize_sqlite3_stmt_vec(v, index + VEC_ALLOC_STEP);
 	}
 
 	sqlite3_stmt* item = v->items[index];
@@ -138,7 +137,7 @@ void del_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index)
 	if(config.debug & DEBUG_VECTORS)
 		logg("Deleting item at index %u of sqlite3_stmt* vector %p", index, v);
 
-	if (index >= v->size)
+	if(index >= v->size)
 		return;
 
 	// Use memmove to ensure there are no gaps in the vector
@@ -148,7 +147,7 @@ void del_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index)
 	v->size--;
 
 	// // Shorten vector to save some space
-	// if (v->size > 0u && v->size == v->capacity / 4)
+	// if(v->size > 0u && v->size == v->capacity / 4)
 	// {
 	// 	vResize(v, v->capacity / 2);
 	// }

--- a/src/vector.c
+++ b/src/vector.c
@@ -51,7 +51,7 @@ static void resize_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int capacity)
 	v->items = items;
 
 	// NULL-initialize newly allocated memory slots
-	for(unsigned int i = capacity - v->capacity; i < capacity; i++)
+	for(unsigned int i = v->capacity; i < capacity; i++)
 		v->items[i] = NULL;
 
 	// Update capacity

--- a/src/vector.c
+++ b/src/vector.c
@@ -1,0 +1,168 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2020 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Dynamic vector routines
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "vector.h"
+// struct config
+#include "config.h"
+// logg()
+#include "log.h"
+
+/********************************* type sqlite3_stmt_vec *********************************/
+sqlite3_stmt_vec *new_sqlite3_stmt_vec(unsigned int initial_size)
+{
+	if(config.debug & DEBUG_VECTORS)
+		logg("Initializing new sqlite3_stmt* vector with size %u", initial_size);
+
+	sqlite3_stmt_vec *v = calloc(1, sizeof(sqlite3_stmt_vec));
+	v->size = initial_size;
+	v->capacity = initial_size;
+	// Calloc ensures they are all set to zero which is the default state
+	v->items = calloc(initial_size, sizeof(sqlite3_stmt *) * initial_size);
+	// Set correct subroutine pointers
+	v->append = append_sqlite3_stmt_vec;
+	v->set = set_sqlite3_stmt_vec;
+	v->get = get_sqlite3_stmt_vec;
+	v->del = del_sqlite3_stmt_vec;
+	v->free = free_sqlite3_stmt_vec;
+	return v;
+}
+
+static void resize_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int capacity)
+{
+	if(config.debug & DEBUG_VECTORS)
+		logg("Resizing sqlite3_stmt* vector %p from %u to %u", v, v->capacity, capacity);
+
+	// If ptr is NULL, the call to realloc(ptr, size) is
+	// equivalent to malloc(size) so we can use it also for
+	// initializing a vector for the first time.
+	sqlite3_stmt **items = realloc(v->items, sizeof(sqlite3_stmt *) * capacity);
+	if (!items)
+	{
+		logg("ERROR: Memory allocation failed in resize_sqlite3_stmt_vec(%p, %u)",
+		       v, capacity);
+		return;
+	}
+
+	// Update items pointer
+	v->items = items;
+
+	// NULL-initialize newly allocated memory slots
+	for(unsigned int i = capacity - v->capacity; i < capacity; i++)
+		v->items[i] = NULL;
+
+	// Update capacity
+	v->capacity = capacity;
+}
+void append_sqlite3_stmt_vec(sqlite3_stmt_vec *v, sqlite3_stmt *item)
+{
+	if(config.debug & DEBUG_VECTORS)
+		logg("Appending item %p to sqlite3_stmt* vector %p", item, v);
+
+	if(v == NULL)
+	{
+		logg("ERROR: Passed NULL vector to append_sqlite3_stmt_vec(%p, %p)",
+		       v, item);
+		return;
+	}
+
+	// Check if vector needs to be resized
+	if (v->capacity == v->size)
+	{
+		resize_sqlite3_stmt_vec(v, v->capacity + VEC_ALLOC_STEP);
+	}
+
+	// Append item
+	unsigned int index = v->size++;
+	v->items[index] = item;
+}
+
+void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt *item)
+{
+	if(config.debug & DEBUG_VECTORS)
+		logg("Setting sqlite3_stmt** %p[%u] <-- %p", v, index, item);
+
+	if(v == NULL)
+	{
+		logg("ERROR: Passed NULL vector to set_sqlite3_stmt_vec(%p, %u, %p)",
+		       v, index, item);
+		return;
+	}
+
+	if (index >= v->size)
+	{
+		// Allocate more memory when trying to set a statement vector entry with
+		// an index larger than the current array size (this makes set an equivalent
+		// alternative to append)
+		resize_sqlite3_stmt_vec(v, index + VEC_ALLOC_STEP);
+	}
+
+	// Set item
+	v->items[index] = item;
+}
+
+// This function has no effects except to return a value. It can
+// be subject to data flow analysis and might be eliminated.
+// Hence, we add the "pure" attribute to this function.
+sqlite3_stmt * __attribute__((pure)) get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index)
+{
+	if(v == NULL)
+	{
+		logg("ERROR: Passed NULL vector to get_sqlite3_stmt_vec(%p, %u)",
+		       v, index);
+		return 0;
+	}
+
+	if (index >= v->size)
+	{
+		logg("ERROR: Boundary violation in get_sqlite3_stmt_vec(%p, %u)",
+		       v, index);
+		return 0;
+	}
+
+	sqlite3_stmt* item = v->items[index];
+	if(config.debug & DEBUG_VECTORS)
+		logg("Getting sqlite3_stmt** %p[%u] --> %p", v, index, item);
+
+	return item;
+}
+
+void del_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index)
+{
+	if(config.debug & DEBUG_VECTORS)
+		logg("Deleting item at index %u of sqlite3_stmt* vector %p", index, v);
+
+	if (index >= v->size)
+		return;
+
+	// Use memmove to ensure there are no gaps in the vector
+	size_t move = v->size - index - 1u;
+	memmove(&v->items[index], &v->items[index + 1u], move * sizeof(v->items[index]));
+
+	v->size--;
+
+	// // Shorten vector to save some space
+	// if (v->size > 0u && v->size == v->capacity / 4)
+	// {
+	// 	vResize(v, v->capacity / 2);
+	// }
+}
+
+void free_sqlite3_stmt_vec(sqlite3_stmt_vec *v)
+{
+	if(config.debug & DEBUG_VECTORS)
+		logg("Freeing sqlite3_stmt* vector %p", v);
+
+	// Free elements of the vector...
+	free(v->items);
+	// ...and then then vector itself
+	free(v);
+	v = NULL;
+}
+/********************************* type sqlite3_stmt_vec *********************************/

--- a/src/vector.c
+++ b/src/vector.c
@@ -14,7 +14,6 @@
 // logg()
 #include "log.h"
 
-/********************************* type sqlite3_stmt_vec *********************************/
 sqlite3_stmt_vec *new_sqlite3_stmt_vec(unsigned int initial_size)
 {
 	if(config.debug & DEBUG_VECTORS)
@@ -36,9 +35,9 @@ static void resize_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int capacity)
 	if(config.debug & DEBUG_VECTORS)
 		logg("Resizing sqlite3_stmt* vector %p from %u to %u", v, v->capacity, capacity);
 
-	// If ptr is NULL, the call to realloc(ptr, size) is
-	// equivalent to malloc(size) so we can use it also for
-	// initializing a vector for the first time.
+	// If ptr is NULL, the call to realloc(ptr, size) is equivalent to
+	// malloc(size) so we can use it also for initializing a vector for the
+	// first time.
 	sqlite3_stmt **items = realloc(v->items, sizeof(sqlite3_stmt *) * capacity);
 	if(!items)
 	{
@@ -73,8 +72,8 @@ void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt 
 	if(index >= v->capacity)
 	{
 		// Allocate more memory when trying to set a statement vector entry with
-		// an index larger than the current array size (this makes set an equivalent
-		// alternative to append)
+		// an index larger than the current array size (this makes set an
+		// equivalent alternative to append)
 		resize_sqlite3_stmt_vec(v, index + VEC_ALLOC_STEP);
 	}
 
@@ -82,9 +81,9 @@ void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt 
 	v->items[index] = item;
 }
 
-// This function has no effects except to return a value. It can
-// be subject to data flow analysis and might be eliminated.
-// Hence, we add the "pure" attribute to this function.
+// This function has no effects except to return a value. It can be subject to
+// data flow analysis and might be eliminated. Hence, we add the "pure"
+// attribute to this function.
 sqlite3_stmt * __attribute__((pure)) get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index)
 {
 	if(v == NULL)
@@ -114,8 +113,7 @@ void free_sqlite3_stmt_vec(sqlite3_stmt_vec *v)
 
 	// Free elements of the vector...
 	free(v->items);
-	// ...and then then vector itself
+	// ...and then the vector itself
 	free(v);
 	v = NULL;
 }
-/********************************* type sqlite3_stmt_vec *********************************/

--- a/src/vector.h
+++ b/src/vector.h
@@ -22,18 +22,14 @@
 #define VEC_ALLOC_STEP 10u
 
 typedef struct sqlite3_stmt_vec {
-	unsigned int size;
 	unsigned int capacity;
 	sqlite3_stmt **items;
 	sqlite3_stmt *(*get)(struct sqlite3_stmt_vec *, unsigned int);
-	void (*append)(struct sqlite3_stmt_vec *, sqlite3_stmt*);
 	void (*set)(struct sqlite3_stmt_vec *, unsigned int, sqlite3_stmt*);
-	void (*del)(struct sqlite3_stmt_vec *, unsigned int);
 	void (*free)(struct sqlite3_stmt_vec *);
 } sqlite3_stmt_vec;
 
 sqlite3_stmt_vec *new_sqlite3_stmt_vec(unsigned int initial_size);
-void append_sqlite3_stmt_vec(sqlite3_stmt_vec *v, sqlite3_stmt* item);
 void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt* item);
 sqlite3_stmt* get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index) __attribute__((pure));
 void del_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index);

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,0 +1,42 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Dynamic vector prototypes
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+#ifndef VECTOR_H
+#define VECTOR_H
+
+#include <stdio.h>
+#include <stdlib.h>
+// memmove()
+#include <string.h>
+// type bool
+#include <stdbool.h>
+// type sqlite3_stmt
+#include "database/sqlite3.h"
+
+#define VEC_ALLOC_STEP 10u
+
+typedef struct sqlite3_stmt_vec {
+	unsigned int size;
+	unsigned int capacity;
+	sqlite3_stmt **items;
+	sqlite3_stmt *(*get)(struct sqlite3_stmt_vec *, unsigned int);
+	void (*append)(struct sqlite3_stmt_vec *, sqlite3_stmt*);
+	void (*set)(struct sqlite3_stmt_vec *, unsigned int, sqlite3_stmt*);
+	void (*del)(struct sqlite3_stmt_vec *, unsigned int);
+	void (*free)(struct sqlite3_stmt_vec *);
+} sqlite3_stmt_vec;
+
+sqlite3_stmt_vec *new_sqlite3_stmt_vec(unsigned int initial_size);
+void append_sqlite3_stmt_vec(sqlite3_stmt_vec *v, sqlite3_stmt* item);
+void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt* item);
+sqlite3_stmt* get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index) __attribute__((pure));
+void del_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index);
+void free_sqlite3_stmt_vec(sqlite3_stmt_vec *v);
+
+#endif //VECTOR_H

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,5 +1,5 @@
 /* Pi-hole: A black hole for Internet advertisements
-*  (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+*  (c) 2020 Pi-hole, LLC (https://pi-hole.net)
 *  Network-wide ad blocking via your own hardware.
 *
 *  FTL Engine


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

FTL is a complex multi-dimensional application. The main process has a number of threads surrounding it, each of which performing specific duties (like updating the database, resolving host names and parsing the network (ARP) cache, ...). To make things even more complicated, FTL adds yet another level of parallelism, namely it forks the main process in order to maintain individual DNS clients connecting over a persisting TCP connections. The forking is done to ensure a non-blocking DNS resolution even in the presence of persistent connections.

During the investigation of #698, we have been remindet that SQLite3 is [not fork-safe](https://www.sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_) even when it is thread-safe. This PR fixes a possible crash as, previously, FTL tried to use the same prepared statements and database connections across forks. As this is not a good idea, we change this with the given PR to individual database connections and prepared statements for different forks.