### PR TITLE
Revert #984

### DIFF
--- a/src/shmem.c
+++ b/src/shmem.c
@@ -513,35 +513,12 @@ SharedMemory create_shm(const char *name, const size_t size, bool create_new)
 	// Using fallocate() will ensure that there's actually space for
 	// this file. Otherwise we end up with a sparse file that can give
 	// SIGBUS if we run out of space while writing to it.
-	int ret = fallocate(fd, 0, 0U, size);
-	const int fallocate_errno = errno;
+	const int ret = fallocate(fd, 0, 0U, size);
 	if(ret != 0)
 	{
-		// Try again with ftruncate() if fallocate() failed with
-		// "Operation not supported"
-		if(errno == ENOTSUP)
-		{
-			ret = ftruncate(fd, size);
-
-			// Report info that space has only been reserved, not
-			// really allocated
-			if(ret == 0)
-			{
-				logg("INFO: create_shm(): Failed to allocate %zu bytes for \"%s\" (%s, %i), "\
-				     "space has only been reserved.",
-				     size, sharedMemory.name, strerror(errno), errno);
-			}
-		}
-		if(ret != 0)
-		{
-			logg("FATAL: create_shm(): Failed to resize \"%s\" (%i) to %zu:",
-			sharedMemory.name, fd, size);
-			logg("       fallocate returned: %s (%i)",
-				strerror(fallocate_errno), fallocate_errno);
-			logg("       ftruncate returned: %s (%i)",
-				strerror(errno), errno);
-			exit(EXIT_FAILURE);
-		}
+		logg("FATAL: create_shm(): Failed to resize \"%s\" (%i) to %zu: %s (%i)",
+		     sharedMemory.name, fd, size, strerror(errno), ret);
+		exit(EXIT_FAILURE);
 	}
 
 	// Create shared memory mapping
@@ -660,35 +637,12 @@ bool realloc_shm(SharedMemory *sharedMemory, const size_t size1, const size_t si
 		// Using fallocate() will ensure that there's actually space for
 		// this file. Otherwise we end up with a sparse file that can give
 		// SIGBUS if we run out of space while writing to it.
-		int ret = fallocate(fd, 0, 0U, size);
-		const int fallocate_errno = errno;
-		if(ret == -1)
+		const int ret = fallocate(fd, 0, 0U, size);
+		if(ret != 0)
 		{
-			// Try again with ftruncate() if fallocate() failed with
-			// "Operation not supported"
-			if(errno == ENOTSUP)
-			{
-				ret = ftruncate(fd, size);
-
-				// Report info that space has only been reserved, not
-				// really allocated
-				if(ret == 0)
-				{
-					logg("INFO: realloc_shm(): Failed to allocate %zu bytes for \"%s\" (%s), "\
-					     "space has only been reserved.",
-					     size, sharedMemory->name, strerror(errno));
-				}
-			}
-			if(ret == -1)
-			{
-				logg("FATAL: realloc_shm(): Failed to resize \"%s\" (%i) to %zu:",
-				     sharedMemory->name, fd, size);
-				logg("       fallocate returned: %s (%i)",
-				     strerror(fallocate_errno), fallocate_errno);
-				logg("       ftruncate returned: %s (%i)",
-				     strerror(errno), errno);
-				exit(EXIT_FAILURE);
-			}
+			logg("FATAL: realloc_shm(): Failed to resize \"%s\" (%i) to %zu: %s (%i)",
+			     sharedMemory->name, fd, size, strerror(errno), ret);
+			exit(EXIT_FAILURE);
 		}
 
 		// Close shared memory object file descriptor as it is no longer


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Reverts pi-hole/FTL#984 as discussed in https://github.com/pi-hole/FTL/issues/977#issuecomment-748586933. The reason for reverting this is that #969 (more specifically commit fd788585a1e3a51cc8c2834954a0d1f6e5ea6fe7) provides a much more elegant solution than the simple fallback we added in #984 that also solves the potential issues of the fallback (possible errors when running out of memory).

It has been confirmed working in https://github.com/pi-hole/FTL/issues/977#issuecomment-748593586

As a side-effect, it will resolve the merge conflict in #969 which can then be merged as well.