### PR TITLE
Automate IP blocking mode

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -480,6 +480,44 @@ void read_FTLconf(void)
 	else
 		logg("   RATE_LIMIT: Disabled");
 
+	// REPLY_ADDR4
+	// Use a specific IP address instead of automatically detecting the
+	// IPv4 interface address a query arrived on
+	// defaults to: not set
+	config.reply_addr.overwrite_v4 = false;
+	config.reply_addr.v4.s_addr = 0;
+	buffer = parse_FTLconf(fp, "REPLY_ADDR4");
+	if(buffer != NULL && inet_pton(AF_INET, buffer, &config.reply_addr.v4))
+		config.reply_addr.overwrite_v4 = true;
+
+	if(config.reply_addr.overwrite_v4)
+	{
+		char addr[INET_ADDRSTRLEN] = { 0 };
+		inet_ntop(AF_INET, &config.reply_addr.v4, addr, INET_ADDRSTRLEN);
+		logg("   REPLY_ADDR4: Using IPv4 address %s in IP blocking mode", addr);
+	}
+	else
+		logg("   REPLY_ADDR4: Automatic interface-dependent detection of address");
+
+	// REPLY_ADDR6
+	// Use a specific IP address instead of automatically detecting the
+	// IPv6 interface address a query arrived on
+	// defaults to: not set
+	config.reply_addr.overwrite_v6 = false;
+	memset(&config.reply_addr.v6, 0, sizeof(config.reply_addr.v6));
+	buffer = parse_FTLconf(fp, "REPLY_ADDR6");
+	if(buffer != NULL && inet_pton(AF_INET6, buffer, &config.reply_addr.v6))
+		config.reply_addr.overwrite_v6 = true;
+
+	if(config.reply_addr.overwrite_v6)
+	{
+		char addr[INET6_ADDRSTRLEN] = { 0 };
+		inet_ntop(AF_INET6, &config.reply_addr.v6, addr, INET6_ADDRSTRLEN);
+		logg("   REPLY_ADDR6: Using IPv6 address %s in IP blocking mode", addr);
+	}
+	else
+		logg("   REPLY_ADDR6: Automatic interface-dependent detection of address");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -19,6 +19,8 @@
 #include <idn-int.h>
 // assert_sizeof
 #include "static_assert.h"
+// struct in_addr, in6_addr
+#include <netinet/in.h>
 
 void getLogFilePath(void);
 void read_FTLconf(void);
@@ -59,8 +61,14 @@ typedef struct {
 	} rate_limit;
 	enum debug_flags debug;
 	time_t DBinterval;
+	struct {
+		bool overwrite_v4 :1;
+		bool overwrite_v6 :1;
+		struct in_addr v4;
+		struct in6_addr v6;
+	} reply_addr;
 } ConfigStruct;
-ASSERT_SIZEOF(ConfigStruct, 64, 56, 56);
+ASSERT_SIZEOF(ConfigStruct, 88, 80, 80);
 
 typedef struct {
 	const char* conf;

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1789,11 +1789,12 @@ static void check_dns_listeners(time_t now)
   for (listener = daemon->listeners; listener; listener = listener->next)
     {
 
-      /******************** Pi-hole modification *******************/
-      FTL_next_iface(listener->iface ? listener->iface->name : NULL,
-                     listener->iface ? listener->iface->index : -1,
-                     daemon->listeners);
-      /*************************************************************/
+      /***************************** Pi-hole modification ****************************/
+      // Get the interface here only if we know the listeners are bound to specific
+      // interfaces (option "bind-interfaces" is used)
+      if(option_bool(OPT_NOWILD))
+	FTL_iface(listener->iface->index, daemon->interfaces);
+      /*******************************************************************************/
 
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))
 	receive_query(listener, now); 
@@ -1881,10 +1882,6 @@ static void check_dns_listeners(time_t now)
 		}
 	    }
 	  
