### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build and test
 on:
   push:
     branches:
-      - '*'
+      - '**'
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+# This workflow builds FTL
+# It is analogous to Circle CI workflow here:
+# ../../.circleci/config.yml
+name: Build and test
+
+on:
+  push:
+    branches:
+     - '*'
+  pull_request:
+    branches:
+     - '*'
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        include:
+         - circle_job: armv4t
+           bin_name: pihole-FTL-armv4-linux-gnueabi
+         - circle_job: armv5te
+           bin_name: pihole-FTL-armv5-linux-gnueabi
+         - circle_job: armv6hf
+           bin_name:  pihole-FTL-armv6-linux-gnueabihf
+         - circle_job: armv7hf
+           bin_name: pihole-FTL-armv7-linux-gnueabihf
+         - circle_job: armv8a
+           bin_name: pihole-FTL-armv8-linux-gnueabihf
+         - circle_job: aarch64
+           bin_name: pihole-FTL-aarch64-linux-gnu
+         - circle_job: x86_64
+           bin_name: pihole-FTL-linux-x86_64
+         - circle_job: x86_64-musl
+           bin_name: pihole-FTL-musl-linux-x86_64
+         - circle_job: x86_32
+           bin_name: pihole-FTL-linux-x86_32
+
+    container: pihole/ftl-build:v1.8-${{ matrix.circle_job }}
+
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: "Build"
+      run: |
+        # Extract branch name or ref from GITHUB_REF variable
+        CIRCLE_TAG=""
+        BRANCH="test"
+        bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${{ matrix.circle_job }}"
+    - name: "Binary checks"
+      run: |
+        export CIRCLE_JOB="${{ matrix.circle_job }}"
+        bash test/arch_test.sh
+    - name: "Compute checksum"
+      run: |
+        mv pihole-FTL "${{ matrix.bin_name }}"
+        sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
+    # NOTE: Steps "Upload binary to binary bucket" and "Verify uploaded binary"
+    # are intentionally left out.
+    - name: "Test"
+      run: |
+          export CIRCLE_JOB="${{ matrix.circle_job }}"
+          mv "${{ matrix.bin_name }}" pihole-FTL
+          test/run.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,12 @@
-# This workflow builds FTL
-# It is analogous to Circle CI workflow here:
-# ../../.circleci/config.yml
 name: Build and test
 
 on:
   push:
     branches:
-     - '*'
+      - '*'
   pull_request:
-    branches:
-     - '*'
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -17,51 +14,86 @@ jobs:
     strategy:
       matrix:
         include:
-         - circle_job: armv4t
+         - arch: armv4t
            bin_name: pihole-FTL-armv4-linux-gnueabi
-         - circle_job: armv5te
+         - arch: armv5te
            bin_name: pihole-FTL-armv5-linux-gnueabi
-         - circle_job: armv6hf
+         - arch: armv6hf
            bin_name:  pihole-FTL-armv6-linux-gnueabihf
-         - circle_job: armv7hf
+         - arch: armv7hf
            bin_name: pihole-FTL-armv7-linux-gnueabihf
-         - circle_job: armv8a
+         - arch: armv8a
            bin_name: pihole-FTL-armv8-linux-gnueabihf
-         - circle_job: aarch64
+         - arch: aarch64
            bin_name: pihole-FTL-aarch64-linux-gnu
-         - circle_job: x86_64
+         - arch: x86_64
            bin_name: pihole-FTL-linux-x86_64
-         - circle_job: x86_64-musl
+         - arch: x86_64-musl
            bin_name: pihole-FTL-musl-linux-x86_64
-         - circle_job: x86_32
+         - arch: x86_32
            bin_name: pihole-FTL-linux-x86_32
 
