### PR TITLE
Prevent race collisions when parsing FTL config file

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -22,6 +22,7 @@
 // struct in_addr, in6_addr
 #include <netinet/in.h>
 
+void init_config_mutex(void);
 void getLogFilePath(void);
 void read_FTLconf(void);
 void get_privacy_level(FILE *fp);

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@ int main (int argc, char* argv[])
 	parse_args(argc, argv);
 
 	// Try to open FTL log
+	init_config_mutex();
 	init_FTL_log();
 	timer_start(EXIT_TIMER);
 	logg("########## FTL started on %s! ##########", hostname());


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes #1214. So far, memory was released whenever an operation was finished, however, we've seen a race collision where releasing the memory happened too early.

We address this in two ways:
1. Guard the config parsing in a mutex-protected section, ensuring only one thread can do this at the same time, and
2. do not free the config line memory after having used it.
 
As we need to read the config file every now and then (e.g., checking the privacy level) we can also just keep the memory instead of always getting "fresh" memory. This buys us some (very small) speed advantage at the costs of a few dozen bytes additional memory usage. This shouldn't be an issue in 2021.