### PR TITLE
Fix inconsistent counters on CNAME or exernally blocked queries

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -522,6 +522,8 @@ void DB_read_queries(void)
 				break;
 
 			case QUERY_FORWARDED: // Forwarded
+			case QUERY_RETRIED: // (fall through)
+			case QUERY_RETRIED_DNSSEC: // (fall through)
 				counters->forwarded++;
 				upstreamsData *upstream = getUpstream(upstreamID, true);
 				if(upstream != NULL)
@@ -539,8 +541,6 @@ void DB_read_queries(void)
 				overTime[timeidx].cached++;
 				break;
 
-			case QUERY_RETRIED: // Retried query
-			case QUERY_RETRIED_DNSSEC: // fall through
 			case QUERY_IN_PROGRESS:
 				// Nothing to be done here
 				break;

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -388,12 +388,11 @@ void DB_read_queries(void)
 			continue;
 		}
 
-		const char *upstream = NULL;
+		const char *buffer = NULL;
 		int upstreamID = -1; // Default if not forwarded
-		// Determine upstreamID only when status == 2 (forwarded) as the
-		// field need not to be filled for other query status types
+		// Try to extract the upstream from the "forward" column if non-empty
 		if(sqlite3_column_bytes(stmt, 6) > 0 &&
-		   (upstream = (const char *)sqlite3_column_text(stmt, 6)) != NULL)
+		   (buffer = (const char *)sqlite3_column_text(stmt, 6)) != NULL)
 		{
 			// Get IP address and port of upstream destination
 			char serv_addr[INET6_ADDRSTRLEN] = { 0 };
@@ -401,9 +400,9 @@ void DB_read_queries(void)
 			// We limit the number of bytes written into the serv_addr buffer
 			// to prevent buffer overflows. If there is no port available in
 			// the database, we skip extracting them and use the default port
-			sscanf(upstream, "%"xstr(INET6_ADDRSTRLEN)"[^#]#%u", serv_addr, &serv_port);
+			sscanf(buffer, "%"xstr(INET6_ADDRSTRLEN)"[^#]#%u", serv_addr, &serv_port);
 			serv_addr[INET6_ADDRSTRLEN-1] = '\0';
-			upstreamID = findUpstreamID(serv_addr, (in_port_t)serv_port, true);
+			upstreamID = findUpstreamID(serv_addr, (in_port_t)serv_port);
 		}
 
 		// Obtain IDs only after filtering which queries we want to keep
@@ -524,6 +523,12 @@ void DB_read_queries(void)
 
 			case QUERY_FORWARDED: // Forwarded
 				counters->forwarded++;
+				upstreamsData *upstream = getUpstream(upstreamID, true);
+				if(upstream != NULL)
+				{
+					upstream->count++;
+					upstream->lastQuery = queryTimeStamp;
+				}
 				// Update overTime data structure
 				overTime[timeidx].forwarded++;
 				break;

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -69,7 +69,7 @@ int findQueryID(const int id)
 	return -1;
 }
 
