### PR TITLE
Use properly-sized buffer for format_time()

### DIFF
--- a/src/dhcp-discover.c
+++ b/src/dhcp-discover.c
@@ -302,7 +302,7 @@ static void print_dhcp_offer(struct in_addr source, dhcp_packet_data *offer_pack
 					logg("%s: Infinite", optname);
 				else
 				{
-					char buffer[32] = { 0 };
+					char buffer[42] = { 0 };
 					format_time(buffer, time, 0.0);
 					logg("%s: %lu (%s)", optname, (unsigned long)time, buffer);
 				}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

1

---
The `format_time` function expects buffer of length 42, but it was called with a buffer of size 32.

https://github.com/pi-hole/FTL/blob/2999e2b57c62b4455187ee9b77840d49df0a8e2e/src/log.h#L21

https://github.com/pi-hole/FTL/blob/2999e2b57c62b4455187ee9b77840d49df0a8e2e/src/dhcp-discover.c#L305-L306