### PR TITLE
Implement support for displaying exact type instead of just "OTHER"

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -878,6 +878,14 @@ void getAllQueries(const char *client_message, const int *sock)
 			continue;
 		// Get query type
 		const char *qtype = querytypes[query->type];
+		char othertype[12] = { 0 }; // Maximum is "TYPE65535" = 10 bytes
+		if(query->type == TYPE_OTHER)
+		{
+			// Format custom type into buffer
+			sprintf(othertype, "TYPE%u", query->qtype);
+			// Replace qtype pointer
+			qtype = othertype;
+		}
 
 		// Hide UNKNOWN queries when not requesting both query status types
 		if(query->status == QUERY_UNKNOWN && !(showpermitted && showblocked))

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -125,7 +125,16 @@ void DB_save_queries(void)
 		sqlite3_bind_int(stmt, 1, query->timestamp);
 
 		// TYPE
-		sqlite3_bind_int(stmt, 2, query->type);
+		if(query->type != TYPE_OTHER)
+		{
+			// Store mapped type if query->type is not OTHER
+			sqlite3_bind_int(stmt, 2, query->type);
+		}
+		else
+		{
+			// Store query type + offset if query-> type is OTHER
+			sqlite3_bind_int(stmt, 2, query->qtype + 100);
+		}
 
 		// STATUS
 		sqlite3_bind_int(stmt, 3, query->status);
@@ -344,7 +353,9 @@ void DB_read_queries(void)
 		}
 
 		const int type = sqlite3_column_int(stmt, 2);
-		if(type < TYPE_A || type >= TYPE_MAX)
+		const bool mapped_type = type >= TYPE_A && type < TYPE_MAX;
+		const bool offset_type = type > 100 && type < (100 + UINT16_MAX);
+		if(!mapped_type && !offset_type)
 		{
 			logg("FTL_db warn: TYPE should not be %i", type);
 			continue;
@@ -423,7 +434,18 @@ void DB_read_queries(void)
 		queriesData* query = getQuery(queryIndex, false);
 		query->magic = MAGICBYTE;
 		query->timestamp = queryTimeStamp;
-		query->type = type;
+		if(type < 100)
+		{
+			// Mapped query type
+			query->type = type;
+		}
+		else
+		{
+			// Offset query type
+			query->type = TYPE_OTHER;
+			query->qtype = type - 100;
+		}
+		
 		query->status = status;
 		query->domainID = domainID;
 		query->clientID = clientID;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -25,15 +25,16 @@ typedef struct {
 	enum privacy_level privacylevel;
 	enum reply_type reply;
 	enum dnssec_status dnssec;
-	time_t timestamp;
+	uint16_t qtype;
 	int domainID;
 	int clientID;
 	int upstreamID;
 	int id; // the ID is a (signed) int in dnsmasq, so no need for a long int here
 	int CNAME_domainID; // only valid if query has a CNAME blocking status
-	unsigned long response; // saved in units of 1/10 milliseconds (1 = 0.1ms, 2 = 0.2ms, 2500 = 250.0ms, etc.)
-	int64_t db;
 	unsigned int timeidx;
+	unsigned long response; // saved in units of 1/10 milliseconds (1 = 0.1ms, 2 = 0.2ms, 2500 = 250.0ms, etc.)
+	time_t timestamp;
+	int64_t db;
 	bool whitelisted;
 	bool complete;
 } queriesData;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -626,6 +626,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	query->magic = MAGICBYTE;
 	query->timestamp = querytimestamp;
 	query->type = querytype;
+	query->qtype = qtype;
 	query->status = QUERY_UNKNOWN;
 	query->domainID = domainID;
 	query->clientID = clientID;

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -21,7 +21,7 @@
 #include "regex_r.h"
 
 /// The version of shared memory used
-#define SHARED_MEMORY_VERSION 10
+#define SHARED_MEMORY_VERSION 11
 
 /// The name of the shared memory. Use this when connecting to the shared memory.
 #define SHMEM_PATH "/dev/shm"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Implement support for displaying exact type instead of the catch-them-all category `OTHER`. The `OTHER` category is still used when it comes to computing statistics to ensure your chart's legend does not explode.

Example:
```
dig -t TYPE65 google.de
dig -t TYPE66 google.de
```
results in:
![Screenshot from 2021-01-03 21-52-16](https://user-images.githubusercontent.com/16748619/103488562-fcef1380-4e0d-11eb-9f46-0de6ee1affd4.png)
(note that type 65 is correctly translated into the named type `HTTPS` rather than showing `TYPE65`)

And the database contains the expected (`16` = `HTTPS` mapped status, `166` = `TYPE66` with offset 100)
``` sql
SELECT * FROM queries WHERE domain = 'google.de' ORDER BY id DESC LIMIT 2;
```
``` plain
id          timestamp   type        status      domain      client      forward         additional_info
----------  ----------  ----------  ----------  ----------  ----------  --------------  ---------------
10910413    1609706951  166         2           google.de   127.0.0.1   127.0.0.1#5353                 
10910412    1609706943  16          2           google.de   127.0.0.1   127.0.0.1#5353 
```

No changed to core of AdminLTE are necessary for this to work. A small change to the long-term queries page will be needed to handle these offset types still as `OTHER`.