### PR TITLE
Fix crash when bind-address is used

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1817,7 +1817,12 @@ static void check_dns_listeners(time_t now)
       // Get the interface here only if we know the listeners are bound to specific
       // interfaces (option "bind-interfaces" is used)
       if(option_bool(OPT_NOWILD))
-	FTL_iface(listener->iface->index, daemon->interfaces);
+      {
+	if(listener != NULL && listener->iface != NULL)
+	  FTL_iface(listener->iface->index, daemon->interfaces);
+	else
+	  FTL_iface(-1, NULL);
+      }
       /*******************************************************************************/
 
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -1154,9 +1154,9 @@ void create_bound_listeners(int dienow)
 			  iface->name, iface->index, daemon->addrbuff, port);
 	      }
 	    // Pi-hole modification
+	    const int port = prettyprint_addr(&iface->addr, daemon->addrbuff);
 	    logg("listening on %s(#%d): %s port %d",
-		 iface->name, iface->index, daemon->addrbuff,
-		 prettyprint_addr(&iface->addr, daemon->addrbuff));
+		 iface->name, iface->index, daemon->addrbuff, port);
 	  }
       }
 
@@ -1184,8 +1184,8 @@ void create_bound_listeners(int dienow)
 	    my_syslog(LOG_DEBUG|MS_DEBUG, _("listening on %s port %d"), daemon->addrbuff, port);
 	  }
 	// Pi-hole modification
-	logg("listening on %s port %d",
-	     daemon->addrbuff, prettyprint_addr(&iface->addr, daemon->addrbuff));
+        const int port = prettyprint_addr(&if_tmp->addr, daemon->addrbuff);
+	logg("listening on %s port %d", daemon->addrbuff, port);
       }
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fix crash when `bind-address` option is used. Original issue reported in https://github.com/pi-hole/docker-pi-hole/issues/855