### PR TITLE
Update embedded dnsmasq to v2.87test4-6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-2.87test4)
+set(DNSMASQ_VERSION pi-hole-2.87test4-6)
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-2.87test3)
+set(DNSMASQ_VERSION pi-hole-2.87test4)
 
 add_subdirectory(src)

--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -1400,10 +1400,12 @@ struct in_addr a_record_from_hosts(char *name, time_t now)
   struct crec *crecp = NULL;
   struct in_addr ret;
   
-  while ((crecp = cache_find_by_name(crecp, name, now, F_IPV4)))
-    if (crecp->flags & F_HOSTS)
-      return crecp->addr.addr4;
-
+  /* If no DNS service, cache not initialised. */
+  if (daemon->port != 0)
+    while ((crecp = cache_find_by_name(crecp, name, now, F_IPV4)))
+      if (crecp->flags & F_HOSTS)
+	return crecp->addr.addr4;
+  
   my_syslog(MS_DHCP | LOG_WARNING, _("No IPv4 address found for %s"), name);
   
   ret.s_addr = 0;

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -17,10 +17,12 @@
 /* Declare static char *compiler_opts  in config.h */
 #define DNSMASQ_COMPILE_OPTS
 
+/* dnsmasq.h has to be included first as it sources config.h */
+#include "dnsmasq.h"
+
 #if defined(HAVE_IDN) || defined(HAVE_LIBIDN2) || defined(LOCALEDIR)
 #include <locale.h>
 #endif
-#include "dnsmasq.h"
 #include "../dnsmasq_interface.h"
 // killed
 #include "../signals.h"

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -17,6 +17,9 @@
 /* Declare static char *compiler_opts  in config.h */
 #define DNSMASQ_COMPILE_OPTS
 
+#if defined(HAVE_IDN) || defined(HAVE_LIBIDN2) || defined(LOCALEDIR)
+#include <locale.h>
+#endif
 #include "dnsmasq.h"
 #include "../dnsmasq_interface.h"
 // killed
@@ -73,8 +76,10 @@ int main_dnsmasq (int argc, char **argv)
   int tftp_prefix_missing = 0;
 #endif
 
-#ifdef LOCALEDIR
+#if defined(HAVE_IDN) || defined(HAVE_LIBIDN2) || defined(LOCALEDIR)
   setlocale(LC_ALL, "");
+#endif
+#ifdef LOCALEDIR
   bindtextdomain("dnsmasq", LOCALEDIR); 
   textdomain("dnsmasq");
 #endif

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -282,7 +282,9 @@ struct event_desc {
 #define OPT_UMBRELLA_DEVID 64
 #define OPT_CMARK_ALST_EN  65
 #define OPT_QUIET_TFTP     66
-#define OPT_LAST           67
+#define OPT_FILTER_A       67
+#define OPT_FILTER_AAAA    68
+#define OPT_LAST           69
 
 #define OPTION_BITS (sizeof(unsigned int)*8)
 #define OPTION_SIZE ( (OPT_LAST/OPTION_BITS)+((OPT_LAST%OPTION_BITS)!=0) )
@@ -1786,7 +1788,11 @@ int do_poll(int timeout);
 size_t rrfilter(struct dns_header *header, size_t plen, int mode);
 u16 *rrfilter_desc(int type);
 int expand_workspace(unsigned char ***wkspc, int *szp, int new);
-
+/* modes. */
+#define RRFILTER_EDNS0   0
+#define RRFILTER_DNSSEC  1
+#define RRFILTER_A       2
+#define RRFILTER_AAAA    3
 /* edns0.c */
 unsigned char *find_pseudoheader(struct dns_header *header, size_t plen,
 				   size_t *len, unsigned char **p, int *is_sign, int *is_last);

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1402,6 +1402,7 @@ void safe_pipe(int *fd, int read_noblock);
 void *whine_malloc(size_t size);
 int sa_len(union mysockaddr *addr);
 int sockaddr_isequal(const union mysockaddr *s1, const union mysockaddr *s2);
+int hostname_order(const char *a, const char *b);
 int hostname_isequal(const char *a, const char *b);
 int hostname_issubdomain(char *a, char *b);
 time_t dnsmasq_time(void);

--- a/src/dnsmasq/domain-match.c
+++ b/src/dnsmasq/domain-match.c
@@ -418,9 +418,8 @@ size_t make_local_answer(int flags, int gotname, size_t size, struct dns_header 
 	else
 	  addr.addr4 = srv->addr;
 	
-	header->ancount = htons(ntohs(header->ancount) + 1);
-	if (!add_resource_record(header, limit, &trunc, sizeof(struct dns_header), &p, daemon->local_ttl, NULL, T_A, C_IN, "4", &addr))
-	  return 0;
+	if (add_resource_record(header, limit, &trunc, sizeof(struct dns_header), &p, daemon->local_ttl, NULL, T_A, C_IN, "4", &addr))
+	  header->ancount = htons(ntohs(header->ancount) + 1);
 	log_query((flags | F_CONFIG | F_FORWARD) & ~F_IPV6, name, (union all_addr *)&addr, NULL, 0);
       }
   
@@ -434,8 +433,8 @@ size_t make_local_answer(int flags, int gotname, size_t size, struct dns_header 
 	else
 	  addr.addr6 = srv->addr;
 	
-	header->ancount = htons(ntohs(header->ancount) + 1);
-	add_resource_record(header, limit, &trunc, sizeof(struct dns_header), &p, daemon->local_ttl, NULL, T_AAAA, C_IN, "6", &addr);
+	if (add_resource_record(header, limit, &trunc, sizeof(struct dns_header), &p, daemon->local_ttl, NULL, T_AAAA, C_IN, "6", &addr))
+	  header->ancount = htons(ntohs(header->ancount) + 1);
 	log_query((flags | F_CONFIG | F_FORWARD) & ~F_IPV4, name, (union all_addr *)&addr, NULL, 0);
       }
 

--- a/src/dnsmasq/domain-match.c
+++ b/src/dnsmasq/domain-match.c
@@ -493,7 +493,7 @@ static int order(char *qdomain, size_t qlen, struct server *serv)
   if (qlen > dlen)
     return -1;
 
-  return strcmp(qdomain, serv->domain);
+  return hostname_order(qdomain, serv->domain);
 }
 
 static int order_servers(struct server *s1, struct server *s2)

