### PR TITLE
Improve self-generated backtraces

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -20,8 +20,43 @@
 // FTL_reload_all_domainlists()
 #include "datastructure.h"
 
+#define BINARY_NAME "pihole-FTL"
+
 volatile sig_atomic_t killed = 0;
 static time_t FTLstarttime = 0;
+
+static void print_addr2line(const char *symbol, const void *address, const int j, const void *offset)
+{
+	// Only do this analysis for our own binary (skip trying to analyse libc.so, etc.)
+	if(strstr(symbol, BINARY_NAME) == NULL)
+		return;
+
+	// Find first occurence of '(' or ' ' in the obtaned symbol string and
+	// assume everything before that is the file name. (Don't go beyond the
+	// string terminator \0)
+	int p = 0;
+	while(symbol[p] != '(' && symbol[p] != ' ' && symbol[p] != '\0')
+		p++;
+
+	// Compute address cleaned by binary offset
+	void *addr = (void*)(address-offset);
+
+	// Invoke addr2line command and get result through pipe
+	char addr2line_cmd[256];
+	snprintf(addr2line_cmd, sizeof(addr2line_cmd), "addr2line %p -e %.*s", addr, p, symbol);
+	FILE *addr2line = NULL;
+	char linebuffer[256];
+	if((addr2line = popen(addr2line_cmd, "r")) != NULL &&
+	   fgets(linebuffer, sizeof(linebuffer), addr2line) != NULL)
+	{
+		char *pos;
+		// Strip possible newline at the end of the addr2line output
+		if ((pos=strchr(linebuffer, '\n')) != NULL)
+			*pos = '\0';
+		logg("addr2line [%04i]: %s", j, linebuffer);
+	}
+	pclose(addr2line);
+}
 
 static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 {
@@ -60,10 +95,25 @@ static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, vo
 	if(bcktrace == NULL)
 		logg("Unable to obtain backtrace symbols!");
 
+	// Try to compute binary offset from backtrace_symbols result
+	void *offset = NULL;
+	for(int j = 0; j < calls; j++)
+	{
+		void *p1 = NULL, *p2 = NULL;
+		char *pend = NULL;
+		if((pend = strrchr(bcktrace[j], '(')) != NULL &&
+		   strstr(bcktrace[j], BINARY_NAME) != NULL &&
+		   sscanf(pend, "(+%p) [%p]", &p1, &p2) == 2)
+		   offset = (void*)(p2-p1);
+	}
+
 	for(int j = 0; j < calls; j++)
 	{
 		logg("B[%04i]: %p, %s", j, buffer[j],
 		     bcktrace != NULL ? bcktrace[j] : "---");
+
+		if(bcktrace != NULL)
+			print_addr2line(bcktrace[j], buffer[j], j, offset);
 	}
 	if(bcktrace != NULL)
 		free(bcktrace);

--- a/src/signals.c
+++ b/src/signals.c
@@ -25,6 +25,7 @@
 volatile sig_atomic_t killed = 0;
 static time_t FTLstarttime = 0;
 
+#if defined(__GLIBC__)
 static void print_addr2line(const char *symbol, const void *address, const int j, const void *offset)
 {
 	// Only do this analysis for our own binary (skip trying to analyse libc.so, etc.)
@@ -53,10 +54,11 @@ static void print_addr2line(const char *symbol, const void *address, const int j
 		// Strip possible newline at the end of the addr2line output
 		if ((pos=strchr(linebuffer, '\n')) != NULL)
 			*pos = '\0';
-		logg("addr2line [%04i]: %s", j, linebuffer);
+		logg("L[%04i]: %s", j, linebuffer);
 	}
 	pclose(addr2line);
 }
+#endif
 
 static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
 {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

We often have to ask for debugging details when users submit error reports. This improves the embedded backtrace generator significantly by allowing FTL to translate its own stack addresses into code lines. This will be very helpful for us in future crashes.

**Before**
```plain                                                                           
[2020-05-20 12:16:51.385 236182] Received signal: Segmentation fault 
[2020-05-20 12:16:51.385 236182]      at address: (nil)                                                                                                                                                   [26/1840]
[2020-05-20 12:16:51.385 236182]      with code: SEGV_MAPERR (Address not mapped to object)                                                                                                                        
[2020-05-20 12:16:51.385 236182] Backtrace:                                                                                                                                                                        
[2020-05-20 12:16:51.386 236182] B[0000]: 0x55d34d506766, ./pihole-FTL(+0x2c766) [0x55d34d506766]                                                                                                                  
[2020-05-20 12:16:51.398 236182] B[0001]: 0x7fd2a0cf53c0, /lib/x86_64-linux-gnu/libpthread.so.0(+0x153c0) [0x7fd2a0cf53c0]                                                                                         
[2020-05-20 12:16:51.398 236182] B[0002]: 0x7fd2a0c794e5, /lib/x86_64-linux-gnu/libc.so.6(+0x18b4e5) [0x7fd2a0c794e5]                                                                                              
[2020-05-20 12:16:51.398 236182] B[0003]: 0x7fd2a0c2fbee, /lib/x86_64-linux-gnu/libc.so.6(inet_pton+0x2e) [0x7fd2a0c2fbee]                                                                                         
[2020-05-20 12:16:51.398 236182] B[0004]: 0x55d34d4ff7cb, ./pihole-FTL(+0x257cb) [0x55d34d4ff7cb]                                                                                                                  
[2020-05-20 12:16:51.406 236182] B[0005]: 0x55d34d61dc02, ./pihole-FTL(+0x143c02) [0x55d34d61dc02]                                                                                                                 
[2020-05-20 12:16:51.475 236182] B[0006]: 0x55d34d62b960, ./pihole-FTL(sqlite3_step+0x2b0) [0x55d34d62b960]                                                                                                        
[2020-05-20 12:16:51.543 236182] B[0007]: 0x55d34d4fd3cf, ./pihole-FTL(+0x233cf) [0x55d34d4fd3cf]                                                                                                                  
[2020-05-20 12:16:51.550 236182] B[0008]: 0x55d34d4ff427, ./pihole-FTL(gravityDB_get_regex_client_groups+0x307) [0x55d34d4ff427]                                                                                   
[2020-05-20 12:16:51.556 236182] B[0009]: 0x55d34d50f15b, ./pihole-FTL(read_regex_from_database+0x22b) [0x55d34d50f15b]                                                                                            
[2020-05-20 12:16:51.564 236182] B[0010]: 0x55d34d506586, ./pihole-FTL(FTL_reload_all_domainlists+0x36) [0x55d34d506586]                                                                                           
[2020-05-20 12:16:51.572 236182] B[0011]: 0x55d34d50ba01, ./pihole-FTL(FTL_dnsmasq_reload+0x141) [0x55d34d50ba01]                                                                                                  
[2020-05-20 12:16:51.582 236182] B[0012]: 0x55d34d538e06, ./pihole-FTL(clear_cache_and_reload+0x26) [0x55d34d538e06]                                                                                               
[2020-05-20 12:16:51.591 236182] B[0013]: 0x55d34d53ace1, ./pihole-FTL(main_dnsmasq+0x1af1) [0x55d34d53ace1]
[2020-05-20 12:16:51.599 236182] B[0014]: 0x55d34d4f9079, ./pihole-FTL(main+0xe9) [0x55d34d4f9079]
[2020-05-20 12:16:51.607 236182] B[0015]: 0x7fd2a0b150b3, /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fd2a0b150b3]
[2020-05-20 12:16:51.607 236182] B[0016]: 0x55d34d4f91ee, ./pihole-FTL(_start+0x2e) [0x55d34d4f91ee]
```

**New** (check out the included `source:line` details)
```plain
[2020-05-20 12:16:51.385 236182] Received signal: Segmentation fault 
[2020-05-20 12:16:51.385 236182]      at address: (nil)                                                                                                                                                   [26/1840]
[2020-05-20 12:16:51.385 236182]      with code: SEGV_MAPERR (Address not mapped to object)                                                                                                                        
[2020-05-20 12:16:51.385 236182] Backtrace:                                                                                                                                                                        
[2020-05-20 12:16:51.386 236182] B[0000]: 0x55d34d506766, ./pihole-FTL(+0x2c766) [0x55d34d506766]                                                                                                                  
[2020-05-20 12:16:51.397 236182] L[0000]: FTL/src/signals.c:91                                                                                                                               
[2020-05-20 12:16:51.398 236182] B[0001]: 0x7fd2a0cf53c0, /lib/x86_64-linux-gnu/libpthread.so.0(+0x153c0) [0x7fd2a0cf53c0]                                                                                         
[2020-05-20 12:16:51.398 236182] B[0002]: 0x7fd2a0c794e5, /lib/x86_64-linux-gnu/libc.so.6(+0x18b4e5) [0x7fd2a0c794e5]                                                                                              
[2020-05-20 12:16:51.398 236182] B[0003]: 0x7fd2a0c2fbee, /lib/x86_64-linux-gnu/libc.so.6(inet_pton+0x2e) [0x7fd2a0c2fbee]                                                                                         
[2020-05-20 12:16:51.398 236182] B[0004]: 0x55d34d4ff7cb, ./pihole-FTL(+0x257cb) [0x55d34d4ff7cb]                                                                                                                  
[2020-05-20 12:16:51.405 236182] L[0004]: FTL/src/database/sqlite3-ext.c:75 (discriminator 4)                                                                                                
[2020-05-20 12:16:51.406 236182] B[0005]: 0x55d34d61dc02, ./pihole-FTL(+0x143c02) [0x55d34d61dc02]                                                                                                                 
[2020-05-20 12:16:51.469 236182] L[0005]: FTL/src/database/sqlite3.c:92508                                                                                                                   
[2020-05-20 12:16:51.475 236182] B[0006]: 0x55d34d62b960, ./pihole-FTL(sqlite3_step+0x2b0) [0x55d34d62b960]                                                                                                        
[2020-05-20 12:16:51.538 236182] L[0006]: FTL/src/database/sqlite3.c:83211                                                                                                                   
[2020-05-20 12:16:51.543 236182] B[0007]: 0x55d34d4fd3cf, ./pihole-FTL(+0x233cf) [0x55d34d4fd3cf]                                                                                                                  
[2020-05-20 12:16:51.549 236182] L[0007]: FTL/src/database/gravity-db.c:246                                                                                                                  
[2020-05-20 12:16:51.550 236182] B[0008]: 0x55d34d4ff427, ./pihole-FTL(gravityDB_get_regex_client_groups+0x307) [0x55d34d4ff427]                                                                                   
[2020-05-20 12:16:51.555 236182] L[0008]: FTL/src/database/gravity-db.c:891 (discriminator 1)                                                                                                
[2020-05-20 12:16:51.556 236182] B[0009]: 0x55d34d50f15b, ./pihole-FTL(read_regex_from_database+0x22b) [0x55d34d50f15b]                                                                                            
[2020-05-20 12:16:51.563 236182] L[0009]: FTL/src/regex.c:191                                                                                                                                
[2020-05-20 12:16:51.564 236182] B[0010]: 0x55d34d506586, ./pihole-FTL(FTL_reload_all_domainlists+0x36) [0x55d34d506586]                                                                                           
[2020-05-20 12:16:51.571 236182] L[0010]: FTL/src/datastructure.c:357                                                                                                                        
[2020-05-20 12:16:51.572 236182] B[0011]: 0x55d34d50ba01, ./pihole-FTL(FTL_dnsmasq_reload+0x141) [0x55d34d50ba01]                                                                                                  
[2020-05-20 12:16:51.581 236182] L[0011]: FTL/src/dnsmasq_interface.c:835                                                                                                                    
[2020-05-20 12:16:51.582 236182] B[0012]: 0x55d34d538e06, ./pihole-FTL(clear_cache_and_reload+0x26) [0x55d34d538e06]                                                                                               
[2020-05-20 12:16:51.590 236182] L[0012]: FTL/src/dnsmasq/dnsmasq.c:1665
[2020-05-20 12:16:51.591 236182] B[0013]: 0x55d34d53ace1, ./pihole-FTL(main_dnsmasq+0x1af1) [0x55d34d53ace1]
[2020-05-20 12:16:51.598 236182] L[0013]: FTL/src/dnsmasq/dnsmasq.c:1425
[2020-05-20 12:16:51.599 236182] B[0014]: 0x55d34d4f9079, ./pihole-FTL(main+0xe9) [0x55d34d4f9079]
[2020-05-20 12:16:51.606 236182] L[0014]: FTL/src/main.c:95
[2020-05-20 12:16:51.607 236182] B[0015]: 0x7fd2a0b150b3, /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fd2a0b150b3]
[2020-05-20 12:16:51.607 236182] B[0016]: 0x55d34d4f91ee, ./pihole-FTL(_start+0x2e) [0x55d34d4f91ee]
[2020-05-20 12:16:51.614 236182] L[0016]: ??:?
```