### PR TITLE
Various enhancements and a few memory-leak fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ version*
 # MAC->Vendor database files
 tools/manuf.data
 tools/macvendor.db
+node_modules

--- a/src/FTL.h
+++ b/src/FTL.h
@@ -144,11 +144,4 @@
 #define str(x) # x
 #define xstr(x) str(x)
 
-extern pthread_t telnet_listenthreadv4;
-extern pthread_t telnet_listenthreadv6;
-extern pthread_t socket_listenthread;
-extern pthread_t DBthread;
-extern pthread_t GCthread;
-extern pthread_t DNSclientthread;
-
 #endif // FTL_H

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1228,9 +1228,10 @@ void getDBstats(const int *sock)
 	format_memory_size(prefix, filesize, &formated);
 
 	if(istelnet[*sock])
-		ssend(*sock,"queries in database: %i\ndatabase filesize: %.2f %sB\nSQLite version: %s\n", get_number_of_queries_in_DB(), formated, prefix, get_sqlite3_version());
+		ssend(*sock, "queries in database: %i\ndatabase filesize: %.2f %sB\nSQLite version: %s\n",
+		             get_number_of_queries_in_DB(NULL), formated, prefix, get_sqlite3_version());
 	else {
-		pack_int32(*sock, get_number_of_queries_in_DB());
+		pack_int32(*sock, get_number_of_queries_in_DB(NULL));
 		pack_int64(*sock, filesize);
 
 		if(!pack_str32(*sock, (char *) get_sqlite3_version()))

--- a/src/api/request.c
+++ b/src/api/request.c
@@ -166,12 +166,6 @@ void process_request(const char *client_message, int *sock)
 		read_regex_from_database();
 		unlock_shm();
 	}
-	else if(command(client_message, ">update-mac-vendor"))
-	{
-		processed = true;
-		logg("Received API request to update vendors in network table");
-		updateMACVendorRecords();
-	}
 	else if(command(client_message, ">delete-lease"))
 	{
 		processed = true;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -18,6 +18,8 @@
 #include "api/socket.h"
 // gravityDB_close()
 #include "database/gravity-db.h"
+// dbclose()
+#include "database/common.h"
 // destroy_shmem()
 #include "shmem.h"
 
@@ -183,8 +185,9 @@ void cleanup(const int ret)
 	}
 	logg("All threads joined");
 
-	// Close gravity database connection
+	// Close database connections
 	gravityDB_close();
+	dbclose();
 
 	// Close sockets and delete Unix socket file handle
 	close_telnet_socket();

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -203,9 +203,8 @@ void cleanup(const int ret)
 	}
 	logg("All threads joined");
 
-	// Close database connections
+	// Close database connection
 	gravityDB_close();
-	dbclose();
 
 	// Close sockets and delete Unix socket file handle
 	close_telnet_socket();

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -10,6 +10,9 @@
 #ifndef DAEMON_H
 #define DAEMON_H
 
+#include "enums.h"
+extern pthread_t threads[THREADS_MAX];
+
 void go_daemon(void);
 void savepid(void);
 char *getUserName(void);

--- a/src/database/aliasclients.h
+++ b/src/database/aliasclients.h
@@ -13,12 +13,12 @@
 // type clientsData
 #include "../datastructure.h"
 
-void reset_aliasclient(clientsData *client);
 
-bool create_aliasclients_table(void);
-bool import_aliasclients(void);
-void reimport_aliasclients(void);
+bool create_aliasclients_table(sqlite3 *db);
+bool import_aliasclients(sqlite3 *db);
+void reimport_aliasclients(sqlite3 *db);
 
 int *get_aliasclient_list(const int aliasclientID);
+void reset_aliasclient(sqlite3 *db, clientsData *client);
 
 #endif //ALIASCLIENTS_TABLE_H

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -24,93 +24,57 @@
 // import_aliasclients()
 #include "aliasclients.h"
 
-sqlite3 *FTL_db = NULL;
 bool DBdeleteoldqueries = false;
 long int lastdbindex = 0;
-static bool db_avail = false;
 
-static pthread_mutex_t dblock;
-
-__attribute__ ((pure)) bool FTL_DB_avail(void)
+void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 {
-	return db_avail;
-}
-
-void dbclose(void)
-{
-	// Mark database as being closed
-	db_avail = false;
-
-	if(config.debug & DEBUG_LOCKS)
-		logg("Unlocking FTL database");
+	if(config.debug & DEBUG_DATABASE)
+		logg("Closing FTL database in %s() (%s:%i)", func, file, line);
 
 	// Only try to close an existing database connection
 	int rc = SQLITE_OK;
-	if( FTL_db != NULL )
+	if(db != NULL && *db != NULL)
 	{
-		if(config.debug & DEBUG_DATABASE)
-			logg("Closing FTL database");
-		if((rc = sqlite3_close(FTL_db)) != SQLITE_OK)
+		if((rc = sqlite3_close(*db)) != SQLITE_OK)
 			logg("Encountered error while trying to close database: %s", sqlite3_errstr(rc));
 
-		FTL_db = NULL;
+		*db = NULL;
 	}
-	else if(config.debug & DEBUG_LOCKS)
-		logg("Unlocking FTL database: already NULL");
-
-	// Unlock mutex on the database
-	pthread_mutex_unlock(&dblock);
-
-	if(config.debug & DEBUG_LOCKS)
-		logg("Unlocking FTL database: Success");
 }
 
