### PR TITLE
Add ability to show only blocked queries for a specific client

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -624,6 +624,8 @@ void getAllQueries(const char *client_message, const int *sock)
 	// Do we want a more specific version of this command (domain/client/time interval filtered)?
 	int from = 0, until = 0;
 
+	bool showpermitted = true, showblocked = true;
+
 	char *domainname = NULL;
 	bool filterdomainname = false;
 	int domainid = -1;
@@ -733,7 +735,15 @@ void getAllQueries(const char *client_message, const int *sock)
 		// Get client name we want to see only (limit length to 255 chars)
 		clientname = calloc(256, sizeof(char));
 		if(clientname == NULL) return;
-		sscanf(client_message, ">getallqueries-client %255s", clientname);
+		if(command(client_message, ">getallqueries-client-blocked"))
+		{
+			showpermitted = false;
+			sscanf(client_message, ">getallqueries-client-blocked %255s", clientname);
+		}
+		else
+		{
+			sscanf(client_message, ">getallqueries-client %255s", clientname);
+		}
 		filterclientname = true;
 
 		// Iterate through all known clients
@@ -760,6 +770,7 @@ void getAllQueries(const char *client_message, const int *sock)
 			free(clientname);
 			return;
 		}
+
 	}
 
 	int ibeg = 0, num;
@@ -775,7 +786,6 @@ void getAllQueries(const char *client_message, const int *sock)
 
 	// Get potentially existing filtering flags
 	char * filter = read_setupVarsconf("API_QUERY_LOG_SHOW");
-	bool showpermitted = true, showblocked = true;
 	if(filter != NULL)
 	{
 		if((strcmp(filter, "permittedonly")) == 0)

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -813,6 +813,10 @@ void getAllQueries(const char *client_message, const int *sock)
 		// Get query type
 		const char *qtype = querytypes[query->type - TYPE_A];
 
+		// Hide UNKNOWN queries when not requesting both query status types
+		if(query->status == QUERY_UNKNOWN && !(showpermitted && showblocked))
+			continue;
+
 		// 1 = gravity.list, 4 = wildcard, 5 = black.list
 		if((query->status == QUERY_GRAVITY ||
 		    query->status == QUERY_REGEX ||


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add new telnet API hook `>getallqueries-client-blocked` allowing to show only blocked queries for a specific client.