### PR TITLE
Log query loop detection to Pi-hole diagnosis system

### DIFF
--- a/src/api/request.c
+++ b/src/api/request.c
@@ -21,6 +21,9 @@
 // Eventqueue routines
 #include "../events.h"
 
+// Prototypes
+extern void FTL_probe_server_loop(void);
+
 bool __attribute__((pure)) command(const char *client_message, const char* cmd) {
 	return strstr(client_message, cmd) != NULL;
 }
@@ -171,6 +174,12 @@ void process_request(const char *client_message, int *sock)
 		processed = true;
 		logg("Received API request to update vendors in network table");
 		updateMACVendorRecords();
+	}
+	else if(command(client_message, ">probe-query-loops"))
+	{
+		processed = true;
+		logg("Received API request to check all known servers for query loops");
+		FTL_probe_server_loop();
 	}
 
 	// Test only at the end if we want to quit or kill

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -19,7 +19,7 @@
 #include "../args.h"
 
 static const char *message_types[MAX_MESSAGE] =
-	{ "REGEX", "SUBNET", "HOSTNAME" };
+	{ "REGEX", "SUBNET", "HOSTNAME", "QUERY LOOP" };
 
 static unsigned char message_blob_types[MAX_MESSAGE][5] =
 	{
@@ -40,6 +40,13 @@ static unsigned char message_blob_types[MAX_MESSAGE][5] =
 		{	// HOSTNAME_MESSAGE: The message column contains the IP address of the device
 			SQLITE_TEXT, // Obtained host name
 			SQLITE_INTEGER, // Position of error in string
+			SQLITE_NULL, // not used
+			SQLITE_NULL, // not used
+			SQLITE_NULL // not used
+		},
+		{	// QUERYLOOP_MESSAGE: The message column contains the IP address of the upstream server
+			SQLITE_INTEGER, // Port of upstream server
+			SQLITE_NULL, // not used
 			SQLITE_NULL, // not used
 			SQLITE_NULL, // not used
 			SQLITE_NULL // not used
@@ -254,4 +261,14 @@ void logg_hostname_warning(const char *ip, const char *name, const unsigned int 
 
 	// Log to database
 	add_message(HOSTNAME_MESSAGE, ip, 2, name, (const int)pos);
+}
+
+void logg_query_loop_warning(const char *server, const int port)
+{
+	// Log to pihole-FTL.log
+	logg("QUERY LOOP WARNING: Disabled upstream server %s#%d as we detected a query loop!",
+	     server, port);
+
+	// Log to database
+	add_message(QUERYLOOP_MESSAGE, server, 1, port);
 }

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -17,7 +17,8 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
                          const int matching_bits, const char *chosen_match_text,
                          const int chosen_match_id);
 void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos);
+void logg_query_loop_warning(const char *server, const int port);
 
-enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, HOSTNAME_MESSAGE, MAX_MESSAGE };
+enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, HOSTNAME_MESSAGE, QUERYLOOP_MESSAGE, MAX_MESSAGE };
 
 #endif //MESSAGETABLE_H

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -1657,7 +1657,10 @@ void check_servers(void)
 	    }
 #ifdef HAVE_LOOP
 	  else if (serv->flags & SERV_LOOP)
+	  {
 	    my_syslog(LOG_INFO, _("NOT using nameserver %s#%d - query loop detected"), daemon->namebuff, port); 
+	    FTL_log_server_loop(daemon->namebuff, port);
+	  }
 #endif
 	  else if (serv->interface[0] != 0)
 	    my_syslog(LOG_INFO, _("using nameserver %s#%d(via %s)"), daemon->namebuff, port, serv->interface); 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2068,3 +2068,20 @@ void FTL_log_server_loop(const char *server, const int port)
 	// This will add both to the FTL log as well as to the message table
 	logg_query_loop_warning(server, port);
 }
+
+// Send probing queries to known servers
+#ifdef HAVE_LOOP
+void FTL_probe_server_loop(void)
+{
+	struct server *serv;
+	// Unmark all servers as looping to give them another chance
+	for (serv = daemon->servers; serv; serv = serv->next)
+		serv->flags &= ~SERV_LOOP;
+
+	// Loop through all upstream servers and send a query to that server
+	// which is identifiable, via their uid. We exclude servers which are
+	// configured for particular domains only. If we see that query back
+	// again, then the server is looping.
+	loop_send_probes();
+}
+#endif

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -42,6 +42,8 @@
 #include <stdatomic.h>
 // Eventqueue routines
 #include "events.h"
+// logg_server_loop_warning()
+#include "database/message-table.h"
 
 static void print_flags(const unsigned int flags);
 static void save_reply_type(const unsigned int flags, const union all_addr *addr,
@@ -2057,4 +2059,12 @@ void FTL_TCP_worker_created(const int confd, const char *iface_name)
 	// We don't need them in the forks, so we clean them up
 	close_telnet_socket();
 	close_unix_socket(false);
+}
+
+// Log detection of a query loop - the corresponding server is disabled for
+// further use unless the list of servers is refreshed or FTL is restarted
+void FTL_log_server_loop(const char *server, const int port)
+{
+	// This will add both to the FTL log as well as to the message table
+	logg_query_loop_warning(server, port);
 }

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -56,6 +56,7 @@ void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
 void FTL_TCP_worker_created(const int confd, const char *iface_name);
 void FTL_TCP_worker_terminating(bool finished);
+void FTL_log_server_loop(const char *server, const int port);
 
 void set_debug_dnsmasq_lines(char enabled);
 extern char debug_dnsmasq_lines;

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -57,6 +57,7 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
 void FTL_TCP_worker_created(const int confd, const char *iface_name);
 void FTL_TCP_worker_terminating(bool finished);
 void FTL_log_server_loop(const char *server, const int port);
+void FTL_probe_server_loop(void);
 
 void set_debug_dnsmasq_lines(char enabled);
 extern char debug_dnsmasq_lines;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Still disable looping servers, however, add a hint to the message table of the Pi-hole diagnosis system to increase visibility.

Note: I'm currently unable to test looping (my router cannot be configured to loop back to the Pi-hole), so I'm marking this as draft until someone (not necessarily me!) can actually test this.