### PR TITLE
Fix incorrect "FATAL: Trying to access upstream ID -1" warning in the logs

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -525,11 +525,16 @@ void DB_read_queries(void)
 			case QUERY_RETRIED: // (fall through)
 			case QUERY_RETRIED_DNSSEC: // (fall through)
 				counters->forwarded++;
-				upstreamsData *upstream = getUpstream(upstreamID, true);
-				if(upstream != NULL)
+				// Only update upstream if there is one (there
+				// won't be one for retried DNSSEC queries)
+				if(upstreamID > -1)
 				{
-					upstream->count++;
-					upstream->lastQuery = queryTimeStamp;
+					upstreamsData *upstream = getUpstream(upstreamID, true);
+					if(upstream != NULL)
+					{
+						upstream->count++;
+						upstream->lastQuery = queryTimeStamp;
+					}
 				}
 				// Update overTime data structure
 				overTime[timeidx].forwarded++;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1933,7 +1933,7 @@ void FTL_forwarding_retried(const struct server *serv, const int oldID, const in
 		{
 			if(dnssec)
 			{
-				// There is point in retrying the query when
+				// There is no point in retrying the query when
 				// we've already got an answer to this query,
 				// but we're awaiting keys for DNSSEC
 				// validation. We're retrying the DNSSEC query

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -994,6 +994,10 @@ domainsData* _getDomain(int domainID, bool checkMagic, int line, const char * fu
 
 upstreamsData* _getUpstream(int upstreamID, bool checkMagic, int line, const char * function, const char * file)
 {
+	// This does not exist, we return a NULL pointer
+	if(upstreamID == -1)
+		return NULL;
+
 	if(check_range(upstreamID, counters->upstreams_MAX, "upstream", line, function, file) &&
 	   check_magic(upstreamID, checkMagic, upstreams[upstreamID].magic, "upstream", line, function, file))
 		return &upstreams[upstreamID];


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Retried queries due to missing DNSSEC validation have no upstream server (the related DNSSEC queries where retried, not this one). Hence, we shouldn't update the counts of any upstream here. This silences an incorrect "FATAL: Trying to access upstream ID -1" warning in the logs.

This issue has been reported on Discourse (see link below).