### PR TITLE
Change FTL database permission to 664

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -212,9 +212,9 @@ static bool db_create(void)
 	// Close database handle
 	dbclose(&db);
 
-	// Explicitly set permissions to 0644
-	// 644 =            u+w       u+r       g+r       o+r
-	const mode_t mode = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH;
+	// Explicitly set permissions to 0664
+	// 664 =            u+w       u+r       g+w       g+r       o+r
+	const mode_t mode = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IROTH;
 	chmod_file(FTLfiles.FTL_db, mode);
 
 	return true;

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -212,11 +212,6 @@ static bool db_create(void)
 	// Close database handle
 	dbclose(&db);
 
-	// Explicitly set permissions to 0664
-	// 664 =            u+w       u+r       g+w       g+r       o+r
-	const mode_t mode = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IROTH;
-	chmod_file(FTLfiles.FTL_db, mode);
-
 	return true;
 }
 
@@ -260,6 +255,11 @@ void db_init(void)
 			return;
 		}
 	}
+
+		// Explicitly set permissions to 0664
+		// 664 =            u+w       u+r       g+w       g+r       o+r
+		const mode_t mode = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IROTH;
+		chmod_file(FTLfiles.FTL_db, mode);
 
 	// Open database
 	sqlite3 *db = dbopen(false);

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -256,10 +256,10 @@ void db_init(void)
 		}
 	}
 
-		// Explicitly set permissions to 0664
-		// 664 =            u+w       u+r       g+w       g+r       o+r
-		const mode_t mode = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IROTH;
-		chmod_file(FTLfiles.FTL_db, mode);
+	// Explicitly set permissions to 0664
+	// 664 =            u+w       u+r       g+w       g+r       o+r
+	const mode_t mode = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IROTH;
+	chmod_file(FTLfiles.FTL_db, mode);
 
 	// Open database
 	sqlite3 *db = dbopen(false);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -525,7 +525,7 @@
   printf "%s\n" "${lines[@]}"
   # Depending on the shell (x86_64-musl is built on busybox) there can be one or multiple spaces between user and group
   [[ ${lines[0]} == *"pihole"?*"pihole"* ]]
-  [[ ${lines[0]} == "-rw-r--r--"* ]]
+  [[ ${lines[0]} == "-rw-rw-r--"* ]]
   run bash -c 'file /etc/pihole/pihole-FTL.db'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "/etc/pihole/pihole-FTL.db: SQLite 3.x database"* ]]
@@ -1024,7 +1024,7 @@
   run bash -c 'ls -l /etc/pihole/pihole-FTL.db'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == *"pihole pihole"* || ${lines[0]} == *"pihole   pihole"* ]]
-  [[ ${lines[0]} == "-rw-r--r--"* ]]
+  [[ ${lines[0]} == "-rw-rw-r--"* ]]
 }
 
 # "ldd" prints library dependencies and the used interpreter for a given program


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

1

---
Sets the file permission of the `pihole-FTL.db` to `664` to allow write permission to the `pihole` group. This is necessary for https://github.com/pi-hole/AdminLTE/pull/1886 as it allows the web interface write permission to delete items from the `message` table