### PR TITLE
Add dnsmasq warnings to message table

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -27,7 +27,7 @@
 #include "../gc.h"
 
 static const char *message_types[MAX_MESSAGE] =
-	{ "REGEX", "SUBNET", "HOSTNAME", "DNSMASQ_CONFIG", "RATE_LIMIT" };
+	{ "REGEX", "SUBNET", "HOSTNAME", "DNSMASQ_CONFIG", "RATE_LIMIT" , "DNSMASQ_WARN" };
 
 static unsigned char message_blob_types[MAX_MESSAGE][5] =
 	{
@@ -62,6 +62,13 @@ static unsigned char message_blob_types[MAX_MESSAGE][5] =
 		{	// RATE_LIMIT: The message column contains the IP address of the client in question
 			SQLITE_INTEGER, // Configured maximum number of queries
 			SQLITE_INTEGER, // Configured rate-limiting interval [seconds]
+			SQLITE_NULL, // Not used
+			SQLITE_NULL, // Not used
+			SQLITE_NULL  // Not used
+		},
+		{	// DNSMASQ_WARN_MESSAGE: The message column contains the full message itself
+			SQLITE_NULL, // Not used
+			SQLITE_NULL, // Not used
 			SQLITE_NULL, // Not used
 			SQLITE_NULL, // Not used
 			SQLITE_NULL  // Not used
@@ -336,4 +343,13 @@ void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit
 
 	// Log to database
 	add_message(RATE_LIMIT_MESSAGE, clientIP, 2, config.rate_limit.count, config.rate_limit.interval);
+}
+
+void logg_warn_dnsmasq_message(char *message)
+{
+	// Log to pihole-FTL.log
+	logg("WARNING in dnsmasq core: %s", message);
+
+	// Log to database
+	add_message(DNSMASQ_WARN_MESSAGE, message, 0);
 }

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -21,5 +21,6 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
 void logg_hostname_warning(const char *ip, const char *name, const unsigned int pos);
 void logg_fatal_dnsmasq_message(const char *message);
 void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit_count);
+void logg_warn_dnsmasq_message(char *message);
 
 #endif //MESSAGETABLE_H

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -16,8 +16,6 @@
 #include "regex_r.h"
 // reload_per_client_regex()
 #include "database/gravity-db.h"
-// flush_message_table()
-#include "database/message-table.h"
 // bool startup
 #include "main.h"
 // reset_aliasclient()
@@ -476,9 +474,6 @@ void FTL_reset_per_client_domain_data(void)
 void FTL_reload_all_domainlists(void)
 {
 	lock_shm();
-
-	// Flush messages stored in the long-term database
-	flush_message_table();
 
 	// (Re-)open gravity database connection
 	gravityDB_reopen();

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -314,6 +314,19 @@ void my_syslog(int priority, const char *format, ...)
       fputc('\n', stderr);
     }
 
+  /* Pi-hole diagnosis system */
+  if(priority == LOG_WARNING)
+    {
+      char *message;
+      va_start(ap, format);
+      if(vasprintf(&message, format, ap))
+        {
+          dnsmasq_diagnosis_warning(message);
+          free(message);
+        }
+      va_end(ap);
+    }
+
   if (log_fd == -1)
     {
 #ifdef __ANDROID__

--- a/src/enums.h
+++ b/src/enums.h
@@ -200,6 +200,7 @@ enum message_type {
 	HOSTNAME_MESSAGE,
 	DNSMASQ_CONFIG_MESSAGE,
 	RATE_LIMIT_MESSAGE,
+	DNSMASQ_WARN_MESSAGE,
 	MAX_MESSAGE
 } __attribute__ ((packed));
 

--- a/src/log.c
+++ b/src/log.c
@@ -452,3 +452,19 @@ void print_FTL_version(void)
 {
     printf("Pi-hole FTL %s\n", get_FTL_version());
 }
+
+// Skip leading string if found
+static char *skipStr(const char *startstr, char *message)
+{
+	const size_t startlen = strlen(startstr);
+	if(strncmp(startstr, message, startlen) == 0)
+		return message + startlen;
+	else
+		return message;
+}
+
+void dnsmasq_diagnosis_warning(char *message)
+{
+	// Crop away any existing initial "warning: "
+	logg_warn_dnsmasq_message(skipStr("warning: ", message));
+}

--- a/src/log.h
+++ b/src/log.h
@@ -23,6 +23,7 @@ void log_FTL_version(bool crashreport);
 void get_timestr(char * const timestring, const time_t timein, const bool millis);
 const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));
 void print_FTL_version(void);
+void dnsmasq_diagnosis_warning(char *message);
 
 // The actual logging routine can take extra options for specialized logging
 // The more general interfaces can be defined here as appropriate shortcuts

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,8 @@
 #include "procps.h"
 // init_overtime()
 #include "overTime.h"
+// flush_message_table()
+#include "database/message-table.h"
 
 char * username;
 bool needGC = false;
@@ -56,6 +58,9 @@ int main (int argc, char* argv[])
 	// Catch signals not handled by dnsmasq
 	// We configure real-time signals later (after dnsmasq has forked)
 	handle_signals();
+
+	// Flush messages stored in the long-term database
+	flush_message_table();
 
 	// Initialize shared memory
 	if(!init_shmem(true))

--- a/src/main.c
+++ b/src/main.c
@@ -59,9 +59,6 @@ int main (int argc, char* argv[])
 	// We configure real-time signals later (after dnsmasq has forked)
 	handle_signals();
 
-	// Flush messages stored in the long-term database
-	flush_message_table();
-
 	// Initialize shared memory
 	if(!init_shmem(true))
 	{
@@ -90,6 +87,9 @@ int main (int argc, char* argv[])
 
 	// Initialize query database (pihole-FTL.db)
 	db_init();
+
+	// Flush messages stored in the long-term database
+	flush_message_table();
 
 	// Try to import queries from long-term database if available
 	if(config.DBimport)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add DNSMASQ_WARN message type whenever dnsmasq logs a warning. Also do not flush the message table on reload (but only on restart) so that config-related (i.e. one-time) warnings are not accidentally deleted.