### PR TITLE
Add pre-compiled ARMv4, ARMv5 and ARMv8 binaries to CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,11 @@ version: 2
   steps:
     - checkout
     - run:
-        name: "Setup"
-        command: |
-          if [[ $CIRCLE_JOB == *"qemu"* ]] ; then sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset ; fi
-    - run:
         name: "Build"
         no_output_timeout: 30m
         command: |
           BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
-          [[ $CIRCLE_JOB == *"qemu"* ]] && DOCKERIFNEEDED="docker run --rm -v $(pwd):/workspace -w /workspace pihole/ftl-build:arm-qemu "
-          $DOCKERIFNEEDED bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}"
+          bash .circleci/build-CI.sh "${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${CIRCLE_JOB}"
     - run:
         name: "Binary checks"
         command: bash test/arch_test.sh
@@ -36,19 +31,34 @@ version: 2
 
 .docker_template: &docker_template
   docker:
-    - image: pihole/ftl-build:v1.3-$CIRCLE_JOB
+    - image: pihole/ftl-build:v1.7-$CIRCLE_JOB
   <<: *job_steps
 
 jobs:
-  arm:
+  armv4t:
     <<: *docker_template
     environment:
-      BIN_NAME: "pihole-FTL-arm-linux-gnueabi"
+      BIN_NAME: "pihole-FTL-armv4-linux-gnueabi"
 
-  armhf:
+  armv5te:
     <<: *docker_template
     environment:
-      BIN_NAME: "pihole-FTL-arm-linux-gnueabihf"
+      BIN_NAME: "pihole-FTL-armv5-linux-gnueabi"
+
+  armv6hf:
+    <<: *docker_template
+    environment:
+      BIN_NAME: "pihole-FTL-armv6-linux-gnueabihf"
+
+  armv7hf:
+    <<: *docker_template
+    environment:
+      BIN_NAME: "pihole-FTL-armv7-linux-gnueabihf"
+
+  armv8a:
+    <<: *docker_template
+    environment:
+      BIN_NAME: "pihole-FTL-armv8-linux-gnueabihf"
 
   aarch64:
     <<: *docker_template
@@ -70,26 +80,27 @@ jobs:
     environment:
       BIN_NAME: "pihole-FTL-linux-x86_32"
 
-  arm-qemu:
-    machine:
-      enabled: true
-    environment:
-      BIN_NAME: "pihole-FTL-armel-native"
-    <<: *job_steps
-
 workflows:
   version: 2
   build:
     jobs:
-      - arm:
+      - armv4t:
           filters:
             tags:
               only: /^v.*/
-      - arm-qemu:
+      - armv5te:
           filters:
             tags:
               only: /^v.*/
-      - armhf:
+      - armv6hf:
+          filters:
+            tags:
+              only: /^v.*/
+      - armv7hf:
+          filters:
+            tags:
+              only: /^v.*/
+      - armv8a:
           filters:
             tags:
               only: /^v.*/

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -64,31 +64,59 @@ check_file() {
   echo "Binary classification checks: OK (${1})"
 }
 
+check_static() {
+  if readelf -l ./pihole-FTL | grep -q INTERP; then
+    echo "Not a static executable, depends on dynamic interpreter"
+    ldd ./pihole-FTL
+    exit 1
+  fi
+  echo "Static executable check: OK"
+}
+
 if [[ "${CIRCLE_JOB}" == "x86_64" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
   check_libs "[librt.so.1] [libpthread.so.0] [libc.so.6]"
-  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, not stripped"
+  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_64-musl" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
   check_libs "" # No dependency on any shared library is intended
-  check_file "ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, with debug_info, not stripped"
+  check_static # Binary should not rely on any dynamic interpreter
+  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_32" ]]; then
 
   check_machine "ELF32" "Intel 80386"
   check_libs "[librt.so.1] [libpthread.so.0] [libc.so.6]"
-  check_file "ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 2.6.32, not stripped"
+  check_file "ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "aarch64" ]]; then
 
   check_machine "ELF64" "AArch64"
   check_libs "[librt.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-aarch64.so.1]"
-  check_file "ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, not stripped"
+  check_file "ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped"
 
-elif [[ "${CIRCLE_JOB}" == "arm" ]]; then
+elif [[ "${CIRCLE_JOB}" == "armv4t" ]]; then
+
+  check_machine "ELF32" "ARM"
+  check_libs "[librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux.so.3]"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.3, for GNU/Linux 3.2.0, not stripped"
+
+  check_CPU_arch "v4T"
+  check_FP_arch "" # No specified FP arch
+
+elif [[ "${CIRCLE_JOB}" == "armv5te" ]]; then
+
+  check_machine "ELF32" "ARM"
+  check_libs "[librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux.so.3]"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.3, for GNU/Linux 3.2.0, with debug_info, not stripped"
+
+  check_CPU_arch "v5TE"
+  check_FP_arch "" # No specified FP arch
+
+elif [[ "${CIRCLE_JOB}" == "armv6hf" ]]; then
 
   check_machine "ELF32" "ARM"
   check_libs "[librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-armhf.so.3]"
@@ -97,27 +125,29 @@ elif [[ "${CIRCLE_JOB}" == "arm" ]]; then
   check_CPU_arch "v6"
   check_FP_arch "VFPv2"
 
-elif [[ "${CIRCLE_JOB}" == "armhf" ]]; then
+elif [[ "${CIRCLE_JOB}" == "armv7hf" ]]; then
 
   check_machine "ELF32" "ARM"
   check_libs "[librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-armhf.so.3]"
-  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, not stripped"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, with debug_info, not stripped"
 
   check_CPU_arch "v7"
   check_FP_arch "VFPv3-D16"
 
-elif [[ "${CIRCLE_JOB}" == "arm-qemu" ]]; then
+elif [[ "${CIRCLE_JOB}" == "armv8a" ]]; then
 
   check_machine "ELF32" "ARM"
-  check_libs "[librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux.so.3]"
-  check_file "ELF 32-bit LSB  shared object, ARM, EABI5 version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 3.2.0, not stripped"
+  check_libs "[librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-armhf.so.3]"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, with debug_info, not stripped"
 
-  check_CPU_arch "v6"
-  check_FP_arch "" # No specified FP arch
+  check_CPU_arch "v8"
+  check_FP_arch "VFPv3-D16"
 
 else
+
   echo "Invalid job ${CIRCLE_JOB}"
   exit 1
+
 fi
 
 exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add additional

- ARMv4 (`armv4t`, 3-stage pipeline, Thumb, ARMv4 first to drop legacy ARM 26-bit addressing),
- ARMv5 (`armv5te`, Thumb, enhanced DSP instructions, caches), and
- ARMv8 (`armv8-a`, fundamental change to the ARM architecture with mandatory vector floating point and SIMD (Neon)) 

workflows.

- ARMv6 (with hard-float, for Raspberry Pi Model 1 and Zero), and
- ARMv7 (with hard-float, for Raspberry Pi Model 2)

already exist and have just been renamed to clarify the supported architecture.