### PR TITLE
Don't try setsockopt of non-existing NETLINK_NO_ENOBUFS option (fixes…

### DIFF
--- a/src/dnsmasq/netlink.c
+++ b/src/dnsmasq/netlink.c
@@ -27,10 +27,6 @@
 #define SOL_NETLINK 270
 #endif
 
-#ifndef NETLINK_NO_ENOBUFS
-#define NETLINK_NO_ENOBUFS 5
-#endif
-
 /* linux 2.6.19 buggers up the headers, patch it up here. */ 
 #ifndef IFA_RTA
 #  define IFA_RTA(r)  \
@@ -83,7 +79,9 @@ void netlink_init(void)
   
   if (daemon->netlinkfd == -1 || 
       (daemon->kernel_version >= KERNEL_VERSION(2,6,30) &&
+#ifdef NETLINK_NO_ENOBUFS
        setsockopt(daemon->netlinkfd, SOL_NETLINK, NETLINK_NO_ENOBUFS, &opt, sizeof(opt)) == -1) ||
+#endif
       getsockname(daemon->netlinkfd, (struct sockaddr *)&addr, &slen) == -1)
     die(_("cannot create netlink socket: %s"), NULL, EC_MISC);
   


### PR DESCRIPTION
Internal, fixes docker builds.

Remember to revert this patch once a suitable one has been merged into the mainstream `dnsmasq` repo

https://circleci.com/gh/pi-hole/docker-pi-hole/588

Once this is merged, I will restore the correct FTL branch to the docker repo