### PR TITLE
Log disk usage in /dev/shm

### DIFF
--- a/src/shmem.c
+++ b/src/shmem.c
@@ -87,9 +87,11 @@ static int get_dev_shm_usage(char buffer[64])
 		return 0;
 	}
 
-	const unsigned long size = f.f_blocks * f.f_frsize;
-	const unsigned long free = f.f_bavail * f.f_bsize;
-	const unsigned long used = size - free;
+	// Explicitly cast the block counts to unsigned long long to avoid
+	// overflowing with drives larger than 4 GB on 32bit systems
+	const unsigned long long size = (unsigned long long)f.f_blocks * f.f_frsize;
+	const unsigned long long free = (unsigned long long)f.f_bavail * f.f_bsize;
+	const unsigned long long used = size - free;
 
 	// Create human-readable total size
 	char prefix_size[2] = { 0 };


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Every time FTL allocates more memory, we explicitly log how much (out of how much) space is used in `/dev/shm`. This should help users to better identify out-of-memory situations. We have just seen such a thing on Discourse (link by Pralor below).

Before this PR, we printed log lines like
```
[2020-09-25 13:34:24.559 42121M] Creating shared memory with name "/FTL-queries" and size 262144
[...]
[2020-09-25 13:34:51.979 42121M] Resizing "/FTL-queries" from 262144 to 524288
```

These log lines now provide more information about the `/dev/shm` where they're living in:
```
[2020-09-25 13:37:38.779 42322M] Creating shared memory with name "FTL-queries" and size 262144 (/dev/shm: 249.7MB used, 4.0GB total)
[...]
[2020-09-25 13:37:55.479 42322M] Resizing "FTL-queries" from 262144 to 524288 (/dev/shm: 249.9MB used, 4.0GB total)
```