### PR TITLE
Use MAXLOGAGE to control which queries get deleted by GC

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -63,8 +63,8 @@ void *GC_thread(void *val)
 			// Requests should not be processed/answered when data is about to change
 			lock_shm();
 
-			// Get minimum time stamp to keep
-			time_t mintime = (now - GCdelay) - MAXLOGAGE*3600;
+			// Get minimum timestamp to keep (this can be set with MAXLOGAGE)
+			time_t mintime = (now - GCdelay) - config.maxlogage;
 
 			// Align to the start of the next hour. This will also align with
 			// the oldest overTime interval after GC is done.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This fixes https://github.com/pi-hole/FTL/issues/1095 by using the configured limit rather than the hard-coded `MAXLOGAGE` (24 hours).