### PR TITLE
Implement special handling of the Mozilla canary domain to disable Firefox automatic DoH

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -537,6 +537,17 @@ void read_FTLconf(void)
 	else
 		logg("   SHOW_DNSSEC: Disabled");
 
+	// MOZILLA_CANARY
+	// Should FTL handle use-application-dns.net specifically and always return NXDOMAIN?
+	// defaults to: true
+	buffer = parse_FTLconf(fp, "MOZILLA_CANARY");
+	config.special_domains.mozilla_canary = read_bool(buffer, true);
+
+	if(config.special_domains.mozilla_canary)
+		logg("   MOZILLA_CANARY: Enabled");
+	else
+		logg("   MOZILLA_CANARY: Disabled");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -47,6 +47,9 @@ typedef struct {
 	bool names_from_netdb;
 	bool edns0_ecs;
 	bool show_dnssec;
+	struct {
+		bool mozilla_canary :1;
+	} special_domains;
 	enum privacy_level privacylevel;
 	enum blocking_mode blockingmode;
 	enum refresh_hostnames refresh_hostnames;

--- a/src/enums.h
+++ b/src/enums.h
@@ -120,6 +120,7 @@ enum domain_client_status {
 	BLACKLIST_BLOCKED,
 	REGEX_BLOCKED,
 	WHITELISTED,
+	SPECIAL_DOMAIN,
 	NOT_BLOCKED
 } __attribute__ ((packed));
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Ensure FTL always replies with `NXDOMAIN` to `A` and `AAAA` queries of `use-application-dns.net`
This is following the recommendation on https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https

Enforcing `NXDOMAIN` for `use-application-dns.net` can be disabled by setting `MOZILLA_CANARY=false` in `/etc/pihole/pihole-FTL.conf`

The Query Log will display this as reply answered from cache:
![Screenshot from 2021-07-04 13-52-05](https://user-images.githubusercontent.com/16748619/124383912-3c1ff380-dccf-11eb-8e03-a00100f575d1.png)


We could also introduce a new "special domain" status, but I don't see this necessary for now (and it'd require another change to the AdminLTE repo as well).