### PR TITLE
ECS: Ignore distant loopback address

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1782,6 +1782,11 @@ static void check_dns_listeners(time_t now)
 	
   for (listener = daemon->listeners; listener; listener = listener->next)
     {
+
+      /******************** Pi-hole modification *******************/
+      FTL_next_iface(listener->iface ? listener->iface->name : NULL);
+      /*************************************************************/
+
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))
 	receive_query(listener, now); 
       

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -534,7 +534,11 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	char *domainString = strdup(name);
 	strtolower(domainString);
 
-	// Get client IP address (can be overwritten by EDNS(0) client subnet (ECS) data)
+	// Get client IP address
+	// The requestor's IP address can be rewritten using EDNS(0) client
+	// subnet (ECS) data), however, we do not rewrite the IPs ::1 and
+	// 127.0.0.1 to avoid queries originating from localhost of the
+	// *distant* machine as queries coming from the *local* machine
 	char clientIP[ADDRSTRLEN] = { 0 };
 	if(config.edns0_ecs && edns->client_set)
 	{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -70,8 +70,18 @@ const char flagnames[][12] = {"F_IMMORTAL ", "F_NAMEP ", "F_REVERSE ", "F_FORWAR
 // Store interface the next query will come from for later usage
 void FTL_next_iface(const char *newiface)
 {
-	strncpy(next_iface, newiface, sizeof(next_iface)-1);
-	next_iface[sizeof(next_iface)-1] = '\0';
+	if(newiface != NULL)
+	{
+		// Copy interface name if available
+		strncpy(next_iface, newiface, sizeof(next_iface)-1);
+		next_iface[sizeof(next_iface)-1] = '\0';
+	}
+	else
+	{
+		// Use dummy when interface record is not available
+		next_iface[0] = '-';
+		next_iface[1] = '\0';
+	}
 }
 
 static bool check_domain_blocked(const char *domain, const int clientID,

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -961,3 +961,41 @@
   printf "%s\n" "${lines[@]}"
   [[ "${lines[@]}" == *"**** new UDP query[A] query \"localhost\" from lo:fe80::b167:af1e:968b:dead "* ]]
 }
+
+@test "EDNS(0) ECS skipped for loopback address (IPv4)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole-FTL.log)"
+
+  # Run test command
+  run bash -c 'dig localhost +short +subnet=127.0.0.1/32 @127.0.0.1'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "127.0.0.1" ]]
+  [[ $status == 0 ]]
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole-FTL.log)"
+
+  # Extract relevant log lines
+  run bash -c "sed -n \"${before},${after}p\" /var/log/pihole-FTL.log"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"EDNS(0) CLIENT SUBNET: Skipped 127.0.0.1/32 (IPv4 loopback address)"* ]]
+}
+
+@test "EDNS(0) ECS skipped for loopback address (IPv6)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole-FTL.log)"
+
+  # Run test command
+  run bash -c 'dig localhost +short +subnet=::1/128 @127.0.0.1'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "127.0.0.1" ]]
+  [[ $status == 0 ]]
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole-FTL.log)"
+
+  # Extract relevant log lines
+  run bash -c "sed -n \"${before},${after}p\" /var/log/pihole-FTL.log"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"EDNS(0) CLIENT SUBNET: Skipped ::1/128 (IPv6 loopback address)"* ]]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

We should not rewrite the client's address if the announced address is a loopback address. See [this Discourse post](https://discourse.pi-hole.net/t/support-for-add-subnet-option-from-dnsmasq-ecs-edns0-client-subnet/35940/89) for further details of what might happen.