### PR TITLE
Return zero domains if no gravity domains are available

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1127,6 +1127,7 @@ int gravityDB_count(const enum gravity_tables list)
 			logg("Count of gravity domains not available. Please run pihole -g");
 			// set the gravity count to zero if no gravity domains are available
 			const int result = 0;
+			return result;
 		}
 		gravityDB_finalizeTable();
 		gravityDB_close();

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1125,6 +1125,8 @@ int gravityDB_count(const enum gravity_tables list)
 		if(list == GRAVITY_TABLE)
 		{
 			logg("Count of gravity domains not available. Please run pihole -g");
+			// set the gravity count to zero if no gravity domains are available
+			const int result = 0;
 		}
 		gravityDB_finalizeTable();
 		gravityDB_close();

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1127,6 +1127,7 @@ int gravityDB_count(const enum gravity_tables list)
 			logg("Count of gravity domains not available. Please run pihole -g");
 			// set the gravity count to zero if no gravity domains are available
 			const int result = 0;
+			logg("Setting gravity count to zero");
 			return result;
 		}
 		gravityDB_finalizeTable();


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

3

If no domains are available on the gravity table the gravity count will error out leaving `counters->gravity` undefined. This in turn will be displayed at the web interface as `-2`.
This PR explicitly returns zero if there were no domains on the gravity table.
See: https://github.com/pi-hole/pi-hole/issues/4519
