### PR TITLE
Verify CI-generated binaries after uploading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,20 +13,34 @@ version: 2
         name: "Binary checks"
         command: bash test/arch_test.sh
     - run:
-        name: "Upload"
+        name: "Compute checksum"
+        command: |
+          mv pihole-FTL "${BIN_NAME}"
+          sha1sum pihole-FTL-* > ${BIN_NAME}.sha1
+    - run:
+        name: "Upload binary to binary bucket"
         command: |
           [ -z "${CIRCLE_PR_USERNAME}" ] || exit 0
           DIR="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
-          mv pihole-FTL "${BIN_NAME}"
-          sha1sum pihole-FTL-* > ${BIN_NAME}.sha1
           mkdir -p ~/.ssh/
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
-          sftp -b - $SSH_USER@$SSH_HOST <<< "-mkdir ${DIR}
-          put ${BIN_NAME}* ${DIR}"
-          mv "${BIN_NAME}" pihole-FTL
+          sftp -b - $SSH_USER@$SSH_HOST <<< "-mkdir html/${DIR}
+          put ${BIN_NAME}* html/${DIR}"
+    - run:
+        name: "Verify uploaded binary"
+        command: |
+          [ -z "${CIRCLE_PR_USERNAME}" ] || exit 0
+          DIR="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+          mkdir download
+          cd download
+          wget "https://ftl.pi-hole.net/${DIR}/${BIN_NAME}"
+          wget "https://ftl.pi-hole.net/${DIR}/${BIN_NAME}.sha1"
+          sha1sum -c "${BIN_NAME}.sha1"
+          cd ..
     - run:
         name: "Test"
         command: |
+          mv "${BIN_NAME}" pihole-FTL
           test/run.sh
 
 .docker_template: &docker_template


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Occassionally, we see that the transfer of the binaries fails for our binary bucket. This can seldomly cause issues for exotic architectures on custom branches. We add an additional step in the CI tool chain that downloads the just uploaded binary + checksum to verify that everything worked well during transmission.