### PR TITLE
Handle TTL for blocked queries seperately 

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -607,6 +607,20 @@ void read_FTLconf(void)
 		logg("   REPLY_WHEN_BUSY: Permit queries when the database is busy");
 	}
 
+	// BLOCK_TTL
+	// defaults to: 2 seconds
+	config.block_ttl = 2;
+	buffer = parse_FTLconf(fp, "BLOCK_TTL");
+
+	unsigned int uval = 0;
+	if(buffer != NULL && sscanf(buffer, "%u", &uval))
+		config.block_ttl = uval;
+
+	if(config.block_ttl == 1)
+		logg("   BLOCK_TTL: 1 second");
+	else
+		logg("   BLOCK_TTL: %u seconds", config.block_ttl);
+
 	// Read DEBUG_... setting from pihole-FTL.conf
 	read_debuging_settings(fp);
 

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ typedef struct {
 	int dns_port;
 	unsigned int delay_startup;
 	unsigned int network_expire;
+	unsigned int block_ttl;
 	struct {
 		unsigned int count;
 		unsigned int interval;
@@ -75,7 +76,7 @@ typedef struct {
 		struct in6_addr v6;
 	} reply_addr;
 } ConfigStruct;
-ASSERT_SIZEOF(ConfigStruct, 80, 72, 72);
+ASSERT_SIZEOF(ConfigStruct, 80, 76, 76);
 
 typedef struct {
 	const char* conf;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

So far, we used `local-ttl=2` hard-coded in dnsmasq's config because this ensured clients won't cache blocked queries for longer times, possibly rendering whitelisting ineffective.

This PR implements a **new TTL for blocked queries only**. This allows users to set `local-ttl` to any value they prefer without this being overwritten in `01-pihole.conf` after each update. This seems useful in context of locally used hostnames that are known to stay constant over long times (e.g., printers, etc.).

The new value defaults to `2` seconds (no change in behavior) and can be controlled using the new FTL config option `BLOCK_TTL=2`