### PR TITLE
Fix FTL crash on closing handle to corrupted databases

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -432,8 +432,6 @@ void gravityDB_close(void)
 	{
 			gravityDB_finalize_client_statements(clientID);
 	}
-	sqlite3_finalize(auditlist_stmt);
-	auditlist_stmt = NULL;
 
 	// Free allocated memory for vectors of prepared client statements
 	free_sqlite3_stmt_vec(whitelist_stmt);
@@ -442,6 +440,10 @@ void gravityDB_close(void)
 	blacklist_stmt = NULL;
 	free_sqlite3_stmt_vec(gravity_stmt);
 	gravity_stmt = NULL;
+
+	// Finalize audit list statement
+	sqlite3_finalize(auditlist_stmt);
+	auditlist_stmt = NULL;
 
 	// Close table
 	sqlite3_close(gravity_db);

--- a/src/vector.c
+++ b/src/vector.c
@@ -111,9 +111,13 @@ void free_sqlite3_stmt_vec(sqlite3_stmt_vec *v)
 	if(config.debug & DEBUG_VECTORS)
 		logg("Freeing sqlite3_stmt* vector %p", v);
 
+	// This vector was never allocated, invoking free_sqlite3_stmt_vec() on a
+	// NULL pointer should be a harmless no-op.
+	if(v == NULL || v->items == NULL)
+		return;
+
 	// Free elements of the vector...
 	free(v->items);
 	// ...and then the vector itself
 	free(v);
-	v = NULL;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

When FTL detects that `gravity.db` has been corrupted in any way (maybe a user deleted an essential table within the database, or the database is malformed due to I/O issues such as unrecoverable power-loss failures), it tries to release all allocated memory for this database. Unfortunately, this could have given rise to a crash under certain conditions when trying to free memory which wasn't allocated. This could have happened when we failed very early in preparing the database statements, such as during the preparation of the audit-list table statement.

We fix this by ensuring that invoking `free_sqlite3_stmt_vec()` on a `NULL` pointer is a harmless no-op. This routine will now simply do nothing if there isn't any memory to be freed.

Fixes #743 and some other issue I recall having seen on our Discourse forum.