### PR TITLE
Make timer output at termination of FTL human readable

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -10,7 +10,7 @@
 
 #include "FTL.h"
 #include "dhcp-discover.h"
-// logg()
+// logg(), format_time()
 #include "log.h"
 // read_FTLconf()
 #include "config.h"
@@ -226,27 +226,6 @@ static bool send_dhcp_discover(const int sock, const uint32_t xid, const char *i
 	return bytes > 0;
 }
 
-static void nice_time(char *buffer, unsigned long seconds)
-{
-	unsigned int days = seconds / (60 * 60 * 24);
-	seconds -= days * (60 * 60 * 24);
-	unsigned int hours = seconds / (60 * 60);
-	seconds -= hours * (60 * 60);
-	unsigned int minutes = seconds / 60;
-	seconds %= 60;
-
-	buffer[0] = ' ';
-	buffer[1] = '\0';
-	if(days > 0)
-		sprintf(buffer + strlen(buffer), "%ud ", days);
-	if(hours > 0)
-		sprintf(buffer + strlen(buffer), "%uh ", hours);
-	if(minutes > 0)
-		sprintf(buffer + strlen(buffer), "%um ", minutes);
-	if(seconds > 0)
-		sprintf(buffer + strlen(buffer), "%lus ", seconds);
-}
-
 // adds a DHCP OFFER to list in memory
 static void print_dhcp_offer(struct in_addr source, dhcp_packet *offer_packet)
 {
@@ -360,7 +339,7 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet *offer_packet)
 			else
 			{
 				char buffer[32] = { 0 };
-				nice_time(buffer, lease_time);
+				format_time(buffer, lease_time, 0.0);
 				logg("%s(%lu seconds)", buffer, (unsigned long)lease_time);
 			}
 		}
@@ -414,7 +393,7 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet *offer_packet)
 			else
 			{
 				char buffer[32] = { 0 };
-				nice_time(buffer, renewal_time);
+				format_time(buffer, renewal_time, 0.0);
 				logg("%s(%lu seconds)", buffer, (unsigned long)renewal_time);
 			}
 		}
@@ -429,7 +408,7 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet *offer_packet)
 			else
 			{
 				char buffer[32] = { 0 };
-				nice_time(buffer, rebinding_time);
+				format_time(buffer, rebinding_time, 0.0);
 				logg("%s(%lu seconds)", buffer, (unsigned long)rebinding_time);
 			}
 		}

--- a/src/log.c
+++ b/src/log.c
@@ -183,6 +183,38 @@ void format_memory_size(char * const prefix, const unsigned long long int bytes,
 	strcpy(prefix, prefixes[i]);
 }
 
