### PR TITLE
Prevent crashing when FTL is started multiple times

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,8 @@ set(sources
         main.h
         overTime.c
         overTime.h
+        procps.c
+        procps.h
         regex.c
         regex_r.h
         resolve.c

--- a/src/gc.c
+++ b/src/gc.c
@@ -56,7 +56,7 @@ void *GC_thread(void *val)
 			{
 				timer_start(GC_TIMER);
 				char timestring[84] = "";
-				get_timestr(timestring, mintime);
+				get_timestr(timestring, mintime, false);
 				logg("GC starting, mintime: %s (%llu)", timestring, (long long)mintime);
 			}
 

--- a/src/log.c
+++ b/src/log.c
@@ -79,18 +79,27 @@ void open_FTL_log(const bool init)
 
 // The size of 84 bytes has been carefully selected for all possible timestamps
 // to always fit into the available space without buffer overflows
-void get_timestr(char * const timestring, const time_t timein)
+void get_timestr(char * const timestring, const time_t timein, const bool millis)
 {
 	struct tm tm;
 	localtime_r(&timein, &tm);
 
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	const int millisec = tv.tv_usec/1000;
+	if(millis)
+	{
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
+		const int millisec = tv.tv_usec/1000;
 
-	sprintf(timestring,"%d-%02d-%02d %02d:%02d:%02d.%03i",
-	        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-	        tm.tm_hour, tm.tm_min, tm.tm_sec, millisec);
+		sprintf(timestring,"%d-%02d-%02d %02d:%02d:%02d.%03i",
+		        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+		        tm.tm_hour, tm.tm_min, tm.tm_sec, millisec);
+	}
+	else
+	{
+		sprintf(timestring,"%d-%02d-%02d %02d:%02d:%02d",
+		        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+		        tm.tm_hour, tm.tm_min, tm.tm_sec);
+	}
 }
 
 void _FTL_log(const bool newline, const char *format, ...)
@@ -104,7 +113,7 @@ void _FTL_log(const bool newline, const char *format, ...)
 
 	pthread_mutex_lock(&lock);
 
-	get_timestr(timestring, time(NULL));
+	get_timestr(timestring, time(NULL), true);
 
 	// Get and log PID of current process to avoid ambiguities when more than one
 	// pihole-FTL instance is logging into the same file

--- a/src/log.h
+++ b/src/log.h
@@ -21,7 +21,7 @@ void format_memory_size(char * const prefix, unsigned long long int bytes,
 void format_time(char buffer[42], unsigned long seconds, double milliseconds);
 const char *get_FTL_version(void) __attribute__ ((malloc));
 void log_FTL_version(bool crashreport);
-void get_timestr(char * const timestring, const time_t timein);
+void get_timestr(char * const timestring, const time_t timein, const bool millis);
 const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));
 
 // The actual logging routine can take extra options for specialized logging

--- a/src/main.c
+++ b/src/main.c
@@ -55,15 +55,15 @@ int main (int argc, char* argv[])
 	// We handle real-time signals later (after dnsmasq has forked)
 	handle_SIGSEGV();
 
-	// Process pihole-FTL.conf
-	read_FTLconf();
-
-	// Initialize shared memory - replace possibly existing files
+	// Initialize shared memory
 	if(!init_shmem(true))
 	{
 		logg("Initialization of shared memory failed.");
 		return EXIT_FAILURE;
 	}
+
+	// Process pihole-FTL.conf
+	read_FTLconf();
 
 	// pihole-FTL should really be run as user "pihole" to not mess up with file permissions
 	// print warning otherwise

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 #include "capabilities.h"
 #include "database/gravity-db.h"
 #include "timers.h"
+#include "procps.h"
 
 char * username;
 bool needGC = false;
@@ -59,6 +60,7 @@ int main (int argc, char* argv[])
 	if(!init_shmem(true))
 	{
 		logg("Initialization of shared memory failed.");
+		check_running_FTL();
 		return EXIT_FAILURE;
 	}
 

