### PR TITLE
Compute reply time also for queries which failed upstream

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2375,6 +2375,13 @@ static void FTL_upstream_error(const union all_addr *addr, const int id, const c
 		return;
 	}
 
+	// Save response time (if not done before)
+	// This is necessary to compute a reply time when there was an error
+	// upstream (e.g., DNSSEC BOGUS)
+	struct timeval response;
+	gettimeofday(&response, 0);
+	set_response_time(query, response);
+
 	// Translate dnsmasq's rcode into something we can use
 	const char *rcodestr = NULL;
 	switch(addr->log.rcode)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes #1233

The issue is that we did not compute the reply time for queried that failed upstream. The API interprets the lack of a computed reply time as "there was no reply" which is wrong here.