### PR TITLE
Simplify handling of `.lua` and `.db` files

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -63,13 +63,23 @@ void parse_args(int argc, char* argv[])
 	if(strEndsWith(argv[0], "dnsmasq"))
 		consume_for_dnsmasq = true;
 
-	if(strEndsWith(argv[0], "lua"))
+	// If the binary name is "lua"  (e.g., symlink /usr/bin/lua -> /usr/bin/pihole-FTL),
+	// we operate in drop-in mode and consume all arguments for the embedded lua engine
+	// Also, we do this if the first argument is a file with ".lua" ending
+	if(strEndsWith(argv[0], "lua") ||
+	   (argc > 1 && strEndsWith(argv[1], ".lua")))
 		exit(run_lua_interpreter(argc, argv, false));
 
+	// If the binary name is "luac"  (e.g., symlink /usr/bin/luac -> /usr/bin/pihole-FTL),
+	// we operate in drop-in mode and consume all arguments for the embedded luac engine
 	if(strEndsWith(argv[0], "luac"))
 		exit(run_luac(argc, argv));
 
-	if(strEndsWith(argv[0], "sqlite3"))
+	// If the binary name is "sqlite3"  (e.g., symlink /usr/bin/sqlite3 -> /usr/bin/pihole-FTL),
+	// we operate in drop-in mode and consume all arguments for the embedded SQLite3 engine
+	// Also, we do this if the first argument is a file with ".db" ending
+	if(strEndsWith(argv[0], "sqlite3") ||
+	   (argc > 1 && strEndsWith(argv[1], ".db")))
 	{
 		if(argc == 1) // No arguments after this one
 			print_FTL_version();

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1042,3 +1042,17 @@
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "Usage: sqlite3 [OPTIONS] FILENAME [SQL]" ]]
 }
+
+@test "Embedded SQLite3 shell is called for .db file" {
+  run bash -c './pihole-FTL abc.db ".version"'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "SQLite 3."* ]]
+}
+
+@test "Embedded LUA engine is called for .lua file" {
+  echo 'print("Hello from LUA")' > abc.lua
+  run bash -c './pihole-FTL abc.lua'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "Hello from LUA" ]]
+  rm abc.lua
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---


If the first argument ends in `*.lua`, we immediately start the embedded LUA engine.
Same for "`*.db` files which are directly routed into the embedded SQLite3 engine.