### PR TITLE
Don't display unrelated blocked CNAME queries when filtering for specific domain

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -914,7 +914,7 @@ void getAllQueries(const char *client_message, const int *sock)
 			// If the domain of this query did not match, the CNAME
 			// domain may still match - we have to check it in
 			// addition if this query is of CNAME blocked type
-			else if(query->CNAME_domainID > -1)
+			else if(query->CNAME_domainID == domainid)
 			{
 				// Get this query
 			}


### PR DESCRIPTION
Signed-off-by: Fabian Preuß <preuss_fabian@gmx.de>

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 3

---
Fixes an issue reported on discourse: [https://discourse.pi-hole.net/t/domain-queries-include-wrong-results/43472](https://discourse.pi-hole.net/t/domain-queries-include-wrong-results/43472)
