### PR TITLE
Customizable locking while database is busy

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -570,6 +570,32 @@ void read_FTLconf(void)
 	else
 		logg("   ADDR2LINE: Disabled");
 
+	// REPLY_WHEN_BUSY
+	// How should FTL handle queries when the gravity database is not available?
+	// defaults to: BLOCK
+	buffer = parse_FTLconf(fp, "REPLY_WHEN_BUSY");
+
+	if(buffer != NULL && strcasecmp(buffer, "DROP") == 0)
+	{
+		config.reply_when_busy = BUSY_DROP;
+		logg("   REPLY_WHEN_BUSY: Drop queries when the database is busy");
+	}
+	else if(buffer != NULL && strcasecmp(buffer, "REFUSE") == 0)
+	{
+		config.reply_when_busy = BUSY_REFUSE;
+		logg("   REPLY_WHEN_BUSY: Refuse queries when the database is busy");
+	}
+	else if(buffer != NULL && strcasecmp(buffer, "BLOCK") == 0)
+	{
+		config.reply_when_busy = BUSY_BLOCK;
+		logg("   REPLY_WHEN_BUSY: Block queries when the database is busy");
+	}
+	else
+	{
+		config.reply_when_busy = BUSY_ALLOW;
+		logg("   REPLY_WHEN_BUSY: Permit queries when the database is busy");
+	}
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -55,6 +55,7 @@ typedef struct {
 	enum privacy_level privacylevel;
 	enum blocking_mode blockingmode;
 	enum refresh_hostnames refresh_hostnames;
+	enum busy_reply reply_when_busy;
 	int maxDBdays;
 	int port;
 	int maxlogage;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1228,7 +1228,7 @@ enum db_result in_whitelist(const char *domain, const DNSCacheData *dns_cache, c
 	// If list statement is not ready and cannot be initialized (e.g. no
 	// access to the database), we return false to prevent an FTL crash
 	if(whitelist_stmt == NULL)
-		return false;
+		return LIST_NOT_AVAILABLE;
 
 	// Check if this client needs a rechecking of group membership
 	gravityDB_client_check_again(client);
@@ -1269,7 +1269,7 @@ enum db_result in_gravity(const char *domain, clientsData *client)
 	// If list statement is not ready and cannot be initialized (e.g. no
 	// access to the database), we return false to prevent an FTL crash
 	if(gravity_stmt == NULL)
-		return false;
+		return LIST_NOT_AVAILABLE;
 
 	// Check if this client needs a rechecking of group membership
 	gravityDB_client_check_again(client);
@@ -1297,7 +1297,7 @@ enum db_result in_blacklist(const char *domain, clientsData *client)
 	// If list statement is not ready and cannot be initialized (e.g. no
 	// access to the database), we return false to prevent an FTL crash
 	if(blacklist_stmt == NULL)
-		return false;
+		return LIST_NOT_AVAILABLE;
 
 	// Check if this client needs a rechecking of group membership
 	gravityDB_client_check_again(client);

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -29,11 +29,11 @@ const char* gravityDB_getDomain(int *rowid);
 char* get_client_names_from_ids(const char *group_ids) __attribute__ ((malloc));
 void gravityDB_finalizeTable(void);
 int gravityDB_count(const enum gravity_tables list);
-bool in_auditlist(const char *domain);
 
-bool in_gravity(const char *domain, clientsData* client);
-bool in_blacklist(const char *domain, clientsData* client);
-bool in_whitelist(const char *domain, const DNSCacheData *dns_cache, clientsData* client);
+enum db_result in_gravity(const char *domain, clientsData *client);
+enum db_result in_blacklist(const char *domain, clientsData *client);
+enum db_result in_whitelist(const char *domain, const DNSCacheData *dns_cache, clientsData *client);
+bool in_auditlist(const char *domain);
 
 bool gravityDB_get_regex_client_groups(clientsData* client, const unsigned int numregex, const regexData *regex,
                                        const unsigned char type, const char* table);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -560,6 +560,7 @@ void DB_read_queries(void)
 			case QUERY_GRAVITY_CNAME: // Blocked by gravity (inside CNAME path)
 			case QUERY_REGEX_CNAME: // Blocked by regex blacklist (inside CNAME path)
 			case QUERY_BLACKLIST_CNAME: // Blocked by exact blacklist (inside CNAME path)
+			case QUERY_DBBUSY: // Blocked because gravity database was busy
 				query->flags.blocked = true;
 				// Get domain pointer
 				domainsData* domain = getDomain(domainID, true);

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -506,6 +506,7 @@ bool __attribute__ ((const)) is_blocked(const enum query_status status)
 		case QUERY_GRAVITY_CNAME:
 		case QUERY_REGEX_CNAME:
 		case QUERY_BLACKLIST_CNAME:
+		case QUERY_DBBUSY:
 			return true;
 	}
 }
