### PR TITLE
Append `no_fqdn_available` when no local suffix has been defined

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2693,8 +2693,11 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw)
 		case PTR_HOSTNAMEFQDN:
 		{
 			char *suffix = daemon->domain_suffix;
+			// If local suffix is not available, we substitute "no_fqdn_available"
+			// see the comment about PIHOLE_PTR=HOSTNAMEFQDN in the Pi-hole docs
+			// for further details on why this was chosen
 			if(!suffix)
-				suffix = (char*)"fqdn";
+				suffix = (char*)"no_fqdn_available";
 			ptrname = calloc(strlen(hostname()) + strlen(suffix) + 2, sizeof(char));
 			if(ptrname)
 			{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

See title. The behavior we are improving here has not been released to `master`, so far.
This PR, together with https://github.com/pi-hole/docs/pull/578, fixes #1205.