### PR TITLE
Fix bit-order in subnet mask generation

### DIFF
--- a/src/database/sqlite3-ext.c
+++ b/src/database/sqlite3-ext.c
@@ -100,7 +100,7 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 	uint8_t bitmask[16] = { 0 };
 	for(int i = 0; i < cidr; i++)
 	{
-		bitmask[i/8] |= (1 << (i%8));
+		bitmask[i/8] |= (1 << (7-(i%8)));
 	}
 
 	// Apply bitmask to both IP addresses
@@ -122,8 +122,10 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 	// Possible debug logging
 	if(config.debug & DEBUG_DATABASE)
 	{
-		logg("SQL: Comparing %s vs. %s (database) - %s",
-		     addrFTL, addrDBcidr,
+		char subnet[INET6_ADDRSTRLEN];
+		inet_ntop(isIPv6_FTL ? AF_INET6 : AF_INET, &bitmask, subnet, sizeof(subnet));
+		logg("SQL: Comparing %s vs. %s (subnet %s) - %s",
+		     addrFTL, addrDBcidr, subnet,
 			 match == 1 ? "!! MATCH !!" : "NO MATCH");
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes bug reported on Discourse + adds more debugging output to the subnet matching.