### PR TITLE
Simple optimizations

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1099,10 +1099,8 @@ static void detect_blocked_IP(const unsigned short flags, const union all_addr *
 				const domainsData* domain = getDomain(query->domainID, true);
 				if(domain != NULL)
 				{
-					char answer[ADDRSTRLEN]; answer[0] = '\0';
-					inet_ntop(AF_INET6, addr, answer, ADDRSTRLEN);
-					logg("Upstream responded with ::, ID %i:\n\t\"%s\" -> \"%s\"",
-					     queryID, getstr(domain->domainpos), answer);
+					logg("Upstream responded with ::, ID %i:\n\t\"%s\" -> \"::\"",
+					     queryID, getstr(domain->domainpos));
 				}
 			}
 		}

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1087,9 +1087,9 @@ static void detect_blocked_IP(const unsigned short flags, const union all_addr *
 	}
 	else if(flags & F_IPV6 &&
 	        addr->addr6.s6_addr32[0] == 0 &&
-					addr->addr6.s6_addr32[1] == 0 &&
-					addr->addr6.s6_addr32[2] == 0 &&
-					addr->addr6.s6_addr32[3] == 0)
+	        addr->addr6.s6_addr32[1] == 0 &&
+	        addr->addr6.s6_addr32[2] == 0 &&
+	        addr->addr6.s6_addr32[3] == 0)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -39,7 +39,7 @@
 static void print_flags(const unsigned int flags);
 static void save_reply_type(const unsigned int flags, queriesData* query, const struct timeval response);
 static unsigned long converttimeval(const struct timeval time) __attribute__((const));
-static void detect_blocked_IP(const unsigned short flags, const char* answer, const int queryID);
+static void detect_blocked_IP(const unsigned short flags, const union all_addr *addr, const int queryID);
 static void query_externally_blocked(const int queryID, const unsigned char status);
 static int findQueryID(const int id);
 static void prepare_blocking_metadata(void);
@@ -424,9 +424,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	if(config.privacylevel >= PRIVACY_NOSTATS)
 		return false;
 
-	// Lock shared memory
-	lock_shm();
-
 	// Get timestamp
 	const time_t querytimestamp = time(NULL);
 
@@ -457,7 +454,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		// Return early to avoid accessing querytypedata out of bounds
 		if(config.debug & DEBUG_QUERIES)
 			logg("Notice: Skipping unknown query type: %s (%i)", types, id);
-		unlock_shm();
 		return false;
 	}
 
@@ -466,9 +462,11 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	{
 		if(config.debug & DEBUG_QUERIES)
 			logg("Not analyzing AAAA query");
-		unlock_shm();
 		return false;
 	}
+
+	// Lock shared memory
+	lock_shm();
 
 	// Ensure we have enough space in the queries struct
 	memory_check(QUERIES);
@@ -568,7 +566,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	// Check and apply possible privacy level rules
 	// The currently set privacy level (at the time the query is
 	// generated) is stored in the queries structure
-	get_privacy_level(NULL);
 	query->privacylevel = config.privacylevel;
 
 	// Increase DNS queries counter
@@ -811,6 +808,9 @@ void FTL_dnsmasq_reload(void)
 
 	logg("Reloading DNS cache");
 
+	// Reload the privacy level in case the user changed it
+	get_privacy_level(NULL);
+
 	// Inspect 01-pihole.conf to see if Pi-hole blocking is enabled,
 	// i.e. if /etc/pihole/gravity.list is sourced as addn-hosts file
 	check_blocking_status();
@@ -956,7 +956,7 @@ void _FTL_reply(const unsigned short flags, const char *name, const union all_ad
 			save_reply_type(flags, query, response);
 
 			// Detect if returned IP indicates that this query was blocked
-			detect_blocked_IP(flags, answer, i);
+			detect_blocked_IP(flags, addr, i);
 		}
 	}
 	else if(flags & F_REVERSE)
@@ -982,9 +982,14 @@ void _FTL_reply(const unsigned short flags, const char *name, const union all_ad
 	unlock_shm();
 }
 
