### PR TITLE
Update dnsmasq to v2.84

### DIFF
--- a/src/dnsmasq/arp.c
+++ b/src/dnsmasq/arp.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/auth.c
+++ b/src/dnsmasq/auth.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/blockdata.c
+++ b/src/dnsmasq/blockdata.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/bpf.c
+++ b/src/dnsmasq/bpf.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -122,8 +122,8 @@ HAVE_AUTH
    define this to include the facility to act as an authoritative DNS
    server for one or more zones.
 
-HAVE_NETTLEHASH
-   include just hash function from nettle, but no DNSSEC.
+HAVE_CRYPTOHASH
+   include just hash function from crypto library, but no DNSSEC.
 
 HAVE_DNSSEC
    include DNSSEC validator.
@@ -192,7 +192,7 @@ RESOLVFILE
 /* #define HAVE_IDN */
 /* #define HAVE_LIBIDN2 */
 /* #define HAVE_CONNTRACK */
-/* #define HAVE_NETTLEHASH */
+/* #define HAVE_CRYPTOHASH */
 /* #define HAVE_DNSSEC */
 
 
@@ -426,10 +426,10 @@ static char *compile_opts =
 "no-"
 #endif
 "auth "
-#if !defined(HAVE_NETTLEHASH) && !defined(HAVE_DNSSEC)
+#if !defined(HAVE_CRYPTOHASH) && !defined(HAVE_DNSSEC)
 "no-"
 #endif
-"nettlehash "
+"cryptohash "
 #ifndef HAVE_DNSSEC
 "no-"
 #endif

--- a/src/dnsmasq/conntrack.c
+++ b/src/dnsmasq/conntrack.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/crypto.c
+++ b/src/dnsmasq/crypto.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/crypto.c
+++ b/src/dnsmasq/crypto.c
@@ -27,7 +27,7 @@
 #endif
 #endif
 
-#if defined(HAVE_DNSSEC) || defined(HAVE_NETTLEHASH)
+#if defined(HAVE_DNSSEC) || defined(HAVE_CRYPTOHASH)
 #include <nettle/nettle-meta.h>
 #include <nettle/bignum.h>
 

--- a/src/dnsmasq/dbus.c
+++ b/src/dnsmasq/dbus.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dhcp-common.c
+++ b/src/dnsmasq/dhcp-common.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dhcp-protocol.h
+++ b/src/dnsmasq/dhcp-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dhcp.c
+++ b/src/dnsmasq/dhcp.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dhcp6-protocol.h
+++ b/src/dnsmasq/dhcp6-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dhcp6.c
+++ b/src/dnsmasq/dhcp6.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dns-protocol.h
+++ b/src/dnsmasq/dns-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -392,8 +392,8 @@ int main_dnsmasq (int argc, char **argv)
   if (daemon->port != 0)
     {
       cache_init();
-
       blockdata_init();
+      hash_questions_init();
     }
 
 #ifdef HAVE_INOTIFY

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
  
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define COPYRIGHT "Copyright (c) 2000-2020 Simon Kelley"
+#define COPYRIGHT "Copyright (c) 2000-2021 Simon Kelley"
 
 /* We do defines that influence behavior of stdio.h, so complain
    if included too early. */

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -157,7 +157,11 @@ extern int capget(cap_user_header_t header, cap_user_data_t data);
 #include <priv.h>
 #endif
 
-#if defined(HAVE_DNSSEC) || defined(HAVE_NETTLEHASH)
+/* Backwards compat with 2.83 */
+#if defined(HAVE_NETTLEHASH)
+#  define HAVE_CRYPTOHASH
+#endif
+#if defined(HAVE_DNSSEC) || defined(HAVE_CRYPTOHASH)
 #  include <nettle/nettle-meta.h>
 #endif
 

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1266,6 +1266,7 @@ size_t filter_rrsigs(struct dns_header *header, size_t plen);
 int setup_timestamp(void);
 
 /* hash_questions.c */
