### PR TITLE
Fix deep CNAME inspection

### DIFF
--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -778,6 +778,15 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	      if (!cname_count--)
 		return 0; /* looped CNAMES */
 	      
+	      // ****************************** Pi-hole modification ******************************
+	      if(FTL_CNAME(name, cpp, daemon->log_display_id))
+	        {
+	          // This query is to be blocked as we found a blocked
+	          // domain while walking the CNAME path. Log to pihole.log here
+	          log_query(F_UPSTREAM, name, NULL, "blocked during CNAME inspection", 0);
+	          return 2;
+	        }
+	      // **********************************************************************************
 	      log_query(secflag | F_CNAME | F_FORWARD | F_UPSTREAM, name, NULL, NULL, 0);
 	      
 	      if (insert)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes deep CNAME inspection. It was broken recently in a `dnsmasq` commit (https://github.com/pi-hole/FTL/commit/09051c65ac55eb26e0ad413722d298f5e1d9ed45),

> This commit also fixes a long-standing bug in caching of CNAME chains leading to a PTR record.

when CNAME handling was redesigned. We also add a proper test of a "deep" CNAME to ensure this won't happen again in the future.