### PR TITLE
Log rate-limiting of clients to the message table

### DIFF
--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -20,7 +20,6 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
                          const int chosen_match_id);
 void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos);
 void logg_fatal_dnsmasq_message(const char *message);
-
-enum message_type { REGEX_MESSAGE, SUBNET_MESSAGE, HOSTNAME_MESSAGE, DNSMASQ_CONFIG_MESSAGE, MAX_MESSAGE };
+void logg_rate_limit_message(const char *clientIP);
 
 #endif //MESSAGETABLE_H

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -46,6 +46,8 @@
 #include <stddef.h>
 // get_edestr()
 #include "api/api_helper.h"
+// logg_rate_limit_message()
+#include "database/message-table.h"
 
 // Private prototypes
 static void print_flags(const unsigned int flags);
@@ -490,11 +492,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		// Log the first rate-limited query for this client in this interval
 		// We do not log the blocked domain for privacy reasons
 		if(client->rate_limit == config.rate_limit.count+1)
-		{
-			const time_t turnaround = get_rate_limit_turnaround();
-			logg("Rate-limiting %s for %ld second%s",
-			     clientIP, turnaround, turnaround == 1 ? "" : "s");
-		}
+			logg_rate_limit_message(clientIP);
 
 		// Block this query
 		force_next_DNS_reply = REPLY_REFUSED;

--- a/src/enums.h
+++ b/src/enums.h
@@ -178,4 +178,13 @@ enum thread_types {
 	THREADS_MAX
 } __attribute__ ((packed));
 
+enum message_type {
+	REGEX_MESSAGE,
+	SUBNET_MESSAGE,
+	HOSTNAME_MESSAGE,
+	DNSMASQ_CONFIG_MESSAGE,
+	RATE_LIMIT_MESSAGE,
+	MAX_MESSAGE
+} __attribute__ ((packed));
+
 #endif // ENUMS_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add hint to Pi-hole diagnosis system when clients are rate-limited. This should make it easier to debug cases of clients going haywire.