### PR TITLE
Add more regex warnings to message table

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,10 @@
           "**/.git/subtree-cache/**": true,
           "cmake/*/**": true,
           "**/node_modules/*/**": true
+        },
+        "files.associations": {
+                "config.h": "c",
+                "stdint.h": "c",
+                "stdint-gcc.h": "c"
         }
 }

--- a/src/config.h
+++ b/src/config.h
@@ -16,7 +16,7 @@
 // typedef int16_t
 #include <sys/types.h>
 // typedef uni32_t
-#include <idn-int.h>
+#include <stdint.h>
 // assert_sizeof
 #include "static_assert.h"
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -168,7 +168,10 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid)
 			}
 			else
 			{
-				logg("   Option \"%s\" not known, ignoring it.", part);
+				char hint[40 + strlen(part)];
+				snprintf(hint, sizeof(hint)-1, "Option \"%s\" not known, ignoring it.", part);
+				logg_regex_warning(regextype[regexid], hint,
+				                   regex[index].database_id, regexin);
 			}
 		}
 		free(buf);

--- a/src/regex.c
+++ b/src/regex.c
@@ -95,7 +95,7 @@ unsigned int __attribute__((pure)) get_num_regex(const enum regex_type regexid)
 #define FTL_REGEX_SEP ";"
 /* Compile regular expressions into data structures that can be used with
    regexec() to match against a string */
-static bool compile_regex(const char *regexin, const enum regex_type regexid)
+static bool compile_regex(const char *regexin, const enum regex_type regexid, const int dbidx)
 {
 	regexData *regex = get_regex_ptr(regexid);
 	int index = num_regex[regexid]++;
@@ -122,7 +122,7 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid)
 				if(regex[index].query_type != 0)
 					logg_regex_warning(regextype[regexid],
 					                   "Overwriting previous querytype setting",
-					                   regex[index].database_id, regexin);
+					                   dbidx, regexin);
 
 				// Test input string against all implemented query types
 				for(enum query_types type = TYPE_A; type < TYPE_MAX; type++)
@@ -145,7 +145,7 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid)
 				// Nothing found
 				if(regex[index].query_type == 0)
 					logg_regex_warning(regextype[regexid], "Unknown querytype",
-					                   regex[index].database_id, regexin);
+					                   dbidx, regexin);
 
 				// Debug output
 				else if(config.debug & DEBUG_REGEX)
@@ -171,7 +171,7 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid)
 				char hint[40 + strlen(part)];
 				snprintf(hint, sizeof(hint)-1, "Option \"%s\" not known, ignoring it.", part);
 				logg_regex_warning(regextype[regexid], hint,
-				                   regex[index].database_id, regexin);
+				                   dbidx, regexin);
 			}
 		}
 		free(buf);
@@ -191,7 +191,7 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid)
 		const size_t length = regerror(errcode, &regex[index].regex, NULL, 0);
 		char *buffer = calloc(length, sizeof(char));
 		(void) regerror (errcode, &regex[index].regex, buffer, length);
-		logg_regex_warning(regextype[regexid], buffer, regex[index].database_id, regexin);
+		logg_regex_warning(regextype[regexid], buffer, dbidx, regexin);
 		free(buffer);
 		regex[index].available = false;
 		return false;
@@ -513,7 +513,7 @@ static void read_regex_table(const enum regex_type regexid)
 			     regextype[regexid], num_regex[regexid], rowid, domain);
 		}
 
-		compile_regex(domain, regexid);
+		compile_regex(domain, regexid, rowid);
 		regex[num_regex[regexid]-1].database_id = rowid;
 
 		// Signal other forks that the regex data has changed and should be updated
@@ -622,7 +622,7 @@ int regex_test(const bool debug_mode, const bool quiet, const char *domainin, co
 		// Compile CLI regex
 		timer_start(REGEX_TIMER);
 		log_ctrl(false, true); // Temporarily re-enable terminal output for error logging
-		if(!compile_regex(regexin, REGEX_CLI))
+		if(!compile_regex(regexin, REGEX_CLI, -1))
 			return EXIT_FAILURE;
 		log_ctrl(false, !quiet); // Re-apply quiet option after compilation
 		logg("    Compiled regex filter in %.3f msec\n", timer_elapsed_msec(REGEX_TIMER));

--- a/src/signals.c
+++ b/src/signals.c
@@ -349,5 +349,10 @@ void handle_realtime_signals(void)
 // Return PID of the main FTL process
 pid_t main_pid(void)
 {
-	return mpid;
+	if(mpid > -1)
+		// Hase already been set
+		return mpid;
+	else
+		// Has not been set so far
+		return getpid();
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes #1050 by ensuring we add all warnings also to the `message` table (so they can be shown on the dashboard). It also fixes incorrect regex links in the message display and adds a bit more error reporting to the network table.