+void hash_questions_init(void);
 unsigned char *hash_questions(struct dns_header *header, size_t plen, char *name);
 
 /* crypto.c */

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -666,6 +666,7 @@ struct frec {
     union mysockaddr source;
     union all_addr dest;
     unsigned int iface, log_id;
+    int fd;
     unsigned short orig_id;
     struct frec_src *next;
   } frec_src;
@@ -673,7 +674,7 @@ struct frec {
   struct randfd *rfd4;
   struct randfd *rfd6;
   unsigned short new_id;
-  int fd, forwardall, flags;
+  int forwardall, flags;
   time_t time;
   unsigned char *hash[HASH_SIZE];
 #ifdef HAVE_DNSSEC 

--- a/src/dnsmasq/domain.c
+++ b/src/dnsmasq/domain.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/dump.c
+++ b/src/dnsmasq/dump.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/edns0.c
+++ b/src/dnsmasq/edns0.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -394,6 +394,9 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	      new->fd = udpfd;
 	    }
 	  
+	  // Pi-hole modification
+	  FTL_query_in_progress(daemon->log_id);
+
 	  return 1;
 	}
 	
@@ -1330,6 +1333,9 @@ void reply_query(int fd, int family, time_t now)
 	    }
 #endif
 
+	  // Pi-hole modification
+	  int first_ID = -1;
+
 	  for (src = &forward->frec_src; src; src = src->next)
 	    {
 	      header->id = htons(src->orig_id);
@@ -1347,6 +1353,8 @@ void reply_query(int fd, int family, time_t now)
 		  daemon->log_source_addr = &src->source;
 		  log_query(F_UPSTREAM, "query", NULL, "duplicate");
 		}
+	      /* Pi-hole modification */
+	      FTL_duplicate_reply(src->log_id, &first_ID);
 	    }
 	}
 

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -391,6 +391,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	      new->dest = *dst_addr;
 	      new->log_id = daemon->log_id;
 	      new->iface = dst_iface;
+	      forward->frec_src.fd = udpfd;
 	    }
 	  
 	  return 1;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -415,8 +415,8 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	  forward->frec_src.dest = *dst_addr;
 	  forward->frec_src.iface = dst_iface;
 	  forward->frec_src.next = NULL;
+	  forward->frec_src.fd = udpfd;
 	  forward->new_id = get_id();
-	  forward->fd = udpfd;
 	  memcpy(forward->hash, hash, HASH_SIZE);
 	  forward->forwardall = 0;
 	  forward->flags = fwd_flags;
@@ -1337,7 +1337,7 @@ void reply_query(int fd, int family, time_t now)
 	      dump_packet(DUMP_REPLY, daemon->packet, (size_t)nn, NULL, &src->source);
 #endif
 	      
-	      send_from(forward->fd, option_bool(OPT_NOWILD) || option_bool (OPT_CLEVERBIND), daemon->packet, nn, 
+	      send_from(src->fd, option_bool(OPT_NOWILD) || option_bool (OPT_CLEVERBIND), daemon->packet, nn, 
 			&src->source, &src->dest, src->iface);
 
 	      if (option_bool(OPT_EXTRALOG) && src != &forward->frec_src)

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -391,7 +391,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	      new->dest = *dst_addr;
 	      new->log_id = daemon->log_id;
 	      new->iface = dst_iface;
-	      forward->frec_src.fd = udpfd;
+	      new->fd = udpfd;
 	    }
 	  
 	  return 1;

--- a/src/dnsmasq/hash_questions.c
+++ b/src/dnsmasq/hash_questions.c
@@ -28,7 +28,7 @@
 
 #include "dnsmasq.h"
 
-#if defined(HAVE_DNSSEC) || defined(HAVE_NETTLEHASH)
+#if defined(HAVE_DNSSEC) || defined(HAVE_CRYPTOHASH)
 
 static const struct nettle_hash *hash;
 static void *ctx;
@@ -71,7 +71,7 @@ unsigned char *hash_questions(struct dns_header *header, size_t plen, char *name
   return digest;
 }
 
