### PR TITLE
Process cached SRV records

### DIFF
--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1941,12 +1941,16 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			    if (crecp->flags & F_NXDOMAIN)
 			      nxdomain = 1;
 			    if (!dryrun)
+			    {
 			      log_query(crecp->flags, name, NULL, NULL);
+			      FTL_cache(crecp->flags, name, NULL, NULL, daemon->log_display_id);
+			    }
 			  }
 			else if (!dryrun)
 			  {
 			    char *target = blockdata_retrieve(crecp->addr.srv.target, crecp->addr.srv.targetlen, NULL);
 			    log_query(crecp->flags, name, NULL, 0);
+			    FTL_cache(crecp->flags, name, NULL, NULL, daemon->log_display_id);
 			    
 			    if (add_resource_record(header, limit, &trunc, nameoffset, &ansp, 
 						    crec_ttl(crecp, now), NULL, T_SRV, C_IN, "sssd",


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

`dnsmasq` added caching for `SRV` records. As FTL wasn't aware of this new type of cache records, it displayed query response "Unknown (0)" for cached SRV records (the first query, which was forwarded, did show the correct status).

As this was missing, it gave rise to a few bug reports, e.g.,
- https://github.com/pi-hole/FTL/issues/759
- https://github.com/pi-hole/pi-hole/issues/3399
- https://discourse.pi-hole.net/t/pi-hole-v5-0-query-log-shows-status-unknown-9-since-having-upgraded-from-v4-4/32386

This PR adds analysis capabilities for cache `SRV` records to resolve these issues.