### PR TITLE
Update embedded dnsmasq to v2.82

### DIFF
--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -473,17 +473,30 @@ void cache_start_insert(void)
 struct crec *cache_insert(char *name, union all_addr *addr, unsigned short class,
 			  time_t now,  unsigned long ttl, unsigned int flags)
 {
-  /* Don't log DNSSEC records here, done elsewhere */
-  if (flags & (F_IPV4 | F_IPV6 | F_CNAME | F_SRV))
+#ifdef HAVE_DNSSEC
+  if (flags & (F_DNSKEY | F_DS)) 
     {
+      /* The DNSSEC validation process works by getting needed records into the
+	 cache, then retrying the validation until they are all in place.
+	 This can be messed up by very short TTLs, and _really_ messed up by
+	 zero TTLs, so we force the TTL to be at least long enough to do a validation.
+	 Ideally, we should use some kind of reference counting so that records are
+	 locked until the validation that asked for them is complete, but this
+	 is much easier, and just as effective. */
+      if (ttl < DNSSEC_MIN_TTL)
+	ttl = DNSSEC_MIN_TTL;
+    }
+  else
+#endif
+    {
+      /* Don't log DNSSEC records here, done elsewhere */
       log_query(flags | F_UPSTREAM, name, addr, NULL);
       FTL_reply(flags, name, addr, daemon->log_display_id);
-      /* Don't mess with TTL for DNSSEC records. */
       if (daemon->max_cache_ttl != 0 && daemon->max_cache_ttl < ttl)
 	ttl = daemon->max_cache_ttl;
       if (daemon->min_cache_ttl != 0 && daemon->min_cache_ttl > ttl)
 	ttl = daemon->min_cache_ttl;
-    }
+    }	
   
   return really_insert(name, addr, class, now, ttl, flags);
 }

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -40,6 +40,7 @@
 #define DHCP_PACKET_MAX 16384 /* hard limit on DHCP packet size */
 #define SMALLDNAME 50 /* most domain names are smaller than this */
 #define CNAME_CHAIN 10 /* chains longer than this atr dropped for loop protection */
+#define DNSSEC_MIN_TTL 60 /* DNSKEY and DS records in cache last at least this long */
 #define HOSTSFILE "/etc/hosts"
 #define ETHERSFILE "/etc/ethers"
 #define DEFLEASE 3600 /* default lease time, 1 hour */

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -43,7 +43,8 @@
 #define DNSSEC_MIN_TTL 60 /* DNSKEY and DS records in cache last at least this long */
 #define HOSTSFILE "/etc/hosts"
 #define ETHERSFILE "/etc/ethers"
-#define DEFLEASE 3600 /* default lease time, 1 hour */
+#define DEFLEASE 3600 /* default DHCPv4 lease time, one hour */
+#define DEFLEASE6 (3600*24) /* default lease time for DHCPv6. One day. */
 /**** Pi-hole modification ****/
 #define CHUSER "root"
 #define CHGRP "root"

--- a/src/dnsmasq/dbus.c
+++ b/src/dnsmasq/dbus.c
@@ -237,7 +237,7 @@ static DBusMessage *dbus_reply_server_loop(DBusMessage *message)
   for (serv = daemon->servers; serv; serv = serv->next)
     if (serv->flags & SERV_LOOP)
       {
-	prettyprint_addr(&serv->addr, daemon->addrbuff);
+	(void)prettyprint_addr(&serv->addr, daemon->addrbuff);
 	dbus_message_iter_append_basic (&args_iter, DBUS_TYPE_STRING, &daemon->addrbuff);
       }
   

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1841,7 +1841,8 @@ static void check_dns_listeners(time_t now)
 		    addr.addr4 = tcp_addr.in.sin_addr;
 		  
 		  for (iface = daemon->interfaces; iface; iface = iface->next)
