### PR TITLE
Do not sync after executing regular expression on a domain

### DIFF
--- a/src/regex.c
+++ b/src/regex.c
@@ -100,10 +100,6 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid)
 	regex_data *regex = get_regex_ptr(regexid);
 	int index = num_regex[regexid]++;
 
-	// Update global counter from private counter
-	// This is safe her because we're (fork-wide) locked
-	num_regex[regexid] = num_regex[regexid];
-
 	// Extract possible Pi-hole extensions
 	char rgxbuf[strlen(regexin) + 1u];
 	// Parse special FTL syntax if present
@@ -268,7 +264,6 @@ int match_regex(const char *input, const DNSCacheData* dns_cache, const int clie
 		// Try to match the compiled regular expression against input
 		if(config.debug & DEBUG_REGEX)
 			logg("Executing: index = %d, preg = %p, str = \"%s\", pmatch = %p", index, &regex[index].regex, input, &match);
-		sync();
 #ifdef USE_TRE_REGEX
 		int retval = tre_regexec(&regex[index].regex, input, 0, &match, 0);
 #else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Do not sync after executing regular expression on a domain. We accidentally added a `sync()` call which should have been called only in debugging mode. This obviously could lead to issues when you're running on a system with a slow disk/storage attached to it. The branch above avoids calling sync. This fixes the new issues brought up in #962 