--- a/src/dnsmasq/edns0.c
+++ b/src/dnsmasq/edns0.c
@@ -178,7 +178,7 @@ size_t add_pseudoheader(struct dns_header *header, size_t plen, unsigned char *l
 	    memcpy(buff, datap, rdlen);	      
 	  
 	  /* now, delete OPT RR */
-	  plen = rrfilter(header, plen, 0);
+	  plen = rrfilter(header, plen, RRFILTER_EDNS0);
 	  
 	  /* Now, force addition of a new one */
 	  p = NULL;	  

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -315,7 +315,6 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
       if (do_bit)
 	forward->flags |= FREC_DO_QUESTION;
 #endif
-      forward->frec_src.log_id = daemon->log_id;
       
       start = first;
 
@@ -414,6 +413,9 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	 for this server */
       forward->flags |= FREC_TEST_PKTSZ;
     }
+
+  /* If a query is retried, use the log_id for the retry when logging the answer. */
+  forward->frec_src.log_id = daemon->log_id;
 
   /* We may be resending a DNSSEC query here, for which the below processing is not necessary. */
   if (!is_dnssec)

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -175,8 +175,8 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
   unsigned int fwd_flags = 0;
   int is_dnssec = forward && (forward->flags & (FREC_DNSKEY_QUERY | FREC_DS_QUERY));
   struct server *master;
-  unsigned int gotname = extract_request(header, plen, daemon->namebuff, NULL);
   void *hash = hash_questions(header, plen, daemon->namebuff);
+  unsigned int gotname = extract_request(header, plen, daemon->namebuff, NULL);
   unsigned char *oph = find_pseudoheader(header, plen, NULL, NULL, NULL, NULL);
   int old_src = 0, old_reply = 0;
   int first, last, start = 0;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -158,11 +158,20 @@ static int domain_no_rebind(char *domain)
 {
   struct rebind_domain *rbd;
   size_t tlen, dlen = strlen(domain);
-  
+  char *dots = strchr(domain, '.');
+
+  /* Match whole labels only. Empty domain matches no dots (any single label) */
   for (rbd = daemon->no_rebind; rbd; rbd = rbd->next)
-    if (dlen >= (tlen = strlen(rbd->domain)) && strcmp(rbd->domain, &domain[dlen - tlen]) == 0)
+    {
+      if (dlen >= (tlen = strlen(rbd->domain)) &&
+	hostname_isequal(rbd->domain, &domain[dlen - tlen]) &&
+	(dlen == tlen || domain[dlen - tlen - 1] == '.'))
       return 1;
 
+      if (tlen == 0 && !dots)
+	return 1;
+    }
+  
   return 0;
 }
 

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -639,7 +639,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
 	  if (added_pheader)
 	    {
 	      /* client didn't send EDNS0, we added one, strip it off before returning answer. */
-	      n = rrfilter(header, n, 0);
+	      n = rrfilter(header, n, RRFILTER_EDNS0);
 	      pheader = NULL;
 	    }
 	  else
