### PR TITLE
Skip CircleCI Upload step on PRs coming from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ version: 2
     - run:
         name: "Upload"
         command: |
-          [[ "$CIRCLE_PROJECT_REPONAME" == "FTL" && "$CIRCLE_PROJECT_USERNAME" == "pi-hole" ]] || exit 0
+          [ -z "${CIRCLE_PR_USERNAME}" ] || exit 0
           DIR="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
           mv pihole-FTL "${BIN_NAME}"
           sha1sum pihole-FTL-* > ${BIN_NAME}.sha1


### PR DESCRIPTION
Internal PR: Following the [CircleCI v2.0 documentation](https://circleci.com/docs/2.0/env-vars/) our check for skipping external contributions from uploading to our binary bucket doesn't work any longer.


We should instead use:

Variable | Type | Value
-- | -- | --
`CIRCLE_PR_USERNAME` | String | The GitHub or Bitbucket username of the user who created the pull request. **Only available on forked PRs.**

I verified that `${CIRCLE_PR_USERNAME}` was indeed set to `fhriley` on #772 whereas it is empty in this build (you can see in the CircleCI run that the binary was uploaded).