@@ -525,7 +526,8 @@ static const char *query_status_str[QUERY_STATUS_MAX] = {
 	"BLACKLIST_CNAME",
 	"RETRIED",
 	"RETRIED_DNSSEC",
-	"IN_PROGRESS"
+	"IN_PROGRESS",
+	"DBBUSY"
 };
 
 void _query_set_status(queriesData *query, const enum query_status new_status, const char *file, const int line)

--- a/src/enums.h
+++ b/src/enums.h
@@ -44,6 +44,7 @@ enum query_status {
 	QUERY_RETRIED,
 	QUERY_RETRIED_DNSSEC,
 	QUERY_IN_PROGRESS,
+	QUERY_DBBUSY,
 	QUERY_STATUS_MAX
 } __attribute__ ((packed));
 
@@ -60,6 +61,7 @@ enum reply_type {
 	REPLY_NOTIMP,
 	REPLY_OTHER,
 	REPLY_DNSSEC,
+	REPLY_NONE,
 	QUERY_REPLY_MAX
 	}  __attribute__ ((packed));
 
@@ -168,6 +170,18 @@ enum refresh_hostnames {
 	REFRESH_NONE
 } __attribute__ ((packed));
 
+enum db_result {
+	NOT_FOUND,
+	FOUND,
+	LIST_NOT_AVAILABLE
+} __attribute__ ((packed));
+
+enum busy_reply {
+	BUSY_BLOCK,
+	BUSY_ALLOW,
+	BUSY_REFUSE,
+	BUSY_DROP
+} __attribute__ ((packed));
 
 enum thread_types {
 	TELNETv4,

--- a/src/gc.c
+++ b/src/gc.c
@@ -148,8 +148,9 @@ void *GC_thread(void *val)
 					case QUERY_EXTERNAL_BLOCKED_NXRA: // Blocked by upstream provider (fall through)
 					case QUERY_EXTERNAL_BLOCKED_NULL: // Blocked by upstream provider (fall through)
 					case QUERY_GRAVITY_CNAME: // Gravity domain in CNAME chain (fall through)
-					case QUERY_BLACKLIST_CNAME: // Exactly blacklisted domain in CNAME chain (fall through)
 					case QUERY_REGEX_CNAME: // Regex blacklisted domain in CNAME chain (fall through)
+					case QUERY_BLACKLIST_CNAME: // Exactly blacklisted domain in CNAME chain (fall through)
+					case QUERY_DBBUSY: // Blocked because gravity database was busy
 						if(domain != NULL)
 							domain->blockedcount--;
 						if(client != NULL)

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -54,7 +54,7 @@ typedef struct {
 	int status[QUERY_STATUS_MAX];
 	int reply[QUERY_REPLY_MAX];
 } countersStruct;
-ASSERT_SIZEOF(countersStruct, 228, 228, 228);
+ASSERT_SIZEOF(countersStruct, 236, 236, 236);
 
 extern countersStruct *counters;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

When the gravity database is locked/busy, Pi-hole allows all queries because it has no way of detecting if they should be blocked or not. However, for very large lists and/or on very busy networks and/or on very (!) slow devices, this may open a windows of up to several seconds where undesired queries may get through, ads and unwanted telemetry could be the result.

This PR adds a config option (`REPLY_WHEN_BUSY`) to customize what happens to queries while the database is locked:
1. `ALLOW` - as before, just allow all queries when the database is busy
2. `BLOCK` - block all queries when the database is busy. This uses the configured `BLOCKINGMODE` (default `NULL`)
3. `REFUSE` - refuse all queries which arrive while the database is busy
4. `DROP` - just drop the queries, i.e., never reply to them at all.

In my opinion, option 4 is the best one because it will typically cause clients to retry the query after some timeout of typically a few seconds. I.e., the DNS resolution will only be delayed but we do never hand out incorrectly either allowed or blocked queries.
`REFUSE` first sounded like a good option, too, however, it turned out that many clients will just immediately retry, causing up to several thousands of queries per second. This does not happen in `DROP` mode.