### PR TITLE
Always chose best (= maximum match) subnet for clients

### DIFF
--- a/src/database/sqlite3-ext.c
+++ b/src/database/sqlite3-ext.c
@@ -130,8 +130,11 @@ static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value 
 	}
 
 	// Return if we found a match between the two addresses
-	// given a possibly specified mask
-	sqlite3_result_int(context, match);
+	// given a possibly specified mask. We return the number of
+	// matching bits (cannot be more than the CIDR field specified)
+	// so the algorithm can decide which subnet match is the most
+	// exact one and prefer it (e.g., 10.8.1.0/24 beats 10.0.0.0/8)
+	sqlite3_result_int(context, match ? cidr : 0);
 }
 
 int sqlite3_pihole_extensions_init(sqlite3 *db, const char **pzErrMsg, const struct sqlite3_api_routines *pApi)

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -195,6 +195,8 @@ int findClientID(const char *clientIP, const bool count)
 	// No query seen so far
 	client->lastQuery = 0;
 	client->numQueriesARP = client->count;
+	// Coonfigured groups are yet unknown
+	client->groups = NULL;
 
 	// Initialize client-specific overTime data
 	for(int i = 0; i < OVERTIME_SLOTS; i++)

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -60,6 +60,7 @@ typedef struct {
 	int blockedcount;
 	int overTime[OVERTIME_SLOTS];
 	unsigned int numQueriesARP;
+	char *groups;
 	size_t ippos;
 	size_t namepos;
 	time_t lastQuery;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This allows to configure specific settings for a whole range of devices but still exclude others. Complain softly (no error) if multiple configured subnets match with the same number of relevant bits.

We log in case there are multiple groups defined matching equally which one FTL chose. It will deterministic chose the most matching *last added one*.

![Screenshot at 2020-05-11 20-25-22](https://user-images.githubusercontent.com/16748619/81597148-8e180280-93c5-11ea-9a23-8d834d38fd4d.png)

resulting in the following log line (only the last line is logged in non-DEBUG mode, I kept all for illustrative proposes here):
```plain
[2020-05-11 20:26:55.425 18858] SQL: Comparing 127.0.0.1 vs. 127.0.0.0/8 (subnet 255.0.0.0) - !! MATCH !!                                            
[2020-05-11 20:26:55.425 18858] SQL: Comparing 127.0.0.1 vs. 127.0.0.0/8 (subnet 255.0.0.0) - !! MATCH !!
[2020-05-11 20:26:55.425 18858] SQL: Comparing 127.0.0.1 vs. 127.0.0.1/8 (subnet 255.0.0.0) - !! MATCH !!
[2020-05-11 20:26:55.425 18858] SQL: Comparing 127.0.0.1 vs. 127.0.0.1/8 (subnet 255.0.0.0) - !! MATCH !!                                                                    
[2020-05-11 20:26:55.425 18858] SQL: Comparing 127.0.0.1 vs. 127.0.0.1/8 (subnet 255.0.0.0) - !! MATCH !!                                            
[2020-05-11 20:26:55.425 18858] SUBNET WARNING: Client 127.0.0.1 is managed by 2 groups (IDs 1,37), all describing /8 subnets. FTL chose the most recent entry 127.0.0.1/8 (ID 37) for this client.
```

This will also show up on the dashboard when the new Pi-hole diagnostics system has been merged:
![Screenshot_2020-05-11 Pi-hole - ubuntu-server(1)](https://user-images.githubusercontent.com/16748619/81597737-78570d00-93c6-11ea-9072-d5a772ec0509.png)