@@ -730,6 +730,17 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
 	      cache_secure = 0;
 	    }
 	}
+
+      /* Before extract_addresses() */
+      if (rcode == NOERROR)
+	{
+	  if (option_bool(OPT_FILTER_A))
+	    n = rrfilter(header, n, RRFILTER_A);
+
+	  if (option_bool(OPT_FILTER_AAAA))
+	    n = rrfilter(header, n, RRFILTER_AAAA);
+	}
+
       /******************************** Pi-hole modification ********************************/
       int ret = extract_addresses(header, n, daemon->namebuff, now, ipsets, nftsets, is_sign, check_rebind, no_cache, cache_secure, &doctored);
       if (ret == 2)
@@ -769,7 +780,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       
       /* If the requestor didn't set the DO bit, don't return DNSSEC info. */
       if (!do_bit)
-	n = rrfilter(header, n, 1);
+	n = rrfilter(header, n, RRFILTER_DNSSEC);
     }
 #endif
 
@@ -793,7 +804,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       u16 swap = htons((u16)ede);
       n = add_pseudoheader(header, n, limit, daemon->edns_pktsz, EDNS0_OPTION_EDE, (unsigned char *)&swap, 2, do_bit, 1);
     }
-  
+
   return n;
 }
 

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -2762,7 +2762,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	
 	if (!arg || !*arg)
 	  flags = SERV_LITERAL_ADDRESS;
