### PR TITLE
Fix database update to version 7 reporting error

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -23,6 +23,8 @@
 #include "sqlite3-ext.h"
 // import_aliasclients()
 #include "aliasclients.h"
+// add_additional_info_column()
+#include "query-table.h"
 
 bool DBdeleteoldqueries = false;
 long int lastdbindex = 0;
@@ -300,10 +302,9 @@ void db_init(void)
 	// Update to version 7 if lower
 	if(dbversion < 7)
 	{
-		// Update to version 7: Create message table
+		// Update to version 7: Add additional_info column to queries table
 		logg("Updating long-term database to version 7");
-		if(dbquery(db, "ALTER TABLE queries ADD COLUMN additional_info TEXT;") != SQLITE_OK ||
-		   !dbquery(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %i );", DB_VERSION, 7) != SQLITE_OK)
+		if(!add_additional_info_column(db))
 		{
 			logg("Column additional_info not initialized, database not available");
 			dbclose(&db);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -321,6 +321,17 @@ void delete_old_queries_in_DB(sqlite3 *db)
 		logg("Notice: Database size is %.2f MB, deleted %i rows", 1e-6*get_FTL_db_filesize(), affected);
 }
 
+bool add_additional_info_column(sqlite3 *db)
+{
+	// Add column additinal_info to queries table
+	SQL_bool(db, "ALTER TABLE queries ADD COLUMN additional_info TEXT;");
+
+	// Update the database version to 7
+	SQL_bool(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %i );", DB_VERSION, 7);
+
+	return true;
+}
+
 // Get most recent 24 hours data from long-term database
 void DB_read_queries(void)
 {

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -14,6 +14,7 @@
 
 int get_number_of_queries_in_DB(sqlite3 *db);
 void delete_old_queries_in_DB(sqlite3 *db);
+bool add_additional_info_column(sqlite3 *db);
 bool DB_save_queries(sqlite3 *db);
 void DB_read_queries(void);
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -500,6 +500,12 @@
   [[ ${lines[0]} == "0" ]]
 }
 
+@test "No \"database not available\" messages in pihole-FTL.log" {
+  run bash -c 'grep -c "database not available" /var/log/pihole-FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0" ]]
+}
+
 @test "No ERROR messages in pihole-FTL.log" {
   run bash -c 'grep -c "ERROR" /var/log/pihole-FTL.log'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix database update to version 7 reporting error when there is none:
``` plain
Column additional_info not initialized, database not available
```

This is not a critical bug as the issue resolves itself on the next start of FTL.