-int findUpstreamID(const char * upstreamString, const in_port_t port, const bool count)
+int findUpstreamID(const char * upstreamString, const in_port_t port)
 {
 	// Go through already knows upstream servers and see if we used one of those
 	for(int upstreamID=0; upstreamID < counters->upstreams; upstreamID++)
@@ -82,14 +82,7 @@ int findUpstreamID(const char * upstreamString, const in_port_t port, const bool
 			continue;
 
 		if(strcmp(getstr(upstream->ippos), upstreamString) == 0 && upstream->port == port)
-		{
-			if(count)
-			{
-				upstream->count++;
-				upstream->lastQuery = time(NULL);
-			}
 			return upstreamID;
-		}
 	}
 	// This upstream server is not known
 	// Store ID
@@ -110,10 +103,7 @@ int findUpstreamID(const char * upstreamString, const in_port_t port, const bool
 	// Set magic byte
 	upstream->magic = MAGICBYTE;
 	// Initialize its counter
-	if(count)
-		upstream->count = 1;
-	else
-		upstream->count = 0;
+	upstream->count = 0;
 	// Save upstream destination IP address
 	upstream->ippos = addstr(upstreamString);
 	upstream->failed = 0;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -111,7 +111,7 @@ ASSERT_SIZEOF(DNSCacheData, 16, 16, 16);
 
 void strtolower(char *str);
 int findQueryID(const int id);
-int findUpstreamID(const char * upstream, const in_port_t port, const bool count);
+int findUpstreamID(const char * upstream, const in_port_t port);
 int findDomainID(const char *domain, const bool count);
 int findClientID(const char *client, const bool count, const bool aliasclient);
 int findCacheID(int domainID, int clientID, enum query_types query_type);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -867,8 +867,18 @@ void _FTL_forwarded(const unsigned int flags, const char *name, const struct ser
 
 	// Get ID of upstream destination, create new upstream record
 	// if not found in current data structure
-	const int upstreamID = findUpstreamID(upstreamIP, upstreamPort, true);
+	const int upstreamID = findUpstreamID(upstreamIP, upstreamPort);
 	query->upstreamID = upstreamID;
+
+	upstreamsData *upstream = getUpstream(upstreamID, true);
+	if(upstream != NULL)
+	{
+		upstream->count++;
+		upstream->lastQuery = time(NULL);
+	}
+
+	// Update counter for forwarded queries
+	counters->forwarded++;
 
 	// Get time index for this query
 	const unsigned int timeidx = query->timeidx;
@@ -919,9 +929,6 @@ void _FTL_forwarded(const unsigned int flags, const char *name, const struct ser
 
 	// Update overTime data
 	overTime[timeidx].forwarded++;
-
-	// Update counter for forwarded queries
-	counters->forwarded++;
 
 	// Release allocated memory
 	free(upstreamIP);
@@ -1258,27 +1265,12 @@ static void query_externally_blocked(const int queryID, const enum query_status 
 		return;
 	}
 
-	// Get time index
-	const unsigned int timeidx = query->timeidx;
-
 	// If query is already known to be externally blocked,
 	// then we have nothing to do here
 	if(query->status == QUERY_EXTERNAL_BLOCKED_IP ||
 	   query->status == QUERY_EXTERNAL_BLOCKED_NULL ||
 	   query->status == QUERY_EXTERNAL_BLOCKED_NXRA)
 		return;
-
-	// Correct counters if necessary ...
-	if(query->status == QUERY_FORWARDED)
-	{
-		counters->forwarded--;
-		overTime[timeidx].forwarded--;
-
-		// Get forward pointer
-		upstreamsData* upstream = getUpstream(query->upstreamID, true);
-		if(upstream != NULL)
-			upstream->count--;
-	}
 
 	// Mark query as blocked
 	domainsData* domain = getDomain(query->domainID, true);
@@ -1427,6 +1419,12 @@ static void query_blocked(queriesData* query, domainsData* domain, clientsData* 
 	else if(query->status == QUERY_FORWARDED)
 	{
 		counters->forwarded--;
+		overTime[query->timeidx].forwarded--;
+
+		// Get forward pointer
+		upstreamsData* upstream = getUpstream(query->upstreamID, true);
+		if(upstream != NULL)
+			upstream->count--;
 	}
 	else if(query->status == QUERY_CACHE)
 	{
@@ -1883,7 +1881,7 @@ void FTL_forwarding_retried(const struct server *serv, const int oldID, const in
 	strtolower(upstreamIP);
 
 	// Get upstream ID
-	const int upstreamID = findUpstreamID(upstreamIP, upstreamPort, false);
+	const int upstreamID = findUpstreamID(upstreamIP, upstreamPort);
 
 	// Possible debugging information
 	if(config.debug & DEBUG_QUERIES)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1899,7 +1899,7 @@ void FTL_forwarding_retried(const struct server *serv, const int oldID, const in
 
 	// Search for corresponding query identified by ID
 	// Retried DNSSEC queries are ignored, we have to flag themselves (newID)
-	// Retried normal queries take over, we have to flat the original query (oldID)
+	// Retried normal queries take over, we have to flag the original query (oldID)
 	const int queryID = findQueryID(dnssec ? newID : oldID);
 	if(queryID >= 0)
 	{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix queries sent upstream being counted incorrectly when modified later on (blocked externally, blocked during CNAME inspection). This also applies to queries loaded from the database.