### PR TITLE
Add NAMES_FROM_NETDB option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -372,6 +372,25 @@ void read_FTLconf(void)
 	else
 		logg("   BLOCK_ESNI: Disabled");
 
+	// NAMES_FROM_NETDB
+	// Should we use the fallback option to try to obtain client names from
+	// checking the network table? Assume this is an IPv6 client without a
+	// host names itself but the network table tells us that this is the same
+	// device where we have a host names for its IPv4 address. In this case,
+	// we use the host name associated to the other address as this is the same
+	// device. This behavior can be disabled using NAMES_FROM_NETDB=false
+	// defaults to: true
+	config.names_from_netdb = true;
+	buffer = parse_FTLconf(fp, "NAMES_FROM_NETDB");
+
+	if(buffer != NULL && strcasecmp(buffer, "false") == 0)
+		config.names_from_netdb = false;
+
+	if(config.names_from_netdb)
+		logg("   NAMES_FROM_NETDB: Enabled, trying to get names from network database");
+	else
+		logg("   NAMES_FROM_NETDB: Disabled");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -39,6 +39,7 @@ typedef struct {
 	bool parse_arp_cache;
 	bool cname_inspection;
 	bool block_esni;
+	bool names_from_netdb;
 } ConfigStruct;
 
 typedef struct {

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -256,7 +256,8 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 	char* newname = resolveHostname(ipaddr);
 
 	// If no hostname was found, try to obtain hostname from the network table
-	if(strlen(newname) == 0)
+	// This may be disabled due to a user setting
+	if(strlen(newname) == 0 && config.names_from_netdb)
 	{
 		free(newname);
 		newname = getDatabaseHostname(ipaddr);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This adds a new option `NAMES_FROM_NETDB` which allows to disable the try to obtain an addresses host name using the network table.

One use case it that there is a IPv6 client without a host names itself.
However, using the network table we can find out that this client is the same device where we also kwon an IPv4 address together with a valid host names for. In this case, we use the host name associated to the other address as this is the same device. This behavior can now be disabled using `NAMES_FROM_NETDB=false`

This feature has been discussed on Discourse: https://discourse.pi-hole.net/t/incorrect-hostnames/33111