-    container: pihole/ftl-build:v1.8-${{ matrix.circle_job }}
+    container: pihole/ftl-build:v1.10-${{ matrix.arch }}
 
     runs-on: ubuntu-latest
     continue-on-error: true
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: "Build"
-      run: |
-        # Extract branch name or ref from GITHUB_REF variable
-        CIRCLE_TAG=""
-        BRANCH="test"
-        bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${BRANCH}" "${CIRCLE_TAG}" "${{ matrix.circle_job }}"
-    - name: "Binary checks"
-      run: |
-        export CIRCLE_JOB="${{ matrix.circle_job }}"
-        bash test/arch_test.sh
-    - name: "Compute checksum"
-      run: |
-        mv pihole-FTL "${{ matrix.bin_name }}"
-        sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
-    # NOTE: Steps "Upload binary to binary bucket" and "Verify uploaded binary"
-    # are intentionally left out.
-    - name: "Test"
-      run: |
-          export CIRCLE_JOB="${{ matrix.circle_job }}"
-          mv "${{ matrix.bin_name }}" pihole-FTL
-          test/run.sh
+      -
+        name: Update git (until we update base image)
+        if: ${{ matrix.arch != 'x86_64-musl' }}
+        run: |
+          echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list;
+          apt-get update
+          apt-get -t stretch-backports install git -y
+      -
+        name: Get Branch/Tag Name
+        id: branch_name
+        run: |
+          GIT_BRANCH=${GITHUB_REF#refs/*/}
+          GIT_TAG=${{ github.event.release.tag_name }}
+          echo ::set-output name=GIT_BRANCH::${GIT_BRANCH}
+          echo ::set-output name=GIT_TAG::${GIT_TAG}
+          echo ::set-output name=OUTPUT_DIR::${GIT_TAG:-${GIT_BRANCH}}
+      -
+        name: Checkout code
+        uses: actions/checkout@v2
+      -
+        name: "Build"
+        run: |
+          bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${{ steps.branch_name.outputs.GIT_BRANCH }}" "${{ steps.branch_name.outputs.GIT_TAG }}" "${{ matrix.arch }}"
+      -
+        name: "Binary checks"
+        run: |
+          export CIRCLE_JOB="${{ matrix.arch }}"
+          bash test/arch_test.sh
+      -
+        name: "Tests"
+        run: |
+            export CIRCLE_JOB="${{ matrix.arch }}"
+            test/run.sh
+      -
+        name: "Generate checksum file"
+        run: |
+          mv pihole-FTL "${{ matrix.bin_name }}"
+          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
+      -
+        name: Attach binaries to release
+        if: ${{ github.event_name == 'release' }}
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: '${{ matrix.bin_name }}*'
+      # Keep this commented out for now until we're ready for GHA to take over (remember to add secrets)
+      # -
+      #   name: Transfer Builds to Pi-hole server for pihole checkout
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   uses: appleboy/scp-action@master
+      #   with:
+      #     host: ${{ secrets.SSH_HOST }}
+      #     username: ${{ secrets.SSH_USER }}
+      #     port: ${{ secrets.SSH_PORT }}
+      #     key: ${{ secrets.SSH_KEY }}
+      #     source: "${{ matrix.bin_name }}*"
+      #     target: "${{ steps.branch_name.outputs.OUTPUT_DIR }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,15 +85,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: '${{ matrix.bin_name }}*'
-      # Keep this commented out for now until we're ready for GHA to take over (remember to add secrets)
-      # -
-      #   name: Transfer Builds to Pi-hole server for pihole checkout
-      #   if: ${{ github.event_name != 'pull_request' }}
-      #   uses: appleboy/scp-action@master
-      #   with:
-      #     host: ${{ secrets.SSH_HOST }}
-      #     username: ${{ secrets.SSH_USER }}
-      #     port: ${{ secrets.SSH_PORT }}
-      #     key: ${{ secrets.SSH_KEY }}
-      #     source: "${{ matrix.bin_name }}*"
-      #     target: "${{ steps.branch_name.outputs.OUTPUT_DIR }}"
+      -
+        name: Transfer Builds to Pi-hole server for pihole checkout
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_KEY }}
+          source: "${{ matrix.bin_name }}*"
+          target: "${{ steps.branch_name.outputs.OUTPUT_DIR }}"


### PR DESCRIPTION
Ready GHA to take over from circle.

This still leaves circle in place to build and push branch builds to ftl.pi-hole.net

However, this will automatically attach binaries built by GHA to the release when we release. I have tested this over on my own fork.  If, for whatever reason, the binaries that GHA builds are duff, we can easily replace them with the ones circle builds.

