### PR TITLE
Fix for `pihole-FTL test`

### DIFF
--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -281,23 +281,24 @@ static int listener(const int sockfd, const char type)
 void close_telnet_socket(void)
 {
 	// Using global variable here
-	if(telnetfd4)
+	if(telnetfd4 != 0)
 		close(telnetfd4);
-	if(telnetfd6)
+	if(telnetfd6 != 0)
 		close(telnetfd6);
 }
 
 void close_unix_socket(bool unlink_file)
 {
+	// Using global variable here
+	if(sock_avail != 0)
+		close(socketfd);
+
+	// The process has to take care of unlinking the socket file description
+	// on exit
 	if(unlink_file)
 	{
-		// The process has to take care of unlinking the socket file description on exit
 		unlink(FTLfiles.socketfile);
 	}
-
-	// Using global variable here
-	if(sock_avail)
-		close(socketfd);
 }
 
 static void *telnet_connection_handler_thread(void *socket_desc)

--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -421,8 +421,8 @@ void *telnet_listening_thread_IPv4(void *args)
 	if(!ipv4telnet)
 		return NULL;
 
-	// Listen as long as FTL is not killed
-	while(!killed)
+	// Listen as long as this thread is not canceled
+	while(true)
 	{
 		// Look for new clients that want to connect
 		const int csck = listener(telnetfd4, 4);
@@ -470,8 +470,8 @@ void *telnet_listening_thread_IPv6(void *args)
 	if(!ipv6telnet)
 		return NULL;
 
-	// Listen as long as FTL is not killed
-	while(!killed)
+	// Listen as long as this thread is not canceled
+	while(true)
 	{
 		// Look for new clients that want to connect
 		const int csck = listener(telnetfd6, 6);
@@ -519,8 +519,8 @@ void *socket_listening_thread(void *args)
 		return NULL;
 	}
 
-	// Listen as long as FTL is not killed
-	while(!killed)
+	// Listen as long as this thread is not canceled
+	while(true)
 	{
 		// Look for new clients that want to connect
 		const int csck = listener(socketfd, 0);
@@ -541,7 +541,7 @@ void *socket_listening_thread(void *args)
 			logg("WARNING: Unable to open socket processing thread: %s", strerror(errno));
 		}
 	}
-	return false;
+	return NULL;
 }
 
 bool ipv6_available(void)

--- a/src/args.c
+++ b/src/args.c
@@ -188,6 +188,9 @@ void parse_args(int argc, char* argv[])
 			argv_dnsmasq[1] = "-d";
 		}
 
