### PR TITLE
Improve warning messages for defect hwclocks

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -236,10 +236,16 @@ void read_FTLconf(void)
 	buffer = parse_FTLconf(fp, "MAXLOGAGE");
 
 	fvalue = 0;
+	const char *hint = "";
 	if(buffer != NULL && sscanf(buffer, "%f", &fvalue))
+	{
 		if(fvalue >= 0.0f && fvalue <= 1.0f*MAXLOGAGE)
 			config.maxlogage = (int)(fvalue * 3600);
-	logg("   MAXLOGAGE: Importing up to %.1f hours of log data", (float)config.maxlogage/3600.0f);
+		else if(fvalue > 1.0f*MAXLOGAGE)
+			hint = " (value has been clipped to " str(MAXLOGAGE) " hours)";
+	}
+	logg("   MAXLOGAGE: Importing up to %.1f hours of log data%s",
+	     (float)config.maxlogage/3600.0f, hint);
 
 	// PRIVACYLEVEL
 	// Specify if we want to anonymize the DNS queries somehow, available options are:

--- a/src/overTime.c
+++ b/src/overTime.c
@@ -78,6 +78,7 @@ void initOverTime(void)
 	}
 }
 
+bool warned_about_hwclock = false;
 unsigned int getOverTimeID(time_t timestamp)
 {
 	// Center timestamp in OVERTIME_INTERVAL
@@ -93,13 +94,19 @@ unsigned int getOverTimeID(time_t timestamp)
 	// Check bounds manually
 	if(id < 0)
 	{
-		logg("WARN: getOverTimeID(%llu): %u is negative: %llu", (long long)timestamp, id, (long long)firstTimestamp);
 		// Return first timestamp in case negative timestamp was determined
 		return 0;
 	}
 	else if(id > OVERTIME_SLOTS-1)
 	{
-		logg("WARN: getOverTimeID(%llu): %i is too large: %llu", (long long)timestamp, id, (long long)firstTimestamp);
+		if(!warned_about_hwclock)
+		{
+			const time_t lastTimestamp = overTime[OVERTIME_SLOTS-1].timestamp;
+			logg("WARN: Found database entries in the future (%llu, last: %llu). "
+			     "Your over-time statistics may be incorrect",
+			     (long long)timestamp, (long long)lastTimestamp);
+			warned_about_hwclock = true;
+		}
 		// Return last timestamp in case a too large timestamp was determined
 		return OVERTIME_SLOTS-1;
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Improve warning message when importing queries from the future (a typical problem of systems starting at 1970-01-01 on every boot). Also, show the warning only once instead of flooding the log file.