### PR TITLE
Fix possible crash during shutdown

### DIFF
--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -392,6 +392,10 @@ static void *socket_connection_handler_thread(void *socket_desc)
 	sprintf(threadname, "socket-%i", sock);
 	prctl(PR_SET_NAME, threadname, 0, 0, 0);
 
+	// Ensure this thread can be canceled at any time (not only at
+	// cancellation points)
+	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+
 	// Store TID of this thread
 	lock_shm();
 	unsigned int tid;
@@ -400,6 +404,7 @@ static void *socket_connection_handler_thread(void *socket_desc)
 		if(api_threads[tid] == 0)
 		{
 			api_threads[tid] = pthread_self();
+			api_tids[tid] = gettid();
 			break;
 		}
 	}
@@ -445,6 +450,7 @@ static void *socket_connection_handler_thread(void *socket_desc)
 
 	// Release thread from list
 	api_threads[tid] = 0;
+	api_tids[tid] = 0;
 
 	return NULL;
 }

--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -411,7 +411,7 @@ static void *socket_connection_handler_thread(void *socket_desc)
 	unlock_shm();
 	if(tid == MAX_API_THREADS)
 	{
-		logg("Not able to spawn new API thread, limit reached.");
+		logg("Not able to spawn new API thread, limit of " str(MAX_API_THREADS) " threads reached.");
 		return false;
 	}
 

--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -16,6 +16,9 @@
 #include "../config.h"
 // global variable killed
 #include "../signals.h"
+// API thread storage
+#include "../daemon.h"
+#include "../shmem.h"
 
 // The backlog argument defines the maximum length
 // to which the queue of pending connections for
@@ -312,10 +315,29 @@ static void *telnet_connection_handler_thread(void *socket_desc)
 	char client_message[SOCKETBUFFERLEN] = "";
 
 	// Set thread name
-	char threadname[16];
+	char threadname[16] = { 0 };
 	sprintf(threadname, "telnet-%i", sock);
 	prctl(PR_SET_NAME, threadname, 0, 0, 0);
-	//Receive from client
+
+	// Store TID of this thread
+	lock_shm();
+	unsigned int tid;
+	for(tid = 0; tid < MAX_API_THREADS; tid++)
+	{
+		if(api_threads[tid] == 0)
+		{
+			api_threads[tid] = pthread_self();
+			break;
+		}
+	}
+	unlock_shm();
+	if(tid == MAX_API_THREADS)
+	{
+		logg("Not able to spawn new API thread, limit reached.");
+		return false;
+	}
+
+	// Receive from client
 	ssize_t n;
 	while((n = recv(sock,client_message,SOCKETBUFFERLEN-1, 0)))
 	{
@@ -343,12 +365,15 @@ static void *telnet_connection_handler_thread(void *socket_desc)
 		}
 	}
 
-	//Free the socket pointer
+	// Free the socket pointer
 	if(sock != 0)
 		close(sock);
 	free(socket_desc);
 
-	return false;
+	// Release thread from list
+	api_threads[tid] = 0;
+
+	return NULL;
 }
 
 
@@ -366,6 +391,24 @@ static void *socket_connection_handler_thread(void *socket_desc)
 	char threadname[16];
 	sprintf(threadname, "socket-%i", sock);
 	prctl(PR_SET_NAME, threadname, 0, 0, 0);
+
+	// Store TID of this thread
+	lock_shm();
+	unsigned int tid;
+	for(tid = 0; tid < MAX_API_THREADS; tid++)
+	{
+		if(api_threads[tid] == 0)
+		{
+			api_threads[tid] = pthread_self();
+			break;
+		}
+	}
+	unlock_shm();
+	if(tid == MAX_API_THREADS)
+	{
+		logg("Not able to spawn new API thread, limit reached.");
+		return false;
+	}
 
 	// Receive from client
 	ssize_t n;
@@ -395,12 +438,15 @@ static void *socket_connection_handler_thread(void *socket_desc)
 		}
 	}
 
-	//Free the socket pointer
+	// Free the socket pointer
 	if(sock != 0)
 		close(sock);
 	free(socket_desc);
 
-	return false;
+	// Release thread from list
+	api_threads[tid] = 0;
+
+	return NULL;
 }
 
 void *telnet_listening_thread_IPv4(void *args)

--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -333,7 +333,7 @@ static void *telnet_connection_handler_thread(void *socket_desc)
 	unlock_shm();
 	if(tid == MAX_API_THREADS)
 	{
-		logg("Not able to spawn new API thread, limit reached.");
+		logg("Not able to spawn new API thread, limit of " str(MAX_API_THREADS) " threads reached.");
 		return false;
 	}
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -29,6 +29,7 @@
 
 pthread_t threads[THREADS_MAX] = { 0 };
 pthread_t api_threads[MAX_API_THREADS] = { 0 };
+pid_t api_tids[MAX_API_THREADS] = { 0 };
 bool resolver_ready = false;
 
 void go_daemon(void)

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -28,6 +28,7 @@
 #include "signals.h"
 
 pthread_t threads[THREADS_MAX] = { 0 };
+pthread_t api_threads[MAX_API_THREADS] = { 0 };
 bool resolver_ready = false;
 
 void go_daemon(void)
@@ -242,6 +243,19 @@ void cleanup(const int ret)
 	if(resolver_ready)
 	{
 		terminate_threads();
+
+		// Cancel and join possibly still running API worker threads
+		for(unsigned int tid = 0; tid < MAX_API_THREADS; tid++)
+		{
+			// Skip if this is an unused slot
+			if(api_threads[tid] == 0)
+				continue;
+
+			// Otherwise, cancel and join the thread
+			logg("Joining API worker thread %d", tid);
+			pthread_cancel(api_threads[tid]);
+			pthread_join(api_threads[tid], NULL);
+		}
 
 		// Close database connection
 		lock_shm();

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -14,6 +14,7 @@
 extern pthread_t threads[THREADS_MAX];
 #define MAX_API_THREADS 40
 extern pthread_t api_threads[MAX_API_THREADS];
+extern pid_t api_tids[MAX_API_THREADS];
 
 void go_daemon(void);
 void savepid(void);

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -12,6 +12,8 @@
 
 #include "enums.h"
 extern pthread_t threads[THREADS_MAX];
+#define MAX_API_THREADS 40
+extern pthread_t api_threads[MAX_API_THREADS];
 
 void go_daemon(void);
 void savepid(void);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Cancel still running API threads at shutdown. This avoids a possible crash when a long-running API task is still running when FTL closes database connections on shut down.