### PR TITLE
Improve TCP worker handling

### DIFF
--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -15,7 +15,7 @@
 */
 
 #define FTABSIZ 150 /* max number of outstanding requests (default) */
-#define MAX_PROCS 20 /* max no children for TCP requests */
+#define MAX_PROCS 60 /* max no children for TCP requests */
 #define CHILD_LIFETIME 300 /* secs 'till terminated (RFC1035 suggests > 120s) */
 #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
 #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -16,7 +16,7 @@
 
 #define FTABSIZ 150 /* max number of outstanding requests (default) */
 #define MAX_PROCS 20 /* max no children for TCP requests */
-#define CHILD_LIFETIME 150 /* secs 'till terminated (RFC1035 suggests > 120s) */
+#define CHILD_LIFETIME 300 /* secs 'till terminated (RFC1035 suggests > 120s) */
 #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
 #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
 #define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1958,7 +1958,7 @@ static void check_dns_listeners(time_t now)
 		fcntl(confd, F_SETFL, flags & ~O_NONBLOCK);
 	      
 	      /******* Pi-hole modification *******/
-	      FTL_TCP_worker_created();
+	      FTL_TCP_worker_created(confd, iface->name);
 	      /************************************/
 
 	      buff = tcp_request(confd, now, &tcp_addr, netmask, auth_dns);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1785,8 +1785,17 @@ static void prepare_blocking_metadata(void)
 // Called when a (forked) TCP worker is terminated by receiving SIGALRM
 // We close the dedicated database connection this client had opened
 // to avoid dangling database locks
+static volatile bool worker_already_terminating = false;
 void FTL_TCP_worker_terminating(bool finished)
 {
+	if(worker_already_terminating)
+	{
+		logg("TCP worker already terminating!");
+		return;
+	}
+	worker_already_terminating = true;
+
+	// Possible debug logging
 	if(config.debug != 0)
 	{
 		const char *reason = finished ? "client disconnected" : "timeout";

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -51,7 +51,7 @@ bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const 
 
 void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
-void FTL_TCP_worker_created(void);
+void FTL_TCP_worker_created(const int confd, const char *iface_name);
 void FTL_TCP_worker_terminating(bool finished);
 
 void set_debug_dnsmasq_lines(char enabled);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

We've seen reports where connection termination due to timeout and foreign client disconnecting can happen at the same time (on milliseconds accuracy). The detailed bug description can be found in https://github.com/pi-hole/FTL/issues/816#issuecomment-660013854.

We're performing four changes in this pull request:

1. We skip second termination if there is already a termination event in progress. This ensures that a running termination cannot be interrupted. To ensure non-interruptibility, we use C11 atomic functions ensuring we generate atomic test code.
2. In addition to step 1, we try to ensure that this situation does not even happen by doubling the TCP worker timeout from 105 seconds to 300 seconds
3. Increase limit for concurrently active TCP workers from 20 to 60.
    We've seen reports where 20 wasn't sufficient in user networks. Given that TCP workers do not really consume all that much more memory, this limit may even be increased further in case we recognize that 60 still isn't sufficient.
4. For debugging proposes, we show for which TCP worker FTL created a fork.
    Previously:
    ```
    TCP worker forked
    ```
    Now:
    ```
    TCP worker forked for client 192.168.0.15 on interface enp0s2 (192.168.0.11)
    ```