### PR TITLE
Remove obsolete AAAA_QUERY_ANALYSIS setting

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -115,16 +115,6 @@ void read_FTLconf(void)
 	else
 		logg("   SOCKET_LISTENING: all destinations");
 
-	// AAAA_QUERY_ANALYSIS
-	// defaults to: Yes
-	buffer = parse_FTLconf(fp, "AAAA_QUERY_ANALYSIS");
-	config.analyze_AAAA = read_bool(buffer, true);
-
-	if(config.analyze_AAAA)
-		logg("   AAAA_QUERY_ANALYSIS: Show AAAA queries");
-	else
-		logg("   AAAA_QUERY_ANALYSIS: Hide AAAA queries");
-
 	// MAXDBDAYS
 	// defaults to: 365 days
 	config.maxDBdays = 365;

--- a/src/config.h
+++ b/src/config.h
@@ -30,7 +30,6 @@ typedef struct {
 	unsigned char privacylevel;
 	unsigned char blockingmode;
 	bool socket_listenlocal;
-	bool analyze_AAAA;
 	bool resolveIPv6;
 	bool resolveIPv4;
 	bool ignore_localhost;

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -355,12 +355,6 @@ void DB_read_queries(void)
 			logg("FTL_db warn: TYPE should not be %i", type);
 			continue;
 		}
-		// Don't import AAAA queries from database if the user set
-		// AAAA_QUERY_ANALYSIS=no in pihole-FTL.conf
-		if(type == TYPE_AAAA && !config.analyze_AAAA)
-		{
-			continue;
-		}
 
 		const int status = sqlite3_column_int(stmt, 3);
 		if(status < QUERY_UNKNOWN || status >= QUERY_STATUS_MAX)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -460,14 +460,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		return false;
 	}
 
-	// Skip AAAA queries if user doesn't want to have them analyzed
-	if(!config.analyze_AAAA && querytype == TYPE_AAAA)
-	{
-		if(config.debug & DEBUG_QUERIES)
-			logg("Not analyzing AAAA query");
-		return false;
-	}
-
 	// Lock shared memory
 	lock_shm();
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

When this was [added over 3 years ago](https://github.com/pi-hole/FTL/pull/63), there may have been [reasons to do so](https://github.com/pi-hole/docker-pi-hole/issues/143#issuecomment-305609805). However, with IPv6 progressing further and further, this option (artificially hide AAAA records even when they are still processed) seems a bit ... falling out of story.

We remove this without replacement. I will update the `release/v5.1` documentation when this gets merged.