### PR TITLE
Do not return regex idx if privacy level > 0

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -993,9 +993,10 @@ void getAllQueries(const char *client_message, const int *sock)
 			CNAME_domain = getCNAMEDomainString(query);
 		}
 
-		// Get ID of blocking regex, if applicable
+		// Get ID of blocking regex, if applicable and permitted by privacy settings
 		int regex_idx = -1;
-		if (query->status == QUERY_REGEX || query->status == QUERY_REGEX_CNAME)
+		if ((query->status == QUERY_REGEX || query->status == QUERY_REGEX_CNAME) &&
+		    config.privacylevel < PRIVACY_HIDE_DOMAINS)
 		{
 			unsigned int cacheID = findCacheID(query->domainID, query->clientID, query->type);
 			DNSCacheData *dns_cache = getDNSCache(cacheID, true);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Only return regex index when allowed by privacy settings. This may leak information, otherwise. Fixes https://github.com/pi-hole/AdminLTE/issues/1684