### PR TITLE
Install proper qemu fix

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -60,6 +60,7 @@ int main_dnsmasq (int argc, char **argv)
   char *bound_device = NULL;
   int did_bind = 0;
   struct server *serv;
+  char *netlink_warn;
 #endif 
 #if defined(HAVE_DHCP) || defined(HAVE_DHCP6)
   struct dhcp_context *context;
@@ -329,7 +330,7 @@ int main_dnsmasq (int argc, char **argv)
 #endif
 
 #if  defined(HAVE_LINUX_NETWORK)
-  netlink_init();
+  netlink_warn = netlink_init();
 #elif defined(HAVE_BSD_NETWORK)
   route_init();
 #endif
@@ -950,6 +951,9 @@ int main_dnsmasq (int argc, char **argv)
 #  ifdef HAVE_LINUX_NETWORK
   if (did_bind)
     my_syslog(MS_DHCP | LOG_INFO, _("DHCP, sockets bound exclusively to interface %s"), bound_device);
+
+  if (netlink_warn)
+    my_syslog(LOG_WARNING, netlink_warn);
 #  endif
 
   /* after dhcp_construct_contexts */

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1455,7 +1455,7 @@ void clear_cache_and_reload(time_t now);
 
 /* netlink.c */
 #ifdef HAVE_LINUX_NETWORK
-void netlink_init(void);
+char *netlink_init(void);
 void netlink_multicast(void);
 #endif
 

--- a/src/dnsmasq/netlink.c
+++ b/src/dnsmasq/netlink.c
@@ -27,6 +27,10 @@
 #define SOL_NETLINK 270
 #endif
 
+#ifndef NETLINK_NO_ENOBUFS
+#define NETLINK_NO_ENOBUFS 5
+#endif
+
 /* linux 2.6.19 buggers up the headers, patch it up here. */ 
 #ifndef IFA_RTA
 #  define IFA_RTA(r)  \
@@ -79,9 +83,7 @@ void netlink_init(void)
   
   if (daemon->netlinkfd == -1 || 
       (daemon->kernel_version >= KERNEL_VERSION(2,6,30) &&
-#ifdef NETLINK_NO_ENOBUFS
        setsockopt(daemon->netlinkfd, SOL_NETLINK, NETLINK_NO_ENOBUFS, &opt, sizeof(opt)) == -1) ||
-#endif
       getsockname(daemon->netlinkfd, (struct sockaddr *)&addr, &slen) == -1)
     die(_("cannot create netlink socket: %s"), NULL, EC_MISC);
   


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Revert intermediate fix and install solution chosen by [`dnsmasq` upstream](http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=913fa15fb1d11f50aeb7a9a1f68de5af0eac0419):

Reply by Simon:
> The presence or absence of `NETLINK_NO_ENOBUFS` in the system headers is only coincidentally related to whether `qemu-user` supports the syscall.
> 
> The best we can do is to convert the `setsockopt()` failure into a warning rather than a hard failure, or fix `qemu-user`, of course.