### PR TITLE
Log dnsmasq config errors to pihole-FTL.log

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -65,7 +65,7 @@ void dbclose(void)
 bool dbopen(void)
 {
 	// Skip subroutine altogether when database is already open
-	if(FTL_db != NULL && db_avail)
+	if(FTL_db != NULL && FTL_DB_avail())
 	{
 		if(config.debug & DEBUG_LOCKS)
 			logg("Not locking FTL database (already open)");

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -90,7 +90,6 @@ static bool add_message(enum message_type type, const char *message,
 {
 	if(!FTL_DB_avail())
 	{
-		logg("No database!");
 		return false;
 	}
 

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -17,7 +17,8 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
                          const int matching_bits, const char *chosen_match_text,
                          const int chosen_match_id);
 void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos);
+void logg_fatal_dnsmasq_message(const char *message);
 
-enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, HOSTNAME_MESSAGE, MAX_MESSAGE };
+enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, HOSTNAME_MESSAGE, DNSMASQ_CONFIG_MESSAGE, MAX_MESSAGE };
 
 #endif //MESSAGETABLE_H

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -15,6 +15,7 @@
 */
 
 #include "dnsmasq.h"
+#include "../log.h"
 
 #ifdef __ANDROID__
 #  include <android/log.h>
@@ -470,6 +471,10 @@ void die(char *message, char *arg1, int exit_code)
   echo_stderr = 0;
   my_syslog(LOG_CRIT, _("FAILED to start up"));
   flush_log();
+
+  /********** Pi-hole modification *************/
+  FTL_log_dnsmasq_fatal(message, arg1, errmess);
+  /*********************************************/
   
   exit(exit_code);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -253,6 +253,20 @@ void format_time(char buffer[42], unsigned long seconds, double milliseconds)
 		sprintf(buffer + strlen(buffer), "%lums ", umilliseconds);
 }
 
+void FTL_log_dnsmasq_fatal(const char *format, ...)
+{
+	// Build a complete string from possible multi-part string passed from dnsmasq
+	char message[256] = { 0 };
+	va_list args;
+	va_start(args, format);
+	vsnprintf(message, sizeof(message), format, args);
+	va_end(args);
+	message[255] = '\0';
+
+	// Log error into FTL's log
+	logg("FATAL ERROR: %s", message);
+}
+
 void log_counter_info(void)
 {
 	logg(" -> Total DNS queries: %i", counters->queries);

--- a/src/log.c
+++ b/src/log.c
@@ -23,6 +23,8 @@
 #include "shmem.h"
 // main_pid()
 #include "signals.h"
+// logg_fatal_dnsmasq_message()
+#include "database/message-table.h"
 
 static pthread_mutex_t lock;
 static FILE *logfile = NULL;
@@ -263,8 +265,8 @@ void FTL_log_dnsmasq_fatal(const char *format, ...)
 	va_end(args);
 	message[255] = '\0';
 
-	// Log error into FTL's log
-	logg("FATAL ERROR: %s", message);
+	// Log error into FTL's log + message table
+	logg_fatal_dnsmasq_message(message);
 }
 
 void log_counter_info(void)

--- a/src/log.h
+++ b/src/log.h
@@ -29,7 +29,7 @@ const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));
 #define logg(format, ...) _FTL_log(true, format, ## __VA_ARGS__)
 #define logg_sameline(format, ...) _FTL_log(false, format, ## __VA_ARGS__)
 void _FTL_log(const bool newline, const char* format, ...) __attribute__ ((format (gnu_printf, 2, 3)));
-void FTL_log_dnsmasq_fatal(const char *format, ...);
+void FTL_log_dnsmasq_fatal(const char *format, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 void log_ctrl(bool vlog, bool vstdout);
 void FTL_log_helper(const unsigned char n, ...);
 

--- a/src/log.h
+++ b/src/log.h
@@ -29,6 +29,7 @@ const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));
 #define logg(format, ...) _FTL_log(true, format, ## __VA_ARGS__)
 #define logg_sameline(format, ...) _FTL_log(false, format, ## __VA_ARGS__)
 void _FTL_log(const bool newline, const char* format, ...) __attribute__ ((format (gnu_printf, 2, 3)));
+void FTL_log_dnsmasq_fatal(const char *format, ...);
 void log_ctrl(bool vlog, bool vstdout);
 void FTL_log_helper(const unsigned char n, ...);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fatal errors during the start-up of the `dnsmasq` core lead to a complete failure of the DNS resolver + a message is logged to `/var/log/pihole.log`. This PR also logs the message to `pihole-FTL.log` and the `message` table from where the Pi-hole diagnosis system will pick it up:

![Screenshot at 2020-11-17 22-41-43](https://user-images.githubusercontent.com/16748619/99455956-e148b000-2928-11eb-87b0-85caea4ef354.png)
