### PR TITLE
Resize shared memory only when locking

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -396,6 +396,9 @@ void DB_read_queries(void)
 			continue;
 		}
 
+		// Lock shared memory
+		lock_shm();
+
 		const char *buffer = NULL;
 		int upstreamID = -1; // Default if not forwarded
 		// Try to extract the upstream from the "forward" column if non-empty
@@ -417,9 +420,6 @@ void DB_read_queries(void)
 		const int timeidx = getOverTimeID(queryTimeStamp);
 		const int domainID = findDomainID(domainname, true);
 		const int clientID = findClientID(clientIP, true, false);
-
-		// Ensure we have enough space in the queries struct
-		memory_check(QUERIES);
 
 		// Set index for this query
 		const int queryIndex = counters->queries;
@@ -558,6 +558,8 @@ void DB_read_queries(void)
 				logg("Warning: Found unknown status %i in long term database!", status);
 				break;
 		}
+
+		unlock_shm();
 	}
 	logg("Imported %i queries from the long-term database", counters->queries);
 

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -89,9 +89,6 @@ int findUpstreamID(const char * upstreamString, const in_port_t port)
 	const int upstreamID = counters->upstreams;
 	logg("New upstream server: %s:%u (%i/%u)", upstreamString, port, upstreamID, counters->upstreams_MAX);
 
-	// Check struct size
-	memory_check(UPSTREAMS);
-
 	// Get upstream pointer
 	upstreamsData* upstream = getUpstream(upstreamID, false);
 	if(upstream == NULL)
@@ -152,9 +149,6 @@ int findDomainID(const char *domainString, const bool count)
 	// Store ID
 	const int domainID = counters->domains;
 
-	// Check struct size
-	memory_check(DOMAINS);
-
 	// Get domain pointer
 	domainsData* domain = getDomain(domainID, false);
 	if(domain == NULL)
@@ -211,9 +205,6 @@ int findClientID(const char *clientIP, const bool count, const bool aliasclient)
 	// If we did not return until here, then this client is definitely new
 	// Store ID
 	const int clientID = counters->clients;
-
-	// Check struct size
-	memory_check(CLIENTS);
 
 	// Get client pointer
 	clientsData* client = getClient(clientID, false);
@@ -331,9 +322,6 @@ int findCacheID(int domainID, int clientID, enum query_types query_type)
 
 	// Get ID of new cache entry
 	const int cacheID = counters->dns_cache_size;
-
-	// Check struct size
-	memory_check(DNS_CACHE);
 
 	// Get client pointer
 	DNSCacheData* dns_cache = getDNSCache(cacheID, false);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -569,6 +569,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 
 	// Lock shared memory
 	lock_shm();
+	const int queryID = counters->queries;
 
 	// Find client IP
 	const int clientID = findClientID(clientIP, true, false);
@@ -603,10 +604,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		unlock_shm();
 		return true;
 	}
-
-	// Ensure we have enough space in the queries struct
-	memory_check(QUERIES);
-	const int queryID = counters->queries;
 
 	// Log new query if in debug mode
 	if(config.debug & DEBUG_QUERIES)

--- a/src/files.c
+++ b/src/files.c
@@ -83,7 +83,7 @@ void ls_dir(const char* path)
 	char full_path[strlen(path)+NAME_MAX+2];
 
 	logg("------ Listing content of directory %s ------", path);
-	logg("File Mode User:Group  Filesize Filename");
+	logg("File Mode User:Group      Size  Filename");
 
 	struct dirent *dircontent = NULL;
 	// Walk directory file by file
@@ -112,12 +112,12 @@ void ls_dir(const char* path)
 			snprintf(user, sizeof(user), "%d", st.st_uid);
 
 		struct group *grp;
-		char group[256];
+		char usergroup[256];
 		// Get out group name
 		if ((grp = getgrgid(st.st_gid)) != NULL)
-			snprintf(group, sizeof(group), "%s", grp->gr_name);
+			snprintf(usergroup, sizeof(usergroup), "%s:%s", user, grp->gr_name);
 		else
-			snprintf(group, sizeof(group), "%d", st.st_gid);
+			snprintf(usergroup, sizeof(usergroup), "%s:%d", user, st.st_gid);
 
 		char permissions[10];
 		// Get human-readable format of permissions as known from ls
