### PR TITLE
Respect RESOLVE_IPV4 and RESOLVE_IPv6 everywhere

### DIFF
--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1695,6 +1695,15 @@ char *__attribute__((malloc)) getNameFromIP(const char *ipaddr)
 		return NULL;
 	}
 
+	// Check if we want to resolve host names
+	if(!resolve_this_name(ipaddr))
+	{
+		if(config.debug & DEBUG_DATABASE)
+			logg("getNameFromIP(\"%s\") - configured to not resolve host name", ipaddr);
+		
+		return NULL;
+	}
+
 	// Check for a host name associated with the same IP address
 	sqlite3_stmt *stmt = NULL;
 	const char *querystr = "SELECT name FROM network_addresses WHERE name IS NOT NULL AND ip = ?;";
@@ -1855,6 +1864,14 @@ void resolveNetworkTableNames(void)
 	if(!FTL_DB_avail())
 	{
 		logg("resolveNetworkTableNames() - Database not available");
+		return;
+	}
+
+	// Check if we want to resolve host names
+	if(!resolve_names())
+	{
+		if(config.debug & DEBUG_DATABASE)
+			logg("resolveNetworkTableNames() - configured to not resolve host names");
 		return;
 	}
 

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -112,12 +112,39 @@ static void print_used_resolvers(const char *message)
 	}
 }
 
+// Return if we want to resolve address to names at all
+// (may be disabled due to config settings)
+bool __attribute__((pure)) resolve_names(void)
+{
+	if(!config.resolveIPv4 && !config.resolveIPv6)
+		return false;
+	return true;
+}
+
+// Return if we want to resolve this type of address to a name
+bool __attribute__((pure)) resolve_this_name(const char *ipaddr)
+{
+	if(!config.resolveIPv4 ||
+	  (!config.resolveIPv6 && strstr(ipaddr,":") != NULL))
+		return false;
+	return true;
+}
+
 char *resolveHostname(const char *addr)
 {
 	// Get host name
 	struct hostent *he = NULL;
 	char *hostname = NULL;
-	bool IPv6 = false;
+
+	// Check if we want to resolve host names
+	if(!resolve_this_name(addr))
+	{
+		if(config.debug & DEBUG_RESOLVER)
+			logg("Configured to not resolve host name for %s", addr);
+		
+		// Return an empty host name
+		return strdup("");
+	}
 
 	if(config.debug & DEBUG_RESOLVER)
 		logg("Trying to resolve %s", addr);
@@ -133,10 +160,9 @@ char *resolveHostname(const char *addr)
 	}
 
 	// Test if we want to resolve an IPv6 address
+	bool IPv6 = false;
 	if(strstr(addr,":") != NULL)
-	{
 		IPv6 = true;
-	}
 
 	// Initialize resolver subroutines if trying to resolve for the first time
 	// res_init() reads resolv.conf to get the default domain name and name server
@@ -248,7 +274,7 @@ char *resolveHostname(const char *addr)
 		}
 		else
 		{
-			// No (he == NULL) or invalid (valid_hostname returned false) hostname found
+			// No hostname found (empty PTR)
 			hostname = strdup("");
 
 			if(config.debug & DEBUG_RESOLVER)
@@ -270,21 +296,14 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 	char* oldname = strdup(getstr(oldnamepos));
 	unlock_shm();
 
-	// Test if we want to resolve an IPv6 address
-	bool IPv6 = false;
-	if(strstr(ipaddr,":") != NULL)
-	{
-		IPv6 = true;
-	}
-
-	if( (IPv6 && !config.resolveIPv6) ||
-	   (!IPv6 && !config.resolveIPv4))
+	// Test if we want to resolve host names, otherwise all calls to resolveHostname()
+	// and getNameFromIP() can be skipped as they will all return empty names (= no records)
+	if(!resolve_this_name(ipaddr))
 	{
 		if(config.debug & DEBUG_RESOLVER)
-		{
-			logg(" ---> \"\" (configured to not resolve %s host names)",
-			     IPv6 ? "IPv6" : "IPv4");
-		}
+			logg(" ---> \"\" (configured to not resolve host name)");
+
+		// Return fixed position of empty string
 		return 0;
 	}
 

--- a/src/resolve.h
+++ b/src/resolve.h
@@ -12,6 +12,8 @@
 
 void *DNSclient_thread(void *val);
 char *resolveHostname(const char *addr);
+bool resolve_names(void) __attribute__((pure));
+bool resolve_this_name(const char *ipaddr) __attribute__((pure));
 
 // musl does not define MAXHOSTNAMELEN
 // If it is not defined, we set the value


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Respect settings `RESOLVE_IPV4` and `RESOLVE_IPv6` also when trying to resolve host names from the database (network table). This should also sort the seldom false-negative test results where FTL incorrectly tried to resolve host names on the CI machines.