### PR TITLE
Reduce disk I/O in database thread

### DIFF
--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -27,6 +27,10 @@
 // Eventqueue routines
 #include "../events.h"
 
+#define DBOPEN_OR_AGAIN() { db = dbopen(false); if(db == NULL) { thread_sleepms(DB, 5000); continue; } }
+#define BREAK_IF_KILLED() { if(killed) break; }
+#define DBCLOSE_OR_BREAK() { dbclose(&db); BREAK_IF_KILLED(); }
+
 void *DB_thread(void *val)
 {
 	// Set thread name
@@ -40,13 +44,7 @@ void *DB_thread(void *val)
 	// Run until shutdown of the process
 	while(!killed)
 	{
-		sqlite3 *db = dbopen(false);
-		if(db == NULL)
-		{
-			// Sleep 5 seconds and try again
-			thread_sleepms(DB, 5000);
-			continue;
-		}
+		sqlite3 *db = NULL;
 		time_t now = time(NULL);
 		if(now - lastDBsave >= config.DBinterval)
 		{
@@ -56,16 +54,10 @@ void *DB_thread(void *val)
 			// Save data to database (if enabled)
 			if(config.DBexport)
 			{
+				DBOPEN_OR_AGAIN();
 				lock_shm();
 				DB_save_queries(db);
 				unlock_shm();
-
-				// Intermediate cancellation-point
-				if(killed)
-				{
-					dbclose(&db);
-					break;
-				}
 
 				// Check if GC should be done on the database
 				if(DBdeleteoldqueries && config.maxDBdays != -1)
@@ -74,6 +66,8 @@ void *DB_thread(void *val)
 					delete_old_queries_in_DB(db);
 					DBdeleteoldqueries = false;
 				}
+
+				DBCLOSE_OR_BREAK();
 			}
 
 			// Parse neighbor cache (fill network table) if enabled
@@ -81,67 +75,44 @@ void *DB_thread(void *val)
 				set_event(PARSE_NEIGHBOR_CACHE);
 		}
 
-		// Intermediate cancellation-point
-		if(killed)
-		{
-			dbclose(&db);
-			break;
-		}
-
 		// Update MAC vendor strings once a month (the MAC vendor
 		// database is not updated very often)
 		if(now % 2592000L == 0)
-			updateMACVendorRecords(db);
-
-		// Intermediate cancellation-point
-		if(killed)
 		{
-			dbclose(&db);
-			break;
+			DBOPEN_OR_AGAIN();
+			updateMACVendorRecords(db);
+			DBCLOSE_OR_BREAK();
 		}
 
+		// Parse ARP cache if requested
 		if(get_and_clear_event(PARSE_NEIGHBOR_CACHE))
-			parse_neighbor_cache(db);
-
-		// Intermediate cancellation-point
-		if(killed)
 		{
-			dbclose(&db);
-			break;
+			DBOPEN_OR_AGAIN();
+			parse_neighbor_cache(db);
+			DBCLOSE_OR_BREAK();
+		}
+
+		// Import alias-clients
+		if(get_and_clear_event(REIMPORT_ALIASCLIENTS))
+		{
+			DBOPEN_OR_AGAIN();
+			lock_shm();
+			reimport_aliasclients(db);
+			unlock_shm();
+			DBCLOSE_OR_BREAK();
 		}
 
 		// Process database related event queue elements
 		if(get_and_clear_event(RELOAD_GRAVITY))
 			FTL_reload_all_domainlists();
 
-		// Intermediate cancellation-point
-		if(killed)
-		{
-			dbclose(&db);
-			break;
-		}
+		BREAK_IF_KILLED();
 
 		// Reload privacy level from pihole-FTL.conf
 		if(get_and_clear_event(RELOAD_PRIVACY_LEVEL))
 			get_privacy_level(NULL);
 
-		// Intermediate cancellation-point
-		if(killed)
-		{
-			dbclose(&db);
-			break;
-		}
-
-		// Import alias-clients
-		if(get_and_clear_event(REIMPORT_ALIASCLIENTS))
-		{
-			lock_shm();
-			reimport_aliasclients(db);
-			unlock_shm();
-		}
-
-		// Close database connection
-		dbclose(&db);
+		BREAK_IF_KILLED();
 
 		// Sleep 1 sec
 		thread_sleepms(DB, 1000);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -262,6 +262,15 @@ int DB_save_queries(sqlite3 *db)
 		return -1;
 	}
 
+	// Store index for next loop interation round and update last time stamp
+	// in the database only if all queries have been saved successfully
+	if(saved > 0 && !error)
+	{
+		lastdbindex = queryID;
+		db_set_FTL_property(db, DB_LASTTIMESTAMP, newlasttimestamp);
+		db_update_counters(db, total, blocked);
+	}
+
 	// Finish prepared statement
 	if((rc = dbquery(db,"END TRANSACTION")) != SQLITE_OK)
 	{
@@ -278,15 +287,6 @@ int DB_save_queries(sqlite3 *db)
 			dbclose(&db);
 
 		return -1;
-	}
-
-	// Store index for next loop interation round and update last time stamp
-	// in the database only if all queries have been saved successfully
-	if(saved > 0 && !error)
-	{
-		lastdbindex = queryID;
-		db_set_FTL_property(db, DB_LASTTIMESTAMP, newlasttimestamp);
-		db_update_counters(db, total, blocked);
 	}
 
 	if(config.debug & DEBUG_DATABASE || saving_failed_before)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR consists of two changes. It fixes #1157.

- Only open database when really necessary. This may reduce disk activity slightly and save a bit of CPU time.
- Update database counters still within the running `TRANSACTION` to reduce I/O