### PR TITLE
Fix possible crash in parse_FTLconf()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -548,6 +548,7 @@ void release_config_memory(void)
 	{
 		free(conflinebuffer);
 		conflinebuffer = NULL;
+		size = 0;
 	}
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

We have to explicitly set `conflinebuffersize` to zero when freeing the buffer itself to avoid `getline()` crashing in some special edge-cases. Thanks @BlueSpaceCanary fir pointing this out!

```
man (3)  getline

       If  *lineptr  is set to NULL and *n is set 0 before the call, then get‐
       line() will allocate a buffer for storing the line.  This buffer should
       be freed by the user program even if getline() failed.
```