### PR TITLE
Log process owner details.

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1757,15 +1757,34 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 
 	// Chown files if FTL started as user root but a dnsmasq config
 	// option states to run as a different user/group (e.g. "nobody")
-	if(ent_pw != NULL && getuid() == 0)
+	if(getuid() == 0)
 	{
-		if(chown(FTLfiles.log, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			logg("Setting ownership (%i:%i) of %s failed: %s (%i)",
-			     ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.log, strerror(errno), errno);
-		if(chown(FTLfiles.FTL_db, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			logg("Setting ownership (%i:%i) of %s failed: %s (%i)",
-			     ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.FTL_db, strerror(errno), errno);
-		chown_all_shmem(ent_pw);
+		if(ent_pw != NULL)
+		{
+			logg("INFO: FTL is going to drop from root to user %s (UID %d)",
+			     ent_pw->pw_name, (int)ent_pw->pw_uid);
+			if(chown(FTLfiles.log, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
+				logg("Setting ownership (%i:%i) of %s failed: %s (%i)",
+				ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.log, strerror(errno), errno);
+			if(chown(FTLfiles.FTL_db, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
+				logg("Setting ownership (%i:%i) of %s failed: %s (%i)",
+				ent_pw->pw_uid, ent_pw->pw_gid, FTLfiles.FTL_db, strerror(errno), errno);
+			chown_all_shmem(ent_pw);
+		}
+		else
+		{
+			logg("INFO: FTL is running as root");
+		}
+	}
+	else
+	{
+		uid_t uid;
+		struct passwd *current_user;
+		if ((current_user = getpwuid(uid = geteuid())) != NULL)
+			logg("INFO: FTL is running as user %s (UID %d)",
+			     current_user->pw_name, (int)current_user->pw_uid);
+		else
+			logg("INFO: Failed to obtain information about FTL user");
 	}
 
 	// Obtain DNS port from dnsmasq daemon


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Log information about the user FTL is running as and whether we're dropping to another user (such as `nobody`/`nogroup`). This should aid debugging issues like #920 in the future. Virtually all users will see
```
[2020-11-12 22:20:18.216 25044M] INFO: FTL is running as user pihole (UID 999)
```

`docker` users will see something like
```
[2020-11-12 22:20:18.216 25044M] INFO: FTL is running as root
```

Last but not least, users with a more complex configuration might see something like
```
[2020-11-12 22:20:18.216 25044M] INFO:FTL is going to drop from root to user nobody (UID xyz)
```
Note that the latter case isn't standard as we always explicitly advise against starting FTL as `root` process outside of (a) sandboxes environments like `docker` or (b) when the underlying system does not support capability management.