### PR TITLE
Only set GIT_BRANCH to the branch name if GIT_TAG is empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,10 @@ jobs:
         name: Get Branch/Tag Name
         id: branch_name
         run: |
-          GIT_BRANCH=${GITHUB_REF#refs/*/}
           GIT_TAG=${{ github.event.release.tag_name }}
+          # If GIT_TAG is set then GIT BRANCH should be "master", else set it from GITHUB_REF
+          GIT_BRANCH=$([ -n "${GIT_TAG}" ] && echo "master" || echo "${GITHUB_REF#refs/*/}")
+
           echo ::set-output name=GIT_BRANCH::${GIT_BRANCH}
           echo ::set-output name=GIT_TAG::${GIT_TAG}
           echo ::set-output name=OUTPUT_DIR::${GIT_TAG:-${GIT_BRANCH}}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Prevents an issue with `pihole -v -f` hitting a condition where it includes additional output. In Circle, tagged releases have `GIT_BRANCH` set to `master`, so this is just replicating that