### PR TITLE
Restore audit wildcard-support

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -126,7 +126,7 @@ bool gravityDB_open(void)
 	// Prepare audit statement
 	if(config.debug & DEBUG_DATABASE)
 		logg("gravityDB_open(): Preparing audit query");
-	rc = sqlite3_prepare_v2(gravity_db, "SELECT EXISTS(SELECT domain from domain_audit WHERE domain = ?);", -1, &auditlist_stmt, NULL);
+	rc = sqlite3_prepare_v2(gravity_db, "SELECT EXISTS(SELECT domain, CASE WHEN substr(domain, 1, 1) = '*' THEN '*' || substr(?, - length(domain) + 1) else  substr(?, - length(domain)) END matcher FROM domain_audit WHERE matcher = domain);", -1, &auditlist_stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
 		logg("gravityDB_open(\"SELECT EXISTS(... domain_audit ...)\") - SQL error prepare: %s", sqlite3_errstr(rc));

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -126,7 +126,27 @@ bool gravityDB_open(void)
 	// Prepare audit statement
 	if(config.debug & DEBUG_DATABASE)
 		logg("gravityDB_open(): Preparing audit query");
-	rc = sqlite3_prepare_v2(gravity_db, "SELECT EXISTS(SELECT domain, CASE WHEN substr(domain, 1, 1) = '*' THEN '*' || substr(?, - length(domain) + 1) else  substr(?, - length(domain)) END matcher FROM domain_audit WHERE matcher = domain);", -1, &auditlist_stmt, NULL);
+
+	// We support adding audit domains with a wildcard character (*)
+	// Example 1: google.de
+	//            matches only google.de
+	// Example 2: *.google.de
+	//            matches all subdomains of google.de
+	//            BUT NOT google.de itself
+	// Example 3: *google.de
+	//            matches 'google.de' and all of its subdomains but
+	//            also other domains starting in google.de, like
+	//            abcgoogle.de
+	rc = sqlite3_prepare_v2(gravity_db,
+	        "SELECT EXISTS("
+	          "SELECT domain, "
+	            "CASE WHEN substr(domain, 1, 1) = '*' " // Does the database string start in '*' ?
+	              "THEN '*' || substr(:input, - length(domain) + 1) " // If so: Crop the input domain and prepend '*'
+	              "ELSE :input " // If not: Use input domain directly for comparison
+	            "END matcher "
+	          "FROM domain_audit WHERE matcher = domain" // Match where (modified) domain equals the database domain
+	        ");", -1, &auditlist_stmt, NULL);
+
 	if( rc != SQLITE_OK )
 	{
 		logg("gravityDB_open(\"SELECT EXISTS(... domain_audit ...)\") - SQL error prepare: %s", sqlite3_errstr(rc));
@@ -607,6 +627,10 @@ static bool domain_in_list(const char *domain, sqlite3_stmt* stmt, const char* l
 	// Bind domain to prepared statement
 	// SQLITE_STATIC: Use the string without first duplicating it internally.
 	// We can do this as domain has dynamic scope that exceeds that of the binding.
+	// We need to bind the domain onl once even to the prepared audit statement as:
+	//     When the same named SQL parameter is used more than once, second and
+	//     subsequent occurrences have the same index as the first occurrence.
+	//     (https://www.sqlite.org/c3ref/bind_blob.html)
 	if((rc = sqlite3_bind_text(stmt, 1, domain, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
 		logg("domain_in_list(\"%s\", %p, %s): Failed to bind domain: %s",


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

With Pi-hole v4.x we had wildcard-support in the audit log. When migrating this list into the database, we lost this ability. This PR is the successor of #722 which aimed at restoring this feature. A few changes were necessary that exceeded Github's ability to suggest changes so I moved this into a new PR, preserving the OP's authorship of the first commit.

This PR is milestoned for still being included in the v5.0 release.