+		// Full start FTL but shut down immediately once everything is up
+		// This ensures we'd catch any dnsmasq config errors,
+		// incorrect file permissions, etc.
 		if(strcmp(argv[i], "test") == 0)
 		{
 			killed = 1;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -169,18 +169,12 @@ pid_t FTL_gettid(void)
 void cleanup(const int ret)
 {
 	// Terminate threads before closing database connections and finishing shared memory
-	if(telnet_listenthreadv4 != 0u)
-		pthread_cancel(telnet_listenthreadv4);
-	if(telnet_listenthreadv6 != 0u)
-		pthread_cancel(telnet_listenthreadv6);
-	if(socket_listenthread != 0u)
-		pthread_cancel(socket_listenthread);
-	if(DBthread != 0u)
-		pthread_cancel(DBthread);
-	if(GCthread != 0u)
-		pthread_cancel(GCthread);
-	if(DNSclientthread != 0u)
-		pthread_cancel(DNSclientthread);
+	pthread_cancel(telnet_listenthreadv4);
+	pthread_cancel(telnet_listenthreadv6);
+	pthread_cancel(socket_listenthread);
+	pthread_cancel(DBthread);
+	pthread_cancel(GCthread);
+	pthread_cancel(DNSclientthread);
 
 	// Close gravity database connection
 	gravityDB_close();

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -168,6 +168,20 @@ pid_t FTL_gettid(void)
 // Clean up on exit
 void cleanup(const int ret)
 {
+	// Terminate threads before closing database connections and finishing shared memory
+	if(telnet_listenthreadv4 != 0u)
+		pthread_cancel(telnet_listenthreadv4);
+	if(telnet_listenthreadv6 != 0u)
+		pthread_cancel(telnet_listenthreadv6);
+	if(socket_listenthread != 0u)
+		pthread_cancel(socket_listenthread);
+	if(DBthread != 0u)
+		pthread_cancel(DBthread);
+	if(GCthread != 0u)
+		pthread_cancel(GCthread);
+	if(DNSclientthread != 0u)
+		pthread_cancel(DNSclientthread);
+
 	// Close gravity database connection
 	gravityDB_close();
 

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -12,11 +12,10 @@
 
 void go_daemon(void);
 void savepid(void);
-char * getUserName(void);
-void removepid(void);
+char *getUserName(void);
 void delay_startup(void);
 bool is_fork(const pid_t mpid, const pid_t pid) __attribute__ ((const));
-
+void cleanup(const int ret);
 
 #include <sys/syscall.h>
 #include <unistd.h>

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -36,7 +36,8 @@ void *DB_thread(void *val)
 	// to the database
 	time_t lastDBsave = time(NULL) - time(NULL)%config.DBinterval;
 
-	while(!killed)
+	// Run as long as this thread is not canceled
+	while(true)
 	{
 		if(FTL_DB_avail())
 		{

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -17,6 +17,8 @@
 #include "gravity-db.h"
 // cli_mode
 #include "../args.h"
+// cleanup()
+#include "../daemon.h"
 
 static const char *message_types[MAX_MESSAGE] =
 	{ "REGEX", "SUBNET", "HOSTNAME", "DNSMASQ_CONFIG" };
@@ -271,4 +273,8 @@ void logg_fatal_dnsmasq_message(const char *message)
 	// Log to database (we have to open the database at this point)
 	dbopen();
 	add_message(DNSMASQ_CONFIG_MESSAGE, message, 0);
+
+	// FTL will dies after this point, so we should make sure to clean up
+	// behind ourselves
+	cleanup(EXIT_FAILURE);
 }

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -12,7 +12,7 @@
 
 int get_number_of_queries_in_DB(void);
 void delete_old_queries_in_DB(void);
-void DB_save_queries(void);
+bool DB_save_queries(void);
 void DB_read_queries(void);
 
 #endif //DATABASE_QUERY_TABLE_H

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -19,6 +19,8 @@
 
 #include "dnsmasq.h"
 #include "../dnsmasq_interface.h"
+// killed
+#include "../signals.h"
 
 struct daemon *daemon;
 
@@ -1026,6 +1028,10 @@ int main_dnsmasq (int argc, char **argv)
   /* Using inotify, have to select a resolv file at startup */
   poll_resolv(1, 0, now);
 #endif
+
+  /*** Pi-hole modification ***/
+  terminate = killed;
+  /****************************/
   
   while (!terminate)
     {

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1740,12 +1740,12 @@ static void save_reply_type(const unsigned int flags, const union all_addr *addr
 	                            query->response;
 }
 
-pthread_t telnet_listenthreadv4;
-pthread_t telnet_listenthreadv6;
-pthread_t socket_listenthread;
-pthread_t DBthread;
-pthread_t GCthread;
-pthread_t DNSclientthread;
+pthread_t telnet_listenthreadv4 = 0u;
+pthread_t telnet_listenthreadv6 = 0u;
+pthread_t socket_listenthread = 0u;
+pthread_t DBthread = 0u;
+pthread_t GCthread = 0u;
+pthread_t DNSclientthread = 0u;
 
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 {

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1768,10 +1768,6 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 	pthread_attr_t attr;
 	// Initialize thread attributes object with default attribute values
 	pthread_attr_init(&attr);
-	// When a detached thread terminates, its resources are automatically
-	// released back to the system without the need for another thread to
-	// join with the terminated thread
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
 	// Start TELNET IPv4 thread
 	if(pthread_create( &telnet_listenthreadv4, &attr, telnet_listening_thread_IPv4, NULL ) != 0)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1740,12 +1740,12 @@ static void save_reply_type(const unsigned int flags, const union all_addr *addr
 	                            query->response;
 }
 
-pthread_t telnet_listenthreadv4 = 0u;
-pthread_t telnet_listenthreadv6 = 0u;
-pthread_t socket_listenthread = 0u;
-pthread_t DBthread = 0u;
-pthread_t GCthread = 0u;
-pthread_t DNSclientthread = 0u;
+pthread_t telnet_listenthreadv4;
+pthread_t telnet_listenthreadv6;
+pthread_t socket_listenthread;
+pthread_t DBthread;
+pthread_t GCthread;
+pthread_t DNSclientthread;
 
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 {

--- a/src/gc.c
+++ b/src/gc.c
@@ -41,7 +41,9 @@ void *GC_thread(void *val)
 	// Remember when we last ran the actions
 	time_t lastGCrun = time(NULL) - time(NULL)%GCinterval;
 	time_t lastRateLimitCleaner = time(NULL);
-	while(!killed)
+
+	// Run as long as this thread is not canceled
+	while(true)
 	{
 		const time_t now = time(NULL);
 		if((unsigned int)(now - lastRateLimitCleaner) >= config.rate_limit.interval)

--- a/src/main.c
+++ b/src/main.c
@@ -98,11 +98,6 @@ int main (int argc, char* argv[])
 
 	logg("Shutting down...");
 
-	// Cancel active threads as we don't need them any more
-	if(ipv4telnet) pthread_cancel(telnet_listenthreadv4);
-	if(ipv6telnet) pthread_cancel(telnet_listenthreadv6);
-	pthread_cancel(socket_listenthread);
-
 	// Save new queries to database (if database is used)
 	if(config.DBexport)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,7 @@ int main (int argc, char* argv[])
 	if(!init_shmem(true))
 	{
 		logg("Initialization of shared memory failed.");
+		// Check if there is already a running FTL process
 		check_running_FTL();
 		return EXIT_FAILURE;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,6 @@
 #include "FTL.h"
 #include "daemon.h"
 #include "log.h"
-#include "api/socket.h"
 #include "setupVars.h"
 #include "args.h"
 #include "config.h"
@@ -20,9 +19,9 @@
 #include "main.h"
 #include "signals.h"
 #include "regex_r.h"
+// init_shmem()
 #include "shmem.h"
 #include "capabilities.h"
-#include "database/gravity-db.h"
 #include "timers.h"
 #include "procps.h"
 
@@ -105,27 +104,7 @@ int main (int argc, char* argv[])
 		logg("Finished final database update");
 	}
 
-	// Close sockets and delete Unix socket file handle
-	close_telnet_socket();
-	close_unix_socket(true);
+	cleanup(exit_code);
 
-	// Empty API port file, port 0 = truncate file
-	saveport(0);
-
-	// Close gravity database connection
-	gravityDB_close();
-
-	// Remove shared memory objects
-	// Important: This invalidated all objects such as
-	//            counters-> ... Do this last when
-	//            terminating in main.c !
-	destroy_shmem();
-
-	//Remove PID file
-	removepid();
-
-	char buffer[42] = { 0 };
-	format_time(buffer, 0, timer_elapsed_msec(EXIT_TIMER));
-	logg("########## FTL terminated after%s! ##########", buffer);
 	return exit_code;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -97,12 +97,15 @@ int main (int argc, char* argv[])
 	main_dnsmasq(argc_dnsmasq, argv_dnsmasq);
 
 	logg("Shutting down...");
+	// Extra grace time is needed as dnsmasq script-helpers may not be
+	// terminating immediately
+	sleepms(250);
 
 	// Save new queries to database (if database is used)
 	if(config.DBexport)
 	{
-		DB_save_queries();
-		logg("Finished final database update");
+		if(DB_save_queries())
+			logg("Finished final database update");
 	}
 
 	cleanup(exit_code);

--- a/src/procps.h
+++ b/src/procps.h
@@ -10,6 +10,6 @@
 
 #ifndef PROCPS_H
 #define PROCPS_H
-void check_running_FTL(void);
+bool check_running_FTL(void);
 
 #endif // POCPS_H

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -584,7 +584,8 @@ void *DNSclient_thread(void *val)
 	// Initial delay until we first try to resolve anything
 	sleepms(2000);
 
-	while(!killed)
+	// Run as long as this thread is not canceled
+	while(true)
 	{
 		// Run whenever necessary to resolve only new clients and
 		// upstream servers

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -89,10 +89,16 @@ void delete_shm(SharedMemory *sharedMemory);
 /// Block until a lock can be obtained
 #define lock_shm() _lock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _lock_shm(const char* func, const int line, const char* file);
+#define lock_log() _lock_log(__FUNCTION__, __LINE__, __FILE__)
+void _lock_log(const char* func, const int line, const char* file);
 
 /// Unlock the lock. Only call this if there is an active lock.
 #define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _unlock_shm(const char* func, const int line, const char* file);
+#define unlock_log() _unlock_log(__FUNCTION__, __LINE__, __FILE__)
+void _unlock_log(const char* func, const int line, const char * file);
+
+/// Block until a lock can be obtained
 
 bool init_shmem(bool create_new);
 void destroy_shmem(void);

--- a/src/signals.c
+++ b/src/signals.c
@@ -237,7 +237,7 @@ static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, voi
 	else
 	{
 		// This is the main process
-		logg("FTL terminated!");
+		cleanup(EXIT_FAILURE);
 	}
 
 	// Terminate process indicating failure

--- a/src/syscalls/vsnprintf.c
+++ b/src/syscalls/vsnprintf.c
@@ -15,13 +15,6 @@
 #undef vsnprintf
 int FTLvsnprintf(const char *file, const char *func, const int line, char *__restrict__ buffer, const size_t maxlen, const char *format, va_list args)
 {
-	// Sanity check
-	if(buffer == NULL)
-	{
-		syscalls_report_error("vsnprintf() called with NULL buffer",
-		                      stdout, 0, format, func, file, line);
-		return 0;
-	}
 	// Print into dynamically allocated memory
 	int _errno, length = 0;
 	do

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -15,7 +15,7 @@
   run bash -c 'su pihole -s /bin/sh -c "/home/pihole/pihole-FTL -f"'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[9]} == *"Initialization of shared memory failed." ]]
-  [[ ${lines[10]} == *"--> pihole-FTL is already running as PID "* ]]
+  [[ ${lines[10]} == *"HINT: pihole-FTL is already running!"* ]]
 }
 
 @test "Starting tests without prior history" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix a few issues revealed when checking why `pihole-FTL test` doesn't work as expected:
1. The `test` option is currently broken: It immediately terminates all FTL components (threads surrounding the resolver, etc.), however, it did not terminate the resolver itself leading to an attempt to `kill` the resolver in the docker container.
1. The log file lock should be shared among processes to ensure we cannot outpace forks (which may result in a log deadlock). This may fix #906 as byproduct of our improvements in here
2. We should not detach threads we want to cancel explicitly later on when terminating
3. Ensure we clean up behind us on crashes and fatal errors (such as port 53 not available, `dnsmasq` config errors, etc.)
4. Improve process-already-running detection (better formatting)

This fixes #1063 and #1064 