### PR TITLE
Tweaks to disabling the FTL database

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -295,7 +295,11 @@ void read_FTLconf(void)
 	config.DBimport = read_bool(buffer, true);
 
 	if(config.DBimport)
+	{
 		logg("   DBIMPORT: Importing history from database");
+		if(config.maxDBdays == 0)
+			logg("      Hint: Exporting queries has been disabled (MAXDBDAYS=0)!");
+	}
 	else
 		logg("   DBIMPORT: Not importing history from database");
 

--- a/src/config.c
+++ b/src/config.c
@@ -186,7 +186,6 @@ void read_FTLconf(void)
 	// defaults to: "/etc/pihole/pihole-FTL.db"
 	buffer = parse_FTLconf(fp, "DBFILE");
 
-	errno = 0;
 	// Use sscanf() to obtain filename from config file parameter only if buffer != NULL
 	if(!(buffer != NULL && sscanf(buffer, "%127ms", &FTLfiles.FTL_db)))
 	{
@@ -194,16 +193,16 @@ void read_FTLconf(void)
 		FTLfiles.FTL_db = strdup("/etc/pihole/pihole-FTL.db");
 	}
 
-	// Test if memory allocation was successful
-	if(FTLfiles.FTL_db == NULL && errno != 0)
-	{
-		logg("FATAL: Allocating memory for FTLfiles.FTL_db failed (%s, %i). Exiting.", strerror(errno), errno);
-		exit(EXIT_FAILURE);
-	}
-	else if(FTLfiles.FTL_db != NULL && strlen(FTLfiles.FTL_db) > 0)
+	if(FTLfiles.FTL_db != NULL && strlen(FTLfiles.FTL_db) > 0)
 		logg("   DBFILE: Using %s", FTLfiles.FTL_db);
 	else
-		logg("   DBFILE: Not using database due to empty filename");
+	{
+		// Use standard path if path was set to zero but override
+		// MAXDBDAYS=0 to ensure no queries are stored in the database
+		FTLfiles.FTL_db = strdup("/etc/pihole/pihole-FTL.db");
+		config.maxDBdays = 0;
+		logg("   DBFILE: Using %s (not storing queries)", FTLfiles.FTL_db);
+	}
 
 	// FTLPORT
 	// On which port should FTL be listening?

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -74,10 +74,6 @@ bool dbopen(void)
 		return true;
 	}
 
-	// Do not open database if it is not to be used
-	if(!use_database())
-		return false;
-
 	if(config.debug & DEBUG_LOCKS)
 		logg("Locking FTL database");
 
@@ -419,16 +415,12 @@ void db_init(void)
 
 	// Log if users asked us to not use the long-term database for queries
 	// We will still use it to store warnings in it
-	if(!use_database())
-	{
-		logg("Not using the long-term database for storing queries");
-		config.DBexport = false;
-		return;
-	}
 	config.DBexport = true;
-
-	// Close database here, we have to reopen it later (after forking)
-	dbclose();
+	if(config.maxDBdays == 0)
+	{
+		logg("Not using the database for storing queries");
+		config.DBexport = false;
+	}
 
 	logg("Database successfully initialized");
 }
@@ -622,20 +614,4 @@ long get_lastID(void)
 const char *get_sqlite3_version(void)
 {
 	return sqlite3_libversion();
-}
-
-// Should the long-term database be used?
-__attribute__ ((pure)) bool use_database()
-{
-	// Check if the user doesn't want to use the database and set an
-	// empty string as file name in FTL's config file or configured
-	// a maximum history of zero days.
-	if(FTLfiles.FTL_db == NULL ||
-	   strlen(FTLfiles.FTL_db) == 0 ||
-	   config.maxDBdays == 0)
-	{
-		return false;
-	}
-
-	return true;
 }

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -43,7 +43,6 @@ long int get_max_query_ID(void);
 bool db_set_counter(const enum counters_table_props ID, const int value);
 bool db_update_counters(const int total, const int blocked);
 const char *get_sqlite3_version(void);
-bool use_database(void)  __attribute__ ((pure));
 
 extern sqlite3 *FTL_db;
 extern long int lastdbindex;

--- a/src/log.c
+++ b/src/log.c
@@ -178,7 +178,13 @@ void FTL_log_helper(const unsigned char n, ...)
 	char *arg[n];
 	va_start(args, n);
 	for(unsigned char i = 0; i < n; i++)
-		arg[i] = strdup(va_arg(args, char*));
+	{
+		const char *argin = va_arg(args, char*);
+		if(argin == NULL)
+			arg[i] = NULL;
+		else
+			arg[i] = strdup(argin);
+	}
 	va_end(args);
 
 	// Select appropriate logging format
@@ -201,7 +207,8 @@ void FTL_log_helper(const unsigned char n, ...)
 
 	// Free allocated memory
 	for(unsigned char i = 0; i < n; i++)
-		free(arg[i]);
+		if(arg[i] != NULL)
+			free(arg[i]);
 }
 
 void format_memory_size(char * const prefix, const unsigned long long int bytes,

--- a/src/main.c
+++ b/src/main.c
@@ -108,7 +108,7 @@ int main (int argc, char* argv[])
 	pthread_cancel(socket_listenthread);
 
 	// Save new queries to database (if database is used)
-	if(use_database())
+	if(config.DBexport)
 	{
 		DB_save_queries();
 		logg("Finished final database update");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

With modern Pi-hole we cannot easily disable the database because it is used for a lot more than simple long-term query logging. Instead, it also contains the entire network table wisdom (and hence an essential source for how to identify clients in groups), messages about warnings and errors such as config errors or regex syntax issues, alias-client definitions and a lot more.

The recommended way to disable the database is setting `MAXDBDAYS=0`.
However, as the documentation mentions that `DBFILE=` is also possible, we handle this case by using the default path if we find an empty path but setting `MAXDBDAYS=0` internally in this case. This allows old configurations to work as before without introducing any issues.