--- a/src/procps.c
+++ b/src/procps.c
@@ -1,0 +1,133 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2021 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  /proc system subroutines
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "procps.h"
+#include "log.h"
+#include <dirent.h>
+// getpid()
+#include <unistd.h>
+
+#define PROCESS_NAME   "pihole-FTL"
+
+static bool get_process_name(const pid_t pid, char name[128])
+{
+	if(pid == 0)
+	{
+		strcpy(name, "init");
+		return true;
+	}
+
+	// Try to open comm file
+	char filename[sizeof("/proc/%u/task/%u/comm") + sizeof(int)*3 * 2];
+	snprintf(filename, sizeof(filename), "/proc/%d/comm", pid);
+	FILE *f = fopen(filename, "r");
+	if(f == NULL)
+		return false;
+
+	// Read name from opened file
+	if(fscanf(f, "%128s", name) != 1)
+		false;
+	fclose(f);
+
+	return true;
+}
+
+
+static bool get_process_ppid(const pid_t pid, pid_t *ppid)
+{
+	// Try to open status file
+	char filename[sizeof("/proc/%u/task/%u/comm") + sizeof(int)*3 * 2];
+	snprintf(filename, sizeof(filename), "/proc/%d/status", pid);
+	FILE *f = fopen(filename, "r");
+	if(f == NULL)
+		return false;
+
+	// Read comm from opened file
+	char buffer[128];
+	while(fgets(buffer, sizeof(buffer), f) != NULL)
+	{
+		if(sscanf(buffer, "PPid: %d\n", ppid) == 1)
+			break;
+	}
+	fclose(f);
+
+	return true;
+}
+
+static bool get_process_creation_time(const pid_t pid, char timestr[84])
+{
+	// Try to open comm file
+	char filename[sizeof("/proc/%u/task/%u/comm") + sizeof(int)*3 * 2];
+	snprintf(filename, sizeof(filename), "/proc/%d/comm", pid);
+	struct stat st;
+	if(stat(filename, &st) < 0)
+		return false;
+	get_timestr(timestr, st.st_ctim.tv_sec, false);
+
+	return true;
+}
+
+void check_running_FTL(void)
+{
+	//pid_t pid;
+	DIR *dirPos;
+	struct dirent *entry;
+
+	// Open /proc
+	errno = 0;
+	if ((dirPos = opendir("/proc")) == NULL)
+	{
+		logg("Dailed to access /proc: %s", strerror(errno));
+		return;
+	}
+
+	// Loop over entries in /proc
+	// This is much more efficient than iterating over all possible PIDs
+	while ((entry = readdir(dirPos)) != NULL)
+	{
+		// We are only interested in subdirectories of /proc
+		if(entry->d_type != DT_DIR)
+			continue;
+		// We are only interested in PID subdirectories
+		if(entry->d_name[0] < '0' || entry->d_name[0] > '9')
+			continue;
+
+		// Extract PID
+		const pid_t pid = strtol(entry->d_name, NULL, 10);
+
+		// Skip our own process
+		if(pid == getpid())
+			continue;
+
+		// Get process name
+		char name[128] = { 0 };
+		if(!get_process_name(pid, name))
+			continue;
+
+		// Get parent process ID (PPID)
+		pid_t ppid;
+		if(!get_process_ppid(pid, &ppid))
+			continue;
+		char ppid_name[128] = { 0 };
+		if(!get_process_name(ppid, ppid_name))
+			continue;
+
+		char timestr[84] = { 0 };
+		get_process_creation_time(pid, timestr);
+
+		// Log this process if it is a duplicate of us
+		if(strcasecmp(name, PROCESS_NAME) == 0)
+			logg("---> %s is already running as PID %d (started %s, child of PID %i (%s))",
+			     PROCESS_NAME, pid, timestr, ppid, ppid_name);
+	}
+
+	closedir(dirPos);
+}

--- a/src/procps.h
+++ b/src/procps.h
@@ -1,0 +1,15 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2021 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  /proc system prototypes
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef PROCPS_H
+#define PROCPS_H
+void check_running_FTL(void);
+
+#endif // POCPS_H

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -548,28 +548,14 @@ SharedMemory create_shm(const char *name, const size_t size, bool create_new)
 	};
 
 	// O_RDWR: Open the object for read-write access (we need to be able to modify the locks)
