### PR TITLE
Fix possible infinite loop when Pi-hole ecosystem is not present

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -58,7 +58,7 @@ void getLogFilePath(void)
 	    ((fp = fopen(FTLfiles.snapConf, "r")) == NULL) &&
 	    ((fp = fopen("pihole-FTL.conf", "r")) == NULL))
 	{
-		printf("Notice: Found no readable FTL config file");
+		printf("Notice: Found no readable FTL config file\n");
 	}
 
 	// Read LOGFILE value if available

--- a/src/log.c
+++ b/src/log.c
@@ -123,7 +123,7 @@ void _FTL_log(const bool newline, const char *format, ...)
 			printf("\n");
 	}
 
-	if(print_log)
+	if(print_log && FTLfiles.log != NULL)
 	{
 		// Open log file
 		FILE *logfile = fopen(FTLfiles.log, "a+");

--- a/src/syscalls/fopen.c
+++ b/src/syscalls/fopen.c
@@ -12,10 +12,12 @@
 //#include "syscalls.h" is implicitly done in FTL.h
 #include "../log.h"
 
+static uint8_t already_writing = 0;
+
 #undef fopen
 FILE *FTLfopen(const char *pathname, const char *mode, const char *file, const char *func, const int line)
 {
-    FILE *file_ptr = 0;
+	FILE *file_ptr = 0;
 	do
 	{
 		// Reset errno before trying to write
@@ -28,9 +30,13 @@ FILE *FTLfopen(const char *pathname, const char *mode, const char *file, const c
 
 	// Final error checking (may have faild for some other reason then an
 	// EINTR = interrupted system call)
-	if(file_ptr == NULL)
+	// The already_writing coutner prevents a possible infinite loop
+	if(file_ptr == NULL && (already_writing++) == 1)
 		logg("WARN: Could not fopen(\"%s\", \"%s\") in %s() (%s:%i): %s",
-             pathname, mode, func, file, line, strerror(errno));
+		     pathname, mode, func, file, line, strerror(errno));
 
-    return file_ptr;
+	// Decrement warning counter
+	already_writing--;
+
+	return file_ptr;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The uninterruptible syscalls could have entered an infinite loop when logging that they can neither open nor create (due to missing permissions) the non-existing log file. Such a loop is now prevented.