-#else /* HAVE_DNSSEC */
+#else /* HAVE_DNSSEC  || HAVE_CRYPTOHASH */
 
 #define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
 typedef unsigned char BYTE;             // 8-bit byte

--- a/src/dnsmasq/hash_questions.c
+++ b/src/dnsmasq/hash_questions.c
@@ -36,8 +36,11 @@ static unsigned char *digest;
 
 void hash_questions_init(void)
 {
-  if (!(hash = hash_find("sha256")) || !hash_init(hash, &ctx, &digest))
+  if (!(hash = hash_find("sha256")))
     die(_("Failed to create SHA-256 hash object"), NULL, EC_MISC);
+
+  ctx = safe_malloc(hash->context_size);
+  digest = safe_malloc(hash->digest_size);
 }
 
 unsigned char *hash_questions(struct dns_header *header, size_t plen, char *name)

--- a/src/dnsmasq/helper.c
+++ b/src/dnsmasq/helper.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/inotify.c
+++ b/src/dnsmasq/inotify.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
  
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/ip6addr.h
+++ b/src/dnsmasq/ip6addr.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/lease.c
+++ b/src/dnsmasq/lease.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/loop.c
+++ b/src/dnsmasq/loop.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/metrics.c
+++ b/src/dnsmasq/metrics.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/metrics.h
+++ b/src/dnsmasq/metrics.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
    
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/netlink.c
+++ b/src/dnsmasq/netlink.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/outpacket.c
+++ b/src/dnsmasq/outpacket.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/poll.c
+++ b/src/dnsmasq/poll.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/radv-protocol.h
+++ b/src/dnsmasq/radv-protocol.h
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/radv.c
+++ b/src/dnsmasq/radv.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/rrfilter.c
+++ b/src/dnsmasq/rrfilter.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/slaac.c
+++ b/src/dnsmasq/slaac.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/ubus.c
+++ b/src/dnsmasq/ubus.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -1,4 +1,4 @@
-/* dnsmasq is Copyright (c) 2000-2020 Simon Kelley
+/* dnsmasq is Copyright (c) 2000-2021 Simon Kelley
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2280,7 +2280,7 @@ void FTL_duplicate_reply(const int id, int *firstID)
 
 	// The original query may have been blocked during CNAME inspection,
 	// correct status in this case
-	if(duplicated_query->status != QUERY_FORWARDED)
+	if(source_query->status != QUERY_FORWARDED)
 		duplicated_query->status = source_query->status;
 	duplicated_query->CNAME_domainID = source_query->CNAME_domainID;
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2180,3 +2180,104 @@ bool FTL_unlink_DHCP_lease(const char *ipaddr)
 	return true;
 	
 }
+
+void FTL_query_in_progress(const int id)
+{
+	// Query (possibly from new source), but the same query may be in
+	// progress from another source.
+
+	// Lock shared memory
+	lock_shm();
+
+	// Search for corresponding query identified by ID
+	const int queryID = findQueryID(id);
+	if(queryID < 0)
+	{
+		// This may happen e.g. if the original query was an unhandled query type
+		unlock_shm();
+		return;
+	}
+
+	// Get query pointer
+	queriesData* query = getQuery(queryID, true);
+	if(query == NULL)
+	{
+		// Memory error, skip this DNSSEC details
+		unlock_shm();
+		return;
+	}
+
+	// Debug logging
+	if(config.debug & DEBUG_QUERIES)
+	{
+		// Get domain pointer
+		const domainsData* domain = getDomain(query->domainID, true);
+		if(domain != NULL)
+		{
+			logg("**** query for %s is already in progress (ID %i)", getstr(domain->domainpos), id);
+		}
+	}
+
+	// Store status
+	query->status = QUERY_IN_PROGRESS;
+
+	// Unlock shared memory
+	unlock_shm();
+}
+
+void FTL_duplicate_reply(const int id, int *firstID)
+{
+	// Reply to duplicated query
+
+	// Check if we can process thes duplicated queries at all
+	if(*firstID == -2)
+		return;
+
+	// Lock shared memory
+	lock_shm();
+
+	// Search for corresponding query identified by ID
+	const int queryID = findQueryID(id);
+	if(queryID < 0)
+	{
+		// This may happen e.g. if the original query was an unhandled query type
+		unlock_shm();
+		*firstID = -2;
+		return;
+	}
+
+	if(*firstID == -1)
+	{
+		// This is not yet a duplicate, we just store the ID
+		// of the successful reply here so we can get it quicker
+		// during the next loop iterations
+		unlock_shm();
+		*firstID = queryID;
+		return;
+	}
+
+	// Get query pointer of duplicate reply
+	queriesData* duplicated_query = getQuery(queryID, true);
+	const queriesData* source_query = getQuery(*firstID, true);
+
+	if(duplicated_query == NULL || source_query == NULL)
+	{
+		// Memory error, skip this duplicate
+		unlock_shm();
+		return;
+	}
+
+	// Debug logging
+	if(config.debug & DEBUG_QUERIES)
+	{
+		logg("**** query %d is duplicate of %d", queryID, *firstID);
+	}
+
+	// Copy relevant information over
+	duplicated_query->reply = source_query->reply;
+	duplicated_query->dnssec = source_query->dnssec;
+	duplicated_query->flags.complete = true;
+
+	// Unlock shared memory
+	unlock_shm();
+}

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2278,6 +2278,12 @@ void FTL_duplicate_reply(const int id, int *firstID)
 	duplicated_query->dnssec = source_query->dnssec;
 	duplicated_query->flags.complete = true;
 
+	// The original query may have been blocked during CNAME inspection,
+	// correct status in this case
+	if(duplicated_query->status != QUERY_FORWARDED)
+		duplicated_query->status = source_query->status;
+	duplicated_query->CNAME_domainID = source_query->CNAME_domainID;
+
 	// Unlock shared memory
 	unlock_shm();
 }

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -53,6 +53,8 @@ void _FTL_get_blocking_metadata(union all_addr **addrp, unsigned int *flags, con
 bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const char* file, const int line);
 
 unsigned int FTL_extract_question_flags(struct dns_header *header, const size_t qlen);
+void FTL_query_in_progress(const int id);
+void FTL_duplicate_reply(const int id, int *firstID);
 
 void FTL_dnsmasq_reload(void);
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw);

--- a/src/enums.h
+++ b/src/enums.h
@@ -42,6 +42,7 @@ enum query_status {
 	QUERY_BLACKLIST_CNAME,
 	QUERY_RETRIED,
 	QUERY_RETRIED_DNSSEC,
+	QUERY_IN_PROGRESS,
 	QUERY_STATUS_MAX
 } __attribute__ ((packed));
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -128,6 +128,11 @@ void *GC_thread(void *val)
 						if(client != NULL)
 							change_clientcount(client, 0, -1, -1, 0);
 						break;
+					case QUERY_IN_PROGRESS:
+						// Nothing to be done here, this was a duplicated query. It
+						// wasn't forwarded on its own to save some traffic (and
+						// reduce the attack surface for cache spoofing)
+						break;
 					case QUERY_STATUS_MAX: // fall through
 					default:
 						/* That cannot happen */


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

According to Simon Kelley, it looks like if two queries are combined (because they ask the same question) then dnsmasq can get confused when it comes to return the answer, the reply to the second query can be sent via the socket that the first one arrived on. That's normally OK, but if the first query arrives via IPv4 and the second via IPv6, for instance, then the bug is triggered.

In addition, FTL can get confused in a similar way because `dnsmasq-v2.83+` forwards multiple queries to the same destination once and stores the other queries as duplicates. They do receive the answer later on, however, this is usually not logged (when `log-queries=extra` is enabled, there will be a warning about the duplicate). Commit 6bb025f in this PR handles such duplicates and introduces a new reply type 14 = "already forwarded" and fixes https://github.com/pi-hole/AdminLTE/issues/1713