-	int shm_oflags = O_RDWR;
-	if(create_new)
-	{
-		// Try unlinking the shared memory object before creating a new one.
-		// If the object is still existing, e.g., due to a past unclean exit
-		// of FTL, shm_open() would fail with error "File exists"
-		int ret = shm_unlink(name);
-		// Check return code. shm_unlink() returns -1 on error and sets errno
-		// We specifically ignore ENOENT (No such file or directory) as this is not an
-		// error in our use case (we only want the file to be deleted when existing)
-		if(ret != 0 && errno != ENOENT)
-			logg("create_shm(): shm_unlink(\"%s\") failed: %s (%i)", name, strerror(errno), errno);
-
-		// Replace shm_oflags
-		// O_CREAT: Create the shared memory object if it does not exist.
-		// O_EXCL: Return an error if a shared memory object with the given name already exists.
-		// O_TRUNC: If the shared memory object already exists, truncate it to zero bytes.
-		shm_oflags |= O_CREAT | O_EXCL | O_TRUNC;
-	}
+	// When creating a new shared memory object, we add to this
+	//   - O_CREAT: Create the shared memory object if it does not exist.
+	//   - O_EXCL: Return an error if a shared memory object with the given name already exists.
+	const int shm_oflags = create_new ? O_RDWR | O_CREAT | O_EXCL : O_RDWR;
 
 	// Create the shared memory file in read/write mode with 600 permissions
-	int fd = shm_open(sharedMemory.name, shm_oflags, S_IRUSR | S_IWUSR);
+	errno = 0;
+	const int fd = shm_open(sharedMemory.name, shm_oflags, S_IRUSR | S_IWUSR);
 
 	// Check for `shm_open` error
 	if(fd == -1)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -11,6 +11,13 @@
   [[ ${lines[6]} == "" ]]
 }
 
+@test "Running a second instance is detected and prevented" {
+  run bash -c 'su pihole -s /bin/sh -c "/home/pihole/pihole-FTL -f"'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[9]} == *"Initialization of shared memory failed." ]]
+  [[ ${lines[10]} == *"--> pihole-FTL is already running as PID "* ]]
+}
+
 @test "Starting tests without prior history" {
   run bash -c 'grep -c "Total DNS queries: 0" /var/log/pihole-FTL.log'
   printf "%s\n" "${lines[@]}"
@@ -499,8 +506,8 @@
   [[ ${lines[0]} == "0" ]]
 }
 
-@test "No FATAL messages in pihole-FTL.log" {
-  run bash -c 'grep -c "FATAL:" /var/log/pihole-FTL.log'
+@test "No FATAL messages in pihole-FTL.log (besides error due to starting FTL more than once)" {
+  run bash -c 'grep "FATAL:" /var/log/pihole-FTL.log | grep -c -v "FATAL: create_shm(): Failed to create shared memory object \"FTL-lock\": File exists"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Undo some shared memory code from the time when we wanted to be able to resume shared memory still in use by an external (Rust) component. FTL should always be the one and only shared memory holder.

This allows us to detect if shared memory objects are currently used and, if so, inferring that another FTL process is running. If this is the case, we stop start startup process early enough to not cause any trouble for the running FTL instance, preventing it from crashing.

In addition, we print some useful lines to the log that should aid self-helping:
```
[2021-02-05 11:45:56.691 18850M] ########## FTL started! ##########
[2021-02-05 11:45:56.691 18850M] FTL branch: fix/no_shmem_stealing
[2021-02-05 11:45:56.691 18850M] FTL version: v5.6-6-gf7035ddf
[2021-02-05 11:45:56.691 18850M] FTL commit: f7035ddf
[2021-02-05 11:45:56.691 18850M] FTL date: 2021-02-05 11:39:59 +0100
[2021-02-05 11:45:56.691 18850M] FTL user: pihole
[2021-02-05 11:45:56.691 18850M] Compiled for x86_64 (compiled locally) using cc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
[2021-02-05 11:45:56.691 18850M] FATAL: create_shm(): Failed to create shared memory object "FTL-lock": File exists
[2021-02-05 11:45:56.691 18850M] Initialization of shared memory failed.
[2021-02-05 11:45:56.696 18850M] ---> pihole-FTL is already running as PID 15691 (started 2021-02-05 10:59:18, child of PID 1 (systemd))
[2021-02-05 11:45:56.697 18850M] ---> pihole-FTL is already running as PID 15698 (started 2021-02-05 10:59:18, child of PID 15691 (pihole-FTL))
```
In this snippet, we see two PIDs for the running FTL instance. One is a TCP worker but our message makes clear that it is related to the other process (and not a zombie or whatever).