### PR TITLE
Add `PIHOLE_PTR=HOSTNAME` option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -552,12 +552,22 @@ void read_FTLconf(void)
 	// Should FTL return "pi.hole" as name for PTR requests to local IP addresses?
 	// defaults to: true
 	buffer = parse_FTLconf(fp, "PIHOLE_PTR");
-	config.pihole_ptr = read_bool(buffer, true);
 
-	if(config.pihole_ptr)
-		logg("   PIHOLE_PTR: Enabled");
+	if(buffer != NULL && strcasecmp(buffer, "false") == 0)
+	{
+		config.pihole_ptr = PTR_NONE;
+		logg("   PIHOLE_PTR: PTR generation disabled");
+	}
+	else if(buffer != NULL && strcasecmp(buffer, "hostname") == 0)
+	{
+		config.pihole_ptr = PTR_HOSTNAME;
+		logg("   PIHOLE_PTR: PTR generation enabled (hostname)");
+	}
 	else
-		logg("   PIHOLE_PTR: Disabled");
+	{
+		config.pihole_ptr = PTR_PIHOLE;
+		logg("   PIHOLE_PTR: PTR generation enabled (pi.hole)");
+	}
 
 	// ADDR2LINE
 	// Should FTL try to call addr2line when generating backtraces?

--- a/src/config.c
+++ b/src/config.c
@@ -550,23 +550,24 @@ void read_FTLconf(void)
 
 	// PIHOLE_PTR
 	// Should FTL return "pi.hole" as name for PTR requests to local IP addresses?
-	// defaults to: true
+	// defaults to: PI.HOLE
 	buffer = parse_FTLconf(fp, "PIHOLE_PTR");
 
-	if(buffer != NULL && strcasecmp(buffer, "false") == 0)
+	if(buffer != NULL && (strcasecmp(buffer, "false") == 0 ||
+	                      strcasecmp(buffer, "false") == 0))
 	{
 		config.pihole_ptr = PTR_NONE;
-		logg("   PIHOLE_PTR: PTR generation disabled");
+		logg("   PIHOLE_PTR: internal PTR generation disabled");
 	}
 	else if(buffer != NULL && strcasecmp(buffer, "hostname") == 0)
 	{
 		config.pihole_ptr = PTR_HOSTNAME;
-		logg("   PIHOLE_PTR: PTR generation enabled (hostname)");
+		logg("   PIHOLE_PTR: internal PTR generation enabled (hostname)");
 	}
 	else
 	{
 		config.pihole_ptr = PTR_PIHOLE;
-		logg("   PIHOLE_PTR: PTR generation enabled (pi.hole)");
+		logg("   PIHOLE_PTR: internal PTR generation enabled (pi.hole)");
 	}
 
 	// ADDR2LINE

--- a/src/config.h
+++ b/src/config.h
@@ -47,7 +47,6 @@ typedef struct {
 	bool names_from_netdb :1;
 	bool edns0_ecs :1;
 	bool show_dnssec :1;
-	bool pihole_ptr :1;
 	bool addr2line :1;
 	struct {
 		bool mozilla_canary :1;
@@ -56,6 +55,7 @@ typedef struct {
 	enum blocking_mode blockingmode;
 	enum refresh_hostnames refresh_hostnames;
 	enum busy_reply reply_when_busy;
+	enum ptr_type pihole_ptr;
 	int maxDBdays;
 	int port;
 	int maxlogage;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -203,7 +203,10 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
      Similarly FREC_NO_CACHE is never set in flags, so a query which is
      contigent on a particular source address EDNS0 option will never be matched. */
   if (forward)
+  {
+          
     old_src = 1;
+  }
   else if ((forward = lookup_frec_by_query(hash, fwd_flags,
 					   FREC_CHECKING_DISABLED | FREC_AD_QUESTION | FREC_DO_QUESTION |
 					   FREC_HAS_PHEADER | FREC_DNSKEY_QUERY | FREC_DS_QUERY | FREC_NO_CACHE)))

--- a/src/enums.h
+++ b/src/enums.h
@@ -203,4 +203,10 @@ enum message_type {
 	MAX_MESSAGE
 } __attribute__ ((packed));
 
+enum ptr_type {
+	PTR_PIHOLE,
+	PTR_HOSTNAME,
+	PTR_NONE
+} __attribute__ ((packed));
+
 #endif // ENUMS_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add `PIHOLE_PTR=HOSTNAME` option allowing users to specify that Pi-hole should respond with the device's hostname (instead of "`pi.hole`") for local interface IP address PTR requests.