### PR TITLE
Add warning for invalid hostnames to FTL message table

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -24,8 +24,14 @@ sqlite3 *FTL_db = NULL;
 bool database = true;
 bool DBdeleteoldqueries = false;
 long int lastdbindex = 0;
+static bool db_avail = false;
 
 static pthread_mutex_t dblock;
+
+__attribute__ ((pure)) bool FTL_DB_avail(void)
+{
+	return db_avail;
+}
 
 void dbclose(void)
 {
@@ -36,6 +42,8 @@ void dbclose(void)
 		rc = sqlite3_close(FTL_db);
 		FTL_db = NULL;
 	}
+
+	db_avail = false;
 
 	// Report any error
 	if( rc != SQLITE_OK )
@@ -85,6 +93,8 @@ bool dbopen(void)
 		dbclose();
 		return false;
 	}
+
+	db_avail = true;
 
 	return true;
 }

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -19,6 +19,7 @@ bool db_set_FTL_property(const unsigned int ID, const int value);
 /// Execute a formatted SQL query and get the return code
 int dbquery(const char *format, ...);
 
+bool FTL_DB_avail(void) __attribute__ ((pure));
 bool dbopen(void);
 void dbclose(void);
 int db_query_int(const char*);

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -102,6 +102,8 @@ static bool add_message(enum message_type type, const char *message,
 		if( rc != SQLITE_OK ){
 			logg("add_message(type=%u, message=%s) - SQL error prepare DELETE: %s",
 				type, message, sqlite3_errstr(rc));
+			if(opened_database)
+				dbclose();
 			return false;
 		}
 
@@ -112,6 +114,8 @@ static bool add_message(enum message_type type, const char *message,
 				type, message, sqlite3_errstr(rc));
 			sqlite3_reset(stmt);
 			sqlite3_finalize(stmt);
+			if(opened_database)
+				dbclose();
 			return false;
 		}
 
@@ -122,6 +126,8 @@ static bool add_message(enum message_type type, const char *message,
 				type, message, sqlite3_errstr(rc));
 			sqlite3_reset(stmt);
 			sqlite3_finalize(stmt);
+			if(opened_database)
+				dbclose();
 			return false;
 		}
 
@@ -130,26 +136,13 @@ static bool add_message(enum message_type type, const char *message,
 		{
 			logg("add_message(type=%u, message=%s) - SQL error step DELETE: %s",
 			type, message, sqlite3_errstr(rc));
+			if(opened_database)
+				dbclose();
 			return false;
 		}
-		if((rc = sqlite3_clear_bindings(stmt)) != SQLITE_OK)
-		{
-			logg("add_message(type=%u, message=%s) - SQL error clear DELETE: %s",
-			type, message, sqlite3_errstr(rc));
-			return false;
-		}
-		if((rc = sqlite3_reset(stmt)) != SQLITE_OK)
-		{
-			logg("add_message(type=%u, message=%s) - SQL error reset DELETE: %s",
-			type, message, sqlite3_errstr(rc));
-			return false;
-		}
-		if((rc = sqlite3_finalize(stmt)) != SQLITE_OK)
-		{
-			logg("add_message(type=%u, message=%s) - SQL error finalize DELETE: %s",
-			type, message, sqlite3_errstr(rc));
-			return false;
-		}
+		sqlite3_clear_bindings(stmt);
+		sqlite3_reset(stmt);
+		sqlite3_finalize(stmt);
 	}
 
 	// Prepare SQLite statement
@@ -157,9 +150,12 @@ static bool add_message(enum message_type type, const char *message,
 	const char *querystr = "INSERT INTO message (timestamp,type,message,blob1,blob2,blob3,blob4,blob5) "
 	                       "VALUES ((cast(strftime('%s', 'now') as int)),?,?,?,?,?,?,?);";
 	int rc = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
-	if( rc != SQLITE_OK ){
+	if( rc != SQLITE_OK )
+	{
 		logg("add_message(type=%u, message=%s) - SQL error prepare: %s",
 		     type, message, sqlite3_errstr(rc));
+		if(opened_database)
+			dbclose();
 		return false;
 	}
 
@@ -170,6 +166,8 @@ static bool add_message(enum message_type type, const char *message,
 		     type, message, sqlite3_errstr(rc));
 		sqlite3_reset(stmt);
 		sqlite3_finalize(stmt);
+		if(opened_database)
+			dbclose();
 		return false;
 	}
 
@@ -180,6 +178,8 @@ static bool add_message(enum message_type type, const char *message,
 		     type, message, sqlite3_errstr(rc));
 		sqlite3_reset(stmt);
 		sqlite3_finalize(stmt);
+		if(opened_database)
+			dbclose();
 		return false;
 	}
 
@@ -211,6 +211,8 @@ static bool add_message(enum message_type type, const char *message,
 			     type, message, 3 + j, datatype, sqlite3_errstr(rc));
 			sqlite3_reset(stmt);
 			sqlite3_finalize(stmt);
