### PR TITLE
Automatically block _esni.* subdomains of blocked domains

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -372,6 +372,19 @@ void read_FTLconf(void)
 	else
 		logg("   DELAY_STARTUP: No delay requested.");
 
+	// BLOCK_ESNI
+	// defaults to: true
+	config.block_esni = true;
+	buffer = parse_FTLconf(fp, "BLOCK_ESNI");
+
+	if(buffer != NULL && strcasecmp(buffer, "false") == 0)
+		config.block_esni = false;
+
+	if(config.block_esni)
+		logg("   BLOCK_ESNI: Enabled, blocking _esni.{blocked domain}");
+	else
+		logg("   BLOCK_ESNI: Disabled");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -39,6 +39,7 @@ typedef struct {
 	bool parse_arp_cache;
 	bool regex_ignorecase;
 	bool cname_inspection;
+	bool block_esni;
 } ConfigStruct;
 
 typedef struct {

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -248,6 +248,7 @@ int findCacheID(int domainID, int clientID)
 	dns_cache->blocking_status = UNKNOWN_BLOCKED;
 	dns_cache->domainID = domainID;
 	dns_cache->clientID = clientID;
+	dns_cache->force_reply = 0u;
 
 	// Increase counter by one
 	counters->dns_cache_size++;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -75,6 +75,7 @@ typedef struct {
 typedef struct {
 	unsigned char magic;
 	unsigned char blocking_status;
+	unsigned char force_reply;
 	int domainID;
 	int clientID;
 	int black_regex_idx;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -617,15 +617,12 @@ void _FTL_get_blocking_metadata(union all_addr **addrp, unsigned int *flags, con
 	// Check first if we need to force our reply to something different than the
 	// default/configured blocking mode For instance, we need to force NXDOMAIN
 	// for intercepted _esni.* queries
-	if(force_next_DNS_reply != 0u)
+	if(force_next_DNS_reply == NXDOMAIN)
 	{
-		if(force_next_DNS_reply == NXDOMAIN)
-		{
-			*flags = F_NXDOMAIN;
-			// Reset DNS reply forcing
-			force_next_DNS_reply = 0u;
-			return;
-		}
+		*flags = F_NXDOMAIN;
+		// Reset DNS reply forcing
+		force_next_DNS_reply = 0u;
+		return;
 	}
 
 	// Add flags according to current blocking mode


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

[Encrypted Server Name Indication (ESNI)](https://tools.ietf.org/html/draft-ietf-tls-esni-06) is certainly a good step into the right direction to enhance privacy on the web. It prevents on-path observers, including ISPs, coffee shop owners and firewalls, from intercepting the TLS Server Name Indication (SNI) extension by encrypting it. This prevents the SNI from being used to determine which websites users are visiting.

ESNI will obviously cause issues for `pixelserv-tls` which will be unable to generate matching certificates on-the-fly when it cannot read the SNI. Cloudflare and Firefox are already enabling ESNI.

According to the IEFT draft, we can easily restore `piselserv-tls`'s operation by replying `NXDOMAIN` to `_esni.*` subdomains of blocked domains as this mimics a "not configured for this domain" behavior.

Discourse feature request: https://discourse.pi-hole.net/t/support-dropping-esni-records-for-blocked-domains/13250

Note that this feature may be disabled by setting `BLOCK_ESNI=false` in `/etc/pihole/pihole-FTL.conf`.