### PR TITLE
Improve locking during heavy TCP forking

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -218,7 +218,9 @@ void cleanup(const int ret)
 		terminate_threads();
 
 		// Close database connection
+		lock_shm();
 		gravityDB_close();
+		unlock_shm();
 
 		// Close sockets and delete Unix socket file handle
 		close_telnet_socket();

--- a/src/database/aliasclients.c
+++ b/src/database/aliasclients.c
@@ -131,6 +131,13 @@ bool import_aliasclients(sqlite3 *db)
 		const int clientID = findClientID(aliasclient_str, false, true);
 
 		clientsData *client = getClient(clientID, true);
+		if(client == NULL)
+		{
+			free(aliasclient_str);
+			continue;
+		}
+
+		// Set client flags
 		client->flags.new = false;
 
 		// Reset counter

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -344,7 +344,9 @@ void db_init(void)
 		dbversion = db_get_int(db, DB_VERSION);
 	}
 
+	lock_shm();
 	import_aliasclients(db);
+	unlock_shm();
 
 	// Close database to prevent having it opened all time
 	// We already closed the database when we returned earlier

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -934,7 +934,8 @@ void gravityDB_close(void)
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		clientsData *client = getClient(clientID, true);
-		gravityDB_finalize_client_statements(client);
+		if(client != NULL)
+			gravityDB_finalize_client_statements(client);
 	}
 
 	// Free allocated memory for vectors of prepared client statements

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -369,6 +369,9 @@ void DB_read_queries(void)
 		return;
 	}
 
+	// Lock shared memory
+	lock_shm();
+
 	// Loop through returned database rows
 	while((rc = sqlite3_step(stmt)) == SQLITE_ROW)
 	{
@@ -430,8 +433,8 @@ void DB_read_queries(void)
 			continue;
 		}
 
-		// Lock shared memory
-		lock_shm();
+		// Ensure we have enough shared memory available for new data
+		shm_ensure_size();
 
 		const char *buffer = NULL;
 		int upstreamID = -1; // Default if not forwarded
@@ -591,9 +594,9 @@ void DB_read_queries(void)
 				logg("Warning: Found unknown status %i in long term database!", status);
 				break;
 		}
-
-		unlock_shm();
 	}
+
+	unlock_shm();
 	logg("Imported %i queries from the long-term database", counters->queries);
 
 	// Update lastdbindex so that the next call to DB_save_queries()

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2044,8 +2044,12 @@ void FTL_TCP_worker_terminating(bool finished)
 		return;
 	}
 
+	// First check if we already locked before. This can happen when a fork
+	// is running into a timeout while it is still processing something and
+	// still holding a lock.
+	if(!is_our_lock())
+		lock_shm();
 	// Close dedicated database connections of this fork
-	lock_shm();
 	gravityDB_close();
 	unlock_shm();
 }

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2045,7 +2045,9 @@ void FTL_TCP_worker_terminating(bool finished)
 	}
 
 	// Close dedicated database connections of this fork
+	lock_shm();
 	gravityDB_close();
+	unlock_shm();
 }
 
 // Called when a (forked) TCP worker is created

--- a/src/main.c
+++ b/src/main.c
@@ -103,8 +103,10 @@ int main (int argc, char* argv[])
 	// Save new queries to database (if database is used)
 	if(config.DBexport)
 	{
+		lock_shm();
 		if(DB_save_queries(NULL))
 			logg("Finished final database update");
+		unlock_shm();
 	}
 
 	cleanup(exit_code);

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -1048,7 +1048,8 @@ queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * func
 	// We are not in a locked situation, return a NULL pointer
 	if(!is_our_lock())
 	{
-		logg("ERROR: Tried to obtain query pointer without lock!");
+		logg("ERROR: Tried to obtain query pointer without lock in %s() (%s:%i)!",
+		     function, file, line);
 		return NULL;
 	}
 
