### PR TITLE
Circle CI: skip uploading build artifacts on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ version: 2
         name: "Upload binary to binary bucket"
         command: |
           [ -z "${CIRCLE_PR_USERNAME}" ] || exit 0
+          [ "${CIRCLE_PROJECT_USERNAME}" == "pi-hole" ] || exit 0
           DIR="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
           mkdir -p ~/.ssh/
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
@@ -30,6 +31,7 @@ version: 2
         name: "Verify uploaded binary"
         command: |
           [ -z "${CIRCLE_PR_USERNAME}" ] || exit 0
+          [ "${CIRCLE_PROJECT_USERNAME}" == "pi-hole" ] || exit 0
           DIR="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
           mkdir download
           cd download


### PR DESCRIPTION
Signed-off-by: Anton Bershanskiy <45960703+bershanskiy@users.noreply.github.com>

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

1

---

When external contributor (like me) forks FTL and enables Circle CI on it, Circle CI tries to upload artifacts to Pi-Hole's FTP server. Of course, upload fails and fails the whole workflow and skips actual test.

Example run before this change:
https://app.circleci.com/pipelines/github/bershanskiy/FTL/1/workflows/9d0fd821-4a83-4b63-826f-60948822beda/jobs/2

Example run after this change:
https://app.circleci.com/pipelines/github/bershanskiy/FTL/2/workflows/32643484-69c6-4465-88d0-8105f7b8a6c8/jobs/15

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
