### PR TITLE
Be less nice

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -100,6 +100,14 @@ bool check_capabilities(void)
 		logg("*************************************************************************");
 		capabilities_okay = false;
 	}
+	if (!(data->permitted & (1 << CAP_SYS_NICE)))
+	{
+		// Necessary for dynamic port binding
+		logg("*************************************************************************");
+		logg("* WARNING: Required Linux capability CAP_SYS_NICE not available         *");
+		logg("*************************************************************************");
+		capabilities_okay = false;
+	}
 
 	// Free allocated memory
 	free(hdr);

--- a/test/run.sh
+++ b/test/run.sh
@@ -23,7 +23,7 @@ chown pihole:pihole /etc/pihole /run/pihole /var/log/pihole.log /var/log/pihole-
 cp ./pihole-FTL /home/pihole
 chmod +x /home/pihole/pihole-FTL
 # Note: We cannot add CAP_NET_RAW and CAP_NET_ADMIN at this point
-setcap CAP_NET_BIND_SERVICE+eip /home/pihole/pihole-FTL
+setcap CAP_NET_BIND_SERVICE,CAP_SYS_NICE+eip /home/pihole/pihole-FTL
 
 # Prepare gravity database
 sqlite3 /etc/pihole/gravity.db < test/gravity.db.sql

--- a/test/run.sh
+++ b/test/run.sh
@@ -23,7 +23,7 @@ chown pihole:pihole /etc/pihole /run/pihole /var/log/pihole.log /var/log/pihole-
 cp ./pihole-FTL /home/pihole
 chmod +x /home/pihole/pihole-FTL
 # Note: We cannot add CAP_NET_RAW and CAP_NET_ADMIN at this point
-setcap CAP_NET_BIND_SERVICE,CAP_SYS_NICE+eip /home/pihole/pihole-FTL
+setcap CAP_NET_BIND_SERVICE+eip /home/pihole/pihole-FTL
 
 # Prepare gravity database
 sqlite3 /etc/pihole/gravity.db < test/gravity.db.sql

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -358,7 +358,7 @@
 }
 
 @test "No WARNING messages in pihole-FTL.log (besides known capability issues)" {
-  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW"'
+  run bash -c 'grep "WARNING:" /var/log/pihole-FTL.log | grep -c -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Set nice value of pihole-FTL to increase DNS server performance. The new niceness default to `-10` (lower is less nice = getting more CPU cycles for our own). The value can be changed through a config option. Changing the niceness can be avoided by setting `NICE=0` (this will set `0` as niceness, which is the default) or `NICE=-999` (this will skip trying to set the niceness, altogether).

If the user is not allowed to change their niceness, FTL will log:
```
NICE: Cannot change niceness to -10 (permission denied)
```

If the user specified an invalid niceness, it will be clamped to the according extremum (`+/- 20`):
```
NICE: Set process niceness to -20 (asked for -100)
```

If everything is fine, the output is:
```
NICE: Set process niceness to -12
```

TODO (pi-hole/core): Add `CAP_SYS_NICE` to FTL so it is allowed to change its own niceness when when running as user `pihole`. Without this, only `root` can change the niceness of processes.