### PR TITLE
Fix virtual interface address determination

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1830,18 +1830,6 @@ static void check_dns_listeners(time_t now)
   for (listener = daemon->listeners; listener; listener = listener->next)
     {
 
-      /***************************** Pi-hole modification ****************************/
-      // Get the interface here only if we know the listeners are bound to specific
-      // interfaces (option "bind-interfaces" is used)
-      if(option_bool(OPT_NOWILD))
-      {
-	if(listener != NULL && listener->iface != NULL)
-	  FTL_iface(listener->iface->index);
-	else
-	  FTL_iface(-1);
-      }
-      /*******************************************************************************/
-
       if (listener->fd != -1 && poll_check(listener->fd, POLLIN))
 	receive_query(listener, now); 
       
@@ -2025,7 +2013,7 @@ static void check_dns_listeners(time_t now)
 	      /************ Pi-hole modification ************/
 	      FTL_TCP_worker_created(confd);
 	      // Store interface this fork is handling exclusively
-	      FTL_iface(iface != NULL ? iface->index : -1);
+	      FTL_iface(iface);
 	      /**********************************************/
 
 	      buff = tcp_request(confd, now, &tcp_addr, netmask, auth_dns);

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1527,7 +1527,17 @@ void receive_query(struct listener *listen, time_t now)
       // This gets the interface in all cases where this is possible here
       // We get here only if "bind-interfaces" is NOT used or this query
       // is received over IPv6
-      FTL_iface(if_index);
+      struct irec *iface;
+	for (iface = daemon->interfaces; iface; iface = iface->next)
+	  {
+	    if (iface->addr.sa.sa_family == AF_INET &&
+	        iface->addr.in.sin_addr.s_addr == dst_addr.addr4.s_addr)
+	    break;
+	    if (iface->addr.sa.sa_family == AF_INET6 &&
+	        IN6_ARE_ADDR_EQUAL(&iface->addr.in6.sin6_addr, &dst_addr.addr6))
+	    break;
+	  }
+      FTL_iface(iface);
       /****************************************************************/
     }
 

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -546,9 +546,9 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
       iface->done = iface->multicast_done = iface->warned = 0;
       iface->index = if_index;
       iface->label = is_label;
-      if ((iface->name = whine_malloc(strlen(ifr.ifr_name)+1)))
+      if ((iface->name = whine_malloc(strlen(label)+1)))
 	{
-	  strcpy(iface->name, ifr.ifr_name);
+	  strcpy(iface->name, label);
 	  iface->next = daemon->interfaces;
 	  daemon->interfaces = iface;
 	  return 1;

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -21,7 +21,8 @@ enum protocol { TCP, UDP, INTERNAL };
 
 void FTL_hook(unsigned int flags, char *name, union all_addr *addr, char *arg, int id, const char* file, const int line);
 
-void FTL_iface(const int ifidx);
+#define FTL_iface(iface) _FTL_iface(iface, __FILE__, __LINE__)
+void _FTL_iface(struct irec *iface, const char* file, const int line);
 
 #define FTL_new_query(flags, name, addr, types, qtype, id, edns, proto) _FTL_new_query(flags, name, addr, types, qtype, id, edns, proto, __FILE__, __LINE__)
 bool _FTL_new_query(const unsigned int flags, const char *name, union mysockaddr *addr, const char *types, const unsigned short qtype, const int id, const ednsData *edns, enum protocol proto, const char* file, const int line);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR ensures we're recognizing virtual interfaces (e.g., `eth0:0`) as distinct interfaces even when the kernel does not treat the as interfaces with their own interface index. This is necessary to pick the correct local address when determining which address is the right one for replying to `A` and `AAAA` queries to `pi.hole` and `<hostname>`.

In addition, we fix a small glitch if the interface we received a query on doesn't have the requested address type (e.g. virtual interfaces only configured with one IPv6 but no IPv6 address). Instead of replying with `0.0.0.0` resp. `::`, we reply with `NODATA` which seems more menaingful.