### PR TITLE
Add GitHub Actions integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+# This workflow builds FTL
+# It is analogous to Circle CI workflow here:
+# ../../.circleci/config.yml
+name: Build and test
+
+on:
+  push:
+    branches:
+     - '*'
+  pull_request:
+    branches:
+     - '*'
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        include:
+         - circle_job: armv4t
+           bin_name: pihole-FTL-armv4-linux-gnueabi
+         - circle_job: armv5te
+           bin_name: pihole-FTL-armv5-linux-gnueabi
+         - circle_job: armv6hf
+           bin_name:  pihole-FTL-armv6-linux-gnueabihf
+         - circle_job: armv7hf
+           bin_name: pihole-FTL-armv7-linux-gnueabihf
+         - circle_job: armv8a
+           bin_name: pihole-FTL-armv8-linux-gnueabihf
+         - circle_job: aarch64
+           bin_name: pihole-FTL-aarch64-linux-gnu
+         - circle_job: x86_64
+           bin_name: pihole-FTL-linux-x86_64
+         - circle_job: x86_64-musl
+           bin_name: pihole-FTL-musl-linux-x86_64
+         - circle_job: x86_32
+           bin_name: pihole-FTL-linux-x86_32
+
+    container: pihole/ftl-build:v1.8-${{ matrix.circle_job }}
+
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: "Build"
+      run: |
+        # Extract branch name or ref from GITHUB_REF variable
+        CIRCLE_TAG=""
+        BRANCH="test"
+        bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${{ matrix.circle_job }}"
+    - name: "Binary checks"
+      run: |
+        export CIRCLE_JOB="${{ matrix.circle_job }}"
+        bash test/arch_test.sh
+    - name: "Compute checksum"
+      run: |
+        mv pihole-FTL "${{ matrix.bin_name }}"
+        sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
+    # NOTE: Steps "Upload binary to binary bucket" and "Verify uploaded binary"
+    # are intentionally left out.
+    - name: "Test"
+      run: |
+          export CIRCLE_JOB="${{ matrix.circle_job }}"
+          mv "${{ matrix.bin_name }}" pihole-FTL
+          test/run.sh


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_
1
---

Add GitHub Actions workflow roughly mirorring Circle CI workflow. Please note:
 - I left out "Upload binary to binary bucket" and "Verify uploaded binary" steps because they they would be better served with  and (if you want, I'll add in step uploading output to [GitHub Artifacts](https://github.com/actions/upload-artifact))
 - There is a weird bug with FTL Lua not reporting FTL version

Motivation:
 - Circle CI is odd, for some reason it stopped being able to clone the repo for me.
```
Using SSH Config Dir '/root/.ssh'
git version 2.11.0
Cloning git repository
Cloning into '.'...
Warning: Permanently added the RSA host key for IP address '140.82.112.3' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

exit status 128
```
 - GitHub Actions have more generous free VM plans.
 - Circle CI require user to give Circle CI pretty powerfull permissions to work properly. (It seems to be intentional on Circle CI's part.) 
 - GitHub Actions have better integration with GitHub and have GitHub artifacts. E.g., external contributors can start them without extra work.