### PR TITLE
[Internal] Whoops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ version: 2
 
 .docker_template: &docker_template
   docker:
-    - image: pihole/ftl-build:v1.12-$CIRCLE_JOB
+    - image: pihole/ftl-build:v1.14-$CIRCLE_JOB
   <<: *job_steps
 
 jobs:


### PR DESCRIPTION
Updates the version of the build container used in the circle builds. Tests had the `apk install pdns-doc` removed, as it was added directly into the build container. 