### PR TITLE
Improve internal resolver algorithm

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -651,6 +651,10 @@ void read_debuging_settings(FILE *fp)
 	// defaults to: false
 	setDebugOption(fp, "DEBUG_VECTORS", DEBUG_VECTORS);
 
+	// DEBUG_RESOLVER
+	// defaults to: false
+	setDebugOption(fp, "DEBUG_RESOLVER", DEBUG_RESOLVER);
+
 	if(config.debug)
 	{
 		logg("*****************************");
@@ -670,6 +674,7 @@ void read_debuging_settings(FILE *fp)
 		logg("* DEBUG_CAPS            %s *", (config.debug & DEBUG_CAPS)? "YES":"NO ");
 		logg("* DEBUG_DNSMASQ_LINES   %s *", (config.debug & DEBUG_DNSMASQ_LINES)? "YES":"NO ");
 		logg("* DEBUG_VECTORS         %s *", (config.debug & DEBUG_VECTORS)? "YES":"NO ");
+		logg("* DEBUG_RESOLVER        %s *", (config.debug & DEBUG_RESOLVER)? "YES":"NO ");
 		logg("*****************************");
 	}
 

--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,7 @@ typedef struct {
 	int DBinterval;
 	int port;
 	int maxlogage;
+	int dns_port;
 	unsigned int delay_startup;
 	int16_t debug;
 	unsigned char privacylevel;
@@ -73,6 +74,7 @@ enum {
   DEBUG_CAPS          = (1 << 12), /* 00010000 00000000 */
   DEBUG_DNSMASQ_LINES = (1 << 13), /* 00100000 00000000 */
   DEBUG_VECTORS       = (1 << 14), /* 01000000 00000000 */
+  DEBUG_RESOLVER      = (1 << 15), /* 10000000 00000000 */
 };
 
 #endif //CONFIG_H

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1617,6 +1617,9 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 			     ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.FTL_db, strerror(errno), errno);
 		chown_all_shmem(ent_pw);
 	}
+
+	// Obtain DNS port from dnsmasq daemon
+	config.dns_port = daemon->port;
 }
 
 // int cache_inserted, cache_live_freed are defined in dnsmasq/cache.c

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -65,14 +65,21 @@ static bool valid_hostname(char* name, const char* clientip)
 	return true;
 }
 
+static void print_used_resolvers(const char *message)
+{
+	logg("%s", message);
+	for(unsigned int i = 0u; i < MAXNS; i++)
+		logg(" %u: %s", i, inet_ntoa(_res.nsaddr_list[i].sin_addr));
+}
+
 static char *resolveHostname(const char *addr)
 {
 	// Get host name
 	struct hostent *he = NULL;
-	char *hostname = NULL;;
+	char *hostname = NULL;
 	bool IPv6 = false;
 
-	if(config.debug & DEBUG_API)
+	if(config.debug & DEBUG_RESOLVER)
 		logg("Trying to resolve %s", addr);
 
 	// Check if this is a hidden client
@@ -80,8 +87,26 @@ static char *resolveHostname(const char *addr)
 	if(strcmp(addr, "0.0.0.0") == 0)
 	{
 		hostname = strdup("hidden");
-		//if(hostname == NULL) return NULL;
+		if(config.debug & DEBUG_RESOLVER)
+			logg("---> \"%s\" (privacy settings)", hostname);
 		return hostname;
+	}
+
+	// Test if we want to resolve an IPv6 address
+	if(strstr(addr,":") != NULL)
+	{
+		IPv6 = true;
+	}
+
+	if( (IPv6 && !config.resolveIPv6) ||
+	   (!IPv6 && !config.resolveIPv4))
+	{
+		if(config.debug & DEBUG_RESOLVER)
+		{
+			logg(" ---> \"\" (configured to not resolve %s host names)",
+			     IPv6 ? "IPv6" : "IPv4");
+			return strdup("");
+		}
 	}
 
 	// Initialize resolver subroutines if trying to resolve for the first time
@@ -94,27 +119,28 @@ static char *resolveHostname(const char *addr)
 		res_initialized = true;
 	}
 
-	// Force last available (MAXNS-1) server used for lookups to 127.0.0.1 (FTL itself)
-	struct in_addr nsbck = { 0 };
-	// Back up corresponding ns record in _res and ...
-	nsbck = _res.nsaddr_list[MAXNS-1].sin_addr;
-	// ... force FTL resolver to 127.0.0.1
-	inet_pton(AF_INET, "127.0.0.1", &_res.nsaddr_list[MAXNS-1].sin_addr);
-
-	// Test if we want to resolve an IPv6 address
-	if(strstr(addr,":") != NULL)
+	// Step 1: Backup configured name servers and invalidate them
+	struct in_addr ns_addr_bck[MAXNS];
+	in_port_t ns_port_bck[MAXNS];
+	for(unsigned int i = 0u; i < MAXNS; i++)
 	{
-		IPv6 = true;
+		ns_addr_bck[i] = _res.nsaddr_list[i].sin_addr;
+		ns_port_bck[i] = _res.nsaddr_list[i].sin_port;
+		_res.nsaddr_list[i].sin_addr.s_addr = 0; // 0.0.0.0
 	}
+	// Step 2: Set 127.0.0.1 (FTL) as the only resolver
+	inet_pton(AF_INET, "127.0.0.1", &_res.nsaddr_list[0].sin_addr);
+	_res.nsaddr_list[0].sin_port = config.dns_port;
 
