### PR TITLE
Store warnings in database table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ DNSMASQ_OPTS = -DHAVE_DNSSEC -DHAVE_DNSSEC_STATIC
 # Flags for compiling with libidn2: -DHAVE_LIBIDN2 -DIDN2_VERSION_NUMBER=0x02000003
 
 FTL_DEPS = *.h database/*.h api/*.h version.h
-FTL_DB_OBJ = database/common.o database/query-table.o database/network-table.o database/gravity-db.o database/database-thread.o database/sqlite3-ext.o
+FTL_DB_OBJ = database/common.o database/query-table.o database/network-table.o database/gravity-db.o database/database-thread.o database/sqlite3-ext.o \
+          database/message-table.o
 FTL_API_OBJ = api/socket.o api/request.o api/msgpack.o api/api.o
 FTL_OBJ = $(FTL_DB_OBJ) $(FTL_API_OBJ) main.o memory.o log.o daemon.o datastructure.o signals.o files.o setupVars.o args.o gc.o config.o \
           dnsmasq_interface.o resolve.o regex.o shmem.o capabilities.o overTime.o timers.o vector.o

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ DNSMASQ_VERSION = "pi-hole-2.81"
 DNSMASQ_OPTS = -DHAVE_DNSSEC -DHAVE_DNSSEC_STATIC -DHAVE_IDN
 
 FTL_DEPS = *.h database/*.h api/*.h version.h
-FTL_DB_OBJ = database/common.o database/query-table.o database/network-table.o database/gravity-db.o database/database-thread.o database/sqlite3-ext.o \
-          database/message-table.o
+FTL_DB_OBJ = database/common.o database/query-table.o database/network-table.o database/gravity-db.o database/database-thread.o \
+             database/sqlite3-ext.o database/message-table.o
 FTL_API_OBJ = api/socket.o api/request.o api/msgpack.o api/api.o
 FTL_OBJ = $(FTL_DB_OBJ) $(FTL_API_OBJ) main.o memory.o log.o daemon.o datastructure.o signals.o files.o setupVars.o args.o gc.o config.o \
           dnsmasq_interface.o resolve.o regex.o shmem.o capabilities.o overTime.o timers.o vector.o

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -104,7 +104,7 @@ int dbquery(const char *format, ...)
 
 	// Log generated SQL string when dbquery() is called
 	// although the database connection is not available
-	if(database == false || ( FTL_db == NULL && !dbopen() ))
+	if(FTL_db == NULL && !dbopen())
 	{
 		logg("dbquery(\"%s\") called but database is not available!", query);
 		sqlite3_free(query);

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -44,14 +44,26 @@ void dbclose(void)
 		database = false;
 	}
 
+	if(config.debug & DEBUG_LOCKS)
+		logg("Unlocking database");
+
 	// Unlock mutex on the database
 	pthread_mutex_unlock(&dblock);
+
+	if(config.debug & DEBUG_LOCKS)
+		logg("Unlocking database: Success");
 }
 
 bool dbopen(void)
 {
+	if(config.debug & DEBUG_LOCKS)
+		logg("Locking database");
+
 	// Lock mutex on the database
 	pthread_mutex_lock(&dblock);
+
+	if(config.debug & DEBUG_LOCKS)
+		logg("Locking database: Success");
 
 	// Try to open database
 	int rc = sqlite3_open_v2(FTLfiles.FTL_db, &FTL_db, SQLITE_OPEN_READWRITE, NULL);

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -74,7 +74,7 @@ static bool add_message(enum message_type type, const char *message,
 
 	// Prepare SQLite statement
 	sqlite3_stmt* stmt = NULL;
-	const char *querystr = "INSERT INTO message (timestamp, type, message, blob1, blob2, blob3, blob4, blob5) "
+	const char *querystr = "INSERT INTO message (timestamp,type,message,blob1,blob2,blob3,blob4,blob5) "
 	                       "VALUES ((cast(strftime('%s', 'now') as int)),?,?,?,?,?,?,?);";
 	int rc = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
@@ -140,15 +140,16 @@ static bool add_message(enum message_type type, const char *message,
 	rc = sqlite3_step(stmt);
 	sqlite3_clear_bindings(stmt);
 	sqlite3_reset(stmt);
-
-	// Close database connection
-	dbclose();
+	sqlite3_finalize(stmt);
 
 	if(rc != SQLITE_DONE)
 	{
 		logg("Encountered error while trying to store message in long-term database: %s", sqlite3_errstr(rc));
 		return false;
 	}
+
+	// Close database connection
+	dbclose();
 
 	return true;
 }

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1,0 +1,132 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2020 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Message table routines
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "database/message-table.h"
+#include "database/common.h"
+#include "log.h"
+// #include "shmem.h"
+// #include "memory.h"
+// #include "timers.h"
+// #include "config.h"
+// #include "datastructure.h"
+
+// Create message table in the database
+bool create_message_table(void)
+{
+	SQL_bool("CREATE TABLE message ( id INTEGER PRIMARY KEY AUTOINCREMENT, " \
+	                                "timestamp INTEGER NOT NULL, " \
+	                                "type TEXT NOT NULL, " \
+	                                "message TEXT NOT NULL, " \
+	                                "txt TEXT, "
+	                                "int INTEGER );");
+
+	// Update database version to 6
+	if(!db_set_FTL_property(DB_VERSION, 6))
+	{
+		logg("create_message_table(): Failed to update database version!");
+		return false;
+	}
+
+	return true;
+}
+
+// Flush message table
+bool flush_message_table(void)
+{
+	SQL_bool("DELETE FROM message;");
+	return true;
+}
+
+static bool add_message(enum message_type type, const char *message, const char *text, const int integer)
+{
+	// Prepare SQLite statement
+	sqlite3_stmt* stmt = NULL;
+	const char *querystr = "INSERT INTO message (timestamp, type, message, txt, int) VALUES ((cast(strftime('%%s', 'now') as int)),?,?,?,?);";
+	int rc = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
+	if( rc != SQLITE_OK ){
+		logg("add_message(type=%u, message=%s, text=%s, integer=%i) - SQL error prepare: %s",
+		     type, message, text, integer, sqlite3_errstr(rc));
+		return false;
+	}
+
+	// Bind type to prepared statement
+	if((rc = sqlite3_bind_int(stmt, 1, type)) != SQLITE_OK)
+	{
+		logg("add_message(type=%u, message=%s, text=%s, integer=%i) - Failed to bind type: %s",
+		     type, message, text, integer, sqlite3_errstr(rc));
+		sqlite3_reset(stmt);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	// Bind message to prepared statement
+	if((rc = sqlite3_bind_text(stmt, 2, message, -1, SQLITE_STATIC)) != SQLITE_OK)
+	{
+		logg("add_message(type=%u, message=%s, text=%s, integer=%i) - Failed to bind message: %s",
+		     type, message, text, integer, sqlite3_errstr(rc));
+		sqlite3_reset(stmt);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	// Bind text to prepared statement
+	if(text != NULL)
+		rc = sqlite3_bind_text(stmt, 3, text, -1, SQLITE_STATIC);
+	else
+		rc = sqlite3_bind_null(stmt, 3);
+
+	if(rc != SQLITE_OK)
+	{
+		logg("add_message(type=%u, message=%s, text=%s, integer=%i) - Failed to bind text: %s",
+		     type, message, text, integer, sqlite3_errstr(rc));
+		sqlite3_reset(stmt);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	// Bind integer to prepared statement
+	if(integer != -1)
+		rc = sqlite3_bind_int(stmt, 4, integer);
+	else
+		rc = sqlite3_bind_null(stmt, 4);
+
+	if(rc != SQLITE_OK)
+	{
+		logg("add_message(type=%u, message=%s, text=%s, integer=%i) - Failed to bind integer: %s",
+		     type, message, text, integer, sqlite3_errstr(rc));
+		sqlite3_reset(stmt);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	// Step and check if successful
+	rc = sqlite3_step(stmt);
+	sqlite3_clear_bindings(stmt);
+	sqlite3_reset(stmt);
+
+	if(rc != SQLITE_DONE)
+	{
+		logg("Encountered error while trying to store message in long-term database: %s", sqlite3_errstr(rc));
+		return false;
+	}
+
+	return true;
+}
+
+void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex)
+{
+	// Log to pihole-FTL.log
+	logg("REGEX WARNING: Invalid regex %s filter \"%s\": %s",
+	     type, regex, warning);
+
+	// Log to database
+	add_message(REGEX_MESSAGE, warning, regex, dbindex);
+}

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -1,0 +1,19 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2020 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  pihole-FTL.db -> message tables prototypes
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+#ifndef MESSAGETABLE_H
+#define MESSAGETABLE_H
+
+bool create_message_table(void);
+bool flush_message_table(void);
+void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex);
+
+enum message_type { UNKNOWN_MESSAGE, REGEX_MESSAGE };
+
+#endif //MESSAGETABLE_H

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -14,6 +14,6 @@ bool create_message_table(void);
 bool flush_message_table(void);
 void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex);
 
-enum message_type { UNKNOWN_MESSAGE, REGEX_MESSAGE };
+enum message_type { REGEX_MESSAGE, MAX_MESSAGE };
 
 #endif //MESSAGETABLE_H

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -16,6 +16,8 @@
 // enum REGEX
 #include "regex_r.h"
 #include "database/gravity-db.h"
+// flush_message_table()
+#include "database/message-table.h"
 
 // converts upper to lower case, and leaves other characters unchanged
 void strtolower(char *str)
@@ -369,6 +371,9 @@ void FTL_reset_per_client_domain_data(void)
 
 void FTL_reload_all_domainlists(void)
 {
+	// Flush messages stored in the long-term database
+	flush_message_table();
+
 	// (Re-)open gravity database connection
 	gravityDB_close();
 	gravityDB_open();

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -35,8 +35,6 @@
 #include "api/api.h"
 // global variable daemonmode
 #include "args.h"
-// flush_message_table()
-#include "database/message-table.h"
 
 static void print_flags(const unsigned int flags);
 static void save_reply_type(const unsigned int flags, queriesData* query, const struct timeval response);
@@ -812,9 +810,6 @@ void FTL_dnsmasq_reload(void)
 	// This is the only hook that is not skipped in PRIVACY_NOSTATS mode
 
 	logg("Reloading DNS cache");
-
-	// Flush messages stored in the long-term database
-	flush_message_table();
 
 	// Inspect 01-pihole.conf to see if Pi-hole blocking is enabled,
 	// i.e. if /etc/pihole/gravity.list is sourced as addn-hosts file

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -35,6 +35,8 @@
 #include "api/api.h"
 // global variable daemonmode
 #include "args.h"
+// flush_message_table()
+#include "database/message-table.h"
 
 static void print_flags(const unsigned int flags);
 static void save_reply_type(const unsigned int flags, queriesData* query, const struct timeval response);
@@ -810,6 +812,9 @@ void FTL_dnsmasq_reload(void)
 	// This is the only hook that is not skipped in PRIVACY_NOSTATS mode
 
 	logg("Reloading DNS cache");
+
+	// Flush messages stored in the long-term database
+	flush_message_table();
 
 	// Inspect 01-pihole.conf to see if Pi-hole blocking is enabled,
 	// i.e. if /etc/pihole/gravity.list is sourced as addn-hosts file

--- a/src/regex.c
+++ b/src/regex.c
@@ -22,6 +22,7 @@
 #include "main.h"
 // add_per_client_regex_client()
 #include "shmem.h"
+#include "database/message-table.h"
 
 static regex_t *regex[2] = { NULL };
 static bool *regex_available[2] = { NULL };
@@ -30,27 +31,21 @@ static char **regexbuffer[2] = { NULL };
 
 const char *regextype[] = { "blacklist", "whitelist" };
 
-// Log Regex failure (most likely a regex syntax error, we include a hint to the error)
-static void log_regex_error(const int errcode, const int index, const unsigned char regexid, const char *regexin)
-{
-	// Get error string and log it
-	const size_t length = regerror(errcode, &regex[regexid][index], NULL, 0);
-	char *buffer = calloc(length,sizeof(char));
-	(void) regerror (errcode, &regex[regexid][index], buffer, length);
-	logg("Warning: Invalid regex %s filter \"%s\": %s (error code %i)", regextype[regexid], regexin, buffer, errcode);
-	free(buffer);
-}
-
 /* Compile regular expressions into data structures that can be used with
    regexec() to match against a string */
