### PR TITLE
Keep upper case characters in host names

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -737,7 +737,7 @@ void getAllQueries(const char *client_message, const int *sock)
 				// (if available) their host names
 				if((strcmp(getstr(forward->ippos), serv_addr) == 0 ||
 				   (forward->namepos != 0 &&
-				    strcmp(getstr(forward->namepos), serv_addr) == 0)) && forward->port == serv_port)
+				    strcasecmp(getstr(forward->namepos), serv_addr) == 0)) && forward->port == serv_port)
 				{
 					forwarddestid = i;
 					break;
@@ -812,7 +812,7 @@ void getAllQueries(const char *client_message, const int *sock)
 			// Try to match the requested string
 			if(strcmp(getstr(client->ippos), clientname) == 0 ||
 			   (client->namepos != 0 &&
-			    strcmp(getstr(client->namepos), clientname) == 0))
+			    strcasecmp(getstr(client->namepos), clientname) == 0))
 			{
 				clientid = i;
 

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -191,10 +191,6 @@ char *resolveHostname(const char *addr)
 		{
 			// Return hostname copied to new memory location
 			hostname = strdup(he->h_name);
-
-			// Convert hostname to lower case
-			if(hostname != NULL)
-				strtolower(hostname);
 		}
 		else
 		{
@@ -241,10 +237,6 @@ char *resolveHostname(const char *addr)
 			{
 				// Return hostname copied to new memory location
 				hostname = strdup(he->h_name);
-
-				// Convert hostname to lower case
-				if(hostname != NULL)
-					strtolower(hostname);
 			}
 			else
 			{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Keep upper case characters in host names because they may make them more readable (like `FritzBox`, `WDMyCloud`, or `VacuumRobot`). Inspired by https://github.com/pi-hole/FTL/issues/924

We make the corresponding API filters case-insensitive to preserve the current behavior (where everything was converted to lowercase) and as capitalization does not play a role in domain names.