### PR TITLE
Mark database as being available when creating a new database

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -195,6 +195,10 @@ static bool db_create(void)
 		logg("Encountered error while trying to create database in rw-mode: %s", sqlite3_errstr(rc));
 		return false;
 	}
+
+	// Mark database as being available so dbquery() doesn't error out
+	db_avail = true;
+
 	// Create Queries table in the database
 	SQL_bool("CREATE TABLE queries ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain TEXT NOT NULL, client TEXT NOT NULL, forward TEXT );");
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Mark database as being available when creating a new database to avoid FTL skipping adding the tables thinking the database connection isn't ready. This fixes a bug in `development` preventing FTL to create new databases from scratch.