-static void detect_blocked_IP(const unsigned short flags, const char* answer, const int queryID)
+static void detect_blocked_IP(const unsigned short flags, const union all_addr *addr, const int queryID)
 {
 	// Compare returned IP against list of known blocking splash pages
+
+	if (!addr)
+	{
+		return;
+	}
 
 	// First, we check if we want to skip this result even before comparing against the known IPs
 	if(flags & F_HOSTS || flags & F_REVERSE)
@@ -1006,14 +1011,9 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 	// (Cisco Umbrella) blocked this query
 	// See https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses-
 	// for a full list of these IP addresses
-	if(flags & F_IPV4 && answer != NULL &&
-		(strcmp("146.112.61.104", answer) == 0 ||
-		 strcmp("146.112.61.105", answer) == 0 ||
-		 strcmp("146.112.61.106", answer) == 0 ||
-		 strcmp("146.112.61.107", answer) == 0 ||
-		 strcmp("146.112.61.108", answer) == 0 ||
-		 strcmp("146.112.61.109", answer) == 0 ||
-		 strcmp("146.112.61.110", answer) == 0 ))
+	in_addr_t ipv4Addr = ntohl(addr->addr4.s_addr);
+	in_addr_t ipv6Addr = ntohl(addr->addr6.s6_addr32[3]);
+	if((flags & F_IPV4) && ipv4Addr >= 0x92703d68 && ipv4Addr <= 0x92703d6e)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
@@ -1023,6 +1023,8 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 				const domainsData* domain = getDomain(query->domainID, true);
 				if(domain != NULL)
 				{
+					char answer[ADDRSTRLEN]; answer[0] = '\0';
+					inet_ntop(AF_INET, addr, answer, ADDRSTRLEN);
 					logg("Upstream responded with known blocking page (IPv4), ID %i:\n\t\"%s\" -> \"%s\"",
 					     queryID, getstr(domain->domainpos), answer);
 				}
@@ -1032,14 +1034,11 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 		// Update status
 		query_externally_blocked(queryID, QUERY_EXTERNAL_BLOCKED_IP);
 	}
-	else if(flags & F_IPV6 && answer != NULL &&
-		(strcmp("::ffff:146.112.61.104", answer) == 0 ||
-		 strcmp("::ffff:146.112.61.105", answer) == 0 ||
-		 strcmp("::ffff:146.112.61.106", answer) == 0 ||
-		 strcmp("::ffff:146.112.61.107", answer) == 0 ||
-		 strcmp("::ffff:146.112.61.108", answer) == 0 ||
-		 strcmp("::ffff:146.112.61.109", answer) == 0 ||
-		 strcmp("::ffff:146.112.61.110", answer) == 0 ))
+	else if(flags & F_IPV6 &&
+					addr->addr6.s6_addr32[0] == 0 &&
+					addr->addr6.s6_addr32[1] == 0 &&
+				  addr->addr6.s6_addr32[2] == 0xffff0000 &&
+					ipv6Addr >= 0x92703d68 && ipv6Addr <= 0x92703d6e)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
@@ -1049,6 +1048,8 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 				const domainsData* domain = getDomain(query->domainID, true);
 				if(domain != NULL)
 				{
+					char answer[ADDRSTRLEN]; answer[0] = '\0';
+					inet_ntop(AF_INET6, addr, answer, ADDRSTRLEN);
 					logg("Upstream responded with known blocking page (IPv6), ID %i:\n\t\"%s\" -> \"%s\"",
 					     queryID, getstr(domain->domainpos), answer);
 				}
@@ -1062,8 +1063,7 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 	// If upstream replied with 0.0.0.0 or ::,
 	// we assume that it filtered the reply as
 	// nothing is reachable under these addresses
-	else if(flags & F_IPV4 && answer != NULL &&
-		strcmp("0.0.0.0", answer) == 0)
+	else if(flags & F_IPV4 && ipv4Addr == 0)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
@@ -1073,6 +1073,8 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 				const domainsData* domain = getDomain(query->domainID, true);
 				if(domain != NULL)
 				{
+					char answer[ADDRSTRLEN]; answer[0] = '\0';
+					inet_ntop(AF_INET, addr, answer, ADDRSTRLEN);
 					logg("Upstream responded with 0.0.0.0, ID %i:\n\t\"%s\" -> \"%s\"",
 					     queryID, getstr(domain->domainpos), answer);
 				}
@@ -1082,8 +1084,11 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 		// Update status
 		query_externally_blocked(queryID, QUERY_EXTERNAL_BLOCKED_NULL);
 	}
