### PR TITLE
Config option MAXDBDAYS fixes and tweaks

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -17,6 +17,9 @@
 // saveport()
 #include "api/socket.h"
 
+// INT_MAX
+#include <limits.h>
+
 ConfigStruct config;
 FTLFileNamesStruct FTLfiles = {
 	// Default path for config file (regular installations)
@@ -132,12 +135,22 @@ void read_FTLconf(void)
 	buffer = parse_FTLconf(fp, "MAXDBDAYS");
 
 	int value = 0;
+	const int maxdbdays_max = INT_MAX / 24 / 60 / 60;
 	if(buffer != NULL && sscanf(buffer, "%i", &value))
-		if(value >= 0)
+	{
+		// Prevent possible overflow
+		if(value > maxdbdays_max)
+			value = maxdbdays_max;
+
+		// Only use valid values
+		if(value == -1 || value >= 0)
 			config.maxDBdays = value;
+	}
 
 	if(config.maxDBdays == 0)
 		logg("   MAXDBDAYS: --- (DB disabled)");
+	else if(config.maxDBdays == -1)
+		logg("   MAXDBDAYS: --- (cleaning disabled)");
 	else
 		logg("   MAXDBDAYS: max age for stored queries is %i days", config.maxDBdays);
 

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -54,7 +54,7 @@ void *DB_thread(void *val)
 					unlock_shm();
 
 					// Check if GC should be done on the database
-					if(DBdeleteoldqueries)
+					if(DBdeleteoldqueries && config.maxDBdays != -1)
 					{
 						// No thread locks needed
 						delete_old_queries_in_DB();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add `MAXDBDAYS=-1` as an option to disable database auto-cleaning and ensure overflow cannot happen. In case of an overflow, we just enforce the maximum of `INT_MAX / 24 / 60 / 60 = 24855 days (roughly 68 years)`

Fixes https://github.com/pi-hole/FTL/issues/1021