### PR TITLE
Improve Linux capabilities check

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -69,37 +69,43 @@ bool check_capabilities(void)
 	}
 
 	bool capabilities_okay = true;
-	if (!(data->permitted & (1 << CAP_NET_ADMIN)))
+	if (!(data->permitted & (1 << CAP_NET_ADMIN)) ||
+	    !(data->effective & (1 << CAP_NET_ADMIN)))
 	{
 		// Needed for ARP-injection (used when we're the DHCP server)
 		logg("WARNING: Required Linux capability CAP_NET_ADMIN not available");
 		capabilities_okay = false;
 	}
-	if (!(data->permitted & (1 << CAP_NET_RAW)))
+	if (!(data->permitted & (1 << CAP_NET_RAW)) ||
+	    !(data->effective & (1 << CAP_NET_RAW)))
 	{
 		// Needed for raw socket access (necessary for ICMP)
 		logg("WARNING: Required Linux capability CAP_NET_RAW not available");
 		capabilities_okay = false;
 	}
-	if (!(data->permitted & (1 << CAP_NET_BIND_SERVICE)))
+	if (!(data->permitted & (1 << CAP_NET_BIND_SERVICE)) ||
+	    !(data->effective & (1 << CAP_NET_BIND_SERVICE)))
 	{
 		// Necessary for dynamic port binding
 		logg("WARNING: Required Linux capability CAP_NET_BIND_SERVICE not available");
 		capabilities_okay = false;
 	}
-	if (!(data->permitted & (1 << CAP_SYS_NICE)))
+	if (!(data->permitted & (1 << CAP_SYS_NICE)) ||
+	    !(data->effective & (1 << CAP_SYS_NICE)))
 	{
 		// Necessary for dynamic port binding
 		logg("WARNING: Required Linux capability CAP_SYS_NICE not available");
 		capabilities_okay = false;
 	}
-	if (!(data->permitted & (1 << CAP_IPC_LOCK)))
+	if (!(data->permitted & (1 << CAP_IPC_LOCK)) ||
+	    !(data->effective & (1 << CAP_IPC_LOCK)))
 	{
 		// Necessary for mmap() to work correctly
 		logg("WARNING: Required Linux capability CAP_IPC_LOCK not available");
 		capabilities_okay = false;
 	}
-	if (!(data->permitted & (1 << CAP_CHOWN)))
+	if (!(data->permitted & (1 << CAP_CHOWN)) ||
+	    !(data->effective & (1 << CAP_CHOWN)))
 	{
 		// Necessary for chown() to work correctly
 		logg("WARNING: Required Linux capability CAP_CHOWN not available");

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -52,21 +52,18 @@ bool check_capabilities(void)
 	data = calloc(sizeof(*data), capsize);
 	capget(hdr, data);
 
-	if(config.debug & DEBUG_CAPS)
+	logg("***************************************");
+	logg("* Linux capability debugging enabled  *");
+	for(unsigned int i = 0u; i < numCaps; i++)
 	{
-		logg("***************************************");
-		logg("* Linux capability debugging enabled  *");
-		for(unsigned int i = 0u; i < numCaps; i++)
-		{
-			const unsigned int capid = capabilityIDs[i];
-			logg("* %-24s (%02u) = %s%s%s *",
-			     capabilityNames[capid], capid,
-			     ((data->permitted   & (1 << capid)) ? "P":"-"),
-			     ((data->inheritable & (1 << capid)) ? "I":"-"),
-			     ((data->effective   & (1 << capid)) ? "E":"-"));
-		}
-		logg("***************************************");
+		const unsigned int capid = capabilityIDs[i];
+		logg("* %-24s (%02u) = %s%s%s *",
+			capabilityNames[capid], capid,
+			((data->permitted   & (1 << capid)) ? "P":"-"),
+			((data->inheritable & (1 << capid)) ? "I":"-"),
+			((data->effective   & (1 << capid)) ? "E":"-"));
 	}
+	logg("***************************************");
 
 	bool capabilities_okay = true;
 	if (!(data->permitted & (1 << CAP_NET_ADMIN)) ||
@@ -93,7 +90,7 @@ bool check_capabilities(void)
 	if (!(data->permitted & (1 << CAP_SYS_NICE)) ||
 	    !(data->effective & (1 << CAP_SYS_NICE)))
 	{
-		// Necessary for dynamic port binding
+		// Necessary for setting higher process priority through nice
 		logg("WARNING: Required Linux capability CAP_SYS_NICE not available");
 		capabilities_okay = false;
 	}
@@ -107,7 +104,7 @@ bool check_capabilities(void)
 	if (!(data->permitted & (1 << CAP_CHOWN)) ||
 	    !(data->effective & (1 << CAP_CHOWN)))
 	{
-		// Necessary for chown() to work correctly
+		// Necessary to chown required files that are owned by another user
 		logg("WARNING: Required Linux capability CAP_CHOWN not available");
 		capabilities_okay = false;
 	}

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -94,13 +94,6 @@ bool check_capabilities(void)
 		logg("WARNING: Required Linux capability CAP_SYS_NICE not available");
 		capabilities_okay = false;
 	}
-	if (!(data->permitted & (1 << CAP_IPC_LOCK)) ||
-	    !(data->effective & (1 << CAP_IPC_LOCK)))
-	{
-		// Necessary for mmap() to work correctly
-		logg("WARNING: Required Linux capability CAP_IPC_LOCK not available");
-		capabilities_okay = false;
-	}
 	if (!(data->permitted & (1 << CAP_CHOWN)) ||
 	    !(data->effective & (1 << CAP_CHOWN)))
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -98,9 +98,9 @@ int main (int argc, char* argv[])
 	log_counter_info();
 	check_setupVarsconf();
 
-	// Check for availability of advanced capabilities
-	// immediately before starting the resolver.
-	check_capabilities();
+	// Check for availability of capabilities in debug mode
+	if(config.debug & DEBUG_CAPS)
+		check_capabilities();
 
 	// Start the resolver
 	startup = false;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10


Do not warn about missing capabilities during startup. The embedded `dnsmasq` does the same but in a better (config-aware) way, i.e. it will not complain about missing `CAP_NET_ADMIN` when DHCP is not enabled. As its warnings are now much more present in all logs, we don't need to do the check twice.

Further/related changes:
- The existing checks remain there but are only used in debug mode (`DEBUG_CAPS`)
- Check for both `E` and `P` flag as we need both for TCP workers
- Remove check for `CAP_IPC_LOCK` as we are not using `mlock()`