### PR TITLE
Update SQLite3 to 3.35.4

### DIFF
--- a/src/database/sqlite3.h
+++ b/src/database/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.35.3"
-#define SQLITE_VERSION_NUMBER 3035003
-#define SQLITE_SOURCE_ID      "2021-03-26 12:12:52 4c5e6c200adc8afe0814936c67a971efc516d1bd739cb620235592f18f40be2a"
+#define SQLITE_VERSION        "3.35.4"
+#define SQLITE_VERSION_NUMBER 3035004
+#define SQLITE_SOURCE_ID      "2021-04-02 15:20:15 5d4c65779dab868b285519b19e4cf9d451d50c6048f06f653aa701ec212df45e"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Yet another bugfix release for 3.35.

CHANGELOG:
- Fix a defect in the query planner optimization:
  - Attempt to process `EXISTS` operators in the `WHERE` clause as if they were `IN` operators, in cases where this is a valid transformation and seems likely to improve performance. 
- Fix a defect in the new `RETURNING` syntax.
- Fix the new `RETURNING` feature so that it raises an error if one of the terms in the `RETURNING` clause references a unknown table, instead of silently ignoring that error.
- Fix an assertion associated with aggregate function processing that was incorrectly triggered by the push-down optimization. 