### PR TITLE
Add others section to upstream servers pie chart

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -555,7 +555,7 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 				// Whats the percentage of cached queries on the total amount of queries?
 				percentage = 1e2f * cached_queries() / counters->queries;
 		}
-		else if(i == -1 && others > 0)
+		else if(i == -1)
 		{
 			// Others
 			ip = "other";

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -498,7 +498,7 @@ void getTopClients(const char *client_message, const int *sock)
 void getUpstreamDestinations(const char *client_message, const int *sock)
 {
 	bool sort = true;
-	int temparray[counters->upstreams][2], totalqueries = 0, totalcount = 0;
+	int temparray[counters->upstreams][2], totalcount = 0;
 
 	if(command(client_message, "unsorted"))
 		sort = false;
@@ -525,34 +525,45 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 		qsort(temparray, counters->upstreams, sizeof(int[2]), cmpdesc);
 	}
 
-	totalqueries = totalcount + cached_queries() + blocked_queries();
+	const int totalqueries = totalcount + cached_queries() + blocked_queries();
+	const int others = counters->queries - totalqueries;
 
 	// Loop over available forward destinations
-	for(int i = -2; i < min(counters->upstreams, 8); i++)
+	for(int i = -3; i < min(counters->upstreams, 8); i++)
 	{
 		float percentage = 0.0f;
 		const char *ip, *name;
 		in_port_t upstream_port = 0;
 
-		if(i == -2)
+		if(i == -3)
 		{
 			// Blocked queries (local lists)
 			ip = "blocklist";
 			name = ip;
 
-			if(totalqueries > 0)
+			if(counters->queries > 0)
 				// Whats the percentage of locked queries on the total amount of queries?
-				percentage = 1e2f * blocked_queries() / totalqueries;
+				percentage = 1e2f * blocked_queries() / counters->queries;
 		}
-		else if(i == -1)
+		else if(i == -2)
 		{
 			// Local cache
 			ip = "cache";
 			name = ip;
 
-			if(totalqueries > 0)
+			if(counters->queries > 0)
 				// Whats the percentage of cached queries on the total amount of queries?
-				percentage = 1e2f * cached_queries() / totalqueries;
+				percentage = 1e2f * cached_queries() / counters->queries;
+		}
+		else if(i == -1 && others > 0)
+		{
+			// Others
+			ip = "other";
+			name = ip;
+
+			if(counters->queries > 0)
+				// Whats the percentage of cached queries on the total amount of queries?
+				percentage = 1e2f * others / counters->queries;
 		}
 		else
 		{
@@ -574,8 +585,8 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 			upstream_port = upstream->port;
 
 			// Get percentage
-			if(totalqueries > 0)
-				percentage = 1e2f * count / totalqueries;
+			if(counters->queries > 0)
+				percentage = 1e2f * count / counters->queries;
 		}
 
 		// Send data:

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -486,11 +486,12 @@
 @test "Upstream Destinations reported correctly" {
   run bash -c 'echo ">forward-dest >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == "-2 17.02 blocklist blocklist" ]]
-  [[ ${lines[2]} == "-1 27.66 cache cache" ]]
-  [[ ${lines[3]} == "0 51.06 127.0.0.1#5555 127.0.0.1#5555" ]]
-  [[ ${lines[4]} == "1 4.26 127.0.0.1#5554 127.0.0.1#5554" ]]
-  [[ ${lines[5]} == "" ]]
+  [[ ${lines[1]} == "-3 17.02 blocklist blocklist" ]]
+  [[ ${lines[2]} == "-2 27.66 cache cache" ]]
+  [[ ${lines[3]} == "-1 0.00 other other" ]]
+  [[ ${lines[4]} == "0 51.06 127.0.0.1#5555 127.0.0.1#5555" ]]
+  [[ ${lines[5]} == "1 4.26 127.0.0.1#5554 127.0.0.1#5554" ]]
+  [[ ${lines[6]} == "" ]]
 }
 
 @test "Query Types reported correctly" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

There are queries which are neither sent upstream nor are they cached or blocked. These are incorrectly ignored in the upstream server pie chart leading to a mismatch of the blocked percentage compared to the value reported at the top. Even when both are correct (their difference is caused by different reference frames), this is confusing. To compensate, we add a new type `other` which summarizes all these queries, causing the two reference frames to be identical.