### PR TITLE
Handle SIGBUS SIGILL and SIGFPE in our crash reporter

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -81,7 +81,7 @@ static void print_addr2line(const char *symbol, const void *address, const int j
 }
 #endif
 
-static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, void *unused)
+static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, void *unused)
 {
 	logg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 	logg("---------------------------->  FTL crashed!  <----------------------------");
@@ -102,14 +102,88 @@ static void __attribute__((noreturn)) SIGSEGV_handler(int sig, siginfo_t *si, vo
 
 	logg("Received signal: %s", strsignal(sig));
 	logg("     at address: %p", si->si_addr);
-	switch (si->si_code)
+
+	// Segmentation fault - program crashed
+	if(sig == SIGSEGV)
 	{
-		case SEGV_MAPERR: logg("     with code:  SEGV_MAPERR (Address not mapped to object)"); break;
-		case SEGV_ACCERR: logg("     with code:  SEGV_ACCERR (Invalid permissions for mapped object)"); break;
-#if defined(SEGV_BNDERR)
-		case SEGV_BNDERR: logg("     with code:  SEGV_BNDERR (Failed address bound checks)"); break;
+		switch (si->si_code)
+		{
+			case SEGV_MAPERR:  logg("     with code:  SEGV_MAPERR (Address not mapped to object)"); break;
+			case SEGV_ACCERR:  logg("     with code:  SEGV_ACCERR (Invalid permissions for mapped object)"); break;
+#ifdef SEGV_BNDERR
+			case SEGV_BNDERR:  logg("     with code:  SEGV_BNDERR (Failed address bound checks)"); break;
 #endif
-		default: logg("     with code:  Unknown (%i)", si->si_code); break;
+#ifdef SEGV_PKUERR
+			case SEGV_PKUERR:  logg("     with code:  SEGV_PKUERR (Protection key checking failure)"); break;
+#endif
+#ifdef SEGV_ACCADI
+			case SEGV_ACCADI:  logg("     with code:  SEGV_ACCADI (ADI not enabled for mapped object)"); break;
+#endif
+#ifdef SEGV_ADIDERR
+			case SEGV_ADIDERR: logg("     with code:  SEGV_ADIDERR (Disrupting MCD error)"); break;
+#endif
+#ifdef SEGV_ADIPERR
+			case SEGV_ADIPERR: logg("     with code:  SEGV_ADIPERR (Precise MCD exception)"); break;
+#endif
+			default:           logg("     with code:  Unknown (%i)", si->si_code); break;
+		}
+	}
+
+	// Bus error - memory manager problem
+	else if(sig == SIGBUS)
+	{
+		switch (si->si_code)
+		{
+			case BUS_ADRALN:    logg("     with code:  BUS_ADRALN (Invalid address alignment)"); break;
+			case BUS_ADRERR:    logg("     with code:  BUS_ADRERR (Non-existant physical address)"); break;
+			case BUS_OBJERR:    logg("     with code:  BUS_OBJERR (Object specific hardware error)"); break;
+			case BUS_MCEERR_AR: logg("     with code:  BUS_MCEERR_AR (Hardware memory error: action required)"); break;
+			case BUS_MCEERR_AO: logg("     with code:  BUS_MCEERR_AO (Hardware memory error: action optional)"); break;
+			default:            logg("     with code:  Unknown (%i)", si->si_code); break;
+		}
+	}
+
+	// Illegal error - Illegal instruction detected
+	else if(sig == SIGILL)
+	{
+		switch (si->si_code)
+		{
+			case ILL_ILLOPC:   logg("     with code:  ILL_ILLOPC (Illegal opcode)"); break;
+			case ILL_ILLOPN:   logg("     with code:  ILL_ILLOPN (Illegal operand)"); break;
+			case ILL_ILLADR:   logg("     with code:  ILL_ILLADR (Illegal addressing mode)"); break;
+			case ILL_ILLTRP:   logg("     with code:  ILL_ILLTRP (Illegal trap)"); break;
+			case ILL_PRVOPC:   logg("     with code:  ILL_PRVOPC (Privileged opcode)"); break;
+			case ILL_PRVREG:   logg("     with code:  ILL_PRVREG (Privileged register)"); break;
+			case ILL_COPROC:   logg("     with code:  ILL_COPROC (Coprocessor error)"); break;
+			case ILL_BADSTK:   logg("     with code:  ILL_BADSTK (Internal stack error)"); break;
+#ifdef ILL_BADIADDR
+			case ILL_BADIADDR: logg("     with code:  ILL_BADIADDR (Unimplemented instruction address)"); break;
+#endif
+			default:           logg("     with code:  Unknown (%i)", si->si_code); break;
+		}
+	}
+
+	// Floating point exception error
+	else if(sig == SIGFPE)
+	{
+		switch (si->si_code)
+		{
+			case FPE_INTDIV:   logg("     with code:  FPE_INTDIV (Integer divide by zero)"); break;
+			case FPE_INTOVF:   logg("     with code:  FPE_INTOVF (Integer overflow)"); break;
+			case FPE_FLTDIV:   logg("     with code:  FPE_FLTDIV (Floating point divide by zero)"); break;
+			case FPE_FLTOVF:   logg("     with code:  FPE_FLTOVF (Floating point overflow)"); break;
+			case FPE_FLTUND:   logg("     with code:  FPE_FLTUND (Floating point underflow)"); break;
+			case FPE_FLTRES:   logg("     with code:  FPE_FLTRES (Floating point inexact result)"); break;
+			case FPE_FLTINV:   logg("     with code:  FPE_FLTINV (Floating point invalid operation)"); break;
+			case FPE_FLTSUB:   logg("     with code:  FPE_FLTSUB (Subscript out of range)"); break;
+#ifdef FPE_FLTUNK
+			case FPE_FLTUNK:   logg("     with code:  FPE_FLTUNK (Undiagnosed floating-point exception)"); break;
+#endif
+#ifdef FPE_CONDTRAP
+			case FPE_CONDTRAP: logg("     with code:  FPE_CONDTRAP (Trap on condition)"); break;
+#endif
+			default:           logg("     with code:  Unknown (%i)", si->si_code); break;
+		}
 	}
 
 // Check GLIBC availability as MUSL does not support live backtrace generation
@@ -217,8 +291,44 @@ void handle_SIGSEGV(void)
 		memset(&SEGVaction, 0, sizeof(struct sigaction));
 		SEGVaction.sa_flags = SA_SIGINFO;
 		sigemptyset(&SEGVaction.sa_mask);
-		SEGVaction.sa_sigaction = &SIGSEGV_handler;
+		SEGVaction.sa_sigaction = &signal_handler;
 		sigaction(SIGSEGV, &SEGVaction, NULL);
+	}
+
+	// Catch SIGBUS
+	sigaction (SIGBUS, NULL, &old_action);
+	if(old_action.sa_handler != SIG_IGN)
+	{
+		struct sigaction SBUGaction;
+		memset(&SBUGaction, 0, sizeof(struct sigaction));
+		SBUGaction.sa_flags = SA_SIGINFO;
+		sigemptyset(&SBUGaction.sa_mask);
+		SBUGaction.sa_sigaction = &signal_handler;
+		sigaction(SIGBUS, &SBUGaction, NULL);
+	}
+
+	// Catch SIGILL
+	sigaction (SIGILL, NULL, &old_action);
+	if(old_action.sa_handler != SIG_IGN)
+	{
+		struct sigaction SBUGaction;
+		memset(&SBUGaction, 0, sizeof(struct sigaction));
+		SBUGaction.sa_flags = SA_SIGINFO;
+		sigemptyset(&SBUGaction.sa_mask);
+		SBUGaction.sa_sigaction = &signal_handler;
+		sigaction(SIGILL, &SBUGaction, NULL);
+	}
+
+	// Catch SIGFPE
+	sigaction (SIGFPE, NULL, &old_action);
+	if(old_action.sa_handler != SIG_IGN)
+	{
+		struct sigaction SBUGaction;
+		memset(&SBUGaction, 0, sizeof(struct sigaction));
+		SBUGaction.sa_flags = SA_SIGINFO;
+		sigemptyset(&SBUGaction.sa_mask);
+		SBUGaction.sa_sigaction = &signal_handler;
+		sigaction(SIGFPE, &SBUGaction, NULL);
 	}
 
 	// Log start time of FTL


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

As soon as the memory in `/dev/shm` is used up completely, access to it may fail and FTL is being killed by the memory manager (receives `SIGBUS`). Before this PR, such an event caused FTL to fail silently.
Now, we catch the memory manager error and show a proper crash report (we cannot do anything else when the memory manager prevents us from reading any memory at all).

It will be visible as a regular crash report with some information, like:
```
[2020-09-25 14:24:53.424 121019M] Received signal: Bus error
[2020-09-25 14:24:53.425 121019M]      at address: 0x7ffff7ca9000
[2020-09-25 14:24:53.425 121019M]      with code:  BUS_ADRERR (Non-existant physical address)
```

Similarly, we catch all possible illegal instruction and floating point exception errors.

The actual problem causing the crash is that we only *reserved* the space in the shared memory but as soon as the memory runs out, the kernel may decide to give the memory to other hungry processes causing our object to become holes. I have a strategy in mind how we can avoid this happening, however, this clearly needs more testing and will be done in yet another PR.