### PR TITLE
Add API callback to remove DHCP leases without the need for a restart

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1453,3 +1453,23 @@ void getUnknownQueries(const int *sock)
 		}
 	}
 }
+
+// FTL_unlink_DHCP_lease()
+extern bool FTL_unlink_DHCP_lease(const char *ipaddr);
+
+void delete_lease(const char *client_message, const int *sock)
+{
+	char ipaddr[INET6_ADDRSTRLEN] = { 0 };
+
+	// Test for integer that specifies number of entries to be shown
+	if(sscanf(client_message, ">delete-lease %"xstr(INET6_ADDRSTRLEN)"s", ipaddr) < 1) {
+		ssend(*sock,"ERROR: No IP address specified!\n");
+		return;
+	}
+	ipaddr[sizeof(ipaddr) - 1] = '\0';
+
+	if(FTL_unlink_DHCP_lease(ipaddr))
+		ssend(*sock,"OK: Removed specified lease\n");
+	else
+		ssend(*sock,"ERROR: Specified IP address invalid!\n");
+}

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1459,17 +1459,22 @@ extern bool FTL_unlink_DHCP_lease(const char *ipaddr);
 
 void delete_lease(const char *client_message, const int *sock)
 {
+	// Extract IP address from request
 	char ipaddr[INET6_ADDRSTRLEN] = { 0 };
-
-	// Test for integer that specifies number of entries to be shown
 	if(sscanf(client_message, ">delete-lease %"xstr(INET6_ADDRSTRLEN)"s", ipaddr) < 1) {
-		ssend(*sock,"ERROR: No IP address specified!\n");
+		ssend(*sock, "ERROR: No IP address specified!\n");
 		return;
 	}
 	ipaddr[sizeof(ipaddr) - 1] = '\0';
 
+	if(config.debug & DEBUG_API)
+		logg("Received request to delete lease for %s", ipaddr);
+
 	if(FTL_unlink_DHCP_lease(ipaddr))
-		ssend(*sock,"OK: Removed specified lease\n");
+		ssend(*sock, "OK: Removed specified lease\n");
 	else
-		ssend(*sock,"ERROR: Specified IP address invalid!\n");
+		ssend(*sock, "ERROR: Specified IP address invalid!\n");
+
+	if(config.debug & DEBUG_API)
+		logg("...done");
 }

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -44,4 +44,7 @@ bool pack_fixstr(const int sock, const char *string);
 bool pack_str32(const int sock, const char *string);
 void pack_map16_start(const int sock, const uint16_t length);
 
+// DHCP lease management
+void delete_lease(const char *client_message, const int *sock);
+
 #endif // API_H

--- a/src/api/request.c
+++ b/src/api/request.c
@@ -172,6 +172,11 @@ void process_request(const char *client_message, int *sock)
 		logg("Received API request to update vendors in network table");
 		updateMACVendorRecords();
 	}
+	else if(command(client_message, ">delete-lease"))
+	{
+		processed = true;
+		delete_lease(client_message, sock);
+	}
 
 	// Test only at the end if we want to quit or kill
 	// so things can be processed before

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2058,3 +2058,44 @@ void FTL_TCP_worker_created(const int confd, const char *iface_name)
 	close_telnet_socket();
 	close_unix_socket(false);
 }
+
+bool FTL_unlink_DHCP_lease(const char *ipaddr)
+{
+	struct dhcp_lease *lease;
+	union all_addr addr;
+	const time_t now = dnsmasq_time();
+
+	// Try to extract IP address
+	if (inet_pton(AF_INET, ipaddr, &addr.addr4) > 0)
+	{
+		lease = lease_find_by_addr(addr.addr4);
+	}
+#ifdef HAVE_DHCP6
+	else if (inet_pton(AF_INET6, ipaddr, &addr.addr6) > 0)
+	{
+		lease = lease6_find_by_addr(&addr.addr6, 128, 0);
+	}
+#endif
+	else
+	{
+		return false;
+	}
+
+	// If a lease exists for this IP address, we unlink it and immediately
+	// update the lease file to reflect the removal of this lease
+	if (lease)
+	{
+		// Unlink the lease for dnsmasq's database
+		lease_prune(lease, now);
+		// Update the lease file
+		lease_update_file(now);
+		// Argument force == 0 ensures the DNS records are only updated
+		// when unlinking the lease above actually changed something
+		// (variable lease.c:dns_dirty is used here)
+		lease_update_dns(0);
+	}
+
+	// Return success
+	return true;
+	
+}

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -60,4 +60,6 @@ void FTL_TCP_worker_terminating(bool finished);
 void set_debug_dnsmasq_lines(char enabled);
 extern char debug_dnsmasq_lines;
 
+bool FTL_unlink_DHCP_lease(const char *ipaddr);
+
 #endif // DNSMASQ_INTERFACE_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

As the title says: Adds a new API callback to remove DHCP leases without the need for a restart. This implements a Discourse feature request. See link for said request + the connected AdminLTE branch below.