### PR TITLE
Add `PIHOLE_PTR=HOSTNAMEFQDN` option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -564,6 +564,11 @@ void read_FTLconf(void)
 		config.pihole_ptr = PTR_HOSTNAME;
 		logg("   PIHOLE_PTR: internal PTR generation enabled (hostname)");
 	}
+	else if(buffer != NULL && strcasecmp(buffer, "hostnamefqdn") == 0)
+	{
+		config.pihole_ptr = PTR_HOSTNAMEFQDN;
+		logg("   PIHOLE_PTR: internal PTR generation enabled (fully-qualified hostname)");
+	}
 	else
 	{
 		config.pihole_ptr = PTR_PIHOLE;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2607,13 +2607,49 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 	// Obtain DNS port from dnsmasq daemon
 	config.dns_port = daemon->port;
 
+	char *ptrname = NULL;
+	// Determine name that should be replied to with on Pi-hole PTRs
+	switch (config.pihole_ptr)
+	{
+		default:
+		case PTR_NONE:
+		case PTR_PIHOLE:
+			ptrname = (char*)"pi.hole";
+			break;
+
+		case PTR_HOSTNAME:
+			ptrname = (char*)hostname();
+			break;
+
+		case PTR_HOSTNAMEFQDN:
+		{
+			char *suffix = daemon->domain_suffix;
+			if(!suffix)
+				suffix = (char*)"fqdn";
+			ptrname = calloc(strlen(hostname()) + strlen(suffix) + 2, sizeof(char));
+			if(ptrname)
+			{
+				// Build "<hostname>.<local suffix>" domain
+				strcpy(ptrname, hostname());
+				strcat(ptrname, ".");
+				strcat(ptrname, suffix);
+			}
+			else
+			{
+				// Fallback to "<hostname>" on memory error
+				ptrname = (char*)hostname();
+			}
+		}
+			break;
+	}
+
 	// Obtain PTR record used for Pi-hole PTR injection (if enabled)
 	if(config.pihole_ptr != PTR_NONE)
 	{
 		// Add PTR record for pi.hole, the address will be injected later
 		pihole_ptr = calloc(1, sizeof(struct ptr_record));
 		pihole_ptr->name = strdup("x.x.x.x.in-addr.arpa");
-		pihole_ptr->ptr = config.pihole_ptr == PTR_PIHOLE ? (char*)"pi.hole" : (char*)hostname();
+		pihole_ptr->ptr = ptrname;
 		pihole_ptr->next = NULL;
 		// Add our PTR record to the end of the linked list
 		if(daemon->ptr != NULL)

--- a/src/enums.h
+++ b/src/enums.h
@@ -206,6 +206,7 @@ enum message_type {
 enum ptr_type {
 	PTR_PIHOLE,
 	PTR_HOSTNAME,
+	PTR_HOSTNAMEFQDN,
 	PTR_NONE
 } __attribute__ ((packed));
 

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -180,9 +180,8 @@ char *resolveHostname(const char *addr)
 	if(strstr(addr,":") != NULL)
 		IPv6 = true;
 
-	// Step 1: Convert address into binary form
+	// Convert address into binary form
 	struct sockaddr_storage ss = { 0 };
-	char *addrp = NULL;
 	if(IPv6)
 	{
 		// Get binary form of IPv6 address
@@ -192,7 +191,6 @@ char *resolveHostname(const char *addr)
 			logg("WARN: Invalid IPv6 address when trying to resolve hostname: %s", addr);
 			return strdup("");
 		}
-		addrp = (char*)&(((struct sockaddr_in6 *)&ss)->sin6_addr);
 	}
 	else
 	{
@@ -203,46 +201,6 @@ char *resolveHostname(const char *addr)
 			logg("WARN: Invalid IPv4 address when trying to resolve hostname: %s", addr);
 			return strdup("");
 		}
-		addrp = (char*)&(((struct sockaddr_in *)&ss)->sin_addr);
-	}
-
-	// Step 2: Read HOSTS file entries
-	bool found = false;
-	struct hostent *he = NULL;
-	// sethostent() opens/rewinds the prefix.ETC.HOSTS file
-	sethostent(1);
-	while(!found && (he = gethostent()) != NULL)
-	{
-		// Skip any non-IPv6 and non-IPv4 entries
-		if((IPv6 && he->h_addrtype != AF_INET6) || // not an IPv6 record
-		   (!IPv6 && he->h_addrtype != AF_INET))   // not an IPv4 record
-			continue;
-
-		// Loop over addresses for this HOSTS record
-		// h_addr_list is a NULL-terminated array of network addresses for the
-		// host
-		for (char **p = he->h_addr_list; *p; p++)
-		{
-			if(memcmp(*p, addrp, he->h_length) == 0)
-			{
-				hostname = strdup(he->h_name);
-				found = true;
-				break;
-			}
-		}
-	}
-
-	// endhostent() closes the prefix.ETC.HOSTS file
-	endhostent();
-
-	if(hostname != NULL)
-	{
-		// Return early when we found the entry in the HOSTS file
-		// No need to generate any PTR queries in this case
-		if(config.debug & DEBUG_RESOLVER)
-			logg(" ---> \"%s\" (found in HOSTS)", hostname);
-
-		return hostname;
 	}
 
 	// Initialize resolver subroutines if trying to resolve for the first time
@@ -263,7 +221,7 @@ char *resolveHostname(const char *addr)
 	// Set FTL as system resolver only if not already the primary resolver
 	if(_res.nsaddr_list[0].sin_addr.s_addr != FTLaddr.s_addr || _res.nsaddr_list[0].sin_port != FTLport)
 	{
-		// Step 3: Backup configured name servers and invalidate them
+		// Backup configured name servers and invalidate them
 		struct in_addr ns_addr_bck[MAXNS];
 		in_port_t ns_port_bck[MAXNS];
 		for(unsigned int i = 0u; i < MAXNS; i++)
@@ -273,7 +231,7 @@ char *resolveHostname(const char *addr)
 			_res.nsaddr_list[i].sin_addr.s_addr = 0; // 0.0.0.0
 		}
 
-		// Step 4: Set FTL at 127.0.0.1 as the only resolver
+		// Set FTL at 127.0.0.1 as the only resolver
 		_res.nsaddr_list[0].sin_addr.s_addr = FTLaddr.s_addr;
 		// Set resolver port
 		_res.nsaddr_list[0].sin_port = FTLport;
@@ -281,11 +239,11 @@ char *resolveHostname(const char *addr)
 		if(config.debug & DEBUG_RESOLVER)
 			print_used_resolvers("Setting nameservers to:");
 
-		// Step 5: Try to resolve address
+		// Try to resolve address
 		char host[NI_MAXHOST] = { 0 };
 		int ret = getnameinfo((struct sockaddr*)&ss, sizeof(ss), host, sizeof(host), NULL, 0, NI_NAMEREQD);
 
-		// Step 6: Check if getnameinfo() returned a host name
+		// Check if getnameinfo() returned a host name
 		if(ret == 0)
 		{
 			if(valid_hostname(host, addr))
@@ -306,7 +264,7 @@ char *resolveHostname(const char *addr)
 			logg(" ---> \"\" (not found internally: %s", gai_strerror(ret));
 		}
 
-		// Step 7: Restore resolvers (without forced FTL)
+		// Restore resolvers (without forced FTL)
 		for(unsigned int i = 0u; i < MAXNS; i++)
 		{
 			_res.nsaddr_list[i].sin_addr = ns_addr_bck[i];
@@ -318,7 +276,7 @@ char *resolveHostname(const char *addr)
 	else if(config.debug & DEBUG_RESOLVER)
 		print_used_resolvers("FTL already primary nameserver:");
 
-	// Step 8: If no host name was found before, try again with system-configured
+	// If no host name was found before, try again with system-configured
 	// resolvers (necessary for docker and friends)
 	if(hostname == NULL)
 	{
@@ -326,7 +284,7 @@ char *resolveHostname(const char *addr)
 		char host[NI_MAXHOST] = { 0 };
 		int ret = getnameinfo((struct sockaddr*)&ss, sizeof(ss), host, sizeof(host), NULL, 0, NI_NAMEREQD);
 
-		// Step 6.1: Check if getnameinfo() returned a host name this time
+		// Check if getnameinfo() returned a host name this time
 		// First check for he not being NULL before trying to dereference it
 		if(ret == 0)
 		{

--- a/test/hostnames.sh
+++ b/test/hostnames.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Test script to test names returned for local interfaces
+# The logic of this mechanism has been extracted from piholeDebug.sh
+
+getIPs() {
+    local dig_result addr
+    local addr_type
+    addr_type=$1
+    local protocol
+    protocol=$2
+
+    addresses="$(ip address show | sed "/${addr_type} /!d;s/^.*${addr_type} //g;s/\/.*$//g;")"
+    if [ -n "${addresses}" ]; then
+        while IFS= read -r addr ; do
+            # Check if Pi-hole can use itself to block a domain
+            dig_result=$(dig +tries=1 +time=2 -"${protocol}" -x "${addr}" @127.0.0.1 +short)
+            if [[ $addr == "127.0.0.1" && $dig_result == "localhost." ]] || [[ $addr == "::1" &&  $dig_result == "ip6-localhost." ]] || [[ $dig_result == "pi.hole." ]]; then
+                echo "${addr} is \"${dig_result}\": OK"
+            else
+                # Otherwise, show a failure
+                echo "${addr}: ERROR"
+                echo "${dig_result}"
+                echo ""
+            fi
+        done <<< "${addresses}"
+    fi
+}
+
+# Test PTR responses on all available IPv4 addresses
+getIPs inet 4
+# Test PTR responses on all available IPv6 addresses
+getIPs inet6 6

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1283,3 +1283,9 @@
   [[ ${lines[0]} == "Hello from LUA" ]]
   rm abc.lua
 }
+
+@test "Pi-hole PTR generation check" {
+  run bash -c "bash test/hostnames.sh | tee dig.log"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[@]}" != *"ERROR"* ]]
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR adds the new `PIHOLE_PTR=HOSTNAMEFQDN` option that replies to local interface address PTR lookups with `<hostname>.<local domain>` if set. We already have `PIHOLE_PTR=HOSTNAME` responding with `<hostname>` alone. Looking up names in `/etc/hosts` is removed from the internal resolver as this makes lookups somewhat opaque. Everything should be done with proper (internal) PTR lookups.
We furthermore add CI testing for the automatic replying with `pi.hole` for all local interface addresses with exceptions for the loopback addresses.