### PR TITLE
Tweak to GHA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,61 +9,49 @@ on:
     types: [published]
 
 jobs:
-  build:
-
-    strategy:
-      matrix:
-        include:
-         - arch: armv4t
-           bin_name: pihole-FTL-armv4-linux-gnueabi
-         - arch: armv5te
-           bin_name: pihole-FTL-armv5-linux-gnueabi
-         - arch: armv6hf
-           bin_name:  pihole-FTL-armv6-linux-gnueabihf
-         - arch: armv7hf
-           bin_name: pihole-FTL-armv7-linux-gnueabihf
-         - arch: armv8a
-           bin_name: pihole-FTL-armv8-linux-gnueabihf
-         - arch: aarch64
-           bin_name: pihole-FTL-aarch64-linux-gnu
-         - arch: x86_64
-           bin_name: pihole-FTL-linux-x86_64
-         - arch: x86_64-musl
-           bin_name: pihole-FTL-musl-linux-x86_64
-         - arch: x86_32
-           bin_name: pihole-FTL-linux-x86_32
-
-    container: ghcr.io/pi-hole/ftl-build:v1.12-${{ matrix.arch }}
-
+  define-shared-vars:
     runs-on: ubuntu-latest
-    continue-on-error: true
-
+    outputs:
+      GIT_TAG: ${{ steps.variables.outputs.GIT_TAG }}
+      GIT_BRANCH: ${{ steps.variables.outputs.GIT_BRANCH }}
+      OUTPUT_DIR: ${{ steps.variables.outputs.OUTPUT_DIR }}
     steps:
       -
-        name: Update git (until we update base image)
-        if: ${{ matrix.arch != 'x86_64-musl' }}
-        run: |
-          echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list;
-          apt-get update
-          apt-get -t stretch-backports install git -y
-      -
-        name: Get Branch/Tag Name
-        id: branch_name
+        name: Set variables needed in all jobs
+        id: variables
         run: |
           GIT_TAG=${{ github.event.release.tag_name }}
           # If GIT_TAG is set then GIT BRANCH should be "master", else set it from GITHUB_REF
           GIT_BRANCH=$([ -n "${GIT_TAG}" ] && echo "master" || echo "${GITHUB_REF#refs/*/}")
-
           echo ::set-output name=GIT_BRANCH::${GIT_BRANCH}
           echo ::set-output name=GIT_TAG::${GIT_TAG}
