### PR TITLE
Update Sqlite3 engine to 3.37.2

### DIFF
--- a/src/database/sqlite3.h
+++ b/src/database/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.37.1"
-#define SQLITE_VERSION_NUMBER 3037001
-#define SQLITE_SOURCE_ID      "2021-12-30 15:30:28 378629bf2ea546f73eee84063c5358439a12f7300e433f18c9e1bddd948dea62"
+#define SQLITE_VERSION        "3.37.2"
+#define SQLITE_VERSION_NUMBER 3037002
+#define SQLITE_SOURCE_ID      "2022-01-06 13:25:41 872ba256cbf61d9290b571c0e6d82a20c224ca3ad82971edc46b29818d5d17a0"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

**CHANGELOG**

1.  Fix [a bug](https://sqlite.org/forum/forumpost/b03d86f9516cb3a2) introduced in [version 3.35.0](../releaselog/3_35_0.html) (2021-03-12) that [can cause database corruption](https://sqlite.org/howtocorrupt.html#svptbug) if a [SAVEPOINT](https://sqlite.org/lang_savepoint.html) is rolled back while in [PRAGMA temp_store=MEMORY](https://sqlite.org/pragma.html#pragma_temp_store) mode, and other changes are made, and then the outer transaction commits. [Check-in 73c2b50211d3ae26](https://sqlite.org/src/info/73c2b50211d3ae26)
2.  Fix a long-standing problem with `ON DELETE CASCADE` and `ON UPDATE CASCADE` in which a cache of the [bytecode](https://sqlite.org/opcode.html) used to implement the cascading change was not being reset following a local DDL change. [Check-in 5232c9777fe4fb13](https://sqlite.org/src/info/5232c9777fe4fb13).
3.  Other minor fixes that should not impact production builds.

We are not affected by any of these bugs.