-	  /********************************** Pi-hole modification *******************************/
-	  FTL_next_iface(iface ? iface->name : NULL, iface ? iface->index : -1, daemon->listeners);
-	  /***************************************************************************************/
-
 	  if (!client_ok)
 	    {
 	      shutdown(confd, SHUT_RDWR);
@@ -1975,15 +1972,18 @@ static void check_dns_listeners(time_t now)
 	      if ((flags = fcntl(confd, F_GETFL, 0)) != -1)
 		fcntl(confd, F_SETFL, flags & ~O_NONBLOCK);
 	      
-	      /******* Pi-hole modification *******/
-	      FTL_TCP_worker_created(confd, iface != NULL ? iface->name : NULL);
-	      /************************************/
+	      /************ Pi-hole modification ************/
+	      FTL_TCP_worker_created(confd);
+	      // Store interface this fork is handling exclusively
+	      FTL_iface(iface != NULL ? iface->index : -1,
+			daemon->interfaces);
+	      /**********************************************/
 
 	      buff = tcp_request(confd, now, &tcp_addr, netmask, auth_dns);
 	       
-	      /******* Pi-hole modification *******/
+	      /************ Pi-hole modification ************/
 	      FTL_TCP_worker_terminating(true);
-	      /************************************/
+	      /**********************************************/
 
 	      shutdown(confd, SHUT_RDWR);
 	      close(confd);

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1789,9 +1789,11 @@ static void check_dns_listeners(time_t now)
   for (listener = daemon->listeners; listener; listener = listener->next)
     {
 
-      /**************************** Pi-hole modification ***************************/
-      FTL_next_iface(listener->iface ? listener->iface->index : -1, daemon->listeners);
-      /*****************************************************************************/
+      /******************** Pi-hole modification *******************/
+      FTL_next_iface(listener->iface ? listener->iface->name : NULL,
+                     listener->iface ? listener->iface->index : -1,
+                     daemon->listeners);
+      /*************************************************************/
 
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))
 	receive_query(listener, now); 
@@ -1879,7 +1881,9 @@ static void check_dns_listeners(time_t now)
 		}
 	    }
 	  
-	  FTL_next_iface(iface ? iface->index : -1, daemon->listeners);
+	  /********************************** Pi-hole modification *******************************/
+	  FTL_next_iface(iface ? iface->name : NULL, iface ? iface->index : -1, daemon->listeners);
+	  /***************************************************************************************/
 
 	  if (!client_ok)
 	    {

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1789,9 +1789,9 @@ static void check_dns_listeners(time_t now)
   for (listener = daemon->listeners; listener; listener = listener->next)
     {
 
-      /******************** Pi-hole modification *******************/
-      FTL_next_iface(listener->iface ? listener->iface->name : NULL);
-      /*************************************************************/
+      /**************************** Pi-hole modification ***************************/
+      FTL_next_iface(listener->iface ? listener->iface->name : NULL, listener->addr);
+      /*****************************************************************************/
 
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))
 	receive_query(listener, now); 
@@ -1879,7 +1879,7 @@ static void check_dns_listeners(time_t now)
 		}
 	    }
 	  
-	  FTL_next_iface(iface ? iface->name : NULL);
+	  FTL_next_iface(iface ? iface->name : NULL, listener->addr);
 
 	  if (!client_ok)
 	    {

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1790,7 +1790,7 @@ static void check_dns_listeners(time_t now)
     {
 
       /**************************** Pi-hole modification ***************************/
-      FTL_next_iface(listener->iface ? listener->iface->name : NULL, listener->addr);
+      FTL_next_iface(listener->iface ? listener->iface->index : -1, daemon->listeners);
       /*****************************************************************************/
 
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))
@@ -1879,7 +1879,7 @@ static void check_dns_listeners(time_t now)
 		}
 	    }
 	  
