### PR TITLE
Extend domain filtering to also check the CNAME domain for domain-fil

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -849,24 +849,28 @@ void getAllQueries(const char *client_message, const int *sock)
 			continue;
 
 		// Skip if domain is not identical with what the user wants to see
-		if(filterdomainname && query->domainID == domainid)
+		if(filterdomainname)
 		{
-			// Get this query
-		}
-		// If the domain of this query did not match, the CNAME
-		// domain may still match - we have to check it in
-		// addition if this query is of CNAME blocked type
-		else if((query->status == QUERY_GRAVITY_CNAME ||
-		         query->status == QUERY_BLACKLIST_CNAME ||
-		         query->status == QUERY_REGEX_CNAME) &&
-		         query->CNAME_domainID == domainid)
-		{
-			// Get this query
-		}
-		else
-		{
-			// Skip this query
-			continue;
+			// Check direct match
+			if(query->domainID == domainid)
+			{
+				// Get this query
+			}
+			// If the domain of this query did not match, the CNAME
+			// domain may still match - we have to check it in
+			// addition if this query is of CNAME blocked type
+			else if((query->status == QUERY_GRAVITY_CNAME ||
+				query->status == QUERY_BLACKLIST_CNAME ||
+				query->status == QUERY_REGEX_CNAME) &&
+				query->CNAME_domainID == domainid)
+			{
+				// Get this query
+			}
+			else
+			{
+				// Skip this query
+				continue;
+			}
 		}
 
 		// Skip if client name and IP are not identical with what the user wants to see

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -849,8 +849,25 @@ void getAllQueries(const char *client_message, const int *sock)
 			continue;
 
 		// Skip if domain is not identical with what the user wants to see
-		if(filterdomainname && query->domainID != domainid)
+		if(filterdomainname && query->domainID == domainid)
+		{
+			// Get this query
+		}
+		// If the domain of this query did not match, the CNAME
+		// domain may still match - we have to check it in
+		// addition if this query is of CNAME blocked type
+		else if((query->status == QUERY_GRAVITY_CNAME ||
+		         query->status == QUERY_BLACKLIST_CNAME ||
+		         query->status == QUERY_REGEX_CNAME) &&
+		         query->CNAME_domainID == domainid)
+		{
+			// Get this query
+		}
+		else
+		{
+			// Skip this query
 			continue;
+		}
 
 		// Skip if client name and IP are not identical with what the user wants to see
 		if(filterclientname && query->clientID != clientid)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Extend domain filtering to also check the CNAME domain for domain-filtering (if this is indicated by the query status).
This fixes a subitem of #833 we seemingly have forgotten.


http://pi.hole/admin/queries.php?domain=aax-eu.amazon.de
![Screenshot at 2020-08-30 21-34-18](https://user-images.githubusercontent.com/16748619/91667952-ae9cd180-eb08-11ea-97dc-de1fa3dab99a.png)


http://pi.hole/admin/queries.php?domain=aax-eu-retail-direct.amazon-adsystem.com
![Screenshot at 2020-08-30 21-34-43](https://user-images.githubusercontent.com/16748619/91667957-b0ff2b80-eb08-11ea-9305-c96e5c8dbf66.png)

Note: Reply type "N/A" is expected as I restarted FTL in between and these are queries re-imported from the database.