### PR TITLE
Add new query types SVCB and HTTPS

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -620,11 +620,11 @@ void getQueryTypes(const int *sock)
 		ssend(*sock, "A (IPv4): %.2f\nAAAA (IPv6): %.2f\nANY: %.2f\nSRV: %.2f\n"
 		             "SOA: %.2f\nPTR: %.2f\nTXT: %.2f\nNAPTR: %.2f\n"
 		             "MX: %.2f\nDS: %.2f\nRRSIG: %.2f\nDNSKEY: %.2f\n"
-		             "NS: %.2f\n" "OTHER: %.2f\n",
+		             "NS: %.2f\n" "OTHER: %.2f\n\nSVCB: %.2f\nHTTPS: %.2f\n",
 		      percentage[TYPE_A], percentage[TYPE_AAAA], percentage[TYPE_ANY], percentage[TYPE_SRV],
 		      percentage[TYPE_SOA], percentage[TYPE_PTR], percentage[TYPE_TXT], percentage[TYPE_NAPTR],
 		      percentage[TYPE_MX], percentage[TYPE_DS], percentage[TYPE_RRSIG], percentage[TYPE_DNSKEY],
-		      percentage[TYPE_NS], percentage[TYPE_OTHER]);
+		      percentage[TYPE_NS], percentage[TYPE_OTHER], percentage[TYPE_SVCB], percentage[TYPE_HTTPS]);
 	}
 	else {
 		pack_str32(*sock, "A (IPv4)");
@@ -655,6 +655,10 @@ void getQueryTypes(const int *sock)
 		pack_float(*sock, percentage[TYPE_NS]);
 		pack_str32(*sock, "OTHER");
 		pack_float(*sock, percentage[TYPE_OTHER]);
+		pack_str32(*sock, "SVCB");
+		pack_float(*sock, percentage[TYPE_SVCB]);
+		pack_str32(*sock, "HTTPS");
+		pack_float(*sock, percentage[TYPE_HTTPS]);
 	}
 }
 
@@ -693,9 +697,9 @@ void getAllQueries(const char *client_message, const int *sock)
 	// Query type filtering?
 	if(command(client_message, ">getallqueries-qtype")) {
 		// Get query type we want to see only
-		unsigned int qtype;
+		unsigned int qtype = 0;
 		sscanf(client_message, ">getallqueries-qtype %u", &qtype);
-		if(qtype < 1 || qtype >= TYPE_MAX)
+		if(qtype < TYPE_A || qtype >= TYPE_MAX)
 		{
 			// Invalid query type requested
 			return;
@@ -870,7 +874,7 @@ void getAllQueries(const char *client_message, const int *sock)
 			continue;
 
 		// Verify query type
-		if(query->type > TYPE_MAX-1)
+		if(query->type >= TYPE_MAX)
 			continue;
 		// Get query type
 		const char *qtype = querytypes[query->type];

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -30,7 +30,8 @@
 #include "events.h"
 
 const char *querytypes[TYPE_MAX] = {"UNKNOWN", "A", "AAAA", "ANY", "SRV", "SOA", "PTR", "TXT",
-                                    "NAPTR", "MX", "DS", "RRSIG", "DNSKEY", "NS", "OTHER"};
+                                    "NAPTR", "MX", "DS", "RRSIG", "DNSKEY", "NS", "OTHER", "SVCB",
+                                    "HTTPS"};
 
 // converts upper to lower case, and leaves other characters unchanged
 void strtolower(char *str)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -513,6 +513,12 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		case T_NS:
 			querytype = TYPE_NS;
 			break;
+		case 64: // Scn. 2 of https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/
+			querytype = TYPE_SVCB;
+			break;
+		case 65: // Scn. 2 of https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/
+			querytype = TYPE_HTTPS;
+			break;
 		default:
 			querytype = TYPE_OTHER;
 			break;

--- a/src/enums.h
+++ b/src/enums.h
@@ -96,6 +96,8 @@ enum query_types {
 	TYPE_DNSKEY,
 	TYPE_NS,
 	TYPE_OTHER,
+	TYPE_SVCB,
+	TYPE_HTTPS,
 	TYPE_MAX
 } __attribute__ ((packed));
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -358,7 +358,9 @@
   [[ ${lines[12]} == "DNSKEY: 0.00" ]]
   [[ ${lines[13]} == "NS: 0.00" ]]
   [[ ${lines[14]} == "OTHER: 0.00" ]]
-  [[ ${lines[15]} == "" ]]
+  [[ ${lines[15]} == "SVCB: 0.00" ]]
+  [[ ${lines[16]} == "HTTPS: 0.00" ]]
+  [[ ${lines[17]} == "" ]]
 }
 
 # Here and below: Acknowledge that there might be a host name after


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add special handling for `SVCB` and `HTTPS` query types as specified by [this](https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/) IETF draft, section 2. Usually, we would not add query types still in draft mode, however, this time a big player in the market (imagine a bitten into fruit) decided to push something not even yet standardized into the market. Hence, many users are seeing this new query type now. The move from this vendor makes it unlikely that the standard can be much different from the draft (without needing a lot of effort), however, we stay fully flexible with Pi-hole as we're only storing a numeric value in the database and can change its translation into a name at any time.