### PR TITLE
Fix GCC9 regression for printing the same buffer into itself

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -229,13 +229,13 @@ static void nice_time(char *buffer, unsigned long seconds)
 	buffer[0] = ' ';
 	buffer[1] = '\0';
 	if(days > 0)
-		sprintf(buffer, "%s%ud ", buffer, days);
+		sprintf(buffer + strlen(buffer), "%ud ", days);
 	if(hours > 0)
-		sprintf(buffer, "%s%uh ", buffer, hours);
+		sprintf(buffer + strlen(buffer), "%uh ", hours);
 	if(minutes > 0)
-		sprintf(buffer, "%s%um ", buffer, minutes);
+		sprintf(buffer + strlen(buffer), "%um ", minutes);
 	if(seconds > 0)
-		sprintf(buffer, "%s%lus ", buffer, seconds);
+		sprintf(buffer + strlen(buffer), "%lus ", seconds);
 }
 
 // adds a DHCP OFFER to list in memory


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes warnings showing up with the most recent `gcc` compiler. The code still works the same, however, it is a bit safer, so this is a good change. The fix is to not print the existing buffer into itself but to append to the string by starting to write from the memory address immediately behind the current content of the buffer.