### PR TITLE
Improvements for `dhcp-discover`

### DIFF
--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -20,7 +20,7 @@
 #include <setjmp.h>
 
 /* Pi-hole modification */
-extern char *get_FTL_version(void);
+#include "../log.h"
 /************************/
 
 static volatile int mem_recover = 0;
@@ -5059,7 +5059,7 @@ void read_opts(int argc, char **argv, char *compile_opts)
   /************************/
 #endif
   /******** Pi-hole modification ********/
-  add_txt("version.FTL", get_FTL_version(), 0 );
+  add_txt("version.FTL", (char*)get_FTL_version(), 0 );
   /**************************************/
 
   while (1) 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Do not explicitly request a lease time in our DHCPREQUEST as this may lead to incorrect responses. Also, when sending a request to lo, we should send it to the interface address instead of the broadcast (lo doesn't support broadcast destinations).