### PR TITLE
Downgrade ftl-build containers to restore Debian stretch support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ version: 2
 
 .docker_template: &docker_template
   docker:
-    - image: pihole/ftl-build:v1.7-$CIRCLE_JOB
+    - image: pihole/ftl-build:v1.8-$CIRCLE_JOB
   <<: *job_steps
 
 jobs:

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -77,20 +77,20 @@ if [[ "${CIRCLE_JOB}" == "x86_64" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
   check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"
-  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, not stripped"
+  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_64-musl" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
-  check_libs "" # No dependency on any shared library is intended
   check_static # Binary should not rely on any dynamic interpreter
+  check_libs "" # No dependency on any shared library is intended
   check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_32" ]]; then
 
   check_machine "ELF32" "Intel 80386"
   check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"
-  check_file "ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 3.2.0, not stripped"
+  check_file "ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 2.6.32, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "aarch64" ]]; then
 
@@ -113,7 +113,7 @@ elif [[ "${CIRCLE_JOB}" == "armv5te" ]]; then
   check_libs "[libm.so.6] [librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux.so.3]"
   check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.3, for GNU/Linux 3.2.0, not stripped"
 
-  check_CPU_arch "v5TE"
+  check_CPU_arch "v4T"
   check_FP_arch "" # No specified FP arch
 
 elif [[ "${CIRCLE_JOB}" == "armv6hf" ]]; then

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -84,7 +84,7 @@ elif [[ "${CIRCLE_JOB}" == "x86_64-musl" ]]; then
   check_machine "ELF64" "Advanced Micro Devices X86-64"
   check_static # Binary should not rely on any dynamic interpreter
   check_libs "" # No dependency on any shared library is intended
-  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, not stripped"
+  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_32" ]]; then
 

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -77,26 +77,26 @@ if [[ "${CIRCLE_JOB}" == "x86_64" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
   check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"
-  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped"
+  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_64-musl" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
   check_libs "" # No dependency on any shared library is intended
   check_static # Binary should not rely on any dynamic interpreter
-  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped"
+  check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "x86_32" ]]; then
 
   check_machine "ELF32" "Intel 80386"
   check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"
-  check_file "ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped"
+  check_file "ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 3.2.0, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "aarch64" ]]; then
 
   check_machine "ELF64" "AArch64"
   check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-aarch64.so.1]"
-  check_file "ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped"
+  check_file "ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, not stripped"
 
 elif [[ "${CIRCLE_JOB}" == "armv4t" ]]; then
 
@@ -111,7 +111,7 @@ elif [[ "${CIRCLE_JOB}" == "armv5te" ]]; then
 
   check_machine "ELF32" "ARM"
   check_libs "[libm.so.6] [librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux.so.3]"
-  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.3, for GNU/Linux 3.2.0, with debug_info, not stripped"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.3, for GNU/Linux 3.2.0, not stripped"
 
   check_CPU_arch "v5TE"
   check_FP_arch "" # No specified FP arch
@@ -129,7 +129,7 @@ elif [[ "${CIRCLE_JOB}" == "armv7hf" ]]; then
 
   check_machine "ELF32" "ARM"
   check_libs "[libm.so.6] [librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-armhf.so.3]"
-  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, with debug_info, not stripped"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, not stripped"
 
   check_CPU_arch "v7"
   check_FP_arch "VFPv3-D16"
@@ -138,7 +138,7 @@ elif [[ "${CIRCLE_JOB}" == "armv8a" ]]; then
 
   check_machine "ELF32" "ARM"
   check_libs "[libm.so.6] [librt.so.1] [libgcc_s.so.1] [libpthread.so.0] [libc.so.6] [ld-linux-armhf.so.3]"
-  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, with debug_info, not stripped"
+  check_file "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, not stripped"
 
   check_CPU_arch "v8"
   check_FP_arch "VFPv3-D16"


### PR DESCRIPTION
Fixes errors like
```
pihole-FTL: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by pihole-FTL)
```

This PR does two things:
1. Use `ftl-build:v1.8` containers (identical to `v1.7` *except* that they're all based on `stretch` instead of `buster`)
2. Update the binary tests to expect the older versions of `glibc`