### PR TITLE
Escape DHCP options if necessary

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -372,7 +372,12 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet_data *offer_pack
 			}
 			else
 			{
-				logg("Unknown option %d with length %d", opttype, optlen);
+				logg_sameline("Unknown option %d:", opttype);
+				// Print bytes
+				for(unsigned i = 0; i < optlen; i++)
+					logg_sameline(" %02X", (unsigned char)offer_packet->options[x+i]);
+				// Add newline when done above
+				logg(" (length %d)", optlen);
 			}
 		}
 

--- a/src/log.h
+++ b/src/log.h
@@ -33,4 +33,6 @@ void FTL_log_dnsmasq_fatal(const char *format, ...) __attribute__ ((format (gnu_
 void log_ctrl(bool vlog, bool vstdout);
 void FTL_log_helper(const unsigned char n, ...);
 
+int binbuf_to_escaped_C_literal(const char *src_buf, size_t src_sz, char *dst_str, size_t dst_sz);
+
 #endif //LOG_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Sanitize string returned by DHCP servers in `dhcp-discover` to reveal if they contain binary garbage like control characters (where they shouldn't).

**edit** Also implement DHCPv4 PCP Option (RFC 7291)