### PR TITLE
docs: fix simple typo, timestemp -> timestamp

### DIFF
--- a/src/overTime.c
+++ b/src/overTime.c
@@ -125,7 +125,7 @@ unsigned int getOverTimeID(time_t timestamp)
 void moveOverTimeMemory(const time_t mintime)
 {
 	const time_t oldestOverTimeIS = overTime[0].timestamp;
-	// Shift SHOULD timestemp into the future by the amount GC is running earlier
+	// Shift SHOULD timestamp into the future by the amount GC is running earlier
 	time_t oldestOverTimeSHOULD = mintime;
 
 	// Center in interval


### PR DESCRIPTION
There is a small typo in src/overTime.c.

Should read `timestamp` rather than `timestemp`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md