### PR TITLE
Cisco Umbrella Remote IP/Device ID support

### DIFF
--- a/src/dnsmasq/dns-protocol.h
+++ b/src/dnsmasq/dns-protocol.h
@@ -82,6 +82,7 @@
 #define EDNS0_OPTION_CLIENT_SUBNET  8     /* IANA */
 #define EDNS0_OPTION_NOMDEVICEID    65073 /* Nominum temporary assignment */
 #define EDNS0_OPTION_NOMCPEID       65074 /* Nominum temporary assignment */
+#define EDNS0_OPTION_UMBRELLA_IP    20292 /* Cisco Umbrella temporary assignment */
 
 struct dns_header {
   u16 id;

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -273,7 +273,8 @@ struct event_desc {
 #define OPT_IGNORE_CLID    59
 #define OPT_SINGLE_PORT    60
 #define OPT_LEASE_RENEW    61
-#define OPT_LAST           62
+#define OPT_UMBRELLA_IP    62
+#define OPT_LAST           63
 
 #define OPTION_BITS (sizeof(unsigned int)*8)
 #define OPTION_SIZE ( (OPT_LAST/OPTION_BITS)+((OPT_LAST%OPTION_BITS)!=0) )

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -273,7 +273,7 @@ struct event_desc {
 #define OPT_IGNORE_CLID    59
 #define OPT_SINGLE_PORT    60
 #define OPT_LEASE_RENEW    61
-#define OPT_UMBRELLA_IP    62
+#define OPT_UMBRELLA       62
 #define OPT_LAST           63
 
 #define OPTION_BITS (sizeof(unsigned int)*8)
@@ -1052,6 +1052,9 @@ extern struct daemon {
   int port, query_port, min_port, max_port;
   unsigned long local_ttl, neg_ttl, max_ttl, min_cache_ttl, max_cache_ttl, auth_ttl, dhcp_ttl, use_dhcp_ttl;
   char *dns_client_id;
+  int umbrella_org;
+  int umbrella_asset;
+  char *umbrella_device;
   struct hostsfile *addn_hosts;
   struct dhcp_context *dhcp, *dhcp6;
   struct ra_interface *ra_interfaces;

--- a/src/dnsmasq/edns0.c
+++ b/src/dnsmasq/edns0.c
@@ -485,7 +485,7 @@ static size_t add_umbrella_opt(struct dns_header *header, size_t plen, unsigned 
     u += sizeof(int);
   }
 
-  len = u - &umbrella_data[0]; // for the header
+  len = u - umbrella_data; // for the header
   return add_pseudoheader(header, plen, (unsigned char *)limit, PACKETSZ, EDNS0_OPTION_UMBRELLA_IP, (unsigned char *)&umbrella_data, len, 0, 1);
 }
 

--- a/src/dnsmasq/edns0.c
+++ b/src/dnsmasq/edns0.c
@@ -427,18 +427,6 @@ int check_source(struct dns_header *header, size_t plen, unsigned char *pseudohe
    return 1;
 }
 
-struct umbrella_opt {
-  u8 magic[4];
-  u8 version;
-  u8 flags;
-  u8 family;
-#ifdef HAVE_IPV6
-  u8 addr[IN6ADDRSZ];
-#else
-  u8 addr[INADDRSZ];
-#endif
-};
-
 #define UMBRELLA_ASSET  0x04
 #define UMBRELLA_ORG    0x08
 #define UMBRELLA_IPV4   0x10

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -172,6 +172,7 @@ struct myoption {
 #define LOPT_SINGLE_PORT   359
 #define LOPT_SCRIPT_TIME   360
 #define LOPT_PXE_VENDOR    361
+#define LOPT_UMBRELLA_IP   362
  
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -345,6 +346,7 @@ static const struct myoption opts[] =
     { "dumpfile", 1, 0, LOPT_DUMPFILE },
     { "dumpmask", 1, 0, LOPT_DUMPMASK },
     { "dhcp-ignore-clid", 0, 0,  LOPT_IGNORE_CLID },
+    { "umbrella-remote-ip", 0, 0, LOPT_UMBRELLA_IP },
     { NULL, 0, 0, 0 }
   };
 
@@ -525,6 +527,8 @@ static struct {
   { LOPT_DUMPFILE, ARG_ONE, "<path>", gettext_noop("Path to debug packet dump file"), NULL },
   { LOPT_DUMPMASK, ARG_ONE, "<hex>", gettext_noop("Mask which packets to dump"), NULL },
   { LOPT_SCRIPT_TIME, OPT_LEASE_RENEW, NULL, gettext_noop("Call dhcp-script when lease expiry changes."), NULL },
+  { LOPT_UMBRELLA_IP, OPT_UMBRELLA_IP, NULL, gettext_noop("Send remote IP information upstream"), NULL },
+
   { 0, 0, NULL, NULL, NULL }
 }; 
 

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -172,7 +172,7 @@ struct myoption {
 #define LOPT_SINGLE_PORT   359
 #define LOPT_SCRIPT_TIME   360
 #define LOPT_PXE_VENDOR    361
-#define LOPT_UMBRELLA_IP   362
+#define LOPT_UMBRELLA	   362
  
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -346,7 +346,7 @@ static const struct myoption opts[] =
     { "dumpfile", 1, 0, LOPT_DUMPFILE },
     { "dumpmask", 1, 0, LOPT_DUMPMASK },
     { "dhcp-ignore-clid", 0, 0,  LOPT_IGNORE_CLID },
-    { "umbrella-remote-ip", 0, 0, LOPT_UMBRELLA_IP },
+    { "umbrella", 1, 0, LOPT_UMBRELLA },
     { NULL, 0, 0, 0 }
   };
 
@@ -527,7 +527,7 @@ static struct {
   { LOPT_DUMPFILE, ARG_ONE, "<path>", gettext_noop("Path to debug packet dump file"), NULL },
   { LOPT_DUMPMASK, ARG_ONE, "<hex>", gettext_noop("Mask which packets to dump"), NULL },
   { LOPT_SCRIPT_TIME, OPT_LEASE_RENEW, NULL, gettext_noop("Call dhcp-script when lease expiry changes."), NULL },
-  { LOPT_UMBRELLA_IP, OPT_UMBRELLA_IP, NULL, gettext_noop("Send remote IP information upstream"), NULL },
+  { LOPT_UMBRELLA, ARG_ONE, "[=<device_id>,<org>,<asset>]", gettext_noop("Send Cisco Umbrella identifiers including remote IP."), NULL },
 
   { 0, 0, NULL, NULL, NULL }
 }; 
@@ -2408,6 +2408,27 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
     case LOPT_CPE_ID: /* --add-dns-client */
       if (arg)
 	daemon->dns_client_id = opt_string_alloc(arg);
+      break;
+
+    case LOPT_UMBRELLA: /* --umbrella */
+      // we always send remote IP information
+      // additional information can be sent if configured.
+      set_option_bool(OPT_UMBRELLA);
+      comma = split(arg);
+      if (arg) {
+        if (strlen(arg) != 16)
+          ret_err(_("Invalid Umbrella device ID"));
+        daemon->umbrella_device = opt_string_alloc(arg);
+        if (comma) {
+          arg = comma;
+          comma = split(arg);
+          if (arg && !atoi_check(arg, &daemon->umbrella_org)) {
+              ret_err(_("Invalid Umbrella organization ID"));
+            if (comma && !atoi_check(comma, &daemon->umbrella_asset))
+                ret_err(_("Invalid Umbrella asset ID"));
+          }
+        }
+      }
       break;
 
     case LOPT_ADD_MAC: /* --add-mac */


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 5

---

This pull request add support for Cisco Umbrella/OpenDNS Device ID and remote IP reporting.  This is based on the information at https://docs.umbrella.com/umbrella-api/docs/identifying-dns-traffic and https://docs.umbrella.com/umbrella-api/docs/identifying-dns-traffic2 . Using `--umbrella` by itself will enable Remote IP reporting. This can not be used for any policy filtering in Cisco Umbrella/OpenDNS. Additional information can be supplied using specific option specifications, multiple can be separated by a comma:

`--umbrella=orgid:1234,deviceid=0123456789abcdef`

Specifies that you want to report organization 1234 using device 0123456789abcdef.  For Cisco Umbrella Enterprise, see [Register (Create) a device](https://docs.umbrella.com/umbrella-api/docs/create-a-device) how to get a Device ID  and [Organization ID endpoint](https://docs.umbrella.com/umbrella-api/docs/organization-endpoint) to get organizations ID. For OpenDNS Home Users, there is no organization, see [Registration API endpoint](https://docs.umbrella.com/umbrella-api/docs/registration-api-endpoint2) for how to get a Device ID.  Asset ID should be ignored unless specifically instructed to use by support.