### PR TITLE
Return DNS port on ">dns-port" telnet command

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1473,3 +1473,9 @@ void delete_lease(const char *client_message, const int *sock)
 	if(config.debug & DEBUG_API)
 		logg("...done");
 }
+
+void getDNSport(const int *sock)
+{
+	// Return DNS port used by FTL
+	ssend(*sock, "%d\n", config.dns_port);
+}

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -30,6 +30,7 @@ void getUnknownQueries(const int *sock);
 
 // DNS resolver methods (dnsmasq_interface.c)
 void getCacheInformation(const int *sock);
+void getDNSport(const int *sock);
 
 // MessagePack serialization helpers
 void pack_eom(const int sock);

--- a/src/api/request.c
+++ b/src/api/request.c
@@ -164,6 +164,11 @@ void process_request(const char *client_message, int *sock)
 		processed = true;
 		delete_lease(client_message, sock);
 	}
+	else if(command(client_message, ">dns-port"))
+	{
+		processed = true;
+		getDNSport(sock);
+	}
 
 	// Test only at the end if we want to quit or kill
 	// so things can be processed before

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -11,6 +11,13 @@
   [[ ${lines[6]} == "" ]]
 }
 
+@test "DNS server port is reported" {
+  run bash -c 'echo ">dns-port >quit" | nc -v 127.0.0.1 4711'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[1]} == "53" ]]
+  [[ ${lines[2]} == "" ]]
+}
+
 @test "Running a second instance is detected and prevented" {
   run bash -c 'su pihole -s /bin/sh -c "/home/pihole/pihole-FTL -f"'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

See title.

Example:
```
$ echo ">dns-port >quit" | nc 127.0.0.1 4711
53
```

Meant to be useful for https://github.com/pi-hole/pi-hole/pull/4485. Can be closed without merging when not used there. Note that the port can also be `0` is someone decides to disable the DNS server part of Pi-hole (possible even when not useful).