### PR TITLE
Add new query retried status

### DIFF
--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -347,7 +347,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	start = daemon->servers; /* at end of list, recycle */
       header->id = htons(forward->new_id);
 
-      FTL_forwarding_failed(forward->sentto);
+      FTL_forwarding_retried(forward->sentto, forward->log_id, daemon->log_id);
     }
   else 
     {

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -311,6 +311,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	  else
 	    log_query(F_NOEXTRA | F_DNSSEC | F_IPV6, "retry", (union all_addr *)&forward->sentto->addr.in6.sin6_addr, "dnssec");
 
+	  FTL_forwarding_retried(forward->sentto, forward->log_id, daemon->log_id, true);
   
 	  if (forward->sentto->sfd)
 	    fd = forward->sentto->sfd->fd;
@@ -347,7 +348,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	start = daemon->servers; /* at end of list, recycle */
       header->id = htons(forward->new_id);
 
-      FTL_forwarding_retried(forward->sentto, forward->log_id, daemon->log_id);
+      FTL_forwarding_retried(forward->sentto, forward->log_id, daemon->log_id, false);
     }
   else 
     {

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1773,7 +1773,7 @@ void getCacheInformation(const int *sock)
 	// looked up for the longest time is evicted.
 }
 
-void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID)
+void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID, const bool dnssec)
 {
 	// Forwarding to upstream server failed
 
@@ -1817,7 +1817,23 @@ void FTL_forwarding_retried(const struct server *server, const int oldID, const 
 
 		// Set retried status
 		if(query != NULL)
-			query->status = QUERY_RETRIED;
+		{
+			if(dnssec)
+			{
+				// There is point in retrying the query when
+				// we've already got an answer to this query,
+				// but we're awaiting keys for DNSSEC
+				// validation. We're retrying the DNSSEC query
+				// instead
+				query->status = QUERY_RETRIED_DNSSEC;
+			}
+			else
+			{
+				// Normal query retry due to answer not arriving
+				// soon enough at the requestor
+				query->status = QUERY_RETRIED;
+			}
+		}
 	}
 
 	// Clean up and unlock shared memory

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1773,7 +1773,7 @@ void getCacheInformation(const int *sock)
 	// looked up for the longest time is evicted.
 }
 
-void _FTL_forwarding_failed(const struct server *server, const char* file, const int line)
+void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID)
 {
 	// Forwarding to upstream server failed
 
@@ -1795,7 +1795,11 @@ void _FTL_forwarding_failed(const struct server *server, const char* file, const
 	const int upstreamID = findUpstreamID(upstreamIP, false);
 
 	// Possible debugging information
-	if(config.debug & DEBUG_QUERIES) logg("**** forwarding to %s (ID %i, %s:%i) FAILED", dest, upstreamID, file, line);
+	if(config.debug & DEBUG_QUERIES)
+	{
+		logg("**** RETRIED query %i as %i to %s (ID %i)",
+		     oldID, newID, dest, upstreamID);
+	}
 
 	// Get upstream pointer
 	upstreamsData* upstream = getUpstream(upstreamID, true);
@@ -1803,6 +1807,18 @@ void _FTL_forwarding_failed(const struct server *server, const char* file, const
 	// Update counter
 	if(upstream != NULL)
 		upstream->failed++;
+
+	// Search for corresponding query identified by ID
+	const int queryID = findQueryID(oldID);
+	if(queryID >= 0)
+	{
+		// Get query pointer
+		queriesData* query = getQuery(queryID, true);
+
+		// Set retried status
+		if(query != NULL)
+			query->status = QUERY_RETRIED;
+	}
 
 	// Clean up and unlock shared memory
 	free(upstreamIP);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1809,7 +1809,9 @@ void FTL_forwarding_retried(const struct server *server, const int oldID, const 
 		upstream->failed++;
 
 	// Search for corresponding query identified by ID
-	const int queryID = findQueryID(oldID);
+	// Retried DNSSEC queries are ignored, we have to flag themselves (newID)
+	// Retried normal queries take over, we have to flat the original query (oldID)
+	const int queryID = findQueryID(dnssec ? newID : oldID);
 	if(queryID >= 0)
 	{
 		// Get query pointer

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -39,7 +39,7 @@ void _FTL_dnssec(const int status, const int id, const char* file, const int lin
 #define FTL_header_analysis(header4, rcode, id) _FTL_header_analysis(header4, rcode, id, __FILE__, __LINE__)
 void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode, const int id, const char* file, const int line);
 
-void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID);
+void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID, const bool dnssec);
 
 #define FTL_upstream_error(rcode, id) _FTL_upstream_error(rcode, id, __FILE__, __LINE__)
 void _FTL_upstream_error(const unsigned int rcode, const int id, const char* file, const int line);

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -39,8 +39,7 @@ void _FTL_dnssec(const int status, const int id, const char* file, const int lin
 #define FTL_header_analysis(header4, rcode, id) _FTL_header_analysis(header4, rcode, id, __FILE__, __LINE__)
 void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode, const int id, const char* file, const int line);
 
-#define FTL_forwarding_failed(server) _FTL_forwarding_failed(server, __FILE__, __LINE__)
-void _FTL_forwarding_failed(const struct server *server, const char* file, const int line);
+void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID);
 
 #define FTL_upstream_error(rcode, id) _FTL_upstream_error(rcode, id, __FILE__, __LINE__)
 void _FTL_upstream_error(const unsigned int rcode, const int id, const char* file, const int line);

--- a/src/enums.h
+++ b/src/enums.h
@@ -41,6 +41,7 @@ enum query_status {
 	QUERY_REGEX_CNAME,
 	QUERY_BLACKLIST_CNAME,
 	QUERY_RETRIED,
+	QUERY_RETRIED_DNSSEC,
 	QUERY_STATUS_MAX
 } __attribute__ ((packed));
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -40,6 +40,7 @@ enum query_status {
 	QUERY_GRAVITY_CNAME,
 	QUERY_REGEX_CNAME,
 	QUERY_BLACKLIST_CNAME,
+	QUERY_RETRIED,
 	QUERY_STATUS_MAX
 } __attribute__ ((packed));
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -100,7 +100,8 @@ void *GC_thread(void *val)
 						// Unknown (?)
 						counters->unknown--;
 						break;
-					case QUERY_FORWARDED:
+					case QUERY_FORWARDED: // (fall through)
+					case QUERY_RETRIED:
 						// Forwarded to an upstream DNS server
 						// Adjust counters
 						counters->forwarded--;

--- a/src/gc.c
+++ b/src/gc.c
@@ -101,7 +101,8 @@ void *GC_thread(void *val)
 						counters->unknown--;
 						break;
 					case QUERY_FORWARDED: // (fall through)
-					case QUERY_RETRIED:
+					case QUERY_RETRIED: // (fall through)
+					case QUERY_RETRIED_DNSSEC:
 						// Forwarded to an upstream DNS server
 						// Adjust counters
 						counters->forwarded--;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add new status `RETRIED` (12) to be used for queries which were retried. If a query was retried five times until we received a reply form upstream, queries 1-4 will be marked as `RETRIED` and only query 5 will stay in status `FORWARDED`. This does not affect the statistics because all five queries where send upstream, so five upstream packages are counted, even when only one query stays in status `FORWARDED`.

**edit** Add another new status `RETRIED_DNSSEC` (13) to be used for queries for which which automatic DNSSEC queries were retried. If we've already got an answer to a query, but we're awaiting keys for validation, there's no point retrying the query, so we're retrying the key query instead.

The web interface will need updating to support this status. This will be done in a follow-up PR.