### PR TITLE
Store subnet warnings in the message table

### DIFF
--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -10,6 +10,11 @@
 #ifndef GRAVITY_H
 #define GRAVITY_H
 
+// global variable counters
+#include "memory.h"
+// clients data structure
+#include "datastructure.h"
+
 // Table indices
 enum { GRAVITY_TABLE, EXACT_BLACKLIST_TABLE, EXACT_WHITELIST_TABLE, REGEX_BLACKLIST_TABLE, REGEX_WHITELIST_TABLE, UNKNOWN_TABLE };
 
@@ -18,6 +23,7 @@ bool gravityDB_prepare_client_statements(const int clientID, clientsData* client
 void gravityDB_close(void);
 bool gravityDB_getTable(unsigned char list);
 const char* gravityDB_getDomain(int *rowid);
+char* get_group_names(const char *group_ids) __attribute__ ((malloc));
 void gravityDB_finalizeTable(void);
 int gravityDB_count(unsigned char list);
 bool in_auditlist(const char *domain);

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -13,7 +13,10 @@
 bool create_message_table(void);
 bool flush_message_table(void);
 void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex);
+void logg_subnet_warning(const char *ip, const int matching_count, const char *matching_ids,
+                         const int matching_bits, const char *chosen_match_text,
+                         const int chosen_match_id);
 
-enum message_type { REGEX_MESSAGE, MAX_MESSAGE };
+enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, MAX_MESSAGE };
 
 #endif //MESSAGETABLE_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Store `SUBNET` warnings in the database. This will add warnings as in this example (first entry):

![Screenshot_2020-05-11 Pi-hole - ubuntu-server(1)](https://user-images.githubusercontent.com/16748619/81600061-4eebb080-93c9-11ea-8d88-b09ddfce56b6.png)