-	if(IPv6 && config.resolveIPv6) // Resolve IPv6 address only if requested
+	// Step 3: Try to resolve addresses
+	if(IPv6) // Resolve IPv6 address
 	{
 		struct in6_addr ipaddr;
 		inet_pton(AF_INET6, addr, &ipaddr);
 		// Known to leak some tiny amounts of memory under certain conditions
 		he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET6);
 	}
-	else if(!IPv6 && config.resolveIPv4) // Resolve IPv4 address only if requested
+	else if(!IPv6) // Resolve IPv4 address
 	{
 		struct in_addr ipaddr;
 		inet_pton(AF_INET, addr, &ipaddr);
@@ -122,24 +148,88 @@ static char *resolveHostname(const char *addr)
 		he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET);
 	}
 
+	// Step 4: Check if gethostbyaddr() returned a host name
 	// First check for he not being NULL before trying to dereference it
-	if(he != NULL && valid_hostname(he->h_name, addr))
+	if(he != NULL)
 	{
-		// Return hostname copied to new memory location
-		hostname = strdup(he->h_name);
+		if(valid_hostname(he->h_name, addr))
+		{
+			// Return hostname copied to new memory location
+			hostname = strdup(he->h_name);
 
-		// Convert hostname to lower case
-		if(hostname != NULL)
-			strtolower(hostname);
+			// Convert hostname to lower case
+			if(hostname != NULL)
+				strtolower(hostname);
+		}
+		else
+		{
+			hostname = strdup("[invalid host name]");
+		}
+
+		if(config.debug & DEBUG_RESOLVER)
+			logg(" ---> \"%s\" (found internally)", hostname);
 	}
-	else
+
+	// Step 5: Restore resolvers (without forced FTL)
+	for(unsigned int i = 0u; i < MAXNS; i++)
 	{
-		// No (he == NULL) or invalid (valid_hostname returned false) hostname found
-		hostname = strdup("");
+		_res.nsaddr_list[i].sin_addr = ns_addr_bck[i];
+		_res.nsaddr_list[i].sin_port = ns_port_bck[i];
 	}
 
-	// Restore ns record in _res
-	_res.nsaddr_list[MAXNS-1].sin_addr = nsbck;
+	// Step 6: If no host name was found before, try again with system-configured
+	// resolvers (necessary for docker and friends)
+	if(hostname == NULL)
+	{
+		if(IPv6) // Resolve IPv6 address
+		{
+			struct in6_addr ipaddr;
+			inet_pton(AF_INET6, addr, &ipaddr);
+			// Known to leak some tiny amounts of memory under certain conditions
+			he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET6);
+		}
+		else // Resolve IPv4 address
+		{
+			struct in_addr ipaddr;
+			inet_pton(AF_INET, addr, &ipaddr);
+			// Known to leak some tiny amounts of memory under certain conditions
+			he = gethostbyaddr(&ipaddr, sizeof ipaddr, AF_INET);
+		}
+
+		// Log used resolvers when in debug mode
+		if(config.debug & DEBUG_RESOLVER)
+			print_used_resolvers("No host name known to FTL, trying other servers as mandated by resolv.conf:");
+
+		// Step 6.1: Check if gethostbyaddr() returned a host name this time
+		// First check for he not being NULL before trying to dereference it
+		if(he != NULL)
+		{
+			if(valid_hostname(he->h_name, addr))
+			{
+				// Return hostname copied to new memory location
+				hostname = strdup(he->h_name);
+
+				// Convert hostname to lower case
+				if(hostname != NULL)
+					strtolower(hostname);
+			}
+			else
+			{
+				hostname = strdup("[invalid host name]");
+			}
+
+			if(config.debug & DEBUG_RESOLVER)
+				logg(" ---> \"%s\" (found externally)", hostname);
+		}
+		else
+		{
+			// No (he == NULL) or invalid (valid_hostname returned false) hostname found
+			hostname = strdup("");
+
+			if(config.debug & DEBUG_RESOLVER)
+				logg(" ---> \"%s\" (%s)", hostname, he != NULL ? he->h_name : "N/A");
+		}
+	}
 
 	// Return result
 	return hostname;
@@ -241,7 +331,7 @@ void resolveClients(const bool onlynew)
 		unlock_shm();
 	}
 
-	if(config.debug & DEBUG_API)
+	if(config.debug & DEBUG_RESOLVER)
 	{
 		logg("%i / %i client host names resolved",
 		     clientscount-skipped, clientscount);
@@ -294,7 +384,7 @@ void resolveForwardDestinations(const bool onlynew)
 		unlock_shm();
 	}
 
-	if(config.debug & DEBUG_API)
+	if(config.debug & DEBUG_RESOLVER)
 	{
 		logg("%i / %i upstream server host names resolved",
 		     upstreams-skipped, upstreams);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR modifies FTL's internal resolver to work in two phases:

- First, try to obtain a host name by using the internal resolver (i.e., FTL).
- In a second step, only executed when FTL didn't know the answer, we ask the resolvers as configured by `resolvconf`.

We've seen that the latter is necessary to get proper name resolution in docker environments. This change turns out to be necessary for some upstream servers such as 1.0.0.1 and ensures that FTL is always the first server that gets asked for host names.

This PR also considers if FTL runs on a non-default (!= 53) port, e.g., in testing environments.