+// Human-readable time
+void format_time(char buffer[42], unsigned long seconds, double milliseconds)
+{
+	unsigned long umilliseconds = 0;
+	if(milliseconds > 0)
+	{
+		seconds = milliseconds / 1000;
+		umilliseconds = (unsigned long)milliseconds % 1000;
+	}
+	const unsigned int days = seconds / (60 * 60 * 24);
+	seconds -= days * (60 * 60 * 24);
+	const unsigned int hours = seconds / (60 * 60);
+	seconds -= hours * (60 * 60);
+	const unsigned int minutes = seconds / 60;
+	seconds %= 60;
+
+	buffer[0] = ' ';
+	buffer[1] = '\0';
+	if(days > 0)
+		sprintf(buffer + strlen(buffer), "%ud ", days);
+	if(hours > 0)
+		sprintf(buffer + strlen(buffer), "%uh ", hours);
+	if(minutes > 0)
+		sprintf(buffer + strlen(buffer), "%um ", minutes);
+	if(seconds > 0)
+		sprintf(buffer + strlen(buffer), "%lus ", seconds);
+
+	// Only append milliseconds when the timer value is less than 10 seconds
+	if((days + hours + minutes) == 0 && seconds < 10 && umilliseconds > 0)
+		sprintf(buffer + strlen(buffer), "%lums ", umilliseconds);
+}
+
 void log_counter_info(void)
 {
 	logg(" -> Total DNS queries: %i", counters->queries);

--- a/src/log.h
+++ b/src/log.h
@@ -18,6 +18,7 @@ void open_FTL_log(const bool test);
 void log_counter_info(void);
 void format_memory_size(char * const prefix, unsigned long long int bytes,
                         double * const formated);
+void format_time(char buffer[42], unsigned long seconds, double milliseconds);
 const char *get_FTL_version(void) __attribute__ ((malloc));
 void log_FTL_version(bool crashreport);
 void get_timestr(char * const timestring, const time_t timein);

--- a/src/main.c
+++ b/src/main.c
@@ -132,6 +132,9 @@ int main (int argc, char* argv[])
 
 	//Remove PID file
 	removepid();
-	logg("########## FTL terminated after %e s! ##########", 1e-3*timer_elapsed_msec(EXIT_TIMER));
+
+	char buffer[42] = { 0 };
+	format_time(buffer, 0, timer_elapsed_msec(EXIT_TIMER));
+	logg("########## FTL terminated after%s! ##########", buffer);
 	return exit_code;
 }

--- a/src/timers.c
+++ b/src/timers.c
@@ -22,7 +22,7 @@ void timer_start(const enum timers i)
 		logg("Code error: Timer %i not defined in timer_start().", i);
 		exit(EXIT_FAILURE);
 	}
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t0[i]);
+	clock_gettime(CLOCK_REALTIME, &t0[i]);
 }
 
 static struct timespec diff(struct timespec start, struct timespec end)
@@ -31,7 +31,7 @@ static struct timespec diff(struct timespec start, struct timespec end)
 	if(end.tv_nsec-start.tv_nsec < 0L)
 	{
 		diff.tv_sec = end.tv_sec - start.tv_sec - 1; // subtract one second here...
-		diff.tv_nsec = 1000000000 + end.tv_nsec - start.tv_nsec; // ...we have to add it here
+		diff.tv_nsec = end.tv_nsec - start.tv_nsec + 1000000000L; // ...we have to add it here
 	}
 	else
 	{
@@ -49,25 +49,9 @@ double timer_elapsed_msec(const enum timers i)
 		exit(EXIT_FAILURE);
 	}
 	struct timespec t1, td;
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t1);
+	clock_gettime(CLOCK_REALTIME, &t1);
 	td = diff(t0[i], t1);
 	return td.tv_sec * 1e3 + td.tv_nsec * 1e-6;
-}
-
-unsigned long timer_elapsed_usec(const enum timers i)
-{
-	struct timespec t1, td;
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t1);
-	td = diff(t0[i], t1);
-	return td.tv_sec * 1000000L + td.tv_nsec / 1000;
-}
-
-unsigned long long timer_elapsed_nsec(const enum timers i)
-{
-	struct timespec t1, td;
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t1);
-	td = diff(t0[i], t1);
-	return td.tv_sec * 1000000000LL + td.tv_nsec;
 }
 
 void sleepms(const int milliseconds)

--- a/src/timers.h
+++ b/src/timers.h
@@ -25,8 +25,6 @@ enum timers {
 
 void timer_start(const enum timers i);
 double timer_elapsed_msec(const enum timers i);
-unsigned long timer_elapsed_usec(const enum timers i);
-unsigned long long timer_elapsed_nsec(const enum timers i);
 void sleepms(const int milliseconds);
 
 #endif //TIMERS_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Make timer output at termination of FTL human readable (days/hours/minutes/seconds).

Exemplary line ***before*** this change:
```
########## FTL terminated after 5.088878e+05 s! ##########
```

Exemplary line ***after*** this change:
```
########## FTL terminated after 5d 21h 41m 27s ! ##########
```