### PR TITLE
Do not record NXDOMAIN from DNS cache as "regex blocked"

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1039,23 +1039,10 @@ void _FTL_reply(const unsigned int flags, const char *name, const union all_addr
 		// Get time index
 		const unsigned int timeidx = query->timeidx;
 
-		// Check whether this query was blocked
-		if(strcmp(answer, "(NXDOMAIN)") == 0 ||
-		   strcmp(answer, "0.0.0.0") == 0 ||
-		   strcmp(answer, "::") == 0)
-		{
-			// Mark query as blocked
-			clientsData* client = getClient(query->clientID, true);
-			query_blocked(query, domain, client, QUERY_REGEX);
-		}
-		else
-		{
-			// Answered from a custom (user provided) cache file
-			counters->cached++;
-			overTime[timeidx].cached++;
-
-			query->status = QUERY_CACHE;
-		}
+		// Answered from a custom (user provided) cache file
+		counters->cached++;
+		overTime[timeidx].cached++;
+		query->status = QUERY_CACHE;
 
 		// Save reply type and update individual reply counters
 		save_reply_type(flags, addr, query, response);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1039,7 +1039,9 @@ void _FTL_reply(const unsigned int flags, const char *name, const union all_addr
 		// Get time index
 		const unsigned int timeidx = query->timeidx;
 
-		// Answered from a custom (user provided) cache file
+		// Answered from a custom (user provided) cache file or because
+		// we're the authorative DNS server (e.g. DHCP server and this
+		// is our own domain)
 		counters->cached++;
 		overTime[timeidx].cached++;
 		query->status = QUERY_CACHE;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

We cannot really decide whether local configuration lines are meant for blocking or something else. Just record such queries as replied to from cache because this is what they are. This code made sense at the time where wildcards were implemented as dnsmasq config lines, however, we've advanced to our own regex engine since then and all config lines should have also been auto-migrated.

This fixes a bug reported on Discourse (see below).

## Example
Assume I'm authoritative for `lan` (this is the case when the Pi-hole DHCP server is used) and run `dig whatever.lan`

Before:
![Screenshot from 2021-01-05 13-35-17](https://user-images.githubusercontent.com/16748619/103647428-9710a200-4f5b-11eb-95e8-1d13a25a7661.png)

Now:
![Screenshot from 2021-01-05 13-35-49](https://user-images.githubusercontent.com/16748619/103647506-b9a2bb00-4f5b-11eb-8fe7-94a781006d83.png)
