### PR TITLE
 Safely reopen gravity database

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -54,6 +54,14 @@ void gravityDB_forked(void)
 	gravityDB_open();
 }
 
+void gravityDB_reopen(void)
+{
+	lock_shm();
+	gravityDB_close();
+	gravityDB_open();
+	unlock_shm();
+}
+
 // Open gravity database
 bool gravityDB_open(void)
 {

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -19,6 +19,7 @@
 enum gravity_tables { GRAVITY_TABLE, EXACT_BLACKLIST_TABLE, EXACT_WHITELIST_TABLE, REGEX_BLACKLIST_TABLE, REGEX_WHITELIST_TABLE, UNKNOWN_TABLE } __attribute__ ((packed));
 
 void gravityDB_forked(void);
+void gravityDB_reopen(void);
 bool gravityDB_open(void);
 bool gravityDB_prepare_client_statements(const int clientID, clientsData* client);
 void gravityDB_close(void);

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -378,8 +378,7 @@ void FTL_reload_all_domainlists(void)
 	flush_message_table();
 
 	// (Re-)open gravity database connection
-	gravityDB_close();
-	gravityDB_open();
+	gravityDB_reopen();
 
 	// Reset number of blocked domains
 	counters->gravity = gravityDB_count(GRAVITY_TABLE);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Wrap gravity reopening in locking to avoid a race collision with API requests. As these are performed from independent threads, it was possible that API calls could have been received in the middle of a database reopening. This can lead to a crash in SQLite3.

Fixes #841 where the fix has already been confirmed to work.