### PR TITLE
Circle CI: SHA-256 hashes for integrity checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ version: 2
         name: "Compute checksum"
         command: |
           mv pihole-FTL "${BIN_NAME}"
-          sha1sum pihole-FTL-* > ${BIN_NAME}.sha1
+          sha256sum pihole-FTL-* > ${BIN_NAME}.sha256
     - run:
         name: "Upload binary to binary bucket"
         command: |
@@ -36,8 +36,8 @@ version: 2
           mkdir download
           cd download
           wget "https://ftl.pi-hole.net/${DIR}/${BIN_NAME}"
-          wget "https://ftl.pi-hole.net/${DIR}/${BIN_NAME}.sha1"
-          sha1sum -c "${BIN_NAME}.sha1"
+          wget "https://ftl.pi-hole.net/${DIR}/${BIN_NAME}.sha256"
+          sha256sum -c "${BIN_NAME}.sha256"
           cd ..
     - run:
         name: "Test"


### PR DESCRIPTION
Signed-off-by: Anton Bershanskiy <45960703+bershanskiy@users.noreply.github.com>

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

---

Publish SHA-256 hashes of built binaries along with SHA-1 hashes. This would allow users to eventually migrate away from SHA-1 to SHA-256. If you would be interested, I can file a matching PR for the official install script.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