-	  FTL_next_iface(iface ? iface->name : NULL, listener->addr);
+	  FTL_next_iface(iface ? iface->index : -1, daemon->listeners);
 
 	  if (!client_ok)
 	    {

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1598,9 +1598,12 @@ void receive_query(struct listener *listen, time_t now)
 	    dst_addr_4.s_addr = 0;
 	}
 
-    /*********** Pi-hole modification ***********/
-    FTL_next_iface(ifr.ifr_name, ifr.ifr_ifindex, daemon->listeners);
-    /********************************************/
+    /********************* Pi-hole modification ***********************/
+    // This gets the interface in all cases where this is possible here
+    // We get here only if "bind-interfaces" is NOT used or this query
+    // is received over IPv6
+    FTL_iface(if_index, daemon->interfaces);
+    /****************************************************************/
     }
    
   /* log_query gets called indirectly all over the place, so 
@@ -2096,6 +2099,7 @@ unsigned char *tcp_request(int confd, time_t now,
 	  check_log_writer(1); 
 	  
 	  /************ Pi-hole modification ************/
+	  // Interface name is known from before forking
 	  if(piholeblocked)
 	    {
 	      union all_addr *addrp = NULL;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1599,7 +1599,7 @@ void receive_query(struct listener *listen, time_t now)
 	}
 
     /*********** Pi-hole modification ***********/
-    FTL_next_iface(ifr.ifr_name, listen->iface->addr);
+    FTL_next_iface(ifr.ifr_ifindex, daemon->listeners);
     /********************************************/
     }
    

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1599,7 +1599,7 @@ void receive_query(struct listener *listen, time_t now)
 	}
 
     /*********** Pi-hole modification ***********/
-    FTL_next_iface(ifr.ifr_ifindex, daemon->listeners);
+    FTL_next_iface(ifr.ifr_name, ifr.ifr_ifindex, daemon->listeners);
     /********************************************/
     }
    

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1599,7 +1599,7 @@ void receive_query(struct listener *listen, time_t now)
 	}
 
     /*********** Pi-hole modification ***********/
-    FTL_next_iface(ifr.ifr_name);
+    FTL_next_iface(ifr.ifr_name, listen->iface->addr);
     /********************************************/
     }
    

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -42,6 +42,7 @@
 // Eventqueue routines
 #include "events.h"
 
+
 static void print_flags(const unsigned int flags);
 static void save_reply_type(const unsigned int flags, const union all_addr *addr,
                             queriesData* query, const struct timeval response);
