### PR TITLE
Do not block shared memory when inactive upstreams are skipped

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -358,6 +358,7 @@ void resolveClients(const bool onlynew)
 		{
 			logg("ERROR: Unable to get client pointer (1) with ID %i, skipping...", clientID);
 			skipped++;
+			unlock_shm();
 			continue;
 		}
 
@@ -401,6 +402,7 @@ void resolveClients(const bool onlynew)
 		{
 			logg("ERROR: Unable to get client pointer (2) with ID %i, skipping...", clientID);
 			skipped++;
+			unlock_shm();
 			continue;
 		}
 
@@ -438,6 +440,7 @@ void resolveForwardDestinations(const bool onlynew)
 		{
 			logg("ERROR: Unable to get upstream pointer with ID %i, skipping...", upstreamID);
 			skipped++;
+			unlock_shm();
 			continue;
 		}
 
@@ -454,6 +457,7 @@ void resolveForwardDestinations(const bool onlynew)
 				logg("Skipping upstream %s (%s) because it was inactive for %i seconds",
 				     getstr(ippos), getstr(oldnamepos), (int)(now - upstream->lastQuery));
 			}
+			unlock_shm();
 			continue;
 		}
 		unlock_shm();
@@ -479,6 +483,7 @@ void resolveForwardDestinations(const bool onlynew)
 		{
 			logg("ERROR: Unable to get upstream pointer with ID %i, skipping...", upstreamID);
 			skipped++;
+			unlock_shm();
 			continue;
 		}
 

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -339,7 +339,7 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 }
 
 // Resolve client host names
-void resolveClients(const bool onlynew)
+static void resolveClients(const bool onlynew)
 {
 	const time_t now = time(NULL);
 	// Lock counter access here, we use a copy in the following loop
@@ -421,7 +421,7 @@ void resolveClients(const bool onlynew)
 }
 
 // Resolve upstream destination host names
-void resolveForwardDestinations(const bool onlynew)
+static void resolveUpstreams(const bool onlynew)
 {
 	const time_t now = time(NULL);
 	// Lock counter access here, we use a copy in the following loop
@@ -517,7 +517,7 @@ void *DNSclient_thread(void *val)
 			// Try to resolve new client host names (onlynew=true)
 			resolveClients(true);
 			// Try to resolve new upstream destination host names (onlynew=true)
-			resolveForwardDestinations(true);
+			resolveUpstreams(true);
 			// Prevent immediate re-run of this routine
 			sleepms(500);
 		}
@@ -532,7 +532,7 @@ void *DNSclient_thread(void *val)
 			// Try to resolve all client host names (onlynew=false)
 			resolveClients(false);
 			// Try to resolve all upstream destination host names (onlynew=false)
-			resolveForwardDestinations(false);
+			resolveUpstreams(false);
 			// Try to resolve host names from clients in the network table
 			// which have empty/undefined host names
 			resolveNetworkTableNames();

--- a/src/resolve.h
+++ b/src/resolve.h
@@ -12,8 +12,6 @@
 
 void *DNSclient_thread(void *val);
 char *resolveHostname(const char *addr);
-void resolveClients(const bool onlynew);
-void resolveForwardDestinations(const bool onlynew);
 
 // musl does not define MAXHOSTNAMELEN
 // If it is not defined, we set the value


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This fixes a variant of the bug in `development` which was forgotten in https://github.com/pi-hole/FTL/pull/889