### PR TITLE
Add more verbose version output (./pihole-FTL -vv)

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -22,6 +22,8 @@
 #include "shmem.h"
 // run_dhcp_discover()
 #include "dhcp-discover.h"
+// defined in dnsmasq.c
+extern void print_dnsmasq_version(void);
 
 bool dnsmasq_debug = false;
 bool daemonmode = true, cli_mode = false;
@@ -136,6 +138,32 @@ void parse_args(int argc, char* argv[])
 			exit(EXIT_SUCCESS);
 		}
 
+		// Extended version output
+		if(strcmp(argv[i], "-vv") == 0)
+		{
+			// Print FTL version
+			printf("****************************** FTL **********************************\n");
+			printf("Version:         %s\n\n", get_FTL_version());
+
+			// Print dnsmasq version and compile time options
+			print_dnsmasq_version();
+
+			// Print SQLite3 version and compile time options
+			printf("****************************** SQLite3 ******************************\n");
+			printf("Version:         %s\n", sqlite3_libversion());
+			printf("Compile options: ");
+			unsigned int o = 0;
+			const char *opt = NULL;
+			while((opt = sqlite3_compileoption_get(o++)) != NULL)
+			{
+				if(o != 1)
+					printf(" ");
+				printf("%s", opt);
+			}
+			printf("\n");
+			exit(EXIT_SUCCESS);
+		}
+
 		if(strcmp(argv[i], "-t") == 0 ||
 		   strcmp(argv[i], "tag") == 0)
 		{
@@ -200,7 +228,8 @@ void parse_args(int argc, char* argv[])
 			printf("\t                    don't go into daemon mode\n");
 			printf("\t    test            Don't start pihole-FTL but\n");
 			printf("\t                    instead quit immediately\n");
-			printf("\t-v, version         Return version\n");
+			printf("\t-v, version         Return FTL version\n");
+			printf("\t-vv                 Return more version information\n");
 			printf("\t-t, tag             Return git tag\n");
 			printf("\t-b, branch          Return git branch\n");
 			printf("\t-f, no-daemon       Don't go into daemon mode\n");

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -2146,3 +2146,12 @@ int delay_dhcp(time_t start, int sec, int fd, uint32_t addr, unsigned short id)
   return 0;
 }
 #endif /* HAVE_DHCP */
+
+/******************************** Pi-hole modification ********************************/
+void print_dnsmasq_version(void)
+{
+  printf("****************************** dnsmasq ******************************\n");
+  printf(_("Version:         %s\n"), VERSION);
+  printf(_("Compile options: %s\n\n"), compile_opts);
+}
+/**************************************************************************************/


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add more verbose version output (`./pihole-FTL -vv`)

Exemplary output:
```
****************************** FTL **********************************
Version:         v5.2-169-g22b99929

****************************** dnsmasq ******************************
Version:         pi-hole-2.81
Compile options: IPv6 GNU-getopt no-DBus no-UBus no-i18n IDN DHCP DHCPv6 no-Lua TFTP no-conntrack ipset auth DNSSEC loop-detect inotify dumpfile

****************************** SQLite3 ******************************
Version:         3.31.1
Compile options: COMPILER=gcc-7.5.0 DEFAULT_FOREIGN_KEYS OMIT_DEPRECATED OMIT_LOAD_EXTENSION OMIT_MEMORYDB OMIT_PROGRESS_CALLBACK THREADSAFE=1
```