@@ -1068,7 +1069,8 @@ clientsData* _getClient(int clientID, bool checkMagic, int line, const char * fu
 	// We are not in a locked situation, return a NULL pointer
 	if(!is_our_lock())
 	{
-		logg("ERROR: Tried to obtain client pointer without lock!");
+		logg("ERROR: Tried to obtain client pointer without lock in %s() (%s:%i)!",
+		     function, file, line);
 		return NULL;
 	}
 
@@ -1089,7 +1091,8 @@ domainsData* _getDomain(int domainID, bool checkMagic, int line, const char * fu
 	// We are not in a locked situation, return a NULL pointer
 	if(!is_our_lock())
 	{
-		logg("ERROR: Tried to obtain domain pointer without lock!");
+		logg("ERROR: Tried to obtain domain pointer without lock in %s() (%s:%i)!",
+		     function, file, line);
 		return NULL;
 	}
 
@@ -1110,7 +1113,8 @@ upstreamsData* _getUpstream(int upstreamID, bool checkMagic, int line, const cha
 	// We are not in a locked situation, return a NULL pointer
 	if(!is_our_lock())
 	{
-		logg("ERROR: Tried to obtain upstream pointer without lock!");
+		logg("ERROR: Tried to obtain upstream pointer without lock in %s() (%s:%i)!",
+		     function, file, line);
 		return NULL;
 	}
 
@@ -1131,7 +1135,8 @@ DNSCacheData* _getDNSCache(int cacheID, bool checkMagic, int line, const char * 
 	// We are not in a locked situation, return a NULL pointer
 	if(!is_our_lock())
 	{
-		logg("ERROR: Tried to obtain cache pointer without lock!");
+		logg("ERROR: Tried to obtain cache pointer without lock in %s() (%s:%i)!",
+		     function, file, line);
 		return NULL;
 	}
 

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -109,7 +109,6 @@ static size_t get_optimal_object_size(const size_t objsize, const size_t minsize
 
 // Private prototypes
 static void *enlarge_shmem_struct(const char type);
-static void shm_ensure_size(void);
 
 static int get_dev_shm_usage(char buffer[64])
 {
@@ -892,7 +891,7 @@ static size_t get_optimal_object_size(const size_t objsize, const size_t minsize
 }
 
 // Enlarge shared memory to be able to hold at least one new record
-static void shm_ensure_size(void)
+void shm_ensure_size(void)
 {
 	if(counters->queries >= counters->queries_MAX-1)
 	{

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -24,6 +24,8 @@
 #include <limits.h>
 // gettid
 #include "daemon.h"
+// generate_backtrace()
+#include "signals.h"
 
 /// The version of shared memory used
 #define SHARED_MEMORY_VERSION 13
@@ -1050,6 +1052,7 @@ queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * func
 	{
 		logg("ERROR: Tried to obtain query pointer without lock in %s() (%s:%i)!",
 		     function, file, line);
+		generate_backtrace();
 		return NULL;
 	}
 
@@ -1071,11 +1074,11 @@ clientsData* _getClient(int clientID, bool checkMagic, int line, const char * fu
 	{
 		logg("ERROR: Tried to obtain client pointer without lock in %s() (%s:%i)!",
 		     function, file, line);
+		generate_backtrace();
 		return NULL;
 	}
 
-	if(is_our_lock() &&
-	   check_range(clientID, counters->clients_MAX, "client", line, function, file) && is_our_lock() &&
+	if(check_range(clientID, counters->clients_MAX, "client", line, function, file) && is_our_lock() &&
 	   check_magic(clientID, checkMagic, clients[clientID].magic, "client", line, function, file))
 		return &clients[clientID];
 	else
@@ -1093,11 +1096,11 @@ domainsData* _getDomain(int domainID, bool checkMagic, int line, const char * fu
 	{
 		logg("ERROR: Tried to obtain domain pointer without lock in %s() (%s:%i)!",
 		     function, file, line);
+		generate_backtrace();
 		return NULL;
 	}
 
-	if(is_our_lock() &&
-	   check_range(domainID, counters->domains_MAX, "domain", line, function, file) &&
+	if(check_range(domainID, counters->domains_MAX, "domain", line, function, file) &&
 	   check_magic(domainID, checkMagic, domains[domainID].magic, "domain", line, function, file))
 		return &domains[domainID];
 	else
@@ -1115,11 +1118,11 @@ upstreamsData* _getUpstream(int upstreamID, bool checkMagic, int line, const cha
 	{
 		logg("ERROR: Tried to obtain upstream pointer without lock in %s() (%s:%i)!",
 		     function, file, line);
+		generate_backtrace();
 		return NULL;
 	}
 
-	if(is_our_lock() &&
-	   check_range(upstreamID, counters->upstreams_MAX, "upstream", line, function, file) && is_our_lock() &&
+	if(check_range(upstreamID, counters->upstreams_MAX, "upstream", line, function, file) && is_our_lock() &&
 	   check_magic(upstreamID, checkMagic, upstreams[upstreamID].magic, "upstream", line, function, file))
 		return &upstreams[upstreamID];
 	else
@@ -1137,11 +1140,11 @@ DNSCacheData* _getDNSCache(int cacheID, bool checkMagic, int line, const char * 
 	{
 		logg("ERROR: Tried to obtain cache pointer without lock in %s() (%s:%i)!",
 		     function, file, line);
+		generate_backtrace();
 		return NULL;
 	}
 
-	if(is_our_lock() &&
-	   check_range(cacheID, counters->dns_cache_MAX, "dns_cache", line, function, file) && is_our_lock() &&
+	if(check_range(cacheID, counters->dns_cache_MAX, "dns_cache", line, function, file) && is_our_lock() &&
 	   check_magic(cacheID, checkMagic, dns_cache[cacheID].magic, "dns_cache", line, function, file))
 		return &dns_cache[cacheID];
 	else

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -89,6 +89,9 @@ void _lock_shm(const char* func, const int line, const char* file);
 #define lock_log() _lock_log(__FUNCTION__, __LINE__, __FILE__)
 void _lock_log(const char* func, const int line, const char* file);
 
+// Return if the current mutex locked the SHM lock
+bool is_our_lock(void);
+
 /// Unlock the lock. Only call this if there is an active lock.
 #define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _unlock_shm(const char* func, const int line, const char* file);

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -92,6 +92,11 @@ void _lock_log(const char* func, const int line, const char* file);
 // Return if the current mutex locked the SHM lock
 bool is_our_lock(void);
 
+// This ensures we have enough space available for more objects
+// The function should only be called from within _lock() and when reading
+// content from the database
+void shm_ensure_size(void);
+
 /// Unlock the lock. Only call this if there is an active lock.
 #define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _unlock_shm(const char* func, const int line, const char* file);

--- a/src/signals.c
+++ b/src/signals.c
@@ -355,7 +355,7 @@ void handle_realtime_signals(void)
 pid_t main_pid(void)
 {
 	if(mpid > -1)
-		// Hase already been set
+		// Has already been set
 		return mpid;
 	else
 		// Has not been set so far

--- a/src/signals.h
+++ b/src/signals.h
@@ -16,6 +16,7 @@ void handle_signals(void);
 void handle_realtime_signals(void);
 pid_t main_pid(void);
 void thread_sleepms(const enum thread_types thread, const int milliseconds);
+void generate_backtrace(void);
 
 extern volatile sig_atomic_t killed;
 extern volatile sig_atomic_t want_to_reimport_aliasclients;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Lock when terminating forks to ensure we remap shared memory if heavy TCP activity causes shared memory objects to resize often.