### PR TITLE
Analyze all DHCP options dnsmasq is aware of

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -276,6 +276,10 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet_data *offer_pack
 
 					logg("%s: %s", opttab[i].name, inet_ntoa(addr_list));
 				}
+
+				// Special case: optlen == 0
+				if(optlen == 0)
+					logg("--- end of options ---");
 			}
 			else if(opttab[i].size & OT_NAME)
 			{
@@ -346,11 +350,16 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet_data *offer_pack
 				}
 				else
 				{
-					unsigned long number = 0;
+					// Log generic (unsigned) number
+					uint32_t number = 0;
 					if(optlen <= 4)
 					{
 						memcpy(&number, &offer_packet->options[x], optlen);
-						logg("%s: %lu", opttab[i].name, number);
+						if(optlen == 2)
+							number = ntohs(number);
+						else if(optlen == 4)
+							number = ntohl(number);
+						logg("%s: %u", opttab[i].name, number);
 					}
 				}
 			}
@@ -369,11 +378,6 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet_data *offer_pack
 					logg("wpad-server: <cntrl sequence> (length %u)", optlen);
 				else
 					logg("wpad-server: \"%s\"", wpad_server);
-			}
-			else if(opttype == 255) // END OF OPTIONS
-			{
-				logg("--- end of options ---");
-				break;
 			}
 			else
 			{

--- a/src/dnsmasq/dhcp-common.c
+++ b/src/dnsmasq/dhcp-common.c
@@ -552,7 +552,7 @@ void  bindtodevice(char *device, int fd)
 }
 #endif
 
-static const struct opttab_t {
+const struct opttab_t {
   char *name;
   u16 val, size;
 } opttab[] = {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

By using the internal list of DHCP options supported by `dnsmasq`, our tool should be able to analyze all interesting DHCP options. This avoids that we'd need to implement more and more options as they are requested (this implements all of them at once). The output of the script changes slightly as we're now using the very same keywords `dnsmasq` would also use for the options.

Example:
```
Scanning all your interfaces for DHCP servers
Timeout: 10 seconds

* Received 300 bytes from enp2s0:192.168.2.10
  Offered IP address: 192.168.2.217
  Server IP address: 192.168.2.10
  Relay-agent IP address: N/A
  DHCP options:
   Message type: DHCPOFFER (2)
   server-identifier: 192.168.2.10
   lease-time: 120 ( 2m )
   renewal-time: 60 ( 1m )
   rebinding-time: 105 ( 1m 45s )
   netmask: 255.255.255.0
   broadcast: 192.168.2.255
   dns-server: 192.168.2.10
   domain-name: "lan"
   router: 192.168.2.1
   --- end of options ---
    
DHCP packets received on interface lo: 0
DHCP packets received on interface enp2s0: 1
```

When adding custom DHCP options such as a TFTP-server (using `dhcp-option=option:tftp-server,192.168.1.98`), this will show up in the scan as additional line in the output above:
```
   tftp-server: "192.168.1.98"
```
A custom MTU set via DHCP would show up as
```
   mtu: 1234
```
(might have been set using `dhcp-option=option:mtu,1234`)