### PR TITLE
Skip clients with no active counts at all (may be old IPv6 addresses)

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1319,6 +1319,9 @@ void getClientsOverTime(const int *sock)
 			// Skip invalid clients and also those managed by alias clients
 			if(client == NULL || client->aliasclient_id >= 0)
 				continue;
+			// Also skip clients with no active counts at all (may be old IPv6 addresses)
+			if(client->count == 0)
+				continue;
 			const int thisclient = client->overTime[slot];
 
 			if(istelnet[*sock])
@@ -1380,7 +1383,11 @@ void getClientNames(const int *sock)
 
 		// Get client pointer
 		const clientsData* client = getClient(clientID, true);
-		if(client == NULL)
+		// Skip invalid clients and also those managed by alias clients
+		if(client == NULL || client->aliasclient_id >= 0)
+			continue;
+		// Skip clients with no active counts at all (may be old IPv6 addresses)
+		if(client->count == 0)
 			continue;
 
 		const char *client_ip = getstr(client->ippos);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Skip clients with no active counts (may be old IPv6 addresses). This should help reducing the workload for the dashboard (specifically the clients-over-time graph) for very active networks (speaking of 500+ clients). See linked Discourse post for further details.