### PR TITLE
Use CircleCI steps for upload SSH keys.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ version: 2
 .job_steps: &job_steps
   steps:
     - checkout
+    - add_ssh_keys:
+        fingerprints:
+          - "25:6c:10:82:c3:70:59:91:50:a2:96:3f:1b:0e:bc:b4"
     - run:
         name: "Setup"
         command: |
@@ -24,7 +27,6 @@ version: 2
           mv pihole-FTL "${BIN_NAME}"
           sha1sum pihole-FTL-* > ${BIN_NAME}.sha1
           mkdir -p ~/.ssh/
-          ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
           sftp -b - $SSH_USER@$SSH_HOST <<< "-mkdir ${DIR}
           put ${BIN_NAME}* ${DIR}"
           mv "${BIN_NAME}" pihole-FTL


### PR DESCRIPTION
***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

---

Use CircleCI steps to load SSH keys instead of trying to scan them in.