-		    if (iface->index == if_index)
+		    if (iface->index == if_index &&
+		        iface->addr.sa.sa_family == tcp_addr.sa.sa_family)
 		      break;
 		  
 		  if (!iface && !loopback_exception(listener->tcpfd, tcp_addr.sa.sa_family, &addr, intr_name))

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -574,7 +574,7 @@ struct irec {
 };
 
 struct listener {
-  int fd, tcpfd, tftpfd, family, used;
+  int fd, tcpfd, tftpfd, used;
   union mysockaddr addr;
   struct irec *iface; /* only sometimes valid for non-wildcard */
   struct listener *next;

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -574,7 +574,8 @@ struct irec {
 };
 
 struct listener {
-  int fd, tcpfd, tftpfd, family;
+  int fd, tcpfd, tftpfd, family, used;
+  union mysockaddr addr;
   struct irec *iface; /* only sometimes valid for non-wildcard */
   struct listener *next;
 };

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -944,6 +944,7 @@ struct shared_network {
 #define CONTEXT_OLD            (1u<<16)
 #define CONTEXT_V6             (1u<<17)
 #define CONTEXT_RA_OFF_LINK    (1u<<18)
+#define CONTEXT_SETLEASE       (1u<<19)
 
 struct ping_result {
   struct in_addr addr;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1316,8 +1316,9 @@ void receive_query(struct listener *listen, time_t now)
 		 CMSG_SPACE(sizeof(struct sockaddr_dl))];
 #endif
   } control_u;
+  int family = listen->addr.sa.sa_family;
    /* Can always get recvd interface for IPv6 */
-  int check_dst = !option_bool(OPT_NOWILD) || listen->family == AF_INET6;
+  int check_dst = !option_bool(OPT_NOWILD) || family == AF_INET6;
 
   /************ Pi-hole modification ************/
   bool piholeblocked = false;
@@ -1334,7 +1335,7 @@ void receive_query(struct listener *listen, time_t now)
     {
       auth_dns = listen->iface->dns_auth;
      
-      if (listen->family == AF_INET)
+      if (family == AF_INET)
 	{
 	  dst_addr_4 = dst_addr.addr4 = listen->iface->addr.in.sin_addr;
 	  netmask = listen->iface->netmask;
@@ -1364,9 +1365,9 @@ void receive_query(struct listener *listen, time_t now)
      information disclosure. */
   memset(daemon->packet + n, 0, daemon->edns_pktsz - n);
   
-  source_addr.sa.sa_family = listen->family;
+  source_addr.sa.sa_family = family;
   
-  if (listen->family == AF_INET)
+  if (family == AF_INET)
     {
        /* Source-port == 0 is an error, we can't send back to that. 
 	  http://www.ietf.org/mail-archive/web/dnsop/current/msg11441.html */
@@ -1386,7 +1387,7 @@ void receive_query(struct listener *listen, time_t now)
     {
       struct addrlist *addr;
 
-      if (listen->family == AF_INET6) 
+      if (family == AF_INET6) 
 	{
 	  for (addr = daemon->interface_addrs; addr; addr = addr->next)
 	    if ((addr->flags & ADDRLIST_IPV6) &&
@@ -1424,7 +1425,7 @@ void receive_query(struct listener *listen, time_t now)
 	return;
 
 #if defined(HAVE_LINUX_NETWORK)
-      if (listen->family == AF_INET)
+      if (family == AF_INET)
 	for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
 	  if (cmptr->cmsg_level == IPPROTO_IP && cmptr->cmsg_type == IP_PKTINFO)
 	    {
@@ -1437,7 +1438,7 @@ void receive_query(struct listener *listen, time_t now)
 	      if_index = p.p->ipi_ifindex;
 	    }
 #elif defined(IP_RECVDSTADDR) && defined(IP_RECVIF)
-      if (listen->family == AF_INET)
+      if (family == AF_INET)
 	{
 	  for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
 	    {
@@ -1462,7 +1463,7 @@ void receive_query(struct listener *listen, time_t now)
 	}
 #endif
       
-      if (listen->family == AF_INET6)
+      if (family == AF_INET6)
 	{
 	  for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
 	    if (cmptr->cmsg_level == IPPROTO_IPV6 && cmptr->cmsg_type == daemon->v6pktinfo)
@@ -1483,16 +1484,16 @@ void receive_query(struct listener *listen, time_t now)
       if (!indextoname(listen->fd, if_index, ifr.ifr_name))
 	return;
       
-      if (!iface_check(listen->family, &dst_addr, ifr.ifr_name, &auth_dns))
+      if (!iface_check(family, &dst_addr, ifr.ifr_name, &auth_dns))
 	{
 	   if (!option_bool(OPT_CLEVERBIND))
 	     enumerate_interfaces(0); 
-	   if (!loopback_exception(listen->fd, listen->family, &dst_addr, ifr.ifr_name) &&
-	       !label_exception(if_index, listen->family, &dst_addr))
+	   if (!loopback_exception(listen->fd, family, &dst_addr, ifr.ifr_name) &&
+	       !label_exception(if_index, family, &dst_addr))
 	     return;
 	}
 
-      if (listen->family == AF_INET && option_bool(OPT_LOCALISE))
+      if (family == AF_INET && option_bool(OPT_LOCALISE))
 	{
 	  struct irec *iface;
 	  
@@ -1537,7 +1538,7 @@ void receive_query(struct listener *listen, time_t now)
 #endif
       char *types = querystr(auth_dns ? "auth" : "query", type);
       
-      if (listen->family == AF_INET) 
+      if (family == AF_INET) 
       {
 	log_query(F_QUERY | F_IPV4 | F_FORWARD, daemon->namebuff, 
 		  (union all_addr *)&source_addr.in.sin_addr, types);

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -700,7 +700,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
   if (!(header->hb4 & HB4_RA) && rcode == NOERROR &&
       server && !(server->flags & SERV_WARNED_RECURSIVE))
     {
-      prettyprint_addr(&server->addr, daemon->namebuff);
+      (void)prettyprint_addr(&server->addr, daemon->namebuff);
       my_syslog(LOG_WARNING, _("nameserver %s refused to do a recursive query"), daemon->namebuff);
       if (!option_bool(OPT_LOG))
 	server->flags |= SERV_WARNED_RECURSIVE;
@@ -991,7 +991,7 @@ void reply_query(int fd, int family, time_t now)
     {
       forward->sentto->edns_pktsz = SAFE_PKTSZ;
       forward->sentto->pktsz_reduced = now;
-      prettyprint_addr(&forward->sentto->addr, daemon->addrbuff);
+      (void)prettyprint_addr(&forward->sentto->addr, daemon->addrbuff);
       my_syslog(LOG_WARNING, _("reducing DNS packet size for nameserver %s to %d"), daemon->addrbuff, SAFE_PKTSZ);
     }
 

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -389,10 +389,11 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
   /* check whether the interface IP has been added already 
      we call this routine multiple times. */
   for (iface = daemon->interfaces; iface; iface = iface->next) 
-    if (sockaddr_isequal(&iface->addr, addr))
+    if (sockaddr_isequal(&iface->addr, addr) && iface->index == if_index)
       {
 	iface->dad = !!(iface_flags & IFACE_TENTATIVE);
 	iface->found = 1; /* for garbage collection */
+	iface->netmask = netmask;
 	return 1;
       }
 

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -641,6 +641,13 @@ int enumerate_interfaces(int reset)
 	  else
 	    {
 	      *up = l->next;
+	      if (l->iface->done)
+	        {
+	          iface = l->iface;
+	          prettyprint_addr(&iface->addr, daemon->addrbuff);
+	          my_syslog(LOG_DEBUG, _("stopped listening on %s(#%d): %s"),
+	                    iface->name, iface->index, daemon->addrbuff);
+	        }
 	      
 	      /* In case it ever returns */
 	      l->iface->done = 0;
@@ -952,6 +959,9 @@ void create_bound_listeners(int dienow)
 	new->next = daemon->listeners;
 	daemon->listeners = new;
 	iface->done = 1;
+	prettyprint_addr(&iface->addr, daemon->addrbuff);
+	my_syslog(LOG_DEBUG, _("listening on %s(#%d): %s"),
+	          iface->name, iface->index, daemon->addrbuff);
       }
 
   /* Check for --listen-address options that haven't been used because there's
@@ -971,6 +981,8 @@ void create_bound_listeners(int dienow)
       {
 	new->next = daemon->listeners;
 	daemon->listeners = new;
+	prettyprint_addr(&if_tmp->addr, daemon->addrbuff);
+	my_syslog(LOG_DEBUG, _("listening on %s"), daemon->addrbuff);
       }
 }
 

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -644,7 +644,7 @@ int enumerate_interfaces(int reset)
 	      if (l->iface->done)
 	        {
 	          iface = l->iface;
-	          prettyprint_addr(&iface->addr, daemon->addrbuff);
+	          (void)prettyprint_addr(&iface->addr, daemon->addrbuff);
 	          my_syslog(LOG_DEBUG, _("stopped listening on %s(#%d): %s"),
 	                    iface->name, iface->index, daemon->addrbuff);
 	        }
@@ -959,7 +959,7 @@ void create_bound_listeners(int dienow)
 	new->next = daemon->listeners;
 	daemon->listeners = new;
 	iface->done = 1;
-	prettyprint_addr(&iface->addr, daemon->addrbuff);
+	(void)prettyprint_addr(&iface->addr, daemon->addrbuff);
 	my_syslog(LOG_DEBUG, _("listening on %s(#%d): %s"),
 	          iface->name, iface->index, daemon->addrbuff);
       }
@@ -981,7 +981,7 @@ void create_bound_listeners(int dienow)
       {
 	new->next = daemon->listeners;
 	daemon->listeners = new;
-	prettyprint_addr(&if_tmp->addr, daemon->addrbuff);
+	(void)prettyprint_addr(&if_tmp->addr, daemon->addrbuff);
 	my_syslog(LOG_DEBUG, _("listening on %s"), daemon->addrbuff);
       }
 }
@@ -1314,7 +1314,7 @@ void pre_allocate_sfds(void)
 	errno != 0 &&
 	option_bool(OPT_NOWILD))
       {
-	prettyprint_addr(&srv->source_addr, daemon->namebuff);
+	(void)prettyprint_addr(&srv->source_addr, daemon->namebuff);
 	if (srv->interface[0] != 0)
 	  {
 	    strcat(daemon->namebuff, " ");

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -718,7 +718,7 @@ int enumerate_interfaces(int reset)
 	  else if (release_listener(l))
 	    {
 	      *up = tmp;
-		freed = 1;
+	      freed = 1;
 	    }
 	}
 
@@ -1035,15 +1035,20 @@ void create_bound_listeners(int dienow)
 	  }
 	else if ((new = create_listeners(&iface->addr, iface->tftp_ok, dienow)))
 	  {
-	    int port;
-
 	    new->iface = iface;
 	    new->next = daemon->listeners;
 	    daemon->listeners = new;
 	    iface->done = 1;
-	    port = prettyprint_addr(&iface->addr, daemon->addrbuff);
-	    my_syslog(LOG_DEBUG, _("listening on %s(#%d): %s port %d"),
-		      iface->name, iface->index, daemon->addrbuff, port);
+
+	    /* Don't log the initial set of listen addresses created
+               at startup, since this is happening before the logging
+               system is initialised and the sign-on printed. */
+            if (!dienow)
+              {
+		int port = prettyprint_addr(&iface->addr, daemon->addrbuff);
+		my_syslog(LOG_DEBUG, _("listening on %s(#%d): %s port %d"),
+			  iface->name, iface->index, daemon->addrbuff, port);
+	      }
 	  }
       }
 
@@ -1062,12 +1067,14 @@ void create_bound_listeners(int dienow)
     if (!if_tmp->used && 
 	(new = create_listeners(&if_tmp->addr, !!option_bool(OPT_TFTP), dienow)))
       {
-	int port;
-
 	new->next = daemon->listeners;
 	daemon->listeners = new;
-	port = prettyprint_addr(&if_tmp->addr, daemon->addrbuff);
-	my_syslog(LOG_DEBUG, _("listening on %s port %d"), daemon->addrbuff, port);
+
+	if (!dienow)
+	  {
+	    int port = prettyprint_addr(&if_tmp->addr, daemon->addrbuff);
+	    my_syslog(LOG_DEBUG, _("listening on %s port %d"), daemon->addrbuff, port);
+	  }
       }
 }
 

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -965,7 +965,6 @@ static struct listener *create_listeners(union mysockaddr *addr, int do_tftp, in
     {
       l = safe_malloc(sizeof(struct listener));
       l->next = NULL;
-      l->family = addr->sa.sa_family;
       l->fd = fd;
       l->tcpfd = tcpfd;
       l->tftpfd = tftpfd;

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -2995,7 +2995,6 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	struct dhcp_context *new = opt_malloc(sizeof(struct dhcp_context));
 	
 	memset (new, 0, sizeof(*new));
-	new->lease_time = DEFLEASE;
 	
 	while(1)
 	  {
@@ -3045,6 +3044,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	if (inet_pton(AF_INET, a[0], &new->start))
 	  {
 	    new->next = daemon->dhcp;
+	    new->lease_time = DEFLEASE;
 	    daemon->dhcp = new;
 	    new->end = new->start;
 	    if (strcmp(a[1], "static") == 0)
@@ -3092,6 +3092,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	    new->flags |= CONTEXT_V6; 
 	    new->prefix = 64; /* default */
 	    new->end6 = new->start6;
+	    new->lease_time = DEFLEASE6;
 	    new->next = daemon->dhcp6;
 	    daemon->dhcp6 = new;
 
@@ -3191,7 +3192,10 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	      }
 	    
 	    if (strcmp(a[leasepos], "infinite") == 0)
-	      new->lease_time = 0xffffffff;
+	      {
+		new->lease_time = 0xffffffff;
+		new->flags |= CONTEXT_SETLEASE;
+	      }
 	    else if (strcmp(a[leasepos], "deprecated") == 0)
 	      new->flags |= CONTEXT_DEPRECATE;
 	    else
@@ -3230,6 +3234,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		      ret_err_free(_("bad dhcp-range"), new);
 		    
 		    new->lease_time = atoi(a[leasepos]) * fac;
+		    new->flags |= CONTEXT_SETLEASE;
 		    /* Leases of a minute or less confuse
 		       some clients, notably Apple's */
 		    if (new->lease_time < 120)
@@ -3237,6 +3242,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		  }
 	      }
 	  }
+
 	break;
       }
 

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1229,7 +1229,7 @@ static int parse_dhcp_opt(char *errstr, char *arg, int flags)
 	  } 
 	else if (c == '.')	
 	  {
-	    is_addr6 = is_dec = is_hex = 0;
+	    is_dec = is_hex = 0;
 	    dots++;
 	  }
 	else if (c == '-')

--- a/src/dnsmasq/radv.c
+++ b/src/dnsmasq/radv.c
@@ -626,8 +626,11 @@ static int add_prefixes(struct in6_addr *local,  int prefix,
 		    real_prefix = context->prefix;
 		  }
 
-		/* find floor time, don't reduce below 3 * RA interval. */
-		if (time > context->lease_time)
+		/* find floor time, don't reduce below 3 * RA interval.
+		   If the lease time has been left as default, don't
+		   use that as a floor. */
+		if ((context->flags & CONTEXT_SETLEASE) &&
+		    time > context->lease_time)
 		  {
 		    time = context->lease_time;
 		    if (time < ((unsigned int)(3 * param->adv_interval)))

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -322,7 +322,7 @@ void tftp_request(struct listener *listen, time_t now)
   transfer->opt_blocksize = transfer->opt_transize = 0;
   transfer->netascii = transfer->carrylf = 0;
  
-  prettyprint_addr(&peer, daemon->addrbuff);
+  (void)prettyprint_addr(&peer, daemon->addrbuff);
   
   /* if we have a nailed-down range, iterate until we find a free one. */
   while (!option_bool(OPT_SINGLE_PORT))
@@ -624,7 +624,7 @@ void check_tftp_listeners(time_t now)
 	    {
 	      strcpy(daemon->namebuff, transfer->file->filename);
 	      sanitise(daemon->namebuff);
-	      prettyprint_addr(&transfer->peer, daemon->addrbuff);
+	      (void)prettyprint_addr(&transfer->peer, daemon->addrbuff);
 	      my_syslog(MS_TFTP | LOG_INFO, endcon ? _("failed sending %s to %s") : _("sent %s to %s"), daemon->namebuff, daemon->addrbuff);
 	      /* unlink */
 	      *up = tmp;
@@ -667,7 +667,7 @@ static void handle_tftp(time_t now, struct tftp_transfer *transfer, ssize_t len)
 	  char *end = daemon->packet + len;
 	  char *err = next(&p, end);
 	  
-	  prettyprint_addr(&transfer->peer, daemon->addrbuff);
+	  (void)prettyprint_addr(&transfer->peer, daemon->addrbuff);
 	  
 	  /* Sanitise error message */
 	  if (!err)

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -61,8 +61,9 @@ void tftp_request(struct listener *listen, time_t now)
   char *prefix = daemon->tftp_prefix;
   struct tftp_prefix *pref;
   union all_addr addra;
+  int family = listen->addr.sa.sa_family;
   /* Can always get recvd interface for IPv6 */
-  int check_dest = !option_bool(OPT_NOWILD) || listen->family == AF_INET6;
+  int check_dest = !option_bool(OPT_NOWILD) || family == AF_INET6;
   union {
     struct cmsghdr align; /* this ensures alignment */
     char control6[CMSG_SPACE(sizeof(struct in6_pktinfo))];
@@ -121,10 +122,10 @@ void tftp_request(struct listener *listen, time_t now)
       if (msg.msg_controllen < sizeof(struct cmsghdr))
         return;
       
-      addr.sa.sa_family = listen->family;
+      addr.sa.sa_family = family;
       
 #if defined(HAVE_LINUX_NETWORK)
-      if (listen->family == AF_INET)
+      if (family == AF_INET)
 	for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
 	  if (cmptr->cmsg_level == IPPROTO_IP && cmptr->cmsg_type == IP_PKTINFO)
 	    {
@@ -138,7 +139,7 @@ void tftp_request(struct listener *listen, time_t now)
 	    }
       
 #elif defined(HAVE_SOLARIS_NETWORK)
-      if (listen->family == AF_INET)
+      if (family == AF_INET)
 	for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
 	  {
 	    union {
@@ -154,7 +155,7 @@ void tftp_request(struct listener *listen, time_t now)
 	  }
       
 #elif defined(IP_RECVDSTADDR) && defined(IP_RECVIF)
-      if (listen->family == AF_INET)
+      if (family == AF_INET)
 	for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
 	  {
 	    union {
@@ -171,7 +172,7 @@ void tftp_request(struct listener *listen, time_t now)
 	  
 #endif
 
-      if (listen->family == AF_INET6)
+      if (family == AF_INET6)
         {
           for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
             if (cmptr->cmsg_level == IPPROTO_IPV6 && cmptr->cmsg_type == daemon->v6pktinfo)
@@ -194,7 +195,7 @@ void tftp_request(struct listener *listen, time_t now)
       
       addra.addr4 = addr.in.sin_addr;
 
-      if (listen->family == AF_INET6)
+      if (family == AF_INET6)
 	addra.addr6 = addr.in6.sin6_addr;
 
       if (daemon->tftp_interfaces)
@@ -210,12 +211,12 @@ void tftp_request(struct listener *listen, time_t now)
       else
 	{
 	  /* Do the same as DHCP */
-	  if (!iface_check(listen->family, &addra, name, NULL))
+	  if (!iface_check(family, &addra, name, NULL))
 	    {
 	      if (!option_bool(OPT_CLEVERBIND))
 		enumerate_interfaces(0); 
-	      if (!loopback_exception(listen->tftpfd, listen->family, &addra, name) &&
-		  !label_exception(if_index, listen->family, &addra))
+	      if (!loopback_exception(listen->tftpfd, family, &addra, name) &&
+		  !label_exception(if_index, family, &addra))
 		return;
 	    }
 	  
@@ -281,7 +282,7 @@ void tftp_request(struct listener *listen, time_t now)
 	  prefix = pref->prefix;  
     }
 
-  if (listen->family == AF_INET)
+  if (family == AF_INET)
     {
       addr.in.sin_port = htons(port);
 #ifdef HAVE_SOCKADDR_SA_LEN
@@ -304,7 +305,7 @@ void tftp_request(struct listener *listen, time_t now)
   
   if (option_bool(OPT_SINGLE_PORT))
     transfer->sockfd = listen->tftpfd;
-  else if ((transfer->sockfd = socket(listen->family, SOCK_DGRAM, 0)) == -1)
+  else if ((transfer->sockfd = socket(family, SOCK_DGRAM, 0)) == -1)
     {
       free(transfer);
       return;
@@ -337,7 +338,7 @@ void tftp_request(struct listener *listen, time_t now)
 	    {
 	      if (++port <= daemon->end_tftp_port)
 		{ 
-		  if (listen->family == AF_INET)
+		  if (family == AF_INET)
 		    addr.in.sin_port = htons(port);
 		  else
 		    addr.in6.sin6_port = htons(port);
@@ -375,7 +376,7 @@ void tftp_request(struct listener *listen, time_t now)
 	      if ((opt = next(&p, end)) && !option_bool(OPT_TFTP_NOBLOCK))
 		{
 		  /* 32 bytes for IP, UDP and TFTP headers, 52 bytes for IPv6 */
-		  int overhead = (listen->family == AF_INET) ? 32 : 52;
+		  int overhead = (family == AF_INET) ? 32 : 52;
 		  transfer->blocksize = atoi(opt);
 		  if (transfer->blocksize < 1)
 		    transfer->blocksize = 1;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Update the embedded `dnsmasq` to the just released (5 hrs ago) dnsmasq v2.82.

Changelog:
```
version 2.82
        Improve behaviour in the face of network interfaces which come
        and go and change index. Thanks to Petr Mensik for the patch.

        Convert hard startup failure on NETLINK_NO_ENOBUFS under qemu-user
        to a warning.

        Allow IPv6 addresses ofthe form [::ffff:1.2.3.4] in --dhcp-option.

        Fix crash under heavy TCP connection load introduced in 2.81. <--- This is already included in FTL 5.1
        Thanks to Frank for good work chasing this down.

        Change default lease time for DHCPv6 to one day.

        Alter calculation of preferred and valid times in router
        advertisements, so that these do not have a floor applied
        of the lease time in the dhcp-range if this is not explicitly
        specified and is merely the default.
        Thanks to Martin-Éric Racine for suggestions on this.
```