### PR TITLE
Explicitly cast time_T

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -166,8 +166,8 @@ void getOverTime(const int *sock)
 	{
 		for(int slot = from; slot < until; slot++)
 		{
-			ssend(*sock,"%li %i %i\n",
-			      overTime[slot].timestamp,
+			ssend(*sock,"%lli %i %i\n",
+			      (long long)overTime[slot].timestamp,
 			      overTime[slot].total,
 			      overTime[slot].blocked);
 		}
@@ -180,14 +180,14 @@ void getOverTime(const int *sock)
 		// Send domains over time
 		pack_map16_start(*sock, (uint16_t) (until - from));
 		for(int slot = from; slot < until; slot++) {
-			pack_int32(*sock, overTime[slot].timestamp);
+			pack_int32(*sock, (int32_t)overTime[slot].timestamp);
 			pack_int32(*sock, overTime[slot].total);
 		}
 
 		// Send ads over time
 		pack_map16_start(*sock, (uint16_t) (until - from));
 		for(int slot = from; slot < until; slot++) {
-			pack_int32(*sock, overTime[slot].timestamp);
+			pack_int32(*sock, (int32_t)overTime[slot].timestamp);
 			pack_int32(*sock, overTime[slot].blocked);
 		}
 	}
@@ -904,8 +904,8 @@ void getAllQueries(const char *client_message, const int *sock)
 
 		if(istelnet[*sock])
 		{
-			ssend(*sock,"%li %s %s %s %i %i %i %lu %s %i",
-				query->timestamp,
+			ssend(*sock,"%lli %s %s %s %i %i %i %lu %s %i",
+				(long long)query->timestamp,
 				qtype,
 				domain,
 				clientIPName,
@@ -921,7 +921,7 @@ void getAllQueries(const char *client_message, const int *sock)
 		}
 		else
 		{
-			pack_int32(*sock, query->timestamp);
+			pack_int32(*sock, (int32_t)query->timestamp);
 
 			// Use a fixstr because the length of qtype is always 4 (max is 31 for fixstr)
 			if(!pack_fixstr(*sock, qtype))
@@ -1039,7 +1039,7 @@ void getQueryTypesOverTime(const int *sock)
 		}
 
 		if(istelnet[*sock])
-			ssend(*sock, "%li %.2f %.2f\n", overTime[slot].timestamp, percentageIPv4, percentageIPv6);
+			ssend(*sock, "%lli %.2f %.2f\n", (long long)overTime[slot].timestamp, percentageIPv4, percentageIPv6);
 		else {
 			pack_int32(*sock, overTime[slot].timestamp);
 			pack_float(*sock, percentageIPv4);
@@ -1180,9 +1180,9 @@ void getClientsOverTime(const int *sock)
 	for(int slot = sendit; slot < until; slot++)
 	{
 		if(istelnet[*sock])
-			ssend(*sock, "%li", overTime[slot].timestamp);
+			ssend(*sock, "%lli", (long long)overTime[slot].timestamp);
 		else
-			pack_int32(*sock, overTime[slot].timestamp);
+			pack_int32(*sock, (int32_t)overTime[slot].timestamp);
 
 		// Loop over forward destinations to generate output to be sent to the client
 		for(int clientID = 0; clientID < counters->clients; clientID++)
@@ -1308,9 +1308,9 @@ void getUnknownQueries(const int *sock)
 		const char *clientIP = getstr(client->ippos);
 
 		if(istelnet[*sock])
-			ssend(*sock, "%li %i %i %s %s %s %i %s\n", query->timestamp, queryID, query->id, type, getstr(domain->domainpos), clientIP, query->status, query->complete ? "true" : "false");
+			ssend(*sock, "%lli %i %i %s %s %s %i %s\n", (long long)query->timestamp, queryID, query->id, type, getstr(domain->domainpos), clientIP, query->status, query->complete ? "true" : "false");
 		else {
-			pack_int32(*sock, query->timestamp);
+			pack_int32(*sock, (int32_t)query->timestamp);
 			pack_int32(*sock, query->id);
 
 			// Use a fixstr because the length of qtype is always 4 (max is 31 for fixstr)

--- a/src/config.c
+++ b/src/config.c
@@ -180,7 +180,7 @@ void read_FTLconf(void)
 	if(config.DBinterval == 60)
 		logg("   DBINTERVAL: saving to DB file every minute");
 	else
-		logg("   DBINTERVAL: saving to DB file every %i seconds", config.DBinterval);
+		logg("   DBINTERVAL: saving to DB file every %lli seconds", (long long)config.DBinterval);
 
 	// DBFILE
 	// defaults to: "/etc/pihole/pihole-FTL.db"

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,6 @@ void read_debuging_settings(FILE *fp);
 
 typedef struct {
 	int maxDBdays;
-	int DBinterval;
 	int port;
 	int maxlogage;
 	int dns_port;
@@ -44,6 +43,7 @@ typedef struct {
 	bool block_esni;
 	bool names_from_netdb;
 	bool edns0_ecs;
+	time_t DBinterval;
 } ConfigStruct;
 
 typedef struct {

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -331,7 +331,7 @@ void DB_read_queries(void)
 	const char *querystr = "SELECT * FROM queries WHERE timestamp >= ?";
 	// Log FTL_db query string in debug mode
 	if(config.debug & DEBUG_DATABASE)
-		logg("DB_read_queries(): \"%s\" with ? = %li", querystr, mintime);
+		logg("DB_read_queries(): \"%s\" with ? = %lli", querystr, (long long)mintime);
 
 	// Prepare SQLite3 statement
 	sqlite3_stmt* stmt = NULL;
@@ -358,12 +358,12 @@ void DB_read_queries(void)
 		// 1483228800 = 01/01/2017 @ 12:00am (UTC)
 		if(queryTimeStamp < 1483228800)
 		{
-			logg("FTL_db warn: TIMESTAMP should be larger than 01/01/2017 but is %li", queryTimeStamp);
+			logg("FTL_db warn: TIMESTAMP should be larger than 01/01/2017 but is %lli", (long long)queryTimeStamp);
 			continue;
 		}
 		if(queryTimeStamp > now)
 		{
-			if(config.debug & DEBUG_DATABASE) logg("FTL_db warn: Skipping query logged in the future (%li)", queryTimeStamp);
+			if(config.debug & DEBUG_DATABASE) logg("FTL_db warn: Skipping query logged in the future (%lli)", (long long)queryTimeStamp);
 			continue;
 		}
 
@@ -390,14 +390,14 @@ void DB_read_queries(void)
 		const char * domainname = (const char *)sqlite3_column_text(stmt, 4);
 		if(domainname == NULL)
 		{
-			logg("FTL_db warn: DOMAIN should never be NULL, %li", queryTimeStamp);
+			logg("FTL_db warn: DOMAIN should never be NULL, %lli", (long long)queryTimeStamp);
 			continue;
 		}
 
 		const char * clientIP = (const char *)sqlite3_column_text(stmt, 5);
 		if(clientIP == NULL)
 		{
-			logg("FTL_db warn: CLIENT should never be NULL, %li", queryTimeStamp);
+			logg("FTL_db warn: CLIENT should never be NULL, %lli", (long long)queryTimeStamp);
 			continue;
 		}
 
@@ -416,7 +416,8 @@ void DB_read_queries(void)
 		{
 			if(upstream == NULL)
 			{
-				logg("WARN (during database import): FORWARD should not be NULL with status QUERY_FORWARDED (timestamp: %li), skipping entry", queryTimeStamp);
+				logg("WARN (during database import): FORWARD should not be NULL with status QUERY_FORWARDED (timestamp: %lli), skipping entry",
+				     (long long)queryTimeStamp);
 				continue;
 			}
 			upstreamID = findUpstreamID(upstream, true);
@@ -537,7 +538,7 @@ void DB_read_queries(void)
 
 			default:
 				logg("Error: Found unknown status %i in long term database!", status);
-				logg("       Timestamp: %li", queryTimeStamp);
+				logg("       Timestamp: %lli", (long long)queryTimeStamp);
 				logg("       Continuing anyway...");
 				break;
 		}

--- a/src/gc.c
+++ b/src/gc.c
@@ -59,7 +59,7 @@ void *GC_thread(void *val)
 				timer_start(GC_TIMER);
 				char timestring[84] = "";
 				get_timestr(timestring, mintime);
-				logg("GC starting, mintime: %s (%lu)", timestring, mintime);
+				logg("GC starting, mintime: %s (%llu)", timestring, (long long)mintime);
 			}
 
 			// Process all queries

--- a/src/overTime.c
+++ b/src/overTime.c
@@ -31,7 +31,7 @@ static void initSlot(const unsigned int index, const time_t timestamp)
 	// Possible debug printing
 	if(config.debug & DEBUG_OVERTIME)
 	{
-		logg("initSlot(%u, %lu): Zeroing overTime slot", index, timestamp);
+		logg("initSlot(%u, %llu): Zeroing overTime slot", index, (long long)timestamp);
 	}
 
 	// Initialize overTime entry
@@ -71,7 +71,10 @@ void initOverTime(void)
 	time_t timestamp = now - now % 3600 + 3600 - (OVERTIME_INTERVAL / 2);
 
 	if(config.debug & DEBUG_OVERTIME)
-		logg("initOverTime(): Initializing %i slots from %lu to %lu", OVERTIME_SLOTS, timestamp-OVERTIME_SLOTS*OVERTIME_INTERVAL, timestamp);
+		logg("initOverTime(): Initializing %i slots from %llu to %llu",
+		     OVERTIME_SLOTS,
+		     (long long)timestamp-OVERTIME_SLOTS*OVERTIME_INTERVAL,
+		     (long long)timestamp);
 
 	// Iterate over overTime
 	for(int i = OVERTIME_SLOTS-1; i >= 0 ; i--)
@@ -98,13 +101,13 @@ unsigned int getOverTimeID(time_t timestamp)
 	// Check bounds manually
 	if(id < 0)
 	{
-		logg("WARN: getOverTimeID(%lu): %u is negative: %lu", timestamp, id, firstTimestamp);
+		logg("WARN: getOverTimeID(%llu): %u is negative: %llu", (long long)timestamp, id, (long long)firstTimestamp);
 		// Return first timestamp in case negative timestamp was determined
 		return 0;
 	}
 	else if(id > OVERTIME_SLOTS-1)
 	{
-		logg("WARN: getOverTimeID(%lu): %i is too large: %lu", timestamp, id, firstTimestamp);
+		logg("WARN: getOverTimeID(%llu): %i is too large: %llu", (long long)timestamp, id, (long long)firstTimestamp);
 		// Return last timestamp in case a too large timestamp was determined
 		return OVERTIME_SLOTS-1;
 	}
@@ -112,7 +115,7 @@ unsigned int getOverTimeID(time_t timestamp)
 	if(config.debug & DEBUG_OVERTIME)
 	{
 		// Debug output
-		logg("getOverTimeID(%lu): %i", timestamp, id);
+		logg("getOverTimeID(%llu): %i", (long long)timestamp, id);
 	}
 
 	return (unsigned int) id;
@@ -138,8 +141,8 @@ void moveOverTimeMemory(const time_t mintime)
 
 	if(config.debug & DEBUG_OVERTIME)
 	{
-		logg("moveOverTimeMemory(): IS: %lu, SHOULD: %lu, MOVING: %u",
-		     oldestOverTimeIS, oldestOverTimeSHOULD, moveOverTime);
+		logg("moveOverTimeMemory(): IS: %llu, SHOULD: %llu, MOVING: %u",
+		     (long long)oldestOverTimeIS, (long long)oldestOverTimeSHOULD, moveOverTime);
 	}
 
 	// Check if the move over amount is valid. This prevents errors if the

--- a/src/signals.c
+++ b/src/signals.c
@@ -90,7 +90,7 @@ static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, vo
 
 	if(FTLstarttime != 0)
 	{
-		logg("FTL has been running for %li seconds", time(NULL)-FTLstarttime);
+		logg("FTL has been running for %lli seconds", (long long)time(NULL) - FTLstarttime);
 	}
 	log_FTL_version(true);
 	char namebuf[16];


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

`musl` 1.2.0 changes the definition of `time_t`, and thereby the definitions of all derived types, to be 64-bit across all archs. This and related changes are collectively referred to as "time64", and are necessary so that data types and functions dealing with time can represent time past early 2038, where the existing 32-bit type on 32-bit archs would overflow.

Explicitly cast `time_t` to (`long long`) before printing to address the `musl`-decision to make `time_t` a 64-bit variable even on 32-bit machines.