### PR TITLE
Add "lua" and "luac" drop-in support

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -27,8 +27,6 @@
 #include "shmem.h"
 // LUA dependencies
 #include "lua/ftl_lua.h"
-#include <readline/history.h>
-#include <wordexp.h>
 // run_dhcp_discover()
 #include "dhcp-discover.h"
 // defined in dnsmasq.c
@@ -58,10 +56,29 @@ void parse_args(int argc, char* argv[])
 	if(strEndsWith(argv[0], "dnsmasq"))
 		consume_for_dnsmasq = true;
 
+	if(strEndsWith(argv[0], "pihole-lua"))
+		exit(run_lua_interpreter(argc, argv, false));
+
 	// start from 1, as argv[0] is the executable name
 	for(int i = 1; i < argc; i++)
 	{
 		bool ok = false;
+
+		// Expose internal lua interpreter
+		if(strcmp(argv[i], "lua") == 0 ||
+		   strcmp(argv[i], "--lua") == 0)
+		{
+			exit(run_lua_interpreter(argc - i, &argv[i], dnsmasq_debug));
+		}
+
+		// Expose internal lua compiler
+		if(strcmp(argv[i], "luac") == 0 ||
+		   strcmp(argv[i], "--luac") == 0)
+		{
+			if(argc == i + 1) // No arguments after this one
+				printf("Pi-hole FTL %s\n", get_FTL_version());
+			exit(luac_main(argc - i, &argv[i]));
+		}
 
 		// Implement dnsmasq's test function, no need to prepare the entire FTL
 		// environment (initialize shared memory, lead queries from long-term
@@ -277,74 +294,6 @@ void parse_args(int argc, char* argv[])
 		{
 			printf("True\n");
 			exit(EXIT_SUCCESS);
-		}
-
-		// Expose internal lua interpreter
-		if(strcmp(argv[i], "lua") == 0 ||
-		   strcmp(argv[i], "--lua") == 0)
-		{
-			if(argc == i + 1) // No arguments after this one
-				printf("Pi-hole FTL %s\n", get_FTL_version());
-#if defined(LUA_USE_READLINE)
-			wordexp_t word;
-			wordexp(LUA_HISTORY_FILE, &word, WRDE_NOCMD);
-			const char *history_file = NULL;
-			if(word.we_wordc == 1)
-			{
-				history_file = word.we_wordv[0];
-				const int ret_r = read_history(history_file);
-				if(dnsmasq_debug)
-				{
-					printf("Reading history ... ");
-					if(ret_r == 0)
-						printf("success\n");
-					else
-						printf("error - %s: %s\n", history_file, strerror(ret_r));
-				}
-
-				// The history file may not exist, try to create an empty one in this case
-				if(ret_r == ENOENT)
-				{
-					if(dnsmasq_debug)
-					{
-						printf("Creating new history file: %s\n", history_file);
-					}
-					FILE *history = fopen(history_file, "w");
-					if(history != NULL)
-						fclose(history);
-				}
-			}
-#else
-			if(dnsmasq_debug)
-				printf("No readline available!\n");
-#endif
-			const int ret = lua_main(argc - i, &argv[i]);
-#if defined(LUA_USE_READLINE)
-			if(history_file != NULL)
-			{
-				const int ret_w = write_history(history_file);
-				if(dnsmasq_debug)
-				{
-					printf("Writing history ... ");
-					if(ret_w == 0)
-						printf("success\n");
-					else
-						printf("error - %s: %s\n", history_file, strerror(ret_w));
-				}
-
-				wordfree(&word);
-			}
-#endif
-			exit(ret);
-		}
-
-		// Expose internal lua compiler
-		if(strcmp(argv[i], "luac") == 0 ||
-		   strcmp(argv[i], "--luac") == 0)
-		{
-			if(argc == i + 1) // No arguments after this one
-				printf("Pi-hole FTL %s\n", get_FTL_version());
-			exit(luac_main(argc - i, &argv[i]));
 		}
 
 		// Complain if invalid options have been found

--- a/src/args.c
+++ b/src/args.c
@@ -59,6 +59,9 @@ void parse_args(int argc, char* argv[])
 	if(strEndsWith(argv[0], "lua"))
 		exit(run_lua_interpreter(argc, argv, false));
 
+	if(strEndsWith(argv[0], "luac"))
+		exit(run_luac(argc, argv));
+
 	// start from 1, as argv[0] is the executable name
 	for(int i = 1; i < argc; i++)
 	{
@@ -75,8 +78,6 @@ void parse_args(int argc, char* argv[])
 		if(strcmp(argv[i], "luac") == 0 ||
 		   strcmp(argv[i], "--luac") == 0)
 		{
-			if(argc == i + 1) // No arguments after this one
-				printf("Pi-hole FTL %s\n", get_FTL_version());
 			exit(luac_main(argc - i, &argv[i]));
 		}
 

--- a/src/args.c
+++ b/src/args.c
@@ -350,7 +350,15 @@ void parse_args(int argc, char* argv[])
 		// Complain if invalid options have been found
 		if(!ok)
 		{
-			printf("pihole-FTL: invalid option -- '%s'\nTry '%s --help' for more information\n", argv[i], argv[0]);
+			printf("pihole-FTL: invalid option -- '%s'\n", argv[i]);
+			printf("Command: \"");
+			for(int j = 0; j < argc; j++)
+			{
+				printf("%s", argv[j]);
+				if(j < argc - 1)
+					printf(" ");
+			}
+			printf("\"\n\nTry '%s --help' for more information\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/src/args.c
+++ b/src/args.c
@@ -351,14 +351,14 @@ void parse_args(int argc, char* argv[])
 		if(!ok)
 		{
 			printf("pihole-FTL: invalid option -- '%s'\n", argv[i]);
-			printf("Command: \"");
+			printf("Command: '");
 			for(int j = 0; j < argc; j++)
 			{
 				printf("%s", argv[j]);
 				if(j < argc - 1)
 					printf(" ");
 			}
-			printf("\"\n\nTry '%s --help' for more information\n", argv[0]);
+			printf("'\nTry '%s --help' for more information\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/src/args.c
+++ b/src/args.c
@@ -56,7 +56,7 @@ void parse_args(int argc, char* argv[])
 	if(strEndsWith(argv[0], "dnsmasq"))
 		consume_for_dnsmasq = true;
 
-	if(strEndsWith(argv[0], "pihole-lua"))
+	if(strEndsWith(argv[0], "lua"))
 		exit(run_lua_interpreter(argc, argv, false));
 
 	// start from 1, as argv[0] is the executable name

--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -74,6 +74,13 @@ int run_lua_interpreter(const int argc, char **argv, bool dnsmasq_debug)
 	return ret;
 }
 
+int run_luac(const int argc, char **argv)
+{
+	if(argc == 1) // No arguments after this one
+		printf("Pi-hole FTL %s\n", get_FTL_version());
+	return luac_main(argc, argv);
+}
+
 // pihole.ftl_version()
 static int pihole_ftl_version(lua_State *L) {
 	lua_pushstring(L, get_FTL_version());

--- a/src/lua/ftl_lua.h
+++ b/src/lua/ftl_lua.h
@@ -11,8 +11,11 @@
 #define FTL_LUA_H
 
 #include "lua.h"
+#include <stdbool.h>
 
 #define LUA_HISTORY_FILE "~/.pihole_lua_history"
+
+int run_lua_interpreter(const int argc, char **argv, bool dnsmasq_debug);
 
 int lua_main (int argc, char **argv);
 int luac_main (int argc, char **argv);

--- a/src/lua/ftl_lua.h
+++ b/src/lua/ftl_lua.h
@@ -16,6 +16,7 @@
 #define LUA_HISTORY_FILE "~/.pihole_lua_history"
 
 int run_lua_interpreter(const int argc, char **argv, bool dnsmasq_debug);
+int run_luac(const int argc, char **argv);
 
 int lua_main (int argc, char **argv);
 int luac_main (int argc, char **argv);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -473,7 +473,8 @@
   run bash -c '/home/pihole/pihole-FTL abc'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "pihole-FTL: invalid option -- 'abc'" ]]
-  [[ ${lines[1]} == "Try '/home/pihole/pihole-FTL --help' for more information" ]]
+  [[ ${lines[1]} == "Command: '/home/pihole/pihole-FTL abc'" ]]
+  [[ ${lines[2]} == "Try '/home/pihole/pihole-FTL --help' for more information" ]]
 }
 
 @test "Help CLI argument return help text" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

- Show complete list of args when complaining about unsupported argument
- Allow `pihole-FTL` to be symlinked to `/usr/bin/lua` (or `/usr/bin/pihole-lua`) and work as drop-in replacement of a regular `lua` interpreter
- The same for `luac`