@@ -138,7 +138,7 @@ void ls_dir(const char* path)
 		format_memory_size(prefix, (unsigned long long)st.st_size, &formated);
 
 		// Log output for this file
-		logg("%s %s:%s %.0f%s %s", permissions, user, group, formated, prefix, filename);
+		logg("%s %-15s %3.0f%s  %s", permissions, usergroup, formated, prefix, filename);
 	}
 
 	logg("---------------------------------------------------");

--- a/src/log.c
+++ b/src/log.c
@@ -226,7 +226,7 @@ void format_memory_size(char * const prefix, const unsigned long long int bytes,
 			break;
 		*formated /= 1e3;
 	}
-	const char* prefixes[8] = { "", "K", "M", "G", "T", "P", "E", "?" };
+	const char* prefixes[8] = { " ", "K", "M", "G", "T", "P", "E", "?" };
 	// Chose matching SI prefix
 	strcpy(prefix, prefixes[i]);
 }

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -254,7 +254,7 @@ size_t addstr(const char *input)
 	char *str = str_escape(input, &N);
 
 	if(N > 0)
-		logg("INFO: FTL escaped %ui characters in \"%s\"", N, str);
+		logg("INFO: FTL escaped %u characters in \"%s\"", N, str);
 
 	// Debugging output
 	if(config.debug & DEBUG_SHMEM)

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -58,6 +58,7 @@ typedef struct {
 	int reply_domain;
 	int dns_cache_size;
 	int dns_cache_MAX;
+	int per_client_regex_MAX;
 	unsigned int regex_change;
 } countersStruct;
 

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -63,6 +63,7 @@ typedef struct {
 
 extern countersStruct *counters;
 
+#ifdef SHMEM_PRIVATE
 /// Create shared memory
 ///
 /// \param name the name of the shared memory
@@ -70,7 +71,7 @@ extern countersStruct *counters;
 /// \param create_new true = delete old file, create new, false = connect to existing object or fail
 /// \return a structure with a pointer to the mounted shared memory. The pointer
 /// will always be valid, because if it failed FTL will have exited.
-SharedMemory create_shm(const char *name, const size_t size, bool create_new);
+static SharedMemory create_shm(const char *name, const size_t size, bool create_new);
 
 /// Reallocate shared memory
 ///
@@ -79,12 +80,13 @@ SharedMemory create_shm(const char *name, const size_t size, bool create_new);
 /// \param size2 the new size (factor 2)
 /// \param resize whether the object should be resized or only remapped
 /// \return if reallocation was successful
-bool realloc_shm(SharedMemory *sharedMemory, const size_t size1, const size_t size2, const bool resize);
+static bool realloc_shm(SharedMemory *sharedMemory, const size_t size1, const size_t size2, const bool resize);
 
 /// Disconnect from shared memory. If there are no other connections to shared memory, it will be deleted.
 ///
 /// \param sharedMemory the shared memory struct
-void delete_shm(SharedMemory *sharedMemory);
+static void delete_shm(SharedMemory *sharedMemory);
+#endif
 
 /// Block until a lock can be obtained
 #define lock_shm() _lock_shm(__FUNCTION__, __LINE__, __FILE__)
@@ -104,7 +106,6 @@ bool init_shmem(bool create_new);
 void destroy_shmem(void);
 size_t addstr(const char *str);
 const char *getstr(const size_t pos);
-void *enlarge_shmem_struct(const char type);
 
 /**
  * Escapes a string by replacing special characters, such as spaces
@@ -131,12 +132,13 @@ void addOverTimeClientSlot(void);
 // Change ownership of shared memory objects
 void chown_all_shmem(struct passwd *ent_pw);
 
+// Get details about shared memory used by FTL
+void log_shmem_details(void);
+
 // Per-client regex buffer storing whether or not a specific regex is enabled for a particular client
 void add_per_client_regex(unsigned int clientID);
 void reset_per_client_regex(const int clientID);
 bool get_per_client_regex(const int clientID, const int regexID);
 void set_per_client_regex(const int clientID, const int regexID, const bool value);
-
-void memory_check(const enum memory_type which);
 
 #endif //SHARED_MEMORY_SERVER_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Instead of enlarging the shared memory objects whenever we need to do so, we enlarge them only in one central spot - that is the time of successful memory locking. This is not really a functional change, however, it makes the code more read- and understandable. Discussions in the past have shown that the current way of handling it isn't at all easy to understand. Also, this reduces the surface for possible mistakes in the future.