### PR TITLE
Allocate shared memory instead of only reserving it

### DIFF
--- a/src/shmem.c
+++ b/src/shmem.c
@@ -559,7 +559,7 @@ bool realloc_shm(SharedMemory *sharedMemory, const size_t size, const bool resiz
 		{
 			logg("FATAL: realloc_shm(): Failed to open shared memory object \"%s\": %s",
 			     sharedMemory->name, strerror(errno));
-			return false;
+			exit(EXIT_FAILURE);
 		}
 
 		// Allocate shared memory object to specified size
@@ -571,7 +571,7 @@ bool realloc_shm(SharedMemory *sharedMemory, const size_t size, const bool resiz
 		{
 			logg("FATAL: realloc_shm(): Failed to resize \"%s\" (%i) to %zu: %s (%i)",
 			     sharedMemory->name, fd, size, strerror(errno), ret);
-			return false;
+			exit(EXIT_FAILURE);
 		}
 
 		// Close shared memory object file descriptor as it is no longer
@@ -589,7 +589,7 @@ bool realloc_shm(SharedMemory *sharedMemory, const size_t size, const bool resiz
 		logg("FATAL: realloc_shm(): mremap(%p, %zu, %zu, MREMAP_MAYMOVE): Failed to reallocate \"%s\": %s",
 		     sharedMemory->ptr, sharedMemory->size, size, sharedMemory->name,
 		     strerror(errno));
-		return false;
+		exit(EXIT_FAILURE);
 	}
 
 	sharedMemory->ptr = new_ptr;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Use `fallocate()` instead of `ftruncate()` when resizing and/or creating shared memory objects.
This ensures we reserve the requested memory exclusively for ourselves. With `ftruncate` we only announce we want the memory, however, other processes can still take the memory when the `/dev/shm` is close to being full.

This has the effect that this PR ensures that FTL does not crash when `/dev/shm` is getting full.

In addition, even when the shared memory arena is full, there will be a better error message, like

```
[2020-10-01 00:18:42.812 13052M] Creating shared memory with name "FTL-lock" and size 48 (/dev/shm: 2.0GB used, 2.0GB total)
[2020-10-01 00:18:42.812 13052M] WARNING: More than 90% of /dev/shm is used
[2020-10-01 00:18:42.812 13052M] FATAL: create_shm(): Failed to resize "FTL-lock" (4) to 48: No space left on device (-1)
```