### PR TITLE
Add further cache metrics

### DIFF
--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -1673,6 +1673,38 @@ static char *sanitise(char *name)
   return name;
 }
 
+/***************** Pi-hole modification *****************/
+void get_dnsmasq_cache_info(struct cache_info *ci)
+{
+  memset(ci, 0, sizeof(struct cache_info));
+  const time_t now = time(NULL);
+  for (int i=0; i < hash_size; i++)
+    for (struct crec *cache = hash_table[i]; cache; cache = cache->hash_next)
+      if(cache->flags & F_IMMORTAL)
+	ci->immortal++;
+      else if(cache->ttd >= now)
+      {
+	if (cache->flags & F_IPV4)
+	  ci->valid.ipv4++;
+	else if (cache->flags & F_IPV6)
+	  ci->valid.ipv6++;
+	else if (cache->flags & F_CNAME)
+	  ci->valid.cname++;
+	else if (cache->flags & F_SRV)
+	  ci->valid.srv++;
+#ifdef HAVE_DNSSEC
+	else if (cache->flags & F_DS)
+	  ci->valid.ds++;
+	else if (cache->flags & F_DNSKEY)
+	  ci->valid.dnskey++;
+#endif
+	else
+	  ci->valid.other++;
+      }
+      else
+	ci->expired++;
+}
+/********************************************************/
 
 void dump_cache(time_t now)
 {

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1257,6 +1257,20 @@ void next_uid(struct crec *crecp);
 /********************************************* Pi-hole modification ***********************************************/
 #define log_query(flags,name,addr,arg) _log_query(flags, name, addr, arg, __FILE__, __LINE__)
 void _log_query(unsigned int flags, char *name, union all_addr *addr, char *arg, const char* file, const int line);
+struct cache_info {
+  struct valid {
+    int ipv4;
+    int ipv6;
+    int cname;
+    int srv;
+    int ds;
+    int dnskey;
+    int other;
+  } valid;
+  int expired;
+  int immortal;
+};
+void get_dnsmasq_cache_info(struct cache_info *ci);
 /******************************************************************************************************************/
 char *record_source(unsigned int index);
 char *querystr(char *desc, unsigned short type);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2326,11 +2326,22 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 // int cache_inserted, cache_live_freed are defined in dnsmasq/cache.c
 void getCacheInformation(const int *sock)
 {
-	ssend(*sock,"cache-size: %i\ncache-live-freed: %i\ncache-inserted: %i\n",
+	struct cache_info ci;
+	get_dnsmasq_cache_info(&ci);
+	ssend(*sock,"cache-size: %i\ncache-live-freed: %i\ncache-inserted: %i\nipv4: %i\nipv6: %i\nsrv: %i\ncname: %i\nds: %i\ndnskey: %i\nother: %i\nexpired: %i\nimmortal: %i\n",
 	            daemon->cachesize,
 	            daemon->metrics[METRIC_DNS_CACHE_LIVE_FREED],
-	            daemon->metrics[METRIC_DNS_CACHE_INSERTED]);
-	// cache-size is obvious
+	            daemon->metrics[METRIC_DNS_CACHE_INSERTED],
+	            ci.valid.ipv4,
+	            ci.valid.ipv6,
+	            ci.valid.srv,
+	            ci.valid.cname,
+	            ci.valid.ds,
+	            ci.valid.dnskey,
+	            ci.valid.other,
+	            ci.expired,
+	            ci.immortal);
+	// <cache-size> is obvious
 	// It means the resolver handled <cache-inserted> names lookups that
 	// needed to be sent to upstream servers and that <cache-live-freed>
 	// was thrown out of the cache before reaching the end of its
@@ -2339,6 +2350,9 @@ void getCacheInformation(const int *sock)
 	// cached. If the cache is full with entries which haven't reached
 	// the end of their time-to-live, then the entry which hasn't been
 	// looked up for the longest time is evicted.
+	// <valid> are cache entries with positive remaining TTL
+	// <expired> cache entries (to be removed when space is needed)
+	// <immortal> cache records never expire (e.g. from /etc/hosts)
 }
 
 void FTL_forwarding_retried(const struct server *serv, const int oldID, const int newID, const bool dnssec)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR adds further cache metrics that can be queried via the API (http://pi.hole/admin/api.php?getCacheInfo). No changes are necessary on the web front end. We add a breakdown of the current cache content for inspection:

![Screenshot from 2021-07-24 13-20-10](https://user-images.githubusercontent.com/16748619/126866865-6467e8e3-92eb-457a-986d-359c340389e6.png)

This has been inspired by the linked Discourse discussion.