### PR TITLE
Fix locale issue in Telnet API

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -80,6 +80,9 @@ int main_dnsmasq (int argc, char **argv)
 
 #if defined(HAVE_IDN) || defined(HAVE_LIBIDN2) || defined(LOCALEDIR)
   setlocale(LC_ALL, "");
+  /*** Pi-hole modification ***/
+  setlocale(LC_NUMERIC, "C");
+  /****************************/
 #endif
 #ifdef LOCALEDIR
   bindtextdomain("dnsmasq", LOCALEDIR); 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The recent `dnsmasq` update included a commit (https://github.com/pi-hole/FTL/commit/95473e7696bd9408a413c0a17123dfc21321edab) that forced the entire `pihole-FTL` process to adhere to the system-wide defined locale. In the majority of non-English locales (German, French, Italian, and Spanish, ...), a comma is used as decimal separator instead of a dot.

This caused troubles in the PHP API scripts that are not aware of the system-wide locale as the comma is not interpreted as decimal separator leading to malfunctions of the statistics on the dashboard.

This PR fixes this by ensuring that the the numeric part of the locale, responsible for things such as decimal separators, is set to `C` which is the standard setting and was used by FTL before the commit mentioned above.