### PR TITLE
Support dynamic linking as fallback

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,10 +192,10 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 # for DNSSEC we need the nettle (+ hogweed) crypto and the gmp math libraries
-find_library(LIBHOGWEED libhogweed${CMAKE_STATIC_LIBRARY_SUFFIX})
-find_library(LIBGMP libgmp${CMAKE_STATIC_LIBRARY_SUFFIX})
-find_library(LIBNETTLE libnettle${CMAKE_STATIC_LIBRARY_SUFFIX})
-find_library(LIBIDN libidn${CMAKE_STATIC_LIBRARY_SUFFIX})
+find_library(LIBHOGWEED NAMES libhogweed${CMAKE_STATIC_LIBRARY_SUFFIX} hogweed)
+find_library(LIBGMP NAMES libgmp${CMAKE_STATIC_LIBRARY_SUFFIX} gmp)
+find_library(LIBNETTLE NAMES libnettle${CMAKE_STATIC_LIBRARY_SUFFIX} nettle)
+find_library(LIBIDN NAMES libidn${CMAKE_STATIC_LIBRARY_SUFFIX} idn)
 
 target_link_libraries(pihole-FTL rt Threads::Threads ${LIBHOGWEED} ${LIBGMP} ${LIBNETTLE} ${LIBIDN})
 
@@ -204,9 +204,9 @@ if(LUA_DL STREQUAL "true")
     target_link_libraries(pihole-FTL ${LIBDL})
 endif()
 
-find_library(LIBREADLINE libreadline${CMAKE_STATIC_LIBRARY_SUFFIX})
-find_library(LIBHISTORY libhistory${CMAKE_STATIC_LIBRARY_SUFFIX})
-find_library(LIBTERMCAP libtermcap${CMAKE_STATIC_LIBRARY_SUFFIX})
+find_library(LIBREADLINE NAMES libreadline${CMAKE_STATIC_LIBRARY_SUFFIX} readline)
+find_library(LIBHISTORY NAMES libhistory${CMAKE_STATIC_LIBRARY_SUFFIX} history)
+find_library(LIBTERMCAP NAMES libtermcap${CMAKE_STATIC_LIBRARY_SUFFIX} termcap)
 if(LIBREADLINE AND LIBHISTORY AND LIBTERMCAP)
     message(STATUS "Building FTL with readline support: YES")
     target_compile_definitions(FTL PRIVATE LUA_USE_READLINE)


### PR DESCRIPTION
Current FTL won't build at all if static libraries are not available.
But dynamic libraries might be usable. Be able to use dynamic libraries
if static are not ready.

Signed-off-by: Petr Menšík <pemensik@redhat.com>

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 3

---

Current FTL won't build at all if static libraries are not available.
But dynamic libraries might be usable. Be able to use dynamic libraries
if static are not ready.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