-	else if (option != 'S')
+	else if (option == 'A')
 	  {
 	    /* # as literal address means return zero address for 4 and 6 */
 	    if (strcmp(arg, "#") == 0)
@@ -2794,7 +2794,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		  flags &= ~SERV_FOR_NODOTS;
 
 		/* address=/#/ matches the same as without domain */
-		if (option != 'S' && domain[0] == '#' && domain[1] == 0)
+		if (option == 'A' && domain[0] == '#' && domain[1] == 0)
 		  domain[0] = 0;
 	      }
 	    

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -179,7 +179,9 @@ struct myoption {
 #define LOPT_CMARK_ALST    366
 #define LOPT_QUIET_TFTP    367
 #define LOPT_NFTSET        368
- 
+#define LOPT_FILTER_A      369
+#define LOPT_FILTER_AAAA   370
+
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
 #else
@@ -216,6 +218,8 @@ static const struct myoption opts[] =
     { "ignore-address", 1, 0, LOPT_IGNORE_ADDR },
     { "selfmx", 0, 0, 'e' },
     { "filterwin2k", 0, 0, 'f' },
+    { "filter-A", 0, 0, LOPT_FILTER_A },
+    { "filter-AAAA", 0, 0, LOPT_FILTER_AAAA },
     { "pid-file", 2, 0, 'x' },
     { "strict-order", 0, 0, 'o' },
     { "server", 1, 0, 'S' },
@@ -386,6 +390,8 @@ static struct {
   { 'e', OPT_SELFMX, NULL, gettext_noop("Return self-pointing MX records for local hosts."), NULL },
   { 'E', OPT_EXPAND, NULL, gettext_noop("Expand simple names in /etc/hosts with domain-suffix."), NULL },
   { 'f', OPT_FILTER, NULL, gettext_noop("Don't forward spurious DNS requests from Windows hosts."), NULL },
+  { LOPT_FILTER_A, OPT_FILTER_A, NULL, gettext_noop("Don't include IPv4 addresses in DNS answers."), NULL },
+  { LOPT_FILTER_AAAA, OPT_FILTER_AAAA, NULL, gettext_noop("Don't include IPv6 addresses in DNS answers."), NULL },
   { 'F', ARG_DUP, "<ipaddr>,...", gettext_noop("Enable DHCP in the range given with lease duration."), NULL },
   { 'g', ARG_ONE, "<groupname>", gettext_noop("Change to this group after startup (defaults to %s)."), CHGRP },
   { 'G', ARG_DUP, "<hostspec>", gettext_noop("Set address or hostname for a specified machine."), NULL },

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -667,7 +667,7 @@ static char *canonicalise_opt(char *s)
     return 0;
 
   if (strlen(s) == 0)
-    return opt_string_alloc("");
+    return opt_malloc(1); /* Heap-allocated empty string */
 
   unhide_metas(s);
   if (!(ret = canonicalise(s, &nomem)) && nomem)

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -2231,8 +2231,10 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	comma = split(arg);
 		
 	new = opt_malloc(sizeof(struct auth_zone));
-	new->domain = opt_string_alloc(arg);
-	new->subnet = NULL;
+	new->domain = canonicalise_opt(arg);
+	if (!new->domain)
+	  ret_err_free(_("invalid auth-zone"), new);
+ 	new->subnet = NULL;
 	new->exclude = NULL;
 	new->interface_names = NULL;
 	new->next = daemon->auth_zones;

--- a/src/dnsmasq/rrfilter.c
+++ b/src/dnsmasq/rrfilter.c
@@ -156,7 +156,7 @@ static int check_rrs(unsigned char *p, struct dns_header *header, size_t plen, i
 }
 	
 
-/* mode is 0 to remove EDNS0, 1 to filter DNSSEC RRs */
+/* mode may be remove EDNS0 or DNSSEC RRs or remove A or AAAA from answer section. */
 size_t rrfilter(struct dns_header *header, size_t plen, int mode)
 {
   static unsigned char **rrs;
@@ -192,20 +192,37 @@ size_t rrfilter(struct dns_header *header, size_t plen, int mode)
       if (!ADD_RDLEN(header, p, plen, rdlen))
 	return plen;
 
-      /* Don't remove the answer. */
-      if (i < ntohs(header->ancount) && type == qtype && class == qclass)
-	continue;
-      
-      if (mode == 0) /* EDNS */
+      if (mode == RRFILTER_EDNS0) /* EDNS */
 	{
 	  /* EDNS mode, remove T_OPT from additional section only */
 	  if (i < (ntohs(header->nscount) + ntohs(header->ancount)) || type != T_OPT)
 	    continue;
 	}
-      else if (type != T_NSEC && type != T_NSEC3 && type != T_RRSIG)
-	/* DNSSEC mode, remove SIGs and NSECs from all three sections. */
-	continue;
-      
+      else if (mode == RRFILTER_DNSSEC)
+	{
+	  if (type != T_NSEC && type != T_NSEC3 && type != T_RRSIG)
+	    /* DNSSEC mode, remove SIGs and NSECs from all three sections. */
+	    continue;
+
+	  /* Don't remove the answer. */
+	  if (i < ntohs(header->ancount) && type == qtype && class == qclass)
+	    continue;
+	}
+      else
+	{
+	  /* Only looking at answer section now. */
+	  if (i >= ntohs(header->ancount))
+	    break;
+
+	  if (class != C_IN)
+	    continue;
+	  
+	  if (mode == RRFILTER_A && type != T_A)
+	    continue;
+
+	  if (mode == RRFILTER_AAAA && type != T_AAAA)
+	    continue;
+	}
       
       if (!expand_workspace(&rrs, &rr_sz, rr_found + 1))
 	return plen; 

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -367,7 +367,7 @@ int sa_len(union mysockaddr *addr)
 }
 
 /* don't use strcasecmp and friends here - they may be messed up by LOCALE */
-int hostname_isequal(const char *a, const char *b)
+int hostname_order(const char *a, const char *b)
 {
   unsigned int c1, c2;
   
@@ -380,11 +380,19 @@ int hostname_isequal(const char *a, const char *b)
     if (c2 >= 'A' && c2 <= 'Z')
       c2 += 'a' - 'A';
     
-    if (c1 != c2)
-      return 0;
+    if (c1 < c2)
+      return -1;
+    else if (c1 > c2)
+      return 1;
+    
   } while (c1);
   
-  return 1;
+  return 0;
+}
+
+int hostname_isequal(const char *a, const char *b)
+{
+  return hostname_order(a, b) == 0;
 }
 
 /* is b equal to or a subdomain of a return 2 for equal, 1 for subdomain */

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -233,8 +233,6 @@ char *canonicalise(char *in, int *nomem)
     {
 #  ifdef HAVE_LIBIDN2
       rc = idn2_to_ascii_lz(in, &ret, IDN2_NONTRANSITIONAL);
-      if (rc == IDN2_DISALLOWED)
-	rc = idn2_to_ascii_lz(in, &ret, IDN2_TRANSITIONAL);
 #  else
       rc = idna_to_ascii_lz(in, &ret, 0);
 #  endif


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This mainly adds bugfixes for issues reported against the current embedded version of `dnsmasq`. The first two bug fixes are important for us as we have seen them being reported on our own platforms.

- 2924c29 fixes query status being reported incorrectly for retired domains and some special edge-cases (see comment message)
- ea689a2 fixes case-insensitive domain matching, see https://github.com/pi-hole/FTL/issues/1254 (fix has been confirmed therein)
- 89a8864 fixes a regression in `rebind-domain-ok` option recently introduced by `dnsmasq` v2.86
- 5129c7e fixes locally generated answers returning an incorrect answer count when the packet gets too large and UDP truncation happens
- 29261a5 fixes a crash when DNS service is disables and PXE/netboot is used (unlikely to happen for Pi-hole)