### PR TITLE
Use REPLY_ADDR4 to overwrite the DNS server in DHCPOFFERs

### DIFF
--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -15,6 +15,7 @@
 */
 
 #include "dnsmasq.h"
+#include "../dnsmasq_interface.h"
 
 #ifdef HAVE_DHCP
 
@@ -2571,7 +2572,15 @@ static void do_options(struct dhcp_context *context,
       if (daemon->port == NAMESERVER_PORT &&
 	  in_list(req_options, OPTION_DNSSERVER) &&
 	  !option_find2(OPTION_DNSSERVER))
-	option_put(mess, end, OPTION_DNSSERVER, INADDRSZ, ntohl(context->local.s_addr));
+	/*** Pi-hole modification ***/
+	{
+	  struct in_addr overwrite;
+	  if(FTL_REPLY_ADDR4(&overwrite))
+	    option_put(mess, end, OPTION_DNSSERVER, INADDRSZ, ntohl(overwrite.s_addr));
+	  else
+	    option_put(mess, end, OPTION_DNSSERVER, INADDRSZ, ntohl(context->local.s_addr));
+	}
+	/****************************/
     }
 
   if (domain && in_list(req_options, OPTION_DOMAINNAME) && 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1026,6 +1026,19 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 	}
 }
 
+// Overwrite reply address if configured to do so
+int FTL_REPLY_ADDR4(struct in_addr *addr)
+{
+	logg("Overwrite address");
+	// Return early if not applicable
+	if(!config.reply_addr.overwrite_v4)
+		return 0;
+
+	// Overwrite IPv4 address
+	memcpy(addr, &config.reply_addr.v4, sizeof(config.reply_addr.v4));
+	return 1;
+}
+
 static void check_pihole_PTR(char *domain)
 {
 	// Return early if Pi-hole PTR is not available

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -52,4 +52,6 @@ bool FTL_unlink_DHCP_lease(const char *ipaddr);
 // defined in src/dnsmasq/cache.c
 extern char *querystr(char *desc, unsigned short type);
 
+int FTL_REPLY_ADDR4(struct in_addr *addr);
+
 #endif // DNSMASQ_INTERFACE_H


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10


Use IP address specified by `REPLY_ADDR4` (if any), to overwrite the automatically added `DNS` server in `DHCPOFFER`s.