-	else if(flags & F_IPV6 && answer != NULL &&
-		strcmp("::", answer) == 0)
+	else if(flags & F_IPV6 &&
+	        addr->addr6.s6_addr32[0] == 0 &&
+					addr->addr6.s6_addr32[1] == 0 &&
+					addr->addr6.s6_addr32[2] == 0 &&
+					addr->addr6.s6_addr32[3] == 0)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{
@@ -1093,6 +1098,8 @@ static void detect_blocked_IP(const unsigned short flags, const char* answer, co
 				const domainsData* domain = getDomain(query->domainID, true);
 				if(domain != NULL)
 				{
+					char answer[ADDRSTRLEN]; answer[0] = '\0';
+					inet_ntop(AF_INET6, addr, answer, ADDRSTRLEN);
 					logg("Upstream responded with ::, ID %i:\n\t\"%s\" -> \"%s\"",
 					     queryID, getstr(domain->domainpos), answer);
 				}
@@ -1151,27 +1158,22 @@ void _FTL_cache(const unsigned int flags, const char *name, const union all_addr
 	if(config.privacylevel >= PRIVACY_NOSTATS)
 		return;
 
-	// Lock shared memory
-	lock_shm();
-
-	// Obtain destination IP address if available for this query type
-	char dest[ADDRSTRLEN]; dest[0] = '\0';
-	if(addr)
-	{
-		inet_ntop((flags & F_IPV4) ? AF_INET : AF_INET6, addr, dest, ADDRSTRLEN);
-	}
-
 	// If domain is "pi.hole", we skip this query
 	// We compare case-insensitive here
 	if(strcasecmp(name, "pi.hole") == 0)
 	{
-		unlock_shm();
 		return;
 	}
 
 	// Debug logging
 	if(config.debug & DEBUG_QUERIES)
 	{
+		// Obtain destination IP address if available for this query type
+		char dest[ADDRSTRLEN]; dest[0] = '\0';
+		if(addr)
+		{
+			inet_ntop((flags & F_IPV4) ? AF_INET : AF_INET6, addr, dest, ADDRSTRLEN);
+		}
 		logg("**** got cache answer for %s / %s / %s (ID %i, %s:%i)", name, dest, arg, id, file, line);
 		print_flags(flags);
 	}
@@ -1179,6 +1181,9 @@ void _FTL_cache(const unsigned int flags, const char *name, const union all_addr
 	// Get response time
 	struct timeval response;
 	gettimeofday(&response, 0);
+
+	// Lock shared memory
+	lock_shm();
 
 	if(((flags & F_HOSTS) && (flags & F_IMMORTAL)) ||
 	   ((flags & F_NAMEP) && (flags & F_DHCP)) ||
@@ -1240,7 +1245,7 @@ void _FTL_cache(const unsigned int flags, const char *name, const union all_addr
 		query->status = requesttype;
 
 		// Detect if returned IP indicates that this query was blocked
-		detect_blocked_IP(flags, dest, queryID);
+		detect_blocked_IP(flags, addr, queryID);
 
 		// Re-read requesttype as detect_blocked_IP() might have changed it
 		requesttype = query->status;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1035,11 +1035,12 @@ static void detect_blocked_IP(const unsigned short flags, const union all_addr *
 		// Update status
 		query_externally_blocked(queryID, QUERY_EXTERNAL_BLOCKED_IP);
 	}
+	// Check for IP block :ffff:146.112.61.104 - :ffff:146.112.61.110
 	else if(flags & F_IPV6 &&
-					addr->addr6.s6_addr32[0] == 0 &&
-					addr->addr6.s6_addr32[1] == 0 &&
-				  addr->addr6.s6_addr32[2] == 0xffff0000 &&
-					ipv6Addr >= 0x92703d68 && ipv6Addr <= 0x92703d6e)
+	        addr->addr6.s6_addr32[0] == 0 &&
+	        addr->addr6.s6_addr32[1] == 0 &&
+	        addr->addr6.s6_addr32[2] == 0xffff0000 &&
+	        ipv6Addr >= 0x92703d68 && ipv6Addr <= 0x92703d6e)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)
 		{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1013,6 +1013,7 @@ static void detect_blocked_IP(const unsigned short flags, const union all_addr *
 	// for a full list of these IP addresses
 	in_addr_t ipv4Addr = ntohl(addr->addr4.s_addr);
 	in_addr_t ipv6Addr = ntohl(addr->addr6.s6_addr32[3]);
+	// Check for IP block 146.112.61.104 - 146.112.61.110
 	if((flags & F_IPV4) && ipv4Addr >= 0x92703d68 && ipv4Addr <= 0x92703d6e)
 	{
 		if(config.debug & DEBUG_EXTBLOCKED)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1075,10 +1075,8 @@ static void detect_blocked_IP(const unsigned short flags, const union all_addr *
 				const domainsData* domain = getDomain(query->domainID, true);
 				if(domain != NULL)
 				{
-					char answer[ADDRSTRLEN]; answer[0] = '\0';
-					inet_ntop(AF_INET, addr, answer, ADDRSTRLEN);
-					logg("Upstream responded with 0.0.0.0, ID %i:\n\t\"%s\" -> \"%s\"",
-					     queryID, getstr(domain->domainpos), answer);
+					logg("Upstream responded with 0.0.0.0, ID %i:\n\t\"%s\" -> \"0.0.0.0\"",
+					     queryID, getstr(domain->domainpos));
 				}
 			}
 		}

--- a/src/signals.c
+++ b/src/signals.c
@@ -19,6 +19,7 @@
 #include "files.h"
 // FTL_reload_all_domainlists()
 #include "datastructure.h"
+#include "config.h"
 
 volatile sig_atomic_t killed = 0;
 static time_t FTLstarttime = 0;
@@ -95,6 +96,9 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *unused)
 		// - exact blacklist
 		// WITHOUT wiping the DNS cache itself
 		FTL_reload_all_domainlists();
+
+		// Reload the privacy level in case the user changed it
+		get_privacy_level(NULL);
 	}
 } 
 


### PR DESCRIPTION
Signed-off-by: Frank Riley <fhriley@gmail.com>

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 5

---

I made two simple optimizations that speed up cached queries quite a bit:

1) The code was opening, reading, and parsing the config file for every query to get the privacy level. Instead, I am using the cached level. Now, a change of privacy level only takes effect when reloading FTL. Considering the performance improvement, I think this is acceptable.

2) `inet_ntop` is an expensive function and was being called for every query. It really only needed to be called for debug logging.

Some performance measurements:

dnsmasq:

```
root@nas:~/software/flamethrower# docker run --rm aiys0211/flamethrower_v0.10.2 -r google.com -l 5 -p 5555 192.168.1.246
binding to 0.0.0.0
flaming target(s) [192.168.1.246] on port 5555 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
0.979354s: send: 94900, avg send: 94900, recv: 58050, avg recv: 58050, min/avg/max resp: 3.7225/25.8708/83.4811ms, in flight: 36854, timeouts: 0
1.97911s: send: 95000, avg send: 94950, recv: 64215, avg recv: 61132, min/avg/max resp: 2.91377/23.6677/71.9452ms, in flight: 67639, timeouts: 0
2.98332s: send: 96700, avg send: 95533, recv: 59665, avg recv: 60643, min/avg/max resp: 3.68906/33.0038/76.0419ms, in flight: 104676, timeouts: 0
3.99045s: send: 98900, avg send: 96374, recv: 56962, avg recv: 59722, min/avg/max resp: 4.64285/34.2271/85.9087ms, in flight: 110000, timeouts: 36608
4.97911s: send: 98500, avg send: 96799, recv: 55473, avg recv: 58872, min/avg/max resp: 4.2708/40.9341/76.7622ms, in flight: 153029, timeouts: 0
stopping, waiting up to 3s for in flight to finish...
8.00364s: send: 0, avg send: 96799, recv: 2231, avg recv: 58872, min/avg/max resp: 18.6338/0/75.0386ms, in flight: 0, timeouts: 150796

------
run id      : 7ffefc9383d0
run start   : 2020-05-20T04:26:59Z
runtime     : 8.00364 s
total sent  : 484000
total rcvd  : 296596
min resp    : 2.91377 ms
avg resp    : 31.5407 ms
max resp    : 85.9087 ms
avg r qps   : 58872
avg s qps   : 96799
avg pkt     : 39 bytes
tcp conn.   : 0
timeouts    : 187404 (38.7198%)
bad recv    : 0
net errors  : 0
responses   :
  NOERROR: 296596
```

FTL before this commit:

```
root@nas:~/software/flamethrower# docker run --rm aiys0211/flamethrower_v0.10.2 -r google.com -l 5 -p 53 192.168.1.72
binding to 0.0.0.0
flaming target(s) [192.168.1.72] on port 53 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
0.98099s: send: 97300, avg send: 97300, recv: 27721, avg recv: 27721, min/avg/max resp: 6.60911/9.1352/30.2459ms, in flight: 69577, timeouts: 0
1.98097s: send: 98900, avg send: 98100, recv: 29352, avg recv: 28536, min/avg/max resp: 6.54893/8.787/14.3497ms, in flight: 139125, timeouts: 0
2.98993s: send: 99600, avg send: 98600, recv: 28447, avg recv: 28506, min/avg/max resp: 6.70575/9.08749/28.7945ms, in flight: 210278, timeouts: 0
4.00507s: send: 97600, avg send: 98350, recv: 28331, avg recv: 28462, min/avg/max resp: 0.895116/9.10428/18.9364ms, in flight: 209297, timeouts: 70252
4.98098s: send: 97300, avg send: 98140, recv: 33093, avg recv: 29388, min/avg/max resp: 0.957621/7.85416/33.5184ms, in flight: 273510, timeouts: 0
stopping, waiting up to 3s for in flight to finish...
8.01389s: send: 0, avg send: 98140, recv: 207, avg recv: 29388, min/avg/max resp: 21.719/0/26.0869ms, in flight: 0, timeouts: 273297

------
run id      : 7ffcb93b11a0
run start   : 2020-05-20T04:42:16Z
runtime     : 8.01389 s
total sent  : 490700
total rcvd  : 147151
min resp    : 0.895116 ms
avg resp    : 8.79363 ms
max resp    : 33.5184 ms
avg r qps   : 29388
avg s qps   : 98140
avg pkt     : 39 bytes
tcp conn.   : 0
timeouts    : 343549 (70.012%)
bad recv    : 0
net errors  : 0
responses   :
  NOERROR: 147151

```

FTL with this commit:

```
root@nas:~/software/flamethrower# docker run --rm aiys0211/flamethrower_v0.10.2 -r google.com -l 5 -p 53 192.168.1.72
binding to 0.0.0.0
flaming target(s) [192.168.1.72] on port 53 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
0.97879s: send: 96600, avg send: 96600, recv: 47111, avg recv: 47111, min/avg/max resp: 1.76676/5.54629/27.5802ms, in flight: 49499, timeouts: 0
1.97846s: send: 97500, avg send: 97050, recv: 51281, avg recv: 49196, min/avg/max resp: 2.05984/5.27898/8.71645ms, in flight: 95708, timeouts: 0
2.98415s: send: 98300, avg send: 97466, recv: 51037, avg recv: 49809, min/avg/max resp: 3.47207/5.28516/7.56595ms, in flight: 142979, timeouts: 0
3.9928s: send: 97000, avg send: 97349, recv: 51054, avg recv: 50120, min/avg/max resp: 0.831406/5.26035/12.2445ms, in flight: 139324, timeouts: 49593
4.97883s: send: 96600, avg send: 97199, recv: 50364, avg recv: 50168, min/avg/max resp: 0.923087/5.29691/20.1244ms, in flight: 185562, timeouts: 0
stopping, waiting up to 3s for in flight to finish...
8.00707s: send: 0, avg send: 97199, recv: 207, avg recv: 50168, min/avg/max resp: 13.5013/0/17.4738ms, in flight: 0, timeouts: 185353

------
run id      : 7ffcbdf26ab0
run start   : 2020-05-20T04:44:00Z
runtime     : 8.00707 s
total sent  : 486000
total rcvd  : 251054
min resp    : 0.831406 ms
avg resp    : 5.33354 ms
max resp    : 27.5802 ms
avg r qps   : 50168
avg s qps   : 97199
avg pkt     : 39 bytes
tcp conn.   : 0
timeouts    : 234946 (48.3428%)
bad recv    : 0
net errors  : 0
responses   :
  NOERROR: 251054
```