### PR TITLE
Fix error displaying if the upstream server failed

### DIFF
--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1012,7 +1012,7 @@ size_t setup_reply(struct dns_header *header, size_t qlen,
       union all_addr a;
       a.log.rcode = SERVFAIL;
       log_query(F_CONFIG | F_RCODE, "error", &a, NULL);
-      FTL_reply(flags, "error", &a, daemon->log_display_id);
+      FTL_reply(F_CONFIG | F_RCODE, "error", &a, daemon->log_display_id);
       SET_RCODE(header, SERVFAIL);
     }
   else if (flags & ( F_IPV4 | F_IPV6))
@@ -1038,7 +1038,7 @@ size_t setup_reply(struct dns_header *header, size_t qlen,
       union all_addr a;
       a.log.rcode = REFUSED;
       log_query(F_CONFIG | F_RCODE, "error", &a, NULL);
-      FTL_reply(flags, "error", &a, daemon->log_display_id);
+      FTL_reply(F_CONFIG | F_RCODE, "error", &a, daemon->log_display_id);
       SET_RCODE(header, REFUSED);
     }
   

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -878,7 +878,7 @@ void _FTL_reply(const unsigned short flags, const char *name, const union all_ad
 		if(rcode == REFUSED)
 		{
 			// This happens, e.g., in a "nowhere to forward to" situation
-			answer = "REFUSED";
+			answer = "REFUSED (nowhere to forward to)";
 		}
 		else if(rcode == SERVFAIL)
 		{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix error displaying if the upstream server replied with REFUSED or SERVFAIL

Before (incorrect):
```
[2020-08-23 14:37:44.124 15047/F15035] **** got reply error is ::500:a505:dcc1:1656:0
```
Now (fixed):
```
[2020-08-23 14:37:44.124 15047/F15035] **** got reply error is REFUSED (nowhere to forward to)
```