### PR TITLE
Only resolve active clients

### DIFF
--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -75,7 +75,11 @@ int findUpstreamID(const char * upstreamString, const bool count)
 
 		if(strcmp(getstr(upstream->ippos), upstreamString) == 0)
 		{
-			if(count) upstream->count++;
+			if(count)
+			{
+				upstream->count++;
+				upstream->lastQuery = time(NULL);
+			}
 			return upstreamID;
 		}
 	}
@@ -111,6 +115,8 @@ int findUpstreamID(const char * upstreamString, const bool count)
 	// to be done separately to be non-blocking
 	upstream->new = true;
 	upstream->namepos = 0; // 0 -> string with length zero
+	// This is a new upstream server
+	upstream->lastQuery = time(NULL);
 	// Increase counter by one
 	counters->upstreams++;
 

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -45,6 +45,7 @@ typedef struct {
 	int failed;
 	size_t ippos;
 	size_t namepos;
+	time_t lastQuery;
 } upstreamsData;
 
 typedef struct {

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -18,7 +18,7 @@
 #include "datastructure.h"
 
 /// The version of shared memory used
-#define SHARED_MEMORY_VERSION 9
+#define SHARED_MEMORY_VERSION 10
 
 /// The name of the shared memory. Use this when connecting to the shared memory.
 #define SHARED_LOCK_NAME "/FTL-lock"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR is a feature request from discourse (see link below). Only try to resolve host names of upstream servers which were recently active. The current limit for "recently active" is hard-coded to two hours.