-bool dbopen(void)
+sqlite3* _dbopen(bool create, const char *func, const int line, const char *file)
 {
-	// Skip subroutine altogether when database is already open
-	if(FTL_db != NULL && FTL_DB_avail())
-	{
-		if(config.debug & DEBUG_LOCKS)
-			logg("Not locking FTL database (already open)");
-		return true;
-	}
-
-	if(config.debug & DEBUG_LOCKS)
-		logg("Locking FTL database");
-
-	// Lock mutex on the database
-	pthread_mutex_lock(&dblock);
-
-	if(config.debug & DEBUG_LOCKS)
-		logg("Locking FTL database: Success");
-
 	// Try to open database
 	if(config.debug & DEBUG_DATABASE)
-		logg("Opening FTL database");
-	int rc = sqlite3_open_v2(FTLfiles.FTL_db, &FTL_db, SQLITE_OPEN_READWRITE, NULL);
+		logg("Opening FTL database in %s() (%s:%i)", func, file, line);
+
+	int flags = SQLITE_OPEN_READWRITE;
+	if(create)
+		flags |= SQLITE_OPEN_CREATE;
+
+	sqlite3 *db = NULL;
+	int rc = sqlite3_open_v2(FTLfiles.FTL_db, &db, flags, NULL);
 	if( rc != SQLITE_OK )
 	{
-		logg("Encountered error while trying to open database: %s", sqlite3_errstr(rc));
-		pthread_mutex_unlock(&dblock);
-		return false;
+		logg("Error while trying to open database: %s", sqlite3_errstr(rc));
+		return NULL;
 	}
 
 	// Explicitly set busy handler to value defined in FTL.h
-	rc = sqlite3_busy_timeout(FTL_db, DATABASE_BUSY_TIMEOUT);
+	rc = sqlite3_busy_timeout(db, DATABASE_BUSY_TIMEOUT);
 	if( rc != SQLITE_OK )
 	{
-		logg("Encountered error while trying to set busy timeout (%d ms) on database: %s",
+		logg("Error while trying to set busy timeout (%d ms) on database: %s",
 		     DATABASE_BUSY_TIMEOUT, sqlite3_errstr(rc));
-		dbclose();
-		return false;
+		dbclose(&db);
+		return NULL;
 	}
 
-	db_avail = true;
-
-	return true;
+	return db;
 }
 
-int dbquery(const char *format, ...)
+int dbquery(sqlite3* db, const char *format, ...)
 {
 	va_list args;
 	va_start(args, format);
@@ -125,7 +89,7 @@ int dbquery(const char *format, ...)
 
 	// Log generated SQL string when dbquery() is called
 	// although the database connection is not available
-	if(!FTL_DB_avail())
+	if(db == NULL)
 	{
 		logg("dbquery(\"%s\") called but database is not available!", query);
 		sqlite3_free(query);
@@ -137,12 +101,12 @@ int dbquery(const char *format, ...)
 		logg("dbquery: \"%s\"", query);
 	}
 
-	int rc = sqlite3_exec(FTL_db, query, NULL, NULL, NULL);
+	int rc = sqlite3_exec(db, query, NULL, NULL, NULL);
 	if( rc != SQLITE_OK ){
 		logg("ERROR: SQL query \"%s\" failed: %s",
 		     query, sqlite3_errstr(rc));
 		sqlite3_free(query);
-		dbclose();
+		dbclose(&db);
 		return rc;
 	}
 
@@ -158,63 +122,51 @@ int dbquery(const char *format, ...)
 	return SQLITE_OK;
 }
 
-static bool create_counter_table(void)
+static bool create_counter_table(sqlite3* db)
 {
 	// Create FTL table in the database (holds properties like database version, etc.)
-	SQL_bool("CREATE TABLE counters ( id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL );");
+	SQL_bool(db, "CREATE TABLE counters ( id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL );");
 
 	// ID 0 = total queries
-	if(!db_set_counter(DB_TOTALQUERIES, 0))
-		return false;
+	db_set_counter(db, DB_TOTALQUERIES, 0);
 
 	// ID 1 = total blocked queries
-	if(!db_set_counter(DB_BLOCKEDQUERIES, 0))
-		return false;
+	db_set_counter(db, DB_BLOCKEDQUERIES, 0);
 
 	// Time stamp of creation of the counters database
-	if(!db_set_FTL_property(DB_FIRSTCOUNTERTIMESTAMP, time(NULL)))
-		return false;
+	db_set_counter(db, DB_FIRSTCOUNTERTIMESTAMP, (unsigned long)time(0));
 
 	// Update database version to 2
-	if(!db_set_FTL_property(DB_VERSION, 2))
-		return false;
+	db_set_FTL_property(db, DB_VERSION, 2);
 
 	return true;
 }
 
 static bool db_create(void)
 {
-	int rc = sqlite3_open_v2(FTLfiles.FTL_db, &FTL_db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
-	if( rc != SQLITE_OK )
-	{
-		logg("Encountered error while trying to create database in rw-mode: %s", sqlite3_errstr(rc));
+	sqlite3 *db = dbopen(true);
+	if(db == NULL)
 		return false;
-	}
-
-	// Mark database as being available so dbquery() doesn't error out
-	db_avail = true;
 
 	// Create Queries table in the database
-	SQL_bool("CREATE TABLE queries ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain TEXT NOT NULL, client TEXT NOT NULL, forward TEXT );");
+	SQL_bool(db, "CREATE TABLE queries ( id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain TEXT NOT NULL, client TEXT NOT NULL, forward TEXT );");
 
 	// Add an index on the timestamps (not a unique index!)
-	SQL_bool("CREATE INDEX idx_queries_timestamps ON queries (timestamp);");
+	SQL_bool(db, "CREATE INDEX idx_queries_timestamps ON queries (timestamp);");
 
 	// Create FTL table in the database (holds properties like database version, etc.)
-	SQL_bool("CREATE TABLE ftl ( id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL );");
-
+	SQL_bool(db, "CREATE TABLE ftl ( id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL );");
 
 	// Set FTL_db version 1
-	if(dbquery("INSERT INTO ftl (ID,VALUE) VALUES(%i,1);", DB_VERSION) != SQLITE_OK)
+	if(!db_set_FTL_property(db, DB_VERSION, 1))
 		return false;
 
 	// Most recent timestamp initialized to 00:00 1 Jan 1970
-	if(dbquery("INSERT INTO ftl (ID,VALUE) VALUES(%i,0);", DB_LASTTIMESTAMP) != SQLITE_OK)
+	if(!db_set_FTL_property(db, DB_LASTTIMESTAMP, 0))
 		return false;
 
-	// Done initializing the database
-	// Close database handle, it will be reopened in db_init()
-	dbclose();
+	// Close database handle
+	dbclose(&db);
 
 	// Explicitly set permissions to 0644
 	// 644 =            u+w       u+r       g+r       o+r
@@ -234,15 +186,6 @@ void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg)
 
 void db_init(void)
 {
-	// Initialize database lock mutex
-	int rc;
-	if((rc = pthread_mutex_init(&dblock, NULL)) != 0)
-	{
-		logg("FATAL: FTL_db mutex init failed (%s, %i)\n", strerror(rc), rc);
-		// Return failure
-		exit(EXIT_FAILURE);
-	}
-
 	// Initialize SQLite3 logging callback
 	// This ensures SQLite3 errors and warnings are logged to pihole-FTL.log
 	// We use this to possibly catch even more errors in places we do not
@@ -259,22 +202,19 @@ void db_init(void)
 		if (!db_create())
 		{
 			logg("Creation of database failed, database is not available");
-			pthread_mutex_unlock(&dblock);
 			return;
 		}
 	}
 
 	// Open database
-	dbopen();
-
-	db_avail = true;
+	sqlite3 *db = dbopen(false);
 
 	// Test FTL_db version and see if we need to upgrade the database file
-	int dbversion = db_get_FTL_property(DB_VERSION);
+	int dbversion = db_get_int(db, DB_VERSION);
 	if(dbversion < 1)
 	{
 		logg("Database not available, please ensure the database is unlocked when starting pihole-FTL !");
-		dbclose();
+		dbclose(&db);
 		return;
 	}
 	else
@@ -288,14 +228,14 @@ void db_init(void)
 	{
 		// Update to version 2: Create counters table
 		logg("Updating long-term database to version 2");
-		if (!create_counter_table())
+		if (!create_counter_table(db))
 		{
 			logg("Counter table not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 3 if lower
@@ -303,14 +243,14 @@ void db_init(void)
 	{
 		// Update to version 3: Create network table
 		logg("Updating long-term database to version 3");
-		if (!create_network_table())
+		if (!create_network_table(db))
 		{
 			logg("Network table not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 4 if lower
@@ -318,14 +258,14 @@ void db_init(void)
 	{
 		// Update to version 4: Unify clients in network table
 		logg("Updating long-term database to version 4");
-		if(!unify_hwaddr())
+		if(!unify_hwaddr(db))
 		{
 			logg("Unable to unify clients in network table, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 5 if lower
@@ -333,14 +273,14 @@ void db_init(void)
 	{
 		// Update to version 5: Create network-addresses table
 		logg("Updating long-term database to version 5");
-		if(!create_network_addresses_table())
+		if(!create_network_addresses_table(db))
 		{
 			logg("Network-addresses table not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 6 if lower
@@ -348,14 +288,14 @@ void db_init(void)
 	{
 		// Update to version 6: Create message table
 		logg("Updating long-term database to version 6");
-		if(!create_message_table())
+		if(!create_message_table(db))
 		{
 			logg("Message table not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 7 if lower
@@ -363,15 +303,15 @@ void db_init(void)
 	{
 		// Update to version 7: Create message table
 		logg("Updating long-term database to version 7");
-		if(dbquery("ALTER TABLE queries ADD COLUMN additional_info TEXT;") != SQLITE_OK ||
-		   !db_set_FTL_property(DB_VERSION, 7))
+		if(dbquery(db, "ALTER TABLE queries ADD COLUMN additional_info TEXT;") != SQLITE_OK ||
+		   !dbquery(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %i );", DB_VERSION, 7) != SQLITE_OK)
 		{
 			logg("Column additional_info not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 8 if lower
@@ -379,14 +319,14 @@ void db_init(void)
 	{
 		// Update to version 8: Add name field to network_addresses table
 		logg("Updating long-term database to version 8");
-		if(!create_network_addresses_with_names_table())
+		if(!create_network_addresses_with_names_table(db))
 		{
 			logg("Network addresses table not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
 	// Update to version 9 if lower
@@ -394,21 +334,21 @@ void db_init(void)
 	{
 		// Update to version 9: Add aliasclients table
 		logg("Updating long-term database to version 9");
-		if(!create_aliasclients_table())
+		if(!create_aliasclients_table(db))
 		{
 			logg("Aliasclients table not initialized, database not available");
-			dbclose();
+			dbclose(&db);
 			return;
 		}
 		// Get updated version
-		dbversion = db_get_FTL_property(DB_VERSION);
+		dbversion = db_get_int(db, DB_VERSION);
 	}
 
-	import_aliasclients();
+	import_aliasclients(db);
 
 	// Close database to prevent having it opened all time
 	// We already closed the database when we returned earlier
-	dbclose();
+	dbclose(&db);
 
 	// Log if users asked us to not use the long-term database for queries
 	// We will still use it to store warnings in it
@@ -422,100 +362,70 @@ void db_init(void)
 	logg("Database successfully initialized");
 }
 
-int db_get_FTL_property(const enum ftl_table_props ID)
+int db_get_int(sqlite3* db, const enum ftl_table_props ID)
 {
-	if(!FTL_DB_avail())
-	{
-		logg("db_get_FTL_property(%u) called but database is not available!", ID);
-		return DB_FAILED;
-	}
 	// Prepare SQL statement
 	char* querystr = NULL;
 	int ret = asprintf(&querystr, "SELECT VALUE FROM ftl WHERE id = %u;", ID);
 
 	if(querystr == NULL || ret < 0)
 	{
-		logg("Memory allocation failed in db_get_FTL_property with ID = %u (%i)", ID, ret);
+		logg("Memory allocation failed in db_get_int db, with ID = %u (%i)", ID, ret);
 		return DB_FAILED;
 	}
 
-	int value = db_query_int(querystr);
+	int value = db_query_int(db, querystr);
 	free(querystr);
 
 	return value;
 }
 
-bool db_set_FTL_property(const enum ftl_table_props ID, const int value)
+bool db_set_FTL_property(sqlite3 *db, const enum ftl_table_props ID, const long value)
 {
-	if(!FTL_DB_avail())
-	{
-		logg("db_set_FTL_property(%u, %i) called but database is not available!", ID, value);
-		return false;
-	}
-	return dbquery("INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %i );", ID, value) == SQLITE_OK;
+	return dbquery(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %ld );", ID, value) == SQLITE_OK;
 }
 
-bool db_set_counter(const enum counters_table_props ID, const int value)
+bool db_set_counter(sqlite3 *db, const enum counters_table_props ID, const long value)
 {
-	if(!FTL_DB_avail())
+	if(dbquery(db, "INSERT OR REPLACE INTO counters (id, value) VALUES ( %u, %ld );", ID, value) != SQLITE_OK)
 	{
-		logg("db_set_counter(%u, %i) called but database is not available!", ID, value);
-		return false;
-	}
-
-	if(dbquery("INSERT OR REPLACE INTO counters (id, value) VALUES ( %u, %i );", ID, value) != SQLITE_OK)
-	{
-		dbclose();
+		dbclose(&db);
 		return false;
 	}
 
 	return true;
 }
 
-bool db_update_counters(const int total, const int blocked)
+bool db_update_counters(sqlite3 *db, const int total, const int blocked)
 {
-	if(!FTL_DB_avail())
+	if(dbquery(db, "UPDATE counters SET value = value + %i WHERE id = %i;", total, DB_TOTALQUERIES) != SQLITE_OK)
 	{
-		logg("db_update_counters(%i, %i) called but database is not available!", total, blocked);
-		dbclose();
+		dbclose(&db);
 		return false;
 	}
 
-	if(dbquery("UPDATE counters SET value = value + %i WHERE id = %i;", total, DB_TOTALQUERIES) != SQLITE_OK)
+	if(dbquery(db, "UPDATE counters SET value = value + %i WHERE id = %i;", blocked, DB_BLOCKEDQUERIES) != SQLITE_OK)
 	{
-		dbclose();
-		return false;
-	}
-
-	if(dbquery("UPDATE counters SET value = value + %i WHERE id = %i;", blocked, DB_BLOCKEDQUERIES) != SQLITE_OK)
-	{
-		dbclose();
+		dbclose(&db);
 		return false;
 	}
 
 	return true;
 }
 
-int db_query_int(const char* querystr)
+int db_query_int(sqlite3 *db, const char* querystr)
 {
-	if(!FTL_DB_avail())
-	{
-		logg("db_query_int(\"%s\") called but database is not available!", querystr);
-		return DB_FAILED;
-	}
-
 	if(config.debug & DEBUG_DATABASE)
 	{
 		logg("dbquery: \"%s\"", querystr);
 	}
 
 	sqlite3_stmt* stmt;
-	int rc = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
+	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
 		if( rc != SQLITE_BUSY )
 			logg("Encountered prepare error in db_query_int(\"%s\"): %s", querystr, sqlite3_errstr(rc));
-
 		return DB_FAILED;
 	}
 
@@ -525,21 +435,15 @@ int db_query_int(const char* querystr)
 	if( rc == SQLITE_ROW )
 	{
 		result = sqlite3_column_int(stmt, 0);
-
 		if(config.debug & DEBUG_DATABASE)
-		{
 			logg("         ---> Result %i (int)", result);
-		}
 	}
 	else if( rc == SQLITE_DONE )
 	{
 		// No rows available
 		result = DB_NODATA;
-
 		if(config.debug & DEBUG_DATABASE)
-		{
 			logg("         ---> No data");
-		}
 	}
 	else
 	{
@@ -551,14 +455,8 @@ int db_query_int(const char* querystr)
 	return result;
 }
 
-long int get_max_query_ID(void)
+long int get_max_query_ID(sqlite3 *db)
 {
-	if(!FTL_DB_avail())
-	{
-		logg("get_max_query_ID() called but database is not available!");
-		return DB_FAILED;
-	}
-
 	const char *sql = "SELECT MAX(ID) FROM queries";
 	if(config.debug & DEBUG_DATABASE)
 	{
@@ -566,13 +464,13 @@ long int get_max_query_ID(void)
 	}
 
 	sqlite3_stmt* stmt = NULL;
-	int rc = sqlite3_prepare_v2(FTL_db, sql, -1, &stmt, NULL);
+	int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
 		if( rc != SQLITE_BUSY )
 		{
 			logg("Encountered prepare error in get_max_query_ID(): %s", sqlite3_errstr(rc));
-			dbclose();
+			dbclose(&db);
 		}
 
 		// Return okay if the database is busy
@@ -583,7 +481,7 @@ long int get_max_query_ID(void)
 	if( rc != SQLITE_ROW )
 	{
 		logg("Encountered step error in get_max_query_ID(): %s", sqlite3_errstr(rc));
-		dbclose();
+		dbclose(&db);
 		return DB_FAILED;
 	}
 
@@ -594,17 +492,6 @@ long int get_max_query_ID(void)
 	}
 	sqlite3_finalize(stmt);
 	return result;
-}
-
-// Returns ID of the most recent successful INSERT.
-long get_lastID(void)
-{
-	if(!FTL_DB_avail())
-	{
-		logg("get_lastID() called but database is not available!");
-		return DB_FAILED;
-	}
-	return sqlite3_last_insert_rowid(FTL_db);
 }
 
 // Return SQLite3 engine version string

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -34,13 +34,12 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 
 	// Only try to close an existing database connection
 	int rc = SQLITE_OK;
-	if(db != NULL && *db != NULL)
-	{
-		if((rc = sqlite3_close(*db)) != SQLITE_OK)
-			logg("Encountered error while trying to close database: %s", sqlite3_errstr(rc));
+	if(db != NULL && *db != NULL && (rc = sqlite3_close(*db)) != SQLITE_OK)
+		logg("Error while trying to close database: %s",
+		     sqlite3_errstr(rc));
 
-		*db = NULL;
-	}
+	// Always set database pointer to NULL, even when closing failed
+	*db = NULL;
 }
 
 sqlite3* _dbopen(bool create, const char *func, const int line, const char *file)

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -110,16 +110,6 @@ bool dbopen(void)
 	return true;
 }
 
-// (Re-)Open pihole-FTL database connection
-bool piholeFTLDB_reopen(void)
-{
-	// We call this routine when reloading the cache and when forking. Even
-	// when the database handle isn't really valid in this fork, we still
-	// want to close it here to avoid leaking memory
-	dbclose();
-	return dbopen();
-}
-
 int dbquery(const char *format, ...)
 {
 	va_list args;

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -48,6 +48,8 @@ void dbclose(void)
 	int rc = SQLITE_OK;
 	if( FTL_db != NULL )
 	{
+		if(config.debug & DEBUG_DATABASE)
+			logg("Closing FTL database");
 		if((rc = sqlite3_close(FTL_db)) != SQLITE_OK)
 			logg("Encountered error while trying to close database: %s", sqlite3_errstr(rc));
 
@@ -83,6 +85,8 @@ bool dbopen(void)
 		logg("Locking FTL database: Success");
 
 	// Try to open database
+	if(config.debug & DEBUG_DATABASE)
+		logg("Opening FTL database");
 	int rc = sqlite3_open_v2(FTLfiles.FTL_db, &FTL_db, SQLITE_OPEN_READWRITE, NULL);
 	if( rc != SQLITE_OK )
 	{
@@ -107,10 +111,13 @@ bool dbopen(void)
 }
 
 // (Re-)Open pihole-FTL database connection
-void piholeFTLDB_reopen(void)
+bool piholeFTLDB_reopen(void)
 {
+	// We call this routine when reloading the cache and when forking. Even
+	// when the database handle isn't really valid in this fork, we still
+	// want to close it here to avoid leaking memory
 	dbclose();
-	dbopen();
+	return dbopen();
 }
 
 int dbquery(const char *format, ...)

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -151,6 +151,7 @@ int dbquery(const char *format, ...)
 	if( rc != SQLITE_OK ){
 		logg("ERROR: SQL query \"%s\" failed: %s",
 		     query, sqlite3_errstr(rc));
+		sqlite3_free(query);
 		dbclose();
 		return rc;
 	}

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -35,7 +35,6 @@ int dbquery(const char *format, ...);
 bool FTL_DB_avail(void) __attribute__ ((pure));
 bool dbopen(void);
 void dbclose(void);
-bool piholeFTLDB_reopen(void);
 int db_query_int(const char*);
 long get_lastID(void);
 void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg);

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -35,7 +35,7 @@ int dbquery(const char *format, ...);
 bool FTL_DB_avail(void) __attribute__ ((pure));
 bool dbopen(void);
 void dbclose(void);
-void piholeFTLDB_reopen(void);
+bool piholeFTLDB_reopen(void);
 int db_query_int(const char*);
 long get_lastID(void);
 void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg);

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -39,43 +39,47 @@ void *DB_thread(void *val)
 	// Run as long as this thread is not canceled
 	while(true)
 	{
-		if(FTL_DB_avail())
+		sqlite3 *db = dbopen(false);
+		if(db == NULL)
 		{
-			time_t now = time(NULL);
-			if(now - lastDBsave >= config.DBinterval)
+			// Sleep 5 seconds and try again
+			sleepms(5000);
+			continue;
+		}
+		time_t now = time(NULL);
+		if(now - lastDBsave >= config.DBinterval)
+		{
+			// Update lastDBsave timer
+			lastDBsave = time(NULL) - time(NULL)%config.DBinterval;
+
+			// Save data to database (if enabled)
+			if(config.DBexport)
 			{
-				// Update lastDBsave timer
-				lastDBsave = time(NULL) - time(NULL)%config.DBinterval;
+				lock_shm();
+				DB_save_queries(db);
+				unlock_shm();
 
-				// Save data to database (if enabled)
-				if(config.DBexport)
+				// Check if GC should be done on the database
+				if(DBdeleteoldqueries && config.maxDBdays != -1)
 				{
-					lock_shm();
-					DB_save_queries();
-					unlock_shm();
-
-					// Check if GC should be done on the database
-					if(DBdeleteoldqueries && config.maxDBdays != -1)
-					{
-						// No thread locks needed
-						delete_old_queries_in_DB();
-						DBdeleteoldqueries = false;
-					}
+					// No thread locks needed
+					delete_old_queries_in_DB(db);
+					DBdeleteoldqueries = false;
 				}
-
-				// Parse neighbor cache (fill network table) if enabled
-				if (config.parse_arp_cache)
-					set_event(PARSE_NEIGHBOR_CACHE);
 			}
 
-			// Update MAC vendor strings once a month (the MAC vendor
-			// database is not updated very often)
-			if(now % 2592000L == 0)
-				updateMACVendorRecords();
-
-			if(get_and_clear_event(PARSE_NEIGHBOR_CACHE))
-				parse_neighbor_cache();
+			// Parse neighbor cache (fill network table) if enabled
+			if (config.parse_arp_cache)
+				set_event(PARSE_NEIGHBOR_CACHE);
 		}
+
+		// Update MAC vendor strings once a month (the MAC vendor
+		// database is not updated very often)
+		if(now % 2592000L == 0)
+			updateMACVendorRecords(db);
+
+		if(get_and_clear_event(PARSE_NEIGHBOR_CACHE))
+			parse_neighbor_cache(db);
 
 		// Process database related event queue elements
 		if(get_and_clear_event(RELOAD_GRAVITY))
@@ -89,12 +93,15 @@ void *DB_thread(void *val)
 		if(get_and_clear_event(REIMPORT_ALIASCLIENTS))
 		{
 			lock_shm();
-			reimport_aliasclients();
+			reimport_aliasclients(db);
 			unlock_shm();
 		}
 
-		// Sleep 0.1 seconds
-		sleepms(100);
+		// Close database connection
+		dbclose(&db);
+
+		// Sleep 1 second
+		sleepms(1000);
 	}
 
 	return NULL;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -170,19 +170,6 @@ bool gravityDB_reopen(void)
 	// want to close it here to avoid leaking memory
 	gravityDB_close();
 
-	// Finalize prepared list statements for all clients
-	// We can do this here as the fork has its own copy-on-write
-	// variables we still need to finalize/free in order to avoid
-	// leaking memory
-	for(int clientID = 0; clientID < counters->clients; clientID++)
-	{
-		clientsData *client = getClient(clientID, true);
-		gravityDB_finalize_client_statements(client);
-	}
-	free_sqlite3_stmt_vec(&whitelist_stmt);
-	free_sqlite3_stmt_vec(&blacklist_stmt);
-	free_sqlite3_stmt_vec(&gravity_stmt);
-
 	// Re-open gravity database
 	return gravityDB_open();
 }

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -53,10 +53,7 @@ bool gravityDB_opened = false;
 static const char* tablename[] = { "vw_gravity", "vw_blacklist", "vw_whitelist", "vw_regex_blacklist", "vw_regex_whitelist" , "" };
 
 // Prototypes from functions in dnsmasq's source
-void rehash(int size);
-
-// Other private prototypes
-static inline void gravityDB_finalize_client_statements(clientsData *client);
+extern void rehash(int size);
 
 // Open gravity database
 bool gravityDB_open(void)

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -364,7 +364,7 @@ static bool get_client_groupids(clientsData* client)
 			logg("Querying gravity database for MAC address of %s...", ip);
 
 		// Do the lookup
-		hwaddr = getMACfromIP(ip);
+		hwaddr = getMACfromIP(NULL, ip);
 
 		if(hwaddr == NULL && config.debug & DEBUG_CLIENTS)
 		{
@@ -480,7 +480,7 @@ static bool get_client_groupids(clientsData* client)
 			logg("Querying gravity database for host name of %s...", ip);
 
 		// Do the lookup
-		hostname = getNameFromIP(ip);
+		hostname = getNameFromIP(NULL, ip);
 
 		if(hostname == NULL && config.debug & DEBUG_CLIENTS)
 			logg("--> No result.");
@@ -566,7 +566,7 @@ static bool get_client_groupids(clientsData* client)
 			logg("Querying gravity database for interface of %s...", ip);
 
 		// Do the lookup
-		interface = getIfaceFromIP(ip);
+		interface = getIfaceFromIP(NULL, ip);
 
 		if(interface == NULL && config.debug & DEBUG_CLIENTS)
 			logg("--> No result.");

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -18,9 +18,8 @@
 // Table indices
 enum gravity_tables { GRAVITY_TABLE, EXACT_BLACKLIST_TABLE, EXACT_WHITELIST_TABLE, REGEX_BLACKLIST_TABLE, REGEX_WHITELIST_TABLE, UNKNOWN_TABLE } __attribute__ ((packed));
 
-void gravityDB_forked(void);
-void gravityDB_reopen(void);
 bool gravityDB_open(void);
+bool gravityDB_reopen(void);
 void gravityDB_reload_groups(clientsData* client);
 bool gravityDB_prepare_client_statements(clientsData* client);
 void gravityDB_close(void);

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -20,6 +20,7 @@ enum gravity_tables { GRAVITY_TABLE, EXACT_BLACKLIST_TABLE, EXACT_WHITELIST_TABL
 
 bool gravityDB_open(void);
 bool gravityDB_reopen(void);
+void gravityDB_forked(void);
 void gravityDB_reload_groups(clientsData* client);
 bool gravityDB_prepare_client_statements(clientsData* client);
 void gravityDB_close(void);

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -10,7 +10,9 @@
 #ifndef MESSAGETABLE_H
 #define MESSAGETABLE_H
 
-bool create_message_table(void);
+#include "sqlite3.h"
+
+bool create_message_table(sqlite3 *db);
 bool flush_message_table(void);
 void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex);
 void logg_subnet_warning(const char *ip, const int matching_count, const char *matching_ids,

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -10,17 +10,19 @@
 #ifndef NETWORKTABLE_H
 #define NETWORKTABLE_H
 
-bool create_network_table(void);
-bool create_network_addresses_table(void);
-bool create_network_addresses_with_names_table(void);
-void parse_neighbor_cache(void);
-void updateMACVendorRecords(void);
-bool unify_hwaddr(void);
+#include "sqlite3.h"
+
+bool create_network_table(sqlite3 *db);
+bool create_network_addresses_table(sqlite3 *db);
+bool create_network_addresses_with_names_table(sqlite3 *db);
+void parse_neighbor_cache(sqlite3 *db);
+void updateMACVendorRecords(sqlite3 *db);
+bool unify_hwaddr(sqlite3 *db);
 char* getDatabaseHostname(const char* ipaddr) __attribute__((malloc));
-char* __attribute__((malloc)) getMACfromIP(const char* ipaddr);
-int getAliasclientIDfromIP(const char *ipaddr);
-char* __attribute__((malloc)) getNameFromIP(const char* ipaddr);
-char* __attribute__((malloc)) getIfaceFromIP(const char* ipaddr);
+char* __attribute__((malloc)) getMACfromIP(sqlite3 *db, const char* ipaddr);
+int getAliasclientIDfromIP(sqlite3 *db, const char *ipaddr);
+char* __attribute__((malloc)) getNameFromIP(sqlite3 *db, const char* ipaddr);
+char* __attribute__((malloc)) getIfaceFromIP(sqlite3 *db, const char* ipaddr);
 void resolveNetworkTableNames(void);
 
 #endif //NETWORKTABLE_H

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -28,53 +28,71 @@
 
 static bool saving_failed_before = false;
 
-int get_number_of_queries_in_DB(void)
+int get_number_of_queries_in_DB(sqlite3 *db)
 {
-	// This routine is used by the API routines.
-	if(!FTL_DB_avail())
+	// Open pihole-FTL.db database file if needed
+	bool db_opened = false;
+	if(db == NULL)
 	{
-		return DB_FAILED;
+		if((db = dbopen(false)) == NULL)
+		{
+			logg("get_number_of_queries_in_DB() - Failed to open DB");
+			return -1;
+		}
+
+		// Successful
+		db_opened = true;
 	}
 
 	// Count number of rows using the index timestamp is faster than select(*)
-	int result = db_query_int("SELECT COUNT(timestamp) FROM queries");
+	int result = db_query_int(db, "SELECT COUNT(timestamp) FROM queries");
+
+	if(db_opened)
+		dbclose(&db);
 
 	return result;
 }
 
-bool DB_save_queries(void)
+bool DB_save_queries(sqlite3 *db)
 {
-	// The database may be unavailable, e.g. when disabled
-	if(!FTL_DB_avail())
-	{
-		return false;
-	}
-
 	// Start database timer
 	if(config.debug & DEBUG_DATABASE)
 		timer_start(DATABASE_WRITE_TIMER);
+
+	// Open pihole-FTL.db database file if needed
+	bool db_opened = false;
+	if(db == NULL)
+	{
+		if((db = dbopen(false)) == NULL)
+		{
+			logg("DB_save_queries() - Failed to open DB");
+			return NULL;
+		}
+
+		// Successful
+		db_opened = true;
+	}
 
 	unsigned int saved = 0;
 	bool error = false;
 	sqlite3_stmt* stmt = NULL;
 
-	int rc = dbquery("BEGIN TRANSACTION IMMEDIATE");
+	int rc = dbquery(db, "BEGIN TRANSACTION IMMEDIATE");
 	if( rc != SQLITE_OK )
 	{
 		const char *text;
 		if( rc == SQLITE_BUSY )
 			text = "WARNING";
 		else
-		{
 			text = "ERROR";
-			dbclose();
-		}
 
 		logg("%s: Storing queries in long-term database failed: %s", text, sqlite3_errstr(rc));
+		if(db_opened)
+			dbclose(&db);
 		return false;
 	}
 
-	rc = sqlite3_prepare_v2(FTL_db, "INSERT INTO queries VALUES (NULL,?,?,?,?,?,?,?)", -1, &stmt, NULL);
+	rc = sqlite3_prepare_v2(db, "INSERT INTO queries VALUES (NULL,?,?,?,?,?,?,?)", -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
 		const char *text, *spaces;
@@ -87,18 +105,19 @@ bool DB_save_queries(void)
 		{
 			text   = "ERROR";
 			spaces = "     ";
-			dbclose();
 		}
 
 		// dbquery() above already logs the reson for why the query failed
 		logg("%s: Storing queries in long-term database failed: %s\n", text, sqlite3_errstr(rc));
 		logg("%s  Keeping queries in memory for later new attempt", spaces);
 		saving_failed_before = true;
+		if(db_opened)
+			dbclose(&db);
 		return false;
 	}
 
 	// Get last ID stored in the database
-	long int lastID = get_max_query_ID();
+	long int lastID = get_max_query_ID(db);
 
 	int total = 0, blocked = 0;
 	time_t currenttimestamp = time(NULL);
@@ -233,14 +252,15 @@ bool DB_save_queries(void)
 			logg("Keeping queries in memory for later new attempt");
 			saving_failed_before = true;
 		}
-		else
-			dbclose();
+
+		if(db_opened)
+			dbclose(&db);
 
 		return false;
 	}
 
 	// Finish prepared statement
-	if((rc = dbquery("END TRANSACTION")) != SQLITE_OK)
+	if((rc = dbquery(db,"END TRANSACTION")) != SQLITE_OK)
 	{
 		// No need to log the error string here, dbquery() did that already above
 		logg("END TRANSACTION failed when trying to store queries to long-term database");
@@ -250,8 +270,9 @@ bool DB_save_queries(void)
 			logg("Keeping queries in memory for later new attempt");
 			saving_failed_before = true;
 		}
-		else
-			dbclose();
+
+		if(db_opened)
+			dbclose(&db);
 
 		return false;
 	}
@@ -261,13 +282,14 @@ bool DB_save_queries(void)
 	if(saved > 0 && !error)
 	{
 		lastdbindex = queryID;
-		db_set_FTL_property(DB_LASTTIMESTAMP, newlasttimestamp);
-		db_update_counters(total, blocked);
+		db_set_FTL_property(db, DB_LASTTIMESTAMP, newlasttimestamp);
+		db_update_counters(db, total, blocked);
 	}
 
 	if(config.debug & DEBUG_DATABASE || saving_failed_before)
 	{
-		logg("Notice: Queries stored in long-term database: %u (took %.1f ms, last SQLite ID %li)", saved, timer_elapsed_msec(DATABASE_WRITE_TIMER), lastID);
+		logg("Notice: Queries stored in long-term database: %u (took %.1f ms, last SQLite ID %li)",
+		     saved, timer_elapsed_msec(DATABASE_WRITE_TIMER), lastID);
 		if(saving_failed_before)
 		{
 			logg("        Queries from earlier attempt(s) stored successfully");
@@ -275,27 +297,24 @@ bool DB_save_queries(void)
 		}
 	}
 
+	if(db_opened)
+		dbclose(&db);
+
 	return true;
 }
 
-void delete_old_queries_in_DB(void)
+void delete_old_queries_in_DB(sqlite3 *db)
 {
-	// Open database
-	if(!FTL_DB_avail())
-	{
-		return;
-	}
-
 	int timestamp = time(NULL) - config.maxDBdays * 86400;
 
-	if(dbquery("DELETE FROM queries WHERE timestamp <= %i", timestamp) != SQLITE_OK)
+	if(dbquery(db, "DELETE FROM queries WHERE timestamp <= %i", timestamp) != SQLITE_OK)
 	{
 		logg("delete_old_queries_in_DB(): Deleting queries due to age of entries failed!");
 		return;
 	}
 
 	// Get how many rows have been affected (deleted)
-	const int affected = sqlite3_changes(FTL_db);
+	const int affected = sqlite3_changes(db);
 
 	// Print final message only if there is a difference
 	if((config.debug & DEBUG_DATABASE) || affected)
@@ -306,8 +325,12 @@ void delete_old_queries_in_DB(void)
 void DB_read_queries(void)
 {
 	// Open database
-	if(!dbopen())
+	sqlite3 *db;
+	if((db = dbopen(false)) == NULL)
+	{
+		logg("DB_read_queries() - Failed to open DB");
 		return;
+	}
 
 	// Prepare request
 	// Get time stamp 24 hours in the past
@@ -320,10 +343,10 @@ void DB_read_queries(void)
 
 	// Prepare SQLite3 statement
 	sqlite3_stmt* stmt = NULL;
-	int rc = sqlite3_prepare_v2(FTL_db, querystr, -1, &stmt, NULL);
+	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
 		logg("DB_read_queries() - SQL error prepare: %s", sqlite3_errstr(rc));
-		dbclose();
+		dbclose(&db);
 		return;
 	}
 
@@ -331,7 +354,7 @@ void DB_read_queries(void)
 	if((rc = sqlite3_bind_int(stmt, 1, mintime)) != SQLITE_OK)
 	{
 		logg("DB_read_queries() - Failed to bind type mintime: %s", sqlite3_errstr(rc));
-		dbclose();
+		dbclose(&db);
 		return;
 	}
 
@@ -343,12 +366,12 @@ void DB_read_queries(void)
 		// 1483228800 = 01/01/2017 @ 12:00am (UTC)
 		if(queryTimeStamp < 1483228800)
 		{
-			logg("FTL_db warn: TIMESTAMP should be larger than 01/01/2017 but is %lli", (long long)queryTimeStamp);
+			logg("DB warn: TIMESTAMP should be larger than 01/01/2017 but is %lli", (long long)queryTimeStamp);
 			continue;
 		}
 		if(queryTimeStamp > now)
 		{
-			if(config.debug & DEBUG_DATABASE) logg("FTL_db warn: Skipping query logged in the future (%lli)", (long long)queryTimeStamp);
+			if(config.debug & DEBUG_DATABASE) logg("DB warn: Skipping query logged in the future (%lli)", (long long)queryTimeStamp);
 			continue;
 		}
 
@@ -357,7 +380,7 @@ void DB_read_queries(void)
 		const bool offset_type = type > 100 && type < (100 + UINT16_MAX);
 		if(!mapped_type && !offset_type)
 		{
-			logg("FTL_db warn: TYPE should not be %i", type);
+			logg("DB warn: TYPE should not be %i", type);
 			continue;
 		}
 		// Don't import AAAA queries from database if the user set
@@ -370,7 +393,7 @@ void DB_read_queries(void)
 		const int status_int = sqlite3_column_int(stmt, 3);
 		if(status_int < QUERY_UNKNOWN || status_int >= QUERY_STATUS_MAX)
 		{
-			logg("FTL_db warn: STATUS should be within [%i,%i] but is %i", QUERY_UNKNOWN, QUERY_STATUS_MAX-1, status_int);
+			logg("DB warn: STATUS should be within [%i,%i] but is %i", QUERY_UNKNOWN, QUERY_STATUS_MAX-1, status_int);
 			continue;
 		}
 		const enum query_status status = status_int;
@@ -378,14 +401,14 @@ void DB_read_queries(void)
 		const char * domainname = (const char *)sqlite3_column_text(stmt, 4);
 		if(domainname == NULL)
 		{
-			logg("FTL_db warn: DOMAIN should never be NULL, %lli", (long long)queryTimeStamp);
+			logg("DB warn: DOMAIN should never be NULL, %lli", (long long)queryTimeStamp);
 			continue;
 		}
 
 		const char * clientIP = (const char *)sqlite3_column_text(stmt, 5);
 		if(clientIP == NULL)
 		{
-			logg("FTL_db warn: CLIENT should never be NULL, %lli", (long long)queryTimeStamp);
+			logg("DB warn: CLIENT should never be NULL, %lli", (long long)queryTimeStamp);
 			continue;
 		}
 
@@ -574,7 +597,7 @@ void DB_read_queries(void)
 
 	if( rc != SQLITE_DONE ){
 		logg("DB_read_queries() - SQL error step: %s", sqlite3_errstr(rc));
-		dbclose();
+		dbclose(&db);
 		return;
 	}
 
@@ -582,5 +605,5 @@ void DB_read_queries(void)
 	sqlite3_finalize(stmt);
 
 	// Close database here, we have to reopen it later (after forking)
-	dbclose();
+	dbclose(&db);
 }

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -10,9 +10,11 @@
 #ifndef DATABASE_QUERY_TABLE_H
 #define DATABASE_QUERY_TABLE_H
 
-int get_number_of_queries_in_DB(void);
-void delete_old_queries_in_DB(void);
-bool DB_save_queries(void);
+#include "sqlite3.h"
+
+int get_number_of_queries_in_DB(sqlite3 *db);
+void delete_old_queries_in_DB(sqlite3 *db);
+bool DB_save_queries(sqlite3 *db);
 void DB_read_queries(void);
 
 #endif //DATABASE_QUERY_TABLE_H

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -269,7 +269,7 @@ int findClientID(const char *clientIP, const bool count, const bool aliasclient)
 
 	// Check if this client is managed by a alias-client
 	if(!aliasclient)
-		reset_aliasclient(client);
+		reset_aliasclient(NULL, client);
 
 	return clientID;
 }

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -22,8 +22,6 @@
 #include "main.h"
 // reset_aliasclient()
 #include "database/aliasclients.h"
-// piholeFTLDB_reopen()
-#include "database/common.h"
 // config struct
 #include "config.h"
 // set_event(RESOLVE_NEW_HOSTNAMES)
@@ -457,9 +455,6 @@ void FTL_reset_per_client_domain_data(void)
 void FTL_reload_all_domainlists(void)
 {
 	lock_shm();
-
-	// (Re-)open FTL database connection
-	piholeFTLDB_reopen();
 
 	// Flush messages stored in the long-term database
 	flush_message_table();

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1737,13 +1737,6 @@ static void save_reply_type(const unsigned int flags, const union all_addr *addr
 	                            query->response;
 }
 
-pthread_t telnet_listenthreadv4;
-pthread_t telnet_listenthreadv6;
-pthread_t socket_listenthread;
-pthread_t DBthread;
-pthread_t GCthread;
-pthread_t DNSclientthread;
-
 void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 {
 	// Going into daemon mode involves storing the
@@ -1767,28 +1760,28 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 	pthread_attr_init(&attr);
 
 	// Start TELNET IPv4 thread
-	if(pthread_create( &telnet_listenthreadv4, &attr, telnet_listening_thread_IPv4, NULL ) != 0)
+	if(pthread_create( &threads[TELNETv4], &attr, telnet_listening_thread_IPv4, NULL ) != 0)
 	{
 		logg("Unable to open IPv4 telnet listening thread. Exiting...");
 		exit(EXIT_FAILURE);
 	}
 
 	// Start TELNET IPv6 thread
-	if(pthread_create( &telnet_listenthreadv6, &attr, telnet_listening_thread_IPv6, NULL ) != 0)
+	if(pthread_create( &threads[TELNETv6], &attr, telnet_listening_thread_IPv6, NULL ) != 0)
 	{
 		logg("Unable to open IPv6 telnet listening thread. Exiting...");
 		exit(EXIT_FAILURE);
 	}
 
 	// Start SOCKET thread
-	if(pthread_create( &socket_listenthread, &attr, socket_listening_thread, NULL ) != 0)
+	if(pthread_create( &threads[SOCKET], &attr, socket_listening_thread, NULL ) != 0)
 	{
 		logg("Unable to open Unix socket listening thread. Exiting...");
 		exit(EXIT_FAILURE);
 	}
 
 	// Start database thread if database is used
-	if(pthread_create( &DBthread, &attr, DB_thread, NULL ) != 0)
+	if(pthread_create( &threads[DB], &attr, DB_thread, NULL ) != 0)
 	{
 		logg("Unable to open database thread. Exiting...");
 		exit(EXIT_FAILURE);
@@ -1796,7 +1789,7 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 
 	// Start thread that will stay in the background until garbage
 	// collection needs to be done
-	if(pthread_create( &GCthread, &attr, GC_thread, NULL ) != 0)
+	if(pthread_create( &threads[GC], &attr, GC_thread, NULL ) != 0)
 	{
 		logg("Unable to open GC thread. Exiting...");
 		exit(EXIT_FAILURE);
@@ -1804,7 +1797,7 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 
 	// Start thread that will stay in the background until host names
 	// needs to be resolved
-	if(pthread_create( &DNSclientthread, &attr, DNSclient_thread, NULL ) != 0)
+	if(pthread_create( &threads[DNSclient], &attr, DNSclient_thread, NULL ) != 0)
 	{
 		logg("Unable to open DNS client thread. Exiting...");
 		exit(EXIT_FAILURE);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1744,6 +1744,9 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 	else
 		savepid();
 
+	// Open database after forking
+	dbopen();
+
 	// Handle real-time signals in this process (and its children)
 	// Helper processes are already split from the main instance
 	// so they will not listen to real-time signals

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1744,9 +1744,6 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 	else
 		savepid();
 
-	// Open database after forking
-	dbopen();
-
 	// Handle real-time signals in this process (and its children)
 	// Helper processes are already split from the main instance
 	// so they will not listen to real-time signals
@@ -2073,7 +2070,6 @@ void FTL_TCP_worker_terminating(bool finished)
 
 	// Close dedicated database connections of this fork
 	gravityDB_close();
-	dbclose();
 }
 
 // Called when a (forked) TCP worker is created

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -960,11 +960,7 @@ void FTL_dnsmasq_reload(void)
 {
 	// This function is called by the dnsmasq code on receive of SIGHUP
 	// *before* clearing the cache and rereading the lists
-
 	logg("Reloading DNS cache");
-
-	// (Re-)open FTL database connection
-	piholeFTLDB_reopen();
 
 	// Request reload the privacy level
 	set_event(RELOAD_PRIVACY_LEVEL);
@@ -2141,14 +2137,7 @@ void FTL_TCP_worker_created(const int confd, const char *iface_name)
 	// handle isn't valid here
 	if(config.debug != 0)
 		logg("Reopening Gravity database for this fork");
-	lock_shm();
-	gravityDB_reopen();
-	unlock_shm();
-
-	// Reopen FTL's database handle in this fork
-	if(config.debug != 0)
-		logg("Reopening FTL database for this fork");
-	piholeFTLDB_reopen();
+	gravityDB_forked();
 
 	// Children inherit file descriptors from their parents
 	// We don't need them in the forks, so we clean them up

--- a/src/enums.h
+++ b/src/enums.h
@@ -163,4 +163,15 @@ enum refresh_hostnames {
 	REFRESH_NONE
 } __attribute__ ((packed));
 
+
+enum thread_types {
+	TELNETv4,
+	TELNETv6,
+	SOCKET,
+	DB,
+	GC,
+	DNSclient,
+	THREADS_MAX
+} __attribute__ ((packed));
+
 #endif // ENUMS_H

--- a/src/enums.h
+++ b/src/enums.h
@@ -16,7 +16,8 @@ enum memory_type {
 	CLIENTS,
 	DOMAINS,
 	OVERTIME,
-	DNS_CACHE
+	DNS_CACHE,
+	STRINGS
 } __attribute__ ((packed));
 
 enum dnssec_status {

--- a/src/gc.c
+++ b/src/gc.c
@@ -237,7 +237,7 @@ void *GC_thread(void *val)
 			// ever larger and larger
 			DBdeleteoldqueries = true;
 		}
-		sleepms(100);
+		sleepms(1000);
 	}
 
 	return NULL;

--- a/src/log.c
+++ b/src/log.c
@@ -18,7 +18,7 @@
 #include "main.h"
 // global variable daemonmode
 #include "args.h"
-// global counters variable and shared logfile lock
+// global counters variable
 #include "shmem.h"
 // main_pid()
 #include "signals.h"
@@ -102,8 +102,6 @@ void _FTL_log(const bool newline, const char *format, ...)
 	if(!print_log && !print_stdout)
 		return;
 
-	lock_log();
-
 	get_timestr(timestring, time(NULL), true);
 
 	// Get and log PID of current process to avoid ambiguities when more than one
@@ -165,8 +163,6 @@ void _FTL_log(const bool newline, const char *format, ...)
 		// Close log file
 		close_FTL_log();
 	}
-
-	unlock_log();
 }
 
 // Log helper activity (may be script or lua)

--- a/src/log.h
+++ b/src/log.h
@@ -14,7 +14,6 @@
 #include <time.h>
 
 void init_FTL_log(void);
-void open_FTL_log(const bool init);
 void log_counter_info(void);
 void format_memory_size(char * const prefix, unsigned long long int bytes,
                         double * const formated);

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,7 @@ int main (int argc, char* argv[])
 	parse_args(argc, argv);
 
 	// Try to open FTL log
-	open_FTL_log(true);
+	init_FTL_log();
 	timer_start(EXIT_TIMER);
 	logg("########## FTL started! ##########");
 	log_FTL_version(false);
@@ -103,7 +103,7 @@ int main (int argc, char* argv[])
 	// Save new queries to database (if database is used)
 	if(config.DBexport)
 	{
-		if(DB_save_queries())
+		if(DB_save_queries(NULL))
 			logg("Finished final database update");
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -50,10 +50,9 @@ int main (int argc, char* argv[])
 	logg("########## FTL started! ##########");
 	log_FTL_version(false);
 
-	// Catch SIGSEGV (generate a crash report)
-	// Other signals are handled by dnsmasq
-	// We handle real-time signals later (after dnsmasq has forked)
-	handle_SIGSEGV();
+	// Catch signals not handled by dnsmasq
+	// We configure real-time signals later (after dnsmasq has forked)
+	handle_signals();
 
 	// Initialize shared memory
 	if(!init_shmem(true))

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -323,7 +323,7 @@ static size_t resolveAndAddHostname(size_t ippos, size_t oldnamepos)
 	if(strlen(newname) == 0 && config.names_from_netdb)
 	{
 		free(newname);
-		newname = getNameFromIP(ipaddr);
+		newname = getNameFromIP(NULL, ipaddr);
 	}
 
 	// Only store new newname if it is valid and differs from oldname

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -78,36 +78,44 @@ static bool valid_hostname(char* name, const char* clientip)
 static void print_used_resolvers(const char *message)
 {
 	logg("%s", message);
-	for(unsigned int i = 0u; i < 2*MAXNS; i++)
+	for(int i = 0u; i < 2*MAXNS; i++)
 	{
 		int family;
 		in_port_t port;
 		void *addr = NULL;
+		int j = i;
 		if(i < MAXNS)
 		{
+			// Regular name servers (IPv4)
+
+			// Some of the entries may not be configured
+			if(i > _res.nscount || _res.nsaddr_list[j].sin_family != AF_INET)
+				continue;
+
 			// IPv4 name servers
-			addr = &_res.nsaddr_list[i].sin_addr;
-			port = ntohs(_res.nsaddr_list[i].sin_port);
-			family = AF_INET;
+			addr = &_res.nsaddr_list[j].sin_addr;
+			port = ntohs(_res.nsaddr_list[j].sin_port);
+			family = _res.nsaddr_list[j].sin_family;
 		}
 		else
 		{
-			// Extension name servers (typically IPv6)
-
+			// Extension name servers (IPv6)
+			j = i - MAXNS;
 			// Some of the entries may not be configured
-			if(_res._u._ext.nsaddrs[i - MAXNS] == NULL)
+			if(_res._u._ext.nsaddrs[j] == NULL ||
+			   _res._u._ext.nsaddrs[j]->sin6_family != AF_INET6)
 				continue;
-			addr = &_res._u._ext.nsaddrs[i - MAXNS]->sin6_addr;
-			port = ntohs(_res._u._ext.nsaddrs[i - MAXNS]->sin6_port);
-			family = _res._u._ext.nsaddrs[i - MAXNS]->sin6_family;
+			addr = &_res._u._ext.nsaddrs[j]->sin6_addr;
+			port = ntohs(_res._u._ext.nsaddrs[j]->sin6_port);
+			family = _res._u._ext.nsaddrs[j]->sin6_family;
 		}
 
 		// Convert nameserver information to human-readable form
 		char nsname[INET6_ADDRSTRLEN];
 		inet_ntop(family, addr, nsname, INET6_ADDRSTRLEN);
 
-		logg(" %u: %s:%d (IPv%i)", i, nsname, port,
-		     family == AF_INET ? 4 : 6);
+		logg(" %s %u: %s:%d (IPv%i)", i < MAXNS ? "   " : "EXT",
+		     j, nsname, port, family == AF_INET ? 4 : 6);
 	}
 }
 
@@ -140,7 +148,7 @@ char *resolveHostname(const char *addr)
 	{
 		if(config.debug & DEBUG_RESOLVER)
 			logg("Configured to not resolve host name for %s", addr);
-		
+
 		// Return an empty host name
 		return strdup("");
 	}

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -360,7 +360,7 @@ static void _lock(ShmLock *lock, const bool is_shmem, const char* func, const in
 	int result = pthread_mutex_lock(&lock->lock);
 
 	if(config.debug & DEBUG_LOCKS && is_shmem)
-		logg("Obtained lock SHM for %s() (%s:%i)", func, file, line);
+		logg("Obtained SHM lock for %s() (%s:%i)", func, file, line);
 
 	// Turn off the waiting for lock signal to notify everyone who was
 	// deferring to FTL that they can jump in the lock queue.

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -728,11 +728,6 @@ static bool realloc_shm(SharedMemory *sharedMemory, const size_t size1, const si
 {
 	// Absolute target size
 	const size_t size = size1 * size2;
-	// Check if we can skip this routine as nothing is to be done
-	// when an object is not to be resized and its size didn't
-	// change elsewhere
-	if(!resize && size == sharedMemory->size)
-		return true;
 
 	// Log that we are doing something here
 	char df[64] =  { 0 };
@@ -797,6 +792,16 @@ static bool realloc_shm(SharedMemory *sharedMemory, const size_t size1, const si
 	// Update how much memory FTL uses
 	// We add the difference between updated and previous size
 	used_shmem += (size - sharedMemory->size);
+
+	if(config.debug & DEBUG_SHMEM)
+	{
+		if(sharedMemory->ptr == new_ptr)
+			logg("SHMEM pointer not updated: %p (%zu %zu)",
+			     sharedMemory->ptr, sharedMemory->size, size);
+		else
+			logg("SHMEM pointer updated: %p -> %p (%zu %zu)",
+			     sharedMemory->ptr, new_ptr, sharedMemory->size, size);
+	}
 
 	sharedMemory->ptr = new_ptr;
 	sharedMemory->size = size;

--- a/src/signals.c
+++ b/src/signals.c
@@ -302,62 +302,29 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *unused)
 	errno = _errno;
 }
 
-// Register SIGSEGV handler
-void handle_SIGSEGV(void)
+// Register ordinary signals handler
+void handle_signals(void)
 {
 	struct sigaction old_action;
 
-	// Catch SIGSEGV
-	sigaction (SIGSEGV, NULL, &old_action);
-	if(old_action.sa_handler != SIG_IGN)
+	const int signals[] = { SIGSEGV, SIGBUS, SIGABRT, SIGILL, SIGFPE };
+	for(unsigned int i = 0; i < sizeof(signals)/sizeof(signals[0]); i++)
 	{
-		struct sigaction SEGVaction;
-		memset(&SEGVaction, 0, sizeof(struct sigaction));
-		SEGVaction.sa_flags = SA_SIGINFO;
-		sigemptyset(&SEGVaction.sa_mask);
-		SEGVaction.sa_sigaction = &signal_handler;
-		sigaction(SIGSEGV, &SEGVaction, NULL);
-	}
-
-	// Catch SIGBUS
-	sigaction (SIGBUS, NULL, &old_action);
-	if(old_action.sa_handler != SIG_IGN)
-	{
-		struct sigaction SBUGaction;
-		memset(&SBUGaction, 0, sizeof(struct sigaction));
-		SBUGaction.sa_flags = SA_SIGINFO;
-		sigemptyset(&SBUGaction.sa_mask);
-		SBUGaction.sa_sigaction = &signal_handler;
-		sigaction(SIGBUS, &SBUGaction, NULL);
-	}
-
-	// Catch SIGILL
-	sigaction (SIGILL, NULL, &old_action);
-	if(old_action.sa_handler != SIG_IGN)
-	{
-		struct sigaction SBUGaction;
-		memset(&SBUGaction, 0, sizeof(struct sigaction));
-		SBUGaction.sa_flags = SA_SIGINFO;
-		sigemptyset(&SBUGaction.sa_mask);
-		SBUGaction.sa_sigaction = &signal_handler;
-		sigaction(SIGILL, &SBUGaction, NULL);
-	}
-
-	// Catch SIGFPE
-	sigaction (SIGFPE, NULL, &old_action);
-	if(old_action.sa_handler != SIG_IGN)
-	{
-		struct sigaction SBUGaction;
-		memset(&SBUGaction, 0, sizeof(struct sigaction));
-		SBUGaction.sa_flags = SA_SIGINFO;
-		sigemptyset(&SBUGaction.sa_mask);
-		SBUGaction.sa_sigaction = &signal_handler;
-		sigaction(SIGFPE, &SBUGaction, NULL);
+		// Catch this signal
+		sigaction (signals[i], NULL, &old_action);
+		if(old_action.sa_handler != SIG_IGN)
+		{
+			struct sigaction SIGaction;
+			memset(&SIGaction, 0, sizeof(struct sigaction));
+			SIGaction.sa_flags = SA_SIGINFO;
+			sigemptyset(&SIGaction.sa_mask);
+			SIGaction.sa_sigaction = &signal_handler;
+			sigaction(signals[i], &SIGaction, NULL);
+		}
 	}
 
 	// Log start time of FTL
 	FTLstarttime = time(NULL);
-
 }
 
 // Register real-time signal handler

--- a/src/signals.h
+++ b/src/signals.h
@@ -10,7 +10,7 @@
 #ifndef SIGNALS_H
 #define SIGNALS_H
 
-void handle_SIGSEGV(void);
+void handle_signals(void);
 void handle_realtime_signals(void);
 pid_t main_pid(void);
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -26,7 +26,6 @@ sqlite3_stmt_vec *new_sqlite3_stmt_vec(unsigned int initial_size)
 	// Set correct subroutine pointers
 	v->set = set_sqlite3_stmt_vec;
 	v->get = get_sqlite3_stmt_vec;
-	v->free = free_sqlite3_stmt_vec;
 	return v;
 }
 
@@ -106,18 +105,19 @@ sqlite3_stmt * __attribute__((pure)) get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, u
 	return item;
 }
 
-void free_sqlite3_stmt_vec(sqlite3_stmt_vec *v)
+void free_sqlite3_stmt_vec(sqlite3_stmt_vec **v)
 {
 	if(config.debug & DEBUG_VECTORS)
-		logg("Freeing sqlite3_stmt* vector %p", v);
+		logg("Freeing sqlite3_stmt* vector %p", *v);
 
 	// This vector was never allocated, invoking free_sqlite3_stmt_vec() on a
 	// NULL pointer should be a harmless no-op.
-	if(v == NULL || v->items == NULL)
+	if(v == NULL || *v == NULL || (*v)->items == NULL)
 		return;
 
 	// Free elements of the vector...
-	free(v->items);
+	free((*v)->items);
 	// ...and then the vector itself
-	free(v);
+	free(*v);
+	*v = NULL;
 }

--- a/src/vector.h
+++ b/src/vector.h
@@ -28,14 +28,13 @@ typedef struct sqlite3_stmt_vec {
 	sqlite3_stmt **items;
 	sqlite3_stmt *(*get)(struct sqlite3_stmt_vec *, unsigned int);
 	void (*set)(struct sqlite3_stmt_vec *, unsigned int, sqlite3_stmt*);
-	void (*free)(struct sqlite3_stmt_vec *);
 } sqlite3_stmt_vec;
-ASSERT_SIZEOF(sqlite3_stmt_vec, 40, 20, 20);
+ASSERT_SIZEOF(sqlite3_stmt_vec, 32, 16, 16);
 
 sqlite3_stmt_vec *new_sqlite3_stmt_vec(unsigned int initial_size);
 void set_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index, sqlite3_stmt* item);
 sqlite3_stmt* get_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index) __attribute__((pure));
 void del_sqlite3_stmt_vec(sqlite3_stmt_vec *v, unsigned int index);
-void free_sqlite3_stmt_vec(sqlite3_stmt_vec *v);
+void free_sqlite3_stmt_vec(sqlite3_stmt_vec **v);
 
 #endif //VECTOR_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR adds a few technical improvements and fixes a (rarely seen but reproducible) possibility of freezing under excessive TCP query load. Furthermore, we fix a few possible memory leaks. Most of them actually cannot result in memory being actually leaked (memory is freed either way when a fork terminates), however, they made reading `valgrind` logs somewhat harder.

Overview over the individual improvements and fixes contained here:
- Avoid jump depending on uninitialized bytes when only a few nameservers are stored in  `resolv.conf` (this only happened with `DEBUG_RESOLVER=true`)
- Join canceled threads on exit to ensure they exited properly before we exit from the main process. This includes waiting for them to clean up their own stack memory, etc. This makes reading `Valgrind` log outputs a lot simpler.
- Ensure we close FTL database connection when exiting the main process. Again, this has no consequences else than silencing some memory-lost complaints by `valgrind`,
- Ensure shared memory strings bucket is large enough when locking. Do not resize it when we are holding the lock. This avoids an obscure deadlock in case of many forking TCP workers. Also, optimize FTL-domains size
- Don't finalize gravity statements two times (makes the process faster)
- More fine-grained locking in network table processing should decrease delays in DNS resolution on very slow machines
- Reduce rate-limiting checking to once per second (rather than every 100 msec) to stop filling the logs too quickly when `DEBUG_LOCKS=true` is set
- Simplify locking during network table processing and generalize spacial handling for virtual interfaces (`hwaddr 00:00:00:00:00:00`)
- Simplify signal handling and catch `SIGABRT` in addition 
- Do not keep a globally opened SQLite3 connection to the long-term database but open and close connections when needed.

Documentation updated related to this change: https://github.com/pi-hole/docs/pull/485