@@ -104,10 +105,15 @@ void FTL_iface(const int ifidx, const struct irec *ifaces)
 		// Check if this address is different from 0000:0000:0000:0000:0000:0000:0000:0000
 		if(family == AF_INET6 && memcmp(&next_iface.addr6.addr6, &iface->addr.in6.sin6_addr, sizeof(iface->addr.in6.sin6_addr)) != 0)
 		{
+			// Extract first byte
+			// We do not directly access the underlying union as
+			// MUSL defines it differently than GNU C
+			uint8_t firstbyte;
+			memcpy(&firstbyte, &iface->addr.in6.sin6_addr, 1);
 		        // Global Unicast Address (2000::/3, RFC 4291)
-			isGUA = (iface->addr.in6.sin6_addr.__in6_u.__u6_addr8[0] & 0x70) == 0x20;
+			isGUA = (firstbyte & 0x70) == 0x20;
 			// Unique Local Address   (fc00::/7, RFC 4193)
-			isULA = (iface->addr.in6.sin6_addr.__in6_u.__u6_addr8[0] & 0xfe) == 0xfc;
+			isULA = (firstbyte & 0xfe) == 0xfc;
 			// Store IPv6 address only if we don't already have a GUA or ULA address
 			// This makes the preference:
 			//  1. ULA

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -19,7 +19,7 @@ extern int socketfd, telnetfd4, telnetfd6;
 extern unsigned char* pihole_privacylevel;
 enum protocol { TCP, UDP };
 
-void FTL_next_iface(const int ifidx, const struct listener *listeners);
+void FTL_next_iface(const char *newiface, const int ifidx, const struct listener *listeners);
 
 #define FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto) _FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto, __FILE__, __LINE__)
 bool _FTL_new_query(const unsigned int flags, const char *name, const char** blockingreason, const union all_addr *addr, const char *types, const unsigned short qtype, const int id, const ednsData *edns, enum protocol proto, const char* file, const int line);

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -19,7 +19,7 @@ extern int socketfd, telnetfd4, telnetfd6;
 extern unsigned char* pihole_privacylevel;
 enum protocol { TCP, UDP };
 
-void FTL_next_iface(const char *newiface);
+void FTL_next_iface(const char *newiface, const union mysockaddr addr);
 
 #define FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto) _FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto, __FILE__, __LINE__)
 bool _FTL_new_query(const unsigned int flags, const char *name, const char** blockingreason, const union all_addr *addr, const char *types, const unsigned short qtype, const int id, const ednsData *edns, enum protocol proto, const char* file, const int line);

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -19,7 +19,7 @@ extern int socketfd, telnetfd4, telnetfd6;
 extern unsigned char* pihole_privacylevel;
 enum protocol { TCP, UDP };
 
-void FTL_next_iface(const char *newiface, const int ifidx, const struct listener *listeners);
+void FTL_iface(const int ifidx, const struct irec *ifaces);
 
 #define FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto) _FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto, __FILE__, __LINE__)
 bool _FTL_new_query(const unsigned int flags, const char *name, const char** blockingreason, const union all_addr *addr, const char *types, const unsigned short qtype, const int id, const ednsData *edns, enum protocol proto, const char* file, const int line);
@@ -58,7 +58,7 @@ void FTL_duplicate_reply(const int id, int *firstID);
 
 void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);
-void FTL_TCP_worker_created(const int confd, const char *iface_name);
+void FTL_TCP_worker_created(const int confd);
 void FTL_TCP_worker_terminating(bool finished);
 
 void set_debug_dnsmasq_lines(char enabled);

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -19,7 +19,7 @@ extern int socketfd, telnetfd4, telnetfd6;
 extern unsigned char* pihole_privacylevel;
 enum protocol { TCP, UDP };
 
-void FTL_next_iface(const char *newiface, const union mysockaddr addr);
+void FTL_next_iface(const int ifidx, const struct listener *listeners);
 
 #define FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto) _FTL_new_query(flags, name, blockingreason, addr, types, qtype, id, edns, proto, __FILE__, __LINE__)
 bool _FTL_new_query(const unsigned int flags, const char *name, const char** blockingreason, const union all_addr *addr, const char *types, const unsigned short qtype, const int id, const ednsData *edns, enum protocol proto, const char* file, const int line);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Until now, FTL's [Full IP](https://docs.pi-hole.net/ftldns/blockingmode/#pi-holes-full-ip-blocking) and [IP (IPv6 NODATA)](https://docs.pi-hole.net/ftldns/blockingmode/#pi-holes-ip-ipv6-nodata-blocking) blocking modes sourced the IP to deliver on a blocked domain from the `setupVars.conf` values `IPV4_ADDRESS` and `IPV6_ADDRESS`. This is, however, quite a limitation, especially if the device running Pi-hole has more than one interface.

This PR implements an automated IP blocking. Instead of reading the two addresses  from `setupVars.conf`, we now determine the address of the interface a query arrived on. We then use this IP address in the blocked reply. This does not only reduce maintenance (`IPV4_ADDRESS` and `IPV6_ADDRESS` can now be removed from `setupVars.conf`) but also localizes blocked queries.

Example on the Pi-hole itself:
```
$ dig A doubleclick.net +short
127.0.0.1
$ dig AAAA doubleclick.net +short
::1
```
and from my desktop machine:
```
$ dig A doubleclick.net +short
192.168.2.10
$ dig AAAA doubleclick.net +short
fe80::a81c:cafe:dead:beef
```