### PR TITLE
Show also IPv6 nameservers in DEBUG_RESOLVER

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -71,10 +71,37 @@ static bool valid_hostname(char* name, const char* clientip)
 static void print_used_resolvers(const char *message)
 {
 	logg("%s", message);
-	for(unsigned int i = 0u; i < MAXNS; i++)
-		logg(" %u: %s:%d", i,
-		     inet_ntoa(_res.nsaddr_list[i].sin_addr),
-		     ntohs(_res.nsaddr_list[i].sin_port));
+	for(unsigned int i = 0u; i < 2*MAXNS; i++)
+	{
+		int family;
+		in_port_t port;
+		void *addr = NULL;
+		if(i < MAXNS)
+		{
+			// IPv4 name servers
+			addr = &_res.nsaddr_list[i].sin_addr;
+			port = ntohs(_res.nsaddr_list[i].sin_port);
+			family = AF_INET;
+		}
+		else
+		{
+			// Extension name servers (typically IPv6)
+
+			// Some of the entries may not be configured
+			if(_res._u._ext.nsaddrs[i - MAXNS] == NULL)
+				continue;
+			addr = &_res._u._ext.nsaddrs[i - MAXNS]->sin6_addr;
+			port = ntohs(_res._u._ext.nsaddrs[i - MAXNS]->sin6_port);
+			family = _res._u._ext.nsaddrs[i - MAXNS]->sin6_family;
+		}
+
+		// Convert nameserver information to human-readable form
+		char nsname[INET6_ADDRSTRLEN];
+		inet_ntop(family, addr, nsname, INET6_ADDRSTRLEN);
+
+		logg(" %u: %s:%d (IPv%i)", i, nsname, port,
+		     family == AF_INET ? 4 : 6);
+	}
 }
 
 static char *resolveHostname(const char *addr)


### PR DESCRIPTION
#
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Show also possible IPv6 name servers when `DEBUG_RESOLVER` is enabled. They are stored in a somewhat auxiliary (external) structure so they were not included in FTL's debug outputs **even when they were used** during resolving host names. Hence, this PR is a purely cosmetic change without any effect on the functionality. Without `DEBUG_RESOLVER` being enabled, the changed printing routine is never called.

Before:
```
[2020-08-16 21:15:52.793 21996/T22008] Trying to resolve 127.0.0.2
[2020-08-16 21:15:52.793 21996/T22008] Using nameservers:
[2020-08-16 21:15:52.793 21996/T22008]  0: 127.0.0.1:53 (IPv4)
[2020-08-16 21:15:52.793 21996/T22008]  1: 0.0.0.0:0 (IPv4)
[2020-08-16 21:15:52.793 21996/T22008]  2: 0.0.0.0:0 (IPv4)
```

Now:
```
[2020-08-16 21:15:52.793 21996/T22008] Trying to resolve 127.0.0.2
[2020-08-16 21:15:52.793 21996/T22008] Using nameservers:
[2020-08-16 21:15:52.793 21996/T22008]  0: 127.0.0.1:53 (IPv4)
[2020-08-16 21:15:52.793 21996/T22008]  1: 0.0.0.0:0 (IPv4)
[2020-08-16 21:15:52.793 21996/T22008]  2: 0.0.0.0:0 (IPv4)
[2020-08-16 21:15:52.793 21996/T22008]  3: 0.0.0.0:53 (IPv4)
[2020-08-16 21:15:52.793 21996/T22008]  4: ::1:53 (IPv6)
[2020-08-16 21:15:52.793 21996/T22008]  5: fe80::2aea:17ff:44a3:160d:53 (IPv6)
```