+			if(opened_database)
+				dbclose();
 			return false;
 		}
 	}

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -84,8 +84,14 @@ bool flush_message_table(void)
 static bool add_message(enum message_type type, const char *message,
                         const int count,...)
 {
-	// Open database connection
-	dbopen();
+	bool opened_database = false;
+	// Open database connection (if not already open)
+	if(!FTL_DB_avail())
+	{
+		if(!dbopen())
+			return false;
+		opened_database = true;
+	}
 
 	// Prepare SQLite statement
 	sqlite3_stmt* stmt = NULL;
@@ -163,8 +169,9 @@ static bool add_message(enum message_type type, const char *message,
 		return false;
 	}
 
-	// Close database connection
-	dbclose();
+	// Close database connection (if we opened it)
+	if(opened_database)
+		dbclose();
 
 	return true;
 }

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -16,7 +16,7 @@
 #include "database/gravity-db.h"
 
 static const char *message_types[MAX_MESSAGE] =
-	{ "REGEX", "SUBNET" };
+	{ "REGEX", "SUBNET", "HOSTNAME" };
 
 static unsigned char message_blob_types[MAX_MESSAGE][5] =
 	{
@@ -33,6 +33,13 @@ static unsigned char message_blob_types[MAX_MESSAGE][5] =
 			SQLITE_TEXT, // comma-separated list of matching subnets (database IDs)
 			SQLITE_TEXT, // chosen subnet (text representation)
 			SQLITE_INTEGER // chosen subnet (database ID)
+		},
+		{	// HOSTNAME_MESSAGE: The message column contains the IP address of the device
+			SQLITE_TEXT, // Obtained host name
+			SQLITE_INTEGER, // Position of error in string
+			SQLITE_NULL, // not used
+			SQLITE_NULL, // not used
+			SQLITE_NULL // not used
 		}
 	};
 // Create message table in the database
@@ -186,4 +193,14 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
 	char *names = get_group_names(matching_ids);
 	add_message(SUBNET_MESSAGE, ip, 5, matching_count, names, matching_ids, chosen_match_text, chosen_match_id);
 	free(names);
+}
+
+void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos)
+{
+	// Log to pihole-FTL.log
+	logg("HOSTNAME WARNING: Host name of client \"%s\" => \"%s\" contains invalid character at position %d",
+	     ip, name, pos);
+
+	// Log to database
+	add_message(HOSTNAME_MESSAGE, ip, 2, name, (const int)pos);
 }

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -205,7 +205,7 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
 void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos)
 {
 	// Log to pihole-FTL.log
-	logg("HOSTNAME WARNING: Host name of client \"%s\" => \"%s\" contains invalid character at position %d",
+	logg("HOSTNAME WARNING: Host name of client \"%s\" => \"%s\" contains (at least) one invalid character at position %d",
 	     ip, name, pos);
 
 	// Log to database

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -16,7 +16,8 @@ void logg_regex_warning(const char *type, const char *warning, const int dbindex
 void logg_subnet_warning(const char *ip, const int matching_count, const char *matching_ids,
                          const int matching_bits, const char *chosen_match_text,
                          const int chosen_match_id);
+void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos);
 
-enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, MAX_MESSAGE };
+enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, HOSTNAME_MESSAGE, MAX_MESSAGE };
 
 #endif //MESSAGETABLE_H

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -22,6 +22,8 @@
 #include "database/network-table.h"
 // struct _res
 #include <resolv.h>
+// logg_hostname_warning()
+#include "database/message-table.h"
 
 static bool res_initialized = false;
 
@@ -45,8 +47,10 @@ static bool valid_hostname(char* name, const char* clientip)
 
 	// Iterate over characters in hostname
 	// to check for legal char: A-Z a-z 0-9 - _ .
-	for (char c; (c = *name); name++)
+	unsigned int len = strlen(name);
+	for (unsigned int i = 0; i < len; i++)
 	{
+		const char c = name[i];
 		if ((c >= 'A' && c <= 'Z') ||
 		    (c >= 'a' && c <= 'z') ||
 		    (c >= '0' && c <= '9') ||
@@ -56,8 +60,7 @@ static bool valid_hostname(char* name, const char* clientip)
 			continue;
 
 		// Invalid character found, log and return hostname being invalid
-		logg("WARN: Hostname of client %s contains invalid character: %c (char code %d)",
-		     clientip, (unsigned char)c, (unsigned char)c);
+		logg_hostname_warning(clientip, name, i);
 		return false;
 	}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add a message for Pi-hole diagnostics when host names with invalid characters have been found during FTL's internal name resolution (typically client host names containing non-ASCII characters).

Example:
```
$ grep /etc/hosts "127.0.0.53
127.0.0.53 Cöfte
```

results in
id|timestamp|type|message|blob1|blob2|blob3|blob4|blob5
--|--|--|--|--|--|--|--|--
98|1590222660|HOSTNAME|127.0.0.53|Cöfte|1|||

where `message (TEXT)` = IP of the host names, `blob1 (UTF8 TEXT)` = the obtained host names, `blob2 (INT)` = position of the invalid character