### PR TITLE
Clean network addresses

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -376,20 +376,20 @@ void read_FTLconf(void)
 
 	// MAXNETAGE
 	// IP addresses (and associated host names) older than the specified number
-	// of hours are removed to avoid dead entries in the network overview table
-	// defaults to: disabled (0.0 hours)
-	config.network_expire = 0u;
+	// of days are removed to avoid dead entries in the network overview table
+	// defaults to: the same value as MAXDBDAYS
+	config.network_expire = config.maxDBdays;
 	buffer = parse_FTLconf(fp, "MAXNETAGE");
 
-	fvalue = 0;
+	int ivalue = 0;
 	if(buffer != NULL &&
-	    sscanf(buffer, "%f", &fvalue) &&
-	   fvalue >= 0.0f && fvalue <= 8760.0f) // 8760 = 24 * 365
-			config.network_expire = (unsigned int)(fvalue * 3600);
+	    sscanf(buffer, "%i", &ivalue) &&
+	    ivalue > 0 && ivalue <= 8760) // 8760 days = 24 years
+			config.network_expire = ivalue;
 
 	if(config.network_expire > 0u)
-		logg("   MAXNETAGE: Removing IP addresses and host names from network table after %.1f hours",
-		     (float)config.network_expire/3600.0f);
+		logg("   MAXNETAGE: Removing IP addresses and host names from network table after %u days",
+		     config.network_expire);
 	else
 		logg("   MAXNETAGE: No automated removal of IP addresses and host names from the network table");
 

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1100,11 +1100,11 @@ void parse_neighbor_cache(void)
 	// Remove all but the most recent IP addresses not seen for more than a certain time
 	if(config.network_expire > 0u)
 	{
+		const time_t limit = time(NULL)-24*3600*config.network_expire;
 		dbquery("DELETE FROM network_addresses "
-		               "WHERE lastSeen < cast(strftime('%%s', 'now') as int)-%u;",
-		                     config.network_expire);
+		               "WHERE lastSeen < %u;", limit);
 		dbquery("UPDATE network_addresses SET name = NULL "
-		               "WHERE nameUpdated < cast(strftime('%%s', 'now') as int)-%u;", config.network_expire);
+		               "WHERE nameUpdated < %u;", limit);
 	}
 
 	// Start collecting database commands
@@ -1319,9 +1319,6 @@ void parse_neighbor_cache(void)
 	dbquery("DELETE FROM network WHERE id NOT IN "
 	                                  "(SELECT network_id from network_addresses) "
 	                              "AND hwaddr LIKE 'ip-%%';");
-
-	// Delete addresses from network_addresses table which have not be seen for 7 days
-	dbquery("DELETE FROM network_addresses WHERE lastSeen < cast(strftime('%%s', 'now') as int)-604800;");
 
 	// Actually update the database
 	if((rc = dbquery("END TRANSACTION")) != SQLITE_OK) {

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1320,6 +1320,9 @@ void parse_neighbor_cache(void)
 	                                  "(SELECT network_id from network_addresses) "
 	                              "AND hwaddr LIKE 'ip-%%';");
 
+	// Delete addresses from network_addresses table which have not be seen for 7 days
+	dbquery("DELETE FROM network_addresses WHERE lastSeen < cast(strftime('%%s', 'now') as int)-604800;");
+
 	// Actually update the database
 	if((rc = dbquery("END TRANSACTION")) != SQLITE_OK) {
 		const char *text;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR enables cleaning of IP addresses from the `network_addresses` table which have not be seen for a set number of days. The maximum age of entries can be controlled though the `MAXNETAGE` config option and defaults to the value of `MAXDBDAYS`.

`MAXNETAGE` can be set to zero if a user doesn't want auto-cleaning.