### PR TITLE
Do not fail hard when rev-server has a non-zero final address part

### DIFF
--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -967,13 +967,9 @@ static char *domain_rev4(int from_file, char *server, struct in_addr *addr4, int
   
   if (size > 32 || size < 1)
     return _("bad IPv4 prefix length");
-  
-  for (i = 0; i < addrbytes; i++)
-    if (((u8 *)addr4)[3-i] != 0)
-      break;
-  
-  if (i != addrbytes || (((u8 *)addr4)[3-addrbytes] & ((1 << addrbits) - 1)) != 0)
-    return _("address part not zero");
+
+  /* Zero out last address bits according to CIDR mask */
+  ((u8 *)addr4)[3-addrbytes] &= ~((1 << addrbits)-1);
   
   size = size & ~0x7;
   
@@ -1030,13 +1026,9 @@ static char *domain_rev6(int from_file, char *server, struct in6_addr *addr6, in
   
   if (size > 128 || size < 1)
     return _("bad IPv6 prefix length");
-
-  for (i = 0; i < addrbytes; i++)
-    if (addr6->s6_addr[15-i] != 0)
-      break;
   
-  if (i != addrbytes || (addr6->s6_addr[15-addrbytes] & ((1 << addrbits) - 1)) != 0)
-    return _("address part not zero");
+  /* Zero out last address bits according to CIDR mask */
+  addr6->s6_addr[15-addrbytes] &= ~((1 << addrbits) - 1);
   
   size = size & ~0x3;
   


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes #1181 by `dnsmasq v2.78test2` enforcing a special CIDR notation where the remaining bits have to be set to zero (e.g., `192.168.2.0/24` is fine but `192.168.2.1/24` fails). This breaks a lot of existing installations. This PR adds a patch I also sent upstream to `dnsmasq` to, instead of unnecessarily failing hard, just sets those bits to zero. This seems the right thing to do in any case as I do not see any reason for this break in backwards compatibility.
In case the patch is not accepted upstream - or modified - we can always revert this change and insert the fix added by Simon.