### PR TITLE
Show BOOTP server and file strings used by TFTP

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -506,6 +506,18 @@ static bool get_dhcp_offer(const int sock, const uint32_t xid, const char *iface
 		else
 			logg("N/A");
 
+		logg_sameline("  BOOTP server: ");
+		if(offer_packet.sname[0] != 0)
+			logg("%s", offer_packet.sname);
+		else
+			logg("(empty)");
+
+		logg_sameline("  BOOTP file: ");
+		if(offer_packet.file[0] != 0)
+			logg("%s", offer_packet.file);
+		else
+			logg("(empty)");
+
 		logg("  DHCP options:");
 		print_dhcp_offer(source.sin_addr, &offer_packet);
 		pthread_mutex_unlock(&lock);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Show content of the BOOTP server and file strings during `dhcp-discover`. They may contain TFTP details.