-          echo ::set-output name=OUTPUT_DIR::${GIT_TAG:-${GIT_BRANCH}}
+          echo ::set-output name=OUTPUT_DIR::binaries/${GIT_TAG:-${GIT_BRANCH}}
+
+  build-and-test-x86-32-64:
+    needs: define-shared-vars
+    env:
+      GIT_TAG: ${{ needs.define-shared-vars.outputs.GIT_TAG }}
+      GIT_BRANCH: ${{ needs.define-shared-vars.outputs.GIT_BRANCH }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            bin_name: pihole-FTL-linux-x86_64
+          - arch: x86_64-musl
+            bin_name: pihole-FTL-musl-linux-x86_64
+          - arch: x86_32
+            bin_name: pihole-FTL-linux-x86_32
+    container: ghcr.io/pi-hole/ftl-build:v1.14-${{ matrix.arch }}
+    steps:
       -
         name: Checkout code
         uses: actions/checkout@v2
       -
         name: "Build"
         run: |
-          bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${{ steps.branch_name.outputs.GIT_BRANCH }}" "${{ steps.branch_name.outputs.GIT_TAG }}" "${{ matrix.arch }}"
+          bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${GIT_BRANCH}" "${GIT_TAG}" "${{ matrix.arch }}"
       -
         name: "Binary checks"
         run: |
@@ -80,16 +68,86 @@ jobs:
           mv pihole-FTL "${{ matrix.bin_name }}"
           sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
       -
-        name: Transfer Builds to Pi-hole server for pihole checkout
+        name: Upload artifacts to job for later processing
         if: ${{ github.event_name != 'pull_request' }}
-        uses: appleboy/scp-action@master
+        uses: actions/upload-artifact@v2
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          port: ${{ secrets.SSH_PORT }}
+          name: tmp-binary-storage
+          path: '${{ matrix.bin_name }}*'
+
+  build-arm-aarch64:
+    needs: [ build-and-test-x86-32-64, define-shared-vars]
+    env:
+      GIT_TAG: ${{ needs.define-shared-vars.outputs.GIT_TAG }}
+      GIT_BRANCH: ${{ needs.define-shared-vars.outputs.GIT_BRANCH }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+         - arch: armv4t
+           bin_name: pihole-FTL-armv4-linux-gnueabi
+         - arch: armv5te
+           bin_name: pihole-FTL-armv5-linux-gnueabi
+         - arch: armv6hf
+           bin_name:  pihole-FTL-armv6-linux-gnueabihf
+         - arch: armv7hf
+           bin_name: pihole-FTL-armv7-linux-gnueabihf
+         - arch: armv8a
+           bin_name: pihole-FTL-armv8-linux-gnueabihf
+         - arch: aarch64
+           bin_name: pihole-FTL-aarch64-linux-gnu
+    container: ghcr.io/pi-hole/ftl-build:v1.14-${{ matrix.arch }}
+    continue-on-error: true
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v2
+      -
+        name: "Build"
+        run: |
+          bash .circleci/build-CI.sh "-DSTATIC=${STATIC}" "${GIT_BRANCH}" "${GIT_TAG}" "${{ matrix.arch }}"
+      -
+        name: "Binary checks"
+        run: |
+          export CIRCLE_JOB="${{ matrix.arch }}"
+          bash test/arch_test.sh
+      -
+        name: "Generate checksum file"
+        run: |
+          mv pihole-FTL "${{ matrix.bin_name }}"
+          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
+      -
+        name: Upload artifacts to job for later processing
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: tmp-binary-storage
+          path: '${{ matrix.bin_name }}*'
+
+  deploy-binaries:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: [build-arm-aarch64, define-shared-vars]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Binaries built in previous jobs
+        uses: actions/download-artifact@v2
+        with:
+          name: tmp-binary-storage
+      -
+        name: Display structure of downloaded files
+        run: ls -R
+      -
+        name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
           key: ${{ secrets.SSH_KEY }}
-          source: "${{ matrix.bin_name }}*"
-          target: "${{ steps.branch_name.outputs.OUTPUT_DIR }}"
+          known_hosts: 'just-a-placeholder-so-we-dont-get-errors'
+      -
+        name: Transfer Builds to Pi-hole server for pihole checkout
+        run: |
+          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+          sftp -b - ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} <<< "-mkdir ${{ needs.define-shared-vars.outputs.OUTPUT_DIR }}
+          put * ${{ needs.define-shared-vars.outputs.OUTPUT_DIR }}"
       -
         name: Attach binaries to release
         if: ${{ github.event_name == 'release' }}
@@ -97,4 +155,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: '${{ matrix.bin_name }}*'
+          args: '*'

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -15,9 +15,6 @@ elif [ -d /etc/pdns ]; then
   # Alpine
   cp test/pdns/pdns.conf /etc/pdns/pdns.conf
   cp test/pdns/recursor.conf /etc/pdns/recursor.conf
-
-  # TODO: Remove this once the containers are updated
-  apk add --no-cache pdns-doc
 else
   echo "Error: Unable to determine powerDNS config directory"
   exit 1
@@ -119,16 +116,9 @@ pdnsutil check-zone arpa
 echo "********* Done installing PowerDNS configuration **********"
 
 # Start services
-if command -v service; then
-  # Debian
-  service pdns restart
-  service pdns-recursor restart
-else
-  # Alpine
-  killall pdns_server
-  pdns_server --daemon
-  # Have to create the socketdir or the recursor will fails to start
-  mkdir -p /var/run/pdns-recursor
-  killall pdns_recursor
-  pdns_recursor --daemon
-fi
+killall pdns_server
+pdns_server --daemon
+# Have to create the socketdir or the recursor will fails to start
+mkdir -p /var/run/pdns-recursor
+killall pdns_recursor
+pdns_recursor --daemon

--- a/test/run.sh
+++ b/test/run.sh
@@ -64,13 +64,6 @@ umask 0022
 mkdir -p /opt/pihole/libs
 wget -O /opt/pihole/libs/inspect.lua https://ftl.pi-hole.net/libraries/inspect.lua
 
-# Terminate running FTL instance (if any)
-if pidof pihole-FTL &> /dev/null; then
-  echo "Terminating running pihole-FTL instance"
-  killall pihole-FTL
-  sleep 2
-fi
-
 # Start FTL
 if ! su pihole -s /bin/sh -c /home/pihole/pihole-FTL; then
   echo "pihole-FTL failed to start"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

Tweaks to the tests to make things a bit more efficient.  Duplicates things a little for now, but this is an ever evolving configuration as we learn what works and what doesn't...

 Split workflow up into three distinct parts, each depending on the previous part
     1 - Build and Test x86_64/32 binaries
     2 - Build arm/aarch64 binaries (test script is hardcoded to not test these, anyway)
     3 - If relevant, upload binaries via SSH and/or attach to release

~~This also means that when there are transient errors with DNS, causing the tests to fail - we can just restart the workflow and "only" have to rebuild 3 arch's rather than the whole lot~~ Sorted - we now use pdns and all DNS tests are performed "offline"

Temporary artifact storage is used to pass the binaries through to the final step, at which point they are uploaded

~~I would also like to get for https://github.com/pi-hole/docker-base-images/pull/40 to be merged and tagged as v11 so that we can remove the "update git" step~~ Done

An example of the result of this:

![image](https://user-images.githubusercontent.com/1998970/136426642-c4c29dd8-7b68-4742-8117-2833b9fd70d3.png)
