### PR TITLE
Request a lease with validity of 1 second in the DHCPDISCOVER packet

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -174,7 +174,7 @@ static bool send_dhcp_discover(const int sock, const uint32_t xid, const char *i
 	// transaction id is supposed to be random
 	discover_packet.xid = htonl(xid);
 	ntohl(discover_packet.xid);
-	discover_packet.secs = 0xFF;
+	discover_packet.secs = 0x00;
 
 	// tell server it should broadcast its response
 	discover_packet.flags = htons(32768); // DHCP_BROADCAST_FLAG
@@ -191,7 +191,16 @@ static bool send_dhcp_discover(const int sock, const uint32_t xid, const char *i
 	// DHCP message type is embedded in options field
 	discover_packet.options[4] = 53;     // DHCP message type option identifier
 	discover_packet.options[5] = '\x01'; // DHCP message option length in bytes
-	discover_packet.options[6] = 1;
+	discover_packet.options[6] = 1;      // DHCP message type code for DHCPDISCOVER
+
+	// Request a lease with validity of 1 second
+	discover_packet.options[7] = 51;     // Lease time type option identifier
+	discover_packet.options[8] = '\x04'; // DHCP message option length in bytes
+	const uint32_t lease_time = htonl(1);
+	memcpy(&discover_packet.options[9], &lease_time, sizeof(lease_time));
+
+	// Place end option at the end of the options
+	discover_packet.options[13] = 255;
 
 	// send the DHCPDISCOVER packet to the specified address
 	struct sockaddr_in target;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Request a lease with validity of 1 second in the DHCPDISCOVER packet of the `dhcp-discover` feature

Considered valid by `wireshark`
![Screenshot at 2020-09-08 00-37-53](https://user-images.githubusercontent.com/16748619/92419074-8dbd2780-f16b-11ea-82e9-867da8a0d6cf.png)
