### PR TITLE
Use /run instead of /var/run for FTL runtime files

### DIFF
--- a/FTLtest.sh
+++ b/FTLtest.sh
@@ -10,7 +10,7 @@
 
 function GetFTLData {
     # Open connection to FTL
-    exec 3<>/dev/tcp/localhost/"$(cat /var/run/pihole-FTL.port)"
+    exec 3<>/dev/tcp/localhost/"$(cat /run/pihole-FTL.port)"
 
     # Test if connection is open
     if { true >&3; } 2> /dev/null; then

--- a/src/config.c
+++ b/src/config.c
@@ -302,13 +302,13 @@ void read_FTLconf(void)
 		logg("   DBIMPORT: Not importing history from database");
 
 	// PIDFILE
-	getpath(fp, "PIDFILE", "/var/run/pihole-FTL.pid", &FTLfiles.pid);
+	getpath(fp, "PIDFILE", "/run/pihole-FTL.pid", &FTLfiles.pid);
 
 	// PORTFILE
-	getpath(fp, "PORTFILE", "/var/run/pihole-FTL.port", &FTLfiles.port);
+	getpath(fp, "PORTFILE", "/run/pihole-FTL.port", &FTLfiles.port);
 
 	// SOCKETFILE
-	getpath(fp, "SOCKETFILE", "/var/run/pihole/FTL.sock", &FTLfiles.socketfile);
+	getpath(fp, "SOCKETFILE", "/run/pihole/FTL.sock", &FTLfiles.socketfile);
 
 	// SETUPVARSFILE
 	getpath(fp, "SETUPVARSFILE", "/etc/pihole/setupVars.conf", &FTLfiles.setupVars);

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,9 +15,9 @@ fi
 rm -f /etc/pihole/gravity.db /etc/pihole/pihole-FTL.db /var/log/pihole.log /var/log/pihole-FTL.log
 
 # Create necessary directories and files
-mkdir -p /etc/pihole /var/run/pihole /var/log
-touch /var/log/pihole-FTL.log /var/log/pihole.log /var/run/pihole-FTL.pid /var/run/pihole-FTL.port
-chown pihole:pihole /etc/pihole /var/run/pihole /var/log/pihole.log /var/log/pihole-FTL.log /var/run/pihole-FTL.pid /var/run/pihole-FTL.port
+mkdir -p /etc/pihole /run/pihole /var/log
+touch /var/log/pihole-FTL.log /var/log/pihole.log /run/pihole-FTL.pid /run/pihole-FTL.port
+chown pihole:pihole /etc/pihole /run/pihole /var/log/pihole.log /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port
 
 # Copy binary into a location the new user pihole can access
 cp ./pihole-FTL /home/pihole

--- a/tools/socket_client.c
+++ b/tools/socket_client.c
@@ -40,7 +40,7 @@ int main (int argc, char **argv) {
 	address.sun_family = AF_LOCAL;
 
 	char *command = ">stats";
-	strcpy(address.sun_path,"/var/run/pihole/FTL.sock");
+	strcpy(address.sun_path,"/run/pihole/FTL.sock");
 
 	int i;
 	for(i = 1; i < argc; i++) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _8_

---

On modern OS versions, /var/run is not used anymore but /run instead. For backwards compatibility /var/run is a symlink to /run, but /run should be consequently used to be failsafe. The `pihole-FTL.service` file currently uses /run for the port file and both, /var/run + /run inconsistently for the PID file. The following PR addresses this by changing all to /run: https://github.com/pi-hole/pi-hole/pull/3248
Both PRs should be hence merged together, as of: https://github.com/pi-hole/pi-hole/pull/3248#issuecomment-620752054
More background about /run vs /var/run: https://github.com/pi-hole/pi-hole/pull/3248#issuecomment-609713592

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._