### PR TITLE
Added missing NS query type to getQueryTypes()

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -620,11 +620,11 @@ void getQueryTypes(const int *sock)
 		ssend(*sock, "A (IPv4): %.2f\nAAAA (IPv6): %.2f\nANY: %.2f\nSRV: %.2f\n"
 		             "SOA: %.2f\nPTR: %.2f\nTXT: %.2f\nNAPTR: %.2f\n"
 		             "MX: %.2f\nDS: %.2f\nRRSIG: %.2f\nDNSKEY: %.2f\n"
-		             "OTHER: %.2f\n",
+		             "NS: %.2f\n" "OTHER: %.2f\n",
 		      percentage[TYPE_A], percentage[TYPE_AAAA], percentage[TYPE_ANY], percentage[TYPE_SRV],
 		      percentage[TYPE_SOA], percentage[TYPE_PTR], percentage[TYPE_TXT], percentage[TYPE_NAPTR],
 		      percentage[TYPE_MX], percentage[TYPE_DS], percentage[TYPE_RRSIG], percentage[TYPE_DNSKEY],
-		      percentage[TYPE_OTHER]);
+		      percentage[TYPE_NS], percentage[TYPE_OTHER]);
 	}
 	else {
 		pack_str32(*sock, "A (IPv4)");
@@ -651,6 +651,8 @@ void getQueryTypes(const int *sock)
 		pack_float(*sock, percentage[TYPE_RRSIG]);
 		pack_str32(*sock, "DNSKEY");
 		pack_float(*sock, percentage[TYPE_DNSKEY]);
+		pack_str32(*sock, "NS");
+		pack_float(*sock, percentage[TYPE_NS]);
 		pack_str32(*sock, "OTHER");
 		pack_float(*sock, percentage[TYPE_OTHER]);
 	}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -356,8 +356,9 @@
   [[ ${lines[10]} == "DS: 0.00" ]]
   [[ ${lines[11]} == "RRSIG: 0.00" ]]
   [[ ${lines[12]} == "DNSKEY: 0.00" ]]
-  [[ ${lines[13]} == "OTHER: 0.00" ]]
-  [[ ${lines[14]} == "" ]]
+  [[ ${lines[13]} == "NS: 0.00" ]]
+  [[ ${lines[14]} == "OTHER: 0.00" ]]
+  [[ ${lines[15]} == "" ]]
 }
 
 # Here and below: Acknowledge that there might be a host name after


### PR DESCRIPTION
Signed-off-by: Fabian Preuß <preuss_fabian@gmx.de>

**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 2

---

**What does this PR aim to fix?:**

When the Query Types chart tries to fetch the query types, it does not receive info about the "NS" type. This results in two issues:

1. The "NS" type is completely missing from the chart. Tooltips do not add up to 100%.
2. The legend of the Query Types chart on the dashboard allows you to filter the Query Log for a specific query type. This works fine for all types except "OTHER". Clicking on "OTHER" filters the Query Log for the type "NS". There is a mismatch between the query type id that the chart forwards to the Query Log and the one FTL will ultimately send back.

What FTL uses:
["A (IPv4)", "AAAA (IPv6)", "ANY", "SRV", "SOA", "PTR", "TXT", "NAPTR", "MX", "DS", "RRSIG", "DNSKEY", "NS", "OTHER"]
What the chart receives:
["A (IPv4)", "AAAA (IPv6)", "ANY", "SRV", "SOA", "PTR", "TXT", "NAPTR", "MX", "DS", "RRSIG", "DNSKEY", "OTHER"]

**How does this PR accomplish the above?:**

Added query type "NS" to getQueryTypes().
