### PR TITLE
Regex extension: Specify reply type

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1223,7 +1223,7 @@ static void gravityDB_client_check_again(clientsData* client)
 	}
 }
 
-enum db_result in_whitelist(const char *domain, const DNSCacheData *dns_cache, clientsData* client)
+enum db_result in_whitelist(const char *domain, DNSCacheData *dns_cache, clientsData* client)
 {
 	// If list statement is not ready and cannot be initialized (e.g. no
 	// access to the database), we return false to prevent an FTL crash

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -32,7 +32,7 @@ int gravityDB_count(const enum gravity_tables list);
 
 enum db_result in_gravity(const char *domain, clientsData *client);
 enum db_result in_blacklist(const char *domain, clientsData *client);
-enum db_result in_whitelist(const char *domain, const DNSCacheData *dns_cache, clientsData *client);
+enum db_result in_whitelist(const char *domain, DNSCacheData *dns_cache, clientsData *client);
 bool in_auditlist(const char *domain);
 
 bool gravityDB_get_regex_client_groups(clientsData* client, const unsigned int numregex, const regexData *regex,

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -133,6 +133,8 @@ const char *getClientNameString(const queriesData* query);
 
 void change_clientcount(clientsData *client, int total, int blocked, int overTimeIdx, int overTimeMod);
 
+const char *get_query_reply_str(const enum reply_type query) __attribute__ ((const));
+
 // Pointer getter functions
 #define getQuery(queryID, checkMagic) _getQuery(queryID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
 queriesData* _getQuery(int queryID, bool checkMagic, int line, const char * function, const char * file);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -50,6 +50,7 @@
 #include "database/message-table.h"
 
 // Private prototypes
+static const char *reply_status_str[QUERY_REPLY_MAX+1];
 static void print_flags(const unsigned int flags);
 #define query_set_reply(flags, addr, query, response) _query_set_reply(flags, addr, query, response, __FILE__, __LINE__)
 static void _query_set_reply(const unsigned int flags, const union all_addr *addr, queriesData* query, const struct timeval response,
@@ -192,6 +193,16 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 		if(config.debug & DEBUG_FLAGS)
 			logg("Forced DNS reply to NXDOMAIN");
 	}
+	else if(force_next_DNS_reply == REPLY_NODATA)
+	{
+		flags = F_NOERR;
+		// Reset DNS reply forcing
+		force_next_DNS_reply = REPLY_UNKNOWN;
+
+		// Debug logging
+		if(config.debug & DEBUG_FLAGS)
+			logg("Forced DNS reply to NODATA");
+	}
 	else if(force_next_DNS_reply == REPLY_REFUSED)
 	{
 		// Empty flags result in REFUSED
@@ -237,7 +248,7 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 		{
 			// If we block in NXDOMAIN mode, we add the NEGATIVE response
 			// and the NXDOMAIN flags
-			flags =  F_NEG | F_NXDOMAIN;
+			flags = F_NXDOMAIN;
 			if(config.debug & DEBUG_FLAGS)
 				logg("Configured blocking mode is NXDOMAIN");
 		}
@@ -953,6 +964,10 @@ static bool check_domain_blocked(const char *domain, const int clientID,
 		set_dnscache_blockingstatus(dns_cache, client, REGEX_BLOCKED, domain);
 		dns_cache->black_regex_idx = regex_idx;
 
+		// Regex may be overwriting reply type for this domain
+		if(dns_cache->force_reply != REPLY_UNKNOWN)
+			force_next_DNS_reply = dns_cache->force_reply;
+
 		// We block this domain
 		return true;
 	}
@@ -1207,6 +1222,9 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 		// Debug output
 		if(config.debug & DEBUG_QUERIES)
 			logg("Blocking %s as %s is %s", domainstr, blockedDomain, blockingreason);
+
+		if(force_next_DNS_reply != 0)
+			logg("Forcing next reply to %s", reply_status_str[force_next_DNS_reply]);
 	}
 	else if(db_okay)
 	{
@@ -2276,8 +2294,10 @@ static void _query_set_reply(const unsigned int flags, const union all_addr *add
                              const char *file, const int line)
 {
 	// Iterate through possible values
-	if(flags & F_NEG || force_next_DNS_reply == REPLY_NXDOMAIN ||
-	   (flags & F_NOERR && !(flags & (F_IPV4 | F_IPV6)))) // <-- FTL_make_answer() when no A or AAAA is added
+	if(flags & F_NEG ||
+	   (flags & F_NOERR && !(flags & (F_IPV4 | F_IPV6))) || // <-- FTL_make_answer() when no A or AAAA is added
+	   force_next_DNS_reply == REPLY_NXDOMAIN ||
+	   force_next_DNS_reply == REPLY_NODATA)
 	{
 		if(flags & F_NXDOMAIN || force_next_DNS_reply == REPLY_NXDOMAIN)
 			// NXDOMAIN

--- a/src/regex_r.h
+++ b/src/regex_r.h
@@ -28,10 +28,13 @@ extern const char *regextype[];
 #include "static_assert.h"
 
 typedef struct {
-	bool available;
-	bool inverted;
-	bool query_type_inverted;
-	enum query_types query_type;
+	bool available :1;
+	struct {
+		bool inverted :1;
+		bool query_type_inverted :1;
+		enum query_types query_type;
+		enum reply_type reply;
+	} ext;
 	int database_id;
 	char *string;
 	regex_t regex;
@@ -39,7 +42,7 @@ typedef struct {
 ASSERT_SIZEOF(regexData, 32, 20, 20);
 
 unsigned int get_num_regex(const enum regex_type regexid) __attribute__((pure));
-int match_regex(const char *input, const DNSCacheData* dns_cache, const int clientID,
+int match_regex(const char *input, DNSCacheData* dns_cache, const int clientID,
                 const enum regex_type regexid, const bool regextest);
 void allocate_regex_client_enabled(clientsData *client, const int clientID);
 void reload_per_client_regex(clientsData *client);

--- a/src/regex_r.h
+++ b/src/regex_r.h
@@ -27,19 +27,26 @@ extern const char *regextype[];
 // assert_sizeof
 #include "static_assert.h"
 
+#include <netinet/in.h>
+
 typedef struct {
 	bool available :1;
 	struct {
 		bool inverted :1;
 		bool query_type_inverted :1;
+		bool custom_ip4 :1;
+		bool custom_ip6 :1;
 		enum query_types query_type;
 		enum reply_type reply;
+		struct in_addr addr4;
+		struct in6_addr addr6;
 	} ext;
 	int database_id;
 	char *string;
 	regex_t regex;
 } regexData;
-ASSERT_SIZEOF(regexData, 32, 20, 20);
+
+ASSERT_SIZEOF(regexData, 56, 44, 44);
 
 unsigned int get_num_regex(const enum regex_type regexid) __attribute__((pure));
 int match_regex(const char *input, DNSCacheData* dns_cache, const int clientID,
@@ -47,6 +54,7 @@ int match_regex(const char *input, DNSCacheData* dns_cache, const int clientID,
 void allocate_regex_client_enabled(clientsData *client, const int clientID);
 void reload_per_client_regex(clientsData *client);
 void read_regex_from_database(void);
+bool regex_get_redirect(const int regexID, struct in_addr *addr4, struct in6_addr *addr6);
 
 int regex_test(const bool debug_mode, const bool quiet, const char *domainin, const char *regexin);
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -881,6 +881,72 @@
   [[ ${lines[1]} == *"Overwriting previous querytype setting" ]]
 }
 
+@test "Regex Test 41: Option \"^localhost$;reply=NXDOMAIN\" working as expected" {
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "INSERT INTO domainlist (type,domain) VALUES (3,\"^localhost$;reply=NXDOMAIN\");"'
+  printf "sqlite3 INSERT: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid); sleep 1'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+  run bash -c 'dig A localhost @127.0.0.1'
+  printf "dig: %s\n" "${lines[@]}"
+  [[ ${lines[3]} == *"status: NXDOMAIN"* ]]
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "DELETE FROM domainlist WHERE domain = \"^localhost$;reply=NXDOMAIN\";"'
+  printf "sqlite3 DELETE: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid)'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+}
+
+@test "Regex Test 42: Option \"^localhost$;reply=NODATA\" working as expected" {
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "INSERT INTO domainlist (type,domain) VALUES (3,\"^localhost$;reply=NODATA\");"'
+  printf "sqlite3 INSERT: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid); sleep 1'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+  run bash -c 'dig A localhost @127.0.0.1 +short'
+  printf "dig (short): %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "" ]]
+  run bash -c 'dig A localhost @127.0.0.1'
+  printf "dig (full): %s\n" "${lines[@]}"
+  [[ ${lines[3]} == *"status: NOERROR"* ]]
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "DELETE FROM domainlist WHERE domain = \"^localhost$;reply=NODATA\";"'
+  printf "sqlite3 DELETE: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid)'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+}
+
+@test "Regex Test 43: Option \"^localhost$;reply=REFUSED\" working as expected" {
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "INSERT INTO domainlist (type,domain) VALUES (3,\"^localhost$;reply=REFUSED\");"'
+  printf "sqlite3 INSERT: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid); sleep 1'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+  run bash -c 'dig A localhost @127.0.0.1 +short'
+  printf "dig (short): %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "" ]]
+  run bash -c 'dig A localhost @127.0.0.1'
+  printf "dig (full): %s\n" "${lines[@]}"
+  [[ ${lines[3]} == *"status: REFUSED"* ]]
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "DELETE FROM domainlist WHERE domain = \"^localhost$;reply=REFUSED\";"'
+  printf "sqlite3 DELETE: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid)'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+}
+
 # x86_64-musl is built on busybox which has a slightly different
 # variant of ls displaying three, instead of one, spaces between the
 # user and group names.

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -947,6 +947,75 @@
   run sleep 2
 }
 
+@test "Regex Test 44: Option \"^localhost$;reply=1.2.3.4\" working as expected" {
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "INSERT INTO domainlist (type,domain) VALUES (3,\"^localhost$;reply=1.2.3.4\");"'
+  printf "sqlite3 INSERT: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid); sleep 1'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+  run bash -c 'dig A localhost @127.0.0.1 +short'
+  printf "dig A: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "1.2.3.4" ]]
+  run bash -c 'dig AAAA localhost @127.0.0.1 +short'
+  printf "dig AAAA: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "::" ]]
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "DELETE FROM domainlist WHERE domain = \"^localhost$;reply=1.2.3.4\";"'
+  printf "sqlite3 DELETE: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid)'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+}
+
+@test "Regex Test 45: Option \"^localhost$;reply=fe80::1234\" working as expected" {
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "INSERT INTO domainlist (type,domain) VALUES (3,\"^localhost$;reply=fe80::1234\");"'
+  printf "sqlite3 INSERT: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid); sleep 1'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+  run bash -c 'dig A localhost @127.0.0.1 +short'
+  printf "dig A: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0.0.0.0" ]]
+  run bash -c 'dig AAAA localhost @127.0.0.1 +short'
+  printf "dig AAAA: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "fe80::1234" ]]
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "DELETE FROM domainlist WHERE domain = \"^localhost$;reply=fe80::1234\";"'
+  printf "sqlite3 DELETE: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid)'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+}
+
+@test "Regex Test 46: Option \"^localhost$;reply=1.2.3.4;reply=fe80::1234\" working as expected" {
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "INSERT INTO domainlist (type,domain) VALUES (3,\"^localhost$;reply=1.2.3.4;reply=fe80::1234\");"'
+  printf "sqlite3 INSERT: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid); sleep 1'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+  run bash -c 'dig A localhost @127.0.0.1 +short'
+  printf "dig A: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "1.2.3.4" ]]
+  run bash -c 'dig AAAA localhost @127.0.0.1 +short'
+  printf "dig AAAA: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "fe80::1234" ]]
+  run bash -c 'sqlite3 /etc/pihole/gravity.db "DELETE FROM domainlist WHERE domain = \"^localhost$;reply=1.2.3.4;reply=fe80::1234\";"'
+  printf "sqlite3 DELETE: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run bash -c 'kill -RTMIN $(cat /var/run/pihole-FTL.pid)'
+  printf "reload: %s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  run sleep 2
+}
+
 # x86_64-musl is built on busybox which has a slightly different
 # variant of ls displaying three, instead of one, spaces between the
 # user and group names.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Implements a feature request from Discourse:

Regex extension that allows you to specify the reply that is sent to matching queries. This is useful when some of your devices do not support the blocking mode you like to use for the rest of the devices in your network.

Example syntax:
```
regex;reply=NODATA
```