-static bool compile_regex(const char *regexin, const int index, const unsigned char regexid)
+static bool compile_regex(const char *regexin, const int index, const unsigned char regexid, const int dbindex)
 {
 	// We use the extended RegEx flavor (ERE) and specify that matching should
 	// always be case INsensitive
 	const int errcode = regcomp(&regex[regexid][index], regexin, REG_EXTENDED | REG_ICASE);
 	if(errcode != 0)
 	{
-		log_regex_error(errcode, index, regexid, regexin);
+		// Get error string and log it
+		const size_t length = regerror(errcode, &regex[regexid][index], NULL, 0);
+		char *buffer = calloc(length, sizeof(char));
+		(void) regerror (errcode, &regex[regexid][index], buffer, length);
+		logg_regex_warning(regextype[regexid], buffer, dbindex, regexin);
+		free(buffer);
 		return false;
 	}
 
@@ -259,7 +254,7 @@ static void read_regex_table(const unsigned char regexid)
 		{
 			logg("Compiling %s regex %i (database ID %i): %s", regextype[regexid], i, rowid, domain);
 		}
-		regex_available[regexid][i] = compile_regex(domain, i, regexid);
+		regex_available[regexid][i] = compile_regex(domain, i, regexid, rowid);
 		regex_id[regexid][i] = rowid;
 
 		// Increase counter


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR is no. 1 in a series of commits which will eventually lead to a new diagnosis environment in Pi-hole ensuring easily accessible and helpful error messages

Regex errors are now logged more verbosely, like:
```plain
[2020-05-11 20:10:03.636 17925] REGEX WARNING: Invalid regex blacklist filter "(((": Unmatched ( or \(
[2020-05-11 20:10:03.663 17925] REGEX WARNING: Invalid regex blacklist filter "![^(": Unmatched [ or [^
```

caused by

![Screenshot at 2020-05-11 20-13-04](https://user-images.githubusercontent.com/16748619/81596164-e221e780-93c3-11ea-84b2-aaebefc2ab77.png)


Furthermore, the information will be available on the web dashboard where users can easily see and address them:
![Screenshot_2020-05-11 Pi-hole - ubuntu-server](https://user-images.githubusercontent.com/16748619/81596018-a8e97780-93c3-11ea-976f-fce17c441130.png)

The new web interface page will be added in a follow-up pull request.