### PR TITLE
Tweak rate-limiting

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -331,7 +331,7 @@ void logg_rate_limit_message(const char *clientIP)
 	const time_t turnaround = get_rate_limit_turnaround();
 
 	// Log to pihole-FTL.log
-	logg("Rate-limiting %s for %ld second%s",
+	logg("Rate-limiting %s for at least %ld second%s",
 	     clientIP, turnaround, turnaround == 1 ? "" : "s");
 
 	// Log to database

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -326,13 +326,14 @@ void logg_fatal_dnsmasq_message(const char *message)
 	cleanup(EXIT_FAILURE);
 }
 
-void logg_rate_limit_message(const char *clientIP)
+void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit_count)
 {
-	const time_t turnaround = get_rate_limit_turnaround();
+	const time_t turnaround = get_rate_limit_turnaround(rate_limit_count);
 
 	// Log to pihole-FTL.log
-	logg("Rate-limiting %s for at least %ld second%s",
-	     clientIP, turnaround, turnaround == 1 ? "" : "s");
+	logg("Rate-limiting %s for at least %ld second%s (%d quer%s)",
+	     clientIP, turnaround, turnaround == 1 ? "" : "s",
+	     rate_limit_count, rate_limit_count == 1 ? "y" : "ies");
 
 	// Log to database
 	add_message(RATE_LIMIT_MESSAGE, clientIP, 2, config.rate_limit.count, config.rate_limit.interval);

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -331,9 +331,8 @@ void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit
 	const time_t turnaround = get_rate_limit_turnaround(rate_limit_count);
 
 	// Log to pihole-FTL.log
-	logg("Rate-limiting %s for at least %ld second%s (%d quer%s)",
-	     clientIP, turnaround, turnaround == 1 ? "" : "s",
-	     rate_limit_count, rate_limit_count == 1 ? "y" : "ies");
+	logg("Rate-limiting %s for at least %ld second%s",
+	     clientIP, turnaround, turnaround == 1 ? "" : "s");
 
 	// Log to database
 	add_message(RATE_LIMIT_MESSAGE, clientIP, 2, config.rate_limit.count, config.rate_limit.interval);

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -20,6 +20,6 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
                          const int chosen_match_id);
 void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos);
 void logg_fatal_dnsmasq_message(const char *message);
-void logg_rate_limit_message(const char *clientIP);
+void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit_count);
 
 #endif //MESSAGETABLE_H

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -74,6 +74,7 @@ typedef struct {
 		bool new:1;
 		bool found_group:1;
 		bool aliasclient:1;
+		bool rate_limited:1;
 	} flags;
 	int count;
 	int blockedcount;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -575,10 +575,16 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	if(!internal_query && config.rate_limit.count > 0 &&
 	   (++client->rate_limit > config.rate_limit.count  || client->flags.rate_limited))
 	{
-		// Log the first rate-limited query for this client in this interval
-		// We do not log the blocked domain for privacy reasons
 		if(!client->flags.rate_limited)
+		{
+			// Log the first rate-limited query for this client in
+			// this interval. We do not log the blocked domain for
+			// privacy reasons
 			logg_rate_limit_message(clientIP, client->rate_limit);
+			// Reset rate-limiting counter so we can count what
+			// comes within the adjacent interval
+			client->rate_limit = 0;
+		}
 
 		// Memorize this client needs rate-limiting
 		client->flags.rate_limited = true;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -361,7 +361,7 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 		if(flags == 0)
 		{
 			// REFUSED
-			union all_addr addr = { 0 };
+			union all_addr addr = {{ 0 }};
 			addr.log.rcode = REFUSED;
 			addr.log.ede = EDE_BLOCKED;
 			log_query(F_RCODE | F_HOSTS, name, &addr, (char*)blockingreason);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -563,7 +563,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		// Log the first rate-limited query for this client in this interval
 		// We do not log the blocked domain for privacy reasons
 		if(client->rate_limit == config.rate_limit.count+1)
-			logg_rate_limit_message(clientIP);
+			logg_rate_limit_message(clientIP, client->rate_limit);
 
 		// Block this query
 		force_next_DNS_reply = REPLY_REFUSED;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -577,7 +577,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	{
 		// Log the first rate-limited query for this client in this interval
 		// We do not log the blocked domain for privacy reasons
-		if(client->rate_limit == config.rate_limit.count+1)
+		if(!client->flags.rate_limited)
 			logg_rate_limit_message(clientIP, client->rate_limit);
 
 		// Memorize this client needs rate-limiting

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -577,7 +577,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	{
 		// Log the first rate-limited query for this client in this interval
 		// We do not log the blocked domain for privacy reasons
-		logg("XABC: %d / %d", client->rate_limit, config.rate_limit.count+1);
 		if(client->rate_limit == config.rate_limit.count+1)
 			logg_rate_limit_message(clientIP, client->rate_limit);
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -39,16 +39,14 @@ static void reset_rate_limiting(void)
 		// Check if we want to continue rate limiting
 		if(client->rate_limit > config.rate_limit.count)
 		{
-			if(config.debug & DEBUG_QUERIES)
-				logg("Still rate-limiting %s as it made additional %d queries", getstr(client->ippos), client->rate_limit);
+			logg("Still rate-limiting %s as it made additional %d queries", getstr(client->ippos), client->rate_limit);
 			// If so, just reset the counter for the next interval
 			client->rate_limit = 0;
 		}
 		// or if rate-limiting ends for this client now
 		else
 		{
-			if(config.debug & DEBUG_QUERIES)
-				logg("Ending rate-limitation of %s", getstr(client->ippos));
+			logg("Ending rate-limitation of %s", getstr(client->ippos));
 			// Reset counter
 			client->rate_limit = 0;
 			// and unblock

--- a/src/gc.c
+++ b/src/gc.c
@@ -23,17 +23,21 @@
 
 bool doGC = false;
 
+// Subtract rate-limitation count from individual client counters
+// As long as client->rate_limit is still larger than the allowed
+// maximum count, the rate-limitation will just continue
 static void reset_rate_limiting(void)
 {
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		clientsData *client = getClient(clientID, true);
 		if(client != NULL)
-			client->rate_limit = 0;
+			client->rate_limit = MAX((long)client->rate_limit-config.rate_limit.count, 0);
 	}
 }
 
 static time_t lastRateLimitCleaner = 0;
+// Returns how many more seconds until the current rate-limiting interval is over
 time_t get_rate_limit_turnaround(void)
 {
 	return time(NULL) - lastRateLimitCleaner + config.rate_limit.interval;

--- a/src/gc.h
+++ b/src/gc.h
@@ -11,6 +11,6 @@
 #define GC_H
 
 void *GC_thread(void *val);
-time_t get_rate_limit_turnaround(void);
+time_t get_rate_limit_turnaround(const unsigned int rate_limit_count);
 
 #endif //GC_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR tweaks rate-limiting by ensuring clients are not unblocked after the configured interval if they are continuously querying and, hence, deserve continued blocking.

Interesting side-effect: I forgot about this change, sorry. If we'd have it in the current release, #1197 would not have even happened (it is fixed herein as well, even if differently). Nonetheless, it still makes sense to also merge #1197