### PR TITLE
Add special handling of iCloud Private Relay domains

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -621,6 +621,18 @@ void read_FTLconf(void)
 	else
 		logg("   BLOCK_TTL: %u seconds", config.block_ttl);
 
+	// BLOCK_ICLOUD_PR
+	// Should FTL handle the iCloud privacy relay domains specifically and
+	// always return NXDOMAIN??
+	// defaults to: true
+	buffer = parse_FTLconf(fp, "BLOCK_ICLOUD_PR");
+	config.special_domains.icloud_private_relay = read_bool(buffer, true);
+
+	if(config.special_domains.icloud_private_relay)
+		logg("   BLOCK_ICLOUD_PR: Enabled");
+	else
+		logg("   BLOCK_ICLOUD_PR: Disabled");
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -50,6 +50,7 @@ typedef struct {
 	bool addr2line :1;
 	struct {
 		bool mozilla_canary :1;
+		bool icloud_private_relay :1;
 	} special_domains;
 	enum privacy_level privacylevel;
 	enum blocking_mode blockingmode;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1086,6 +1086,30 @@ static bool special_domain(const queriesData *query, const char *domain)
 		return true;
 	}
 
+	// Apple iCloud Private Relay
+	// Some enterprise or school networks might be required to audit all
+	// network traffic by policy, and your network can block access to
+	// Private Relay in these cases. The user will be alerted that they need
+	// to either disable Private Relay for your network or choose another
+	// network.
+	// The fastest and most reliable way to alert users is to return a
+	// negative answer from your network’s DNS resolver, preventing DNS
+	// resolution for the following hostnames used by Private Relay traffic.
+	// Avoid causing DNS resolution timeouts or silently dropping IP packets
+	// sent to the Private Relay server, as this can lead to delays on
+	// client devices.
+	// > mask.icloud.com
+	// > mask-h2.icloud.com
+	// https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay
+	if(config.special_domains.icloud_private_relay &&
+	   (strcasecmp(domain, "mask.icloud.com") == 0 ||
+	    strcasecmp(domain, "mask-h2.icloud.com") == 0))
+	{
+		blockingreason = "Apple iCloud Private Relay domain";
+		force_next_DNS_reply = REPLY_NXDOMAIN;
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Implement special handling of Apple iCloud Private Relay domains to prevent Applie devices from bypassing Pi-hole.

> Some enterprise or school networks might be required to audit all network traffic by policy, and your network can block access to Private Relay in these cases. The user will be alerted that they need to either disable Private Relay for your network or choose another network.
>
> The fastest and most reliable way to alert users is to **return a negative answer from your network’s DNS resolver, preventing DNS resolution for the following hostnames used by Private Relay traffic**. Avoid causing DNS resolution timeouts or silently dropping IP packets sent to the Private Relay server, as this can lead to delays on client devices.
> 
> `mask.icloud.com`
> `mask-h2.icloud.com`

Source: https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay

The new option `BLOCK_ICLOUD_PR=true|false` can be used to control the new behavior.

This is being discussed and tested in the Discourse topic linked below.