### PR TITLE
Fix network byte order confusion in local lookups

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -255,7 +255,9 @@ char *resolveHostname(const char *addr)
 		res_initialized = true;
 	}
 
-	struct in_addr FTLaddr = { INADDR_LOOPBACK };
+	// INADDR_LOOPBACK is in host byte order, however, in_addr has to be in
+	// network byte order, convert it here if necessary
+	struct in_addr FTLaddr = { htonl(INADDR_LOOPBACK) };
 	in_port_t FTLport = htons(config.dns_port);
 
 	// Set FTL as system resolver only if not already the primary resolver


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR fixes #1195 by ensuring local queries are sent to `127.0.0.1` instead of `1.0.0.127`. The issue comes from the networking constant `INADDR_LOOPBACK` being in host byte order whereas `struct in_addr` expects an address in network byte order so we need to convert the static constant. This was not mentioned in [`man 7 ip`](https://man7.org/linux/man-pages/man7/ip.7.html), however, once we've seen the symptoms, it became clear that this is what is meant with
```
           /* Internet address */
           struct in_addr {
               uint32_t       s_addr;     /* address in network byte order */
           };
```
There is no extra information attached to the constant itself that it'd be converted:
```
       There are several special addresses: INADDR_LOOPBACK (127.0.0.1)
       always refers to the local host via the loopback device;
       INADDR_ANY (0.0.0.0) means any address for binding;
       INADDR_BROADCAST (255.255.255.255) means any host and has the
       same effect on bind as INADDR_ANY for historical reasons.
```
You'd naively expect that a constant defined to be used in this context should be defined in a way that doesn't need prior conversion.