### PR TITLE
Keep Query Log details across FTL restart

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -419,6 +419,12 @@ void db_init(void)
 			dbclose(&db);
 			return;
 		}
+
+		// Reopen database after low-level schema editing to reload the schema
+		dbclose(&db);
+		if(!(db = dbopen(false)))
+			return;
+
 		// Get updated version
 		dbversion = db_get_int(db, DB_VERSION);
 	}
@@ -434,6 +440,12 @@ void db_init(void)
 			dbclose(&db);
 			return;
 		}
+
+		// Reopen database after low-level schema editing to reload the schema
+		dbclose(&db);
+		if(!(db = dbopen(false)))
+			return;
+
 		// Get updated version
 		dbversion = db_get_int(db, DB_VERSION);
 	}

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -438,6 +438,21 @@ void db_init(void)
 		dbversion = db_get_int(db, DB_VERSION);
 	}
 
+	// Update to version 12 if lower
+	if(dbversion < 12)
+	{
+		// Update to version 12: Add additional columns for reply type and time, and dnssec status
+		logg("Updating long-term database to version 12");
+		if(!add_query_storage_columns(db))
+		{
+			logg("Additional records not generated, database not available");
+			dbclose(&db);
+			return;
+		}
+		// Get updated version
+		dbversion = db_get_int(db, DB_VERSION);
+	}
+
 	lock_shm();
 	import_aliasclients(db);
 	unlock_shm();

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -812,10 +812,10 @@ void DB_read_queries(void)
 		}
 
 		int reply_type = REPLY_UNKNOWN;
-		if(sqlite3_column_type(stmt, 7) == SQLITE_INTEGER)
+		if(sqlite3_column_type(stmt, 8) == SQLITE_INTEGER)
 		{
 			// The field has been added for database version 12
-			reply_type = sqlite3_column_int(stmt, 7);
+			reply_type = sqlite3_column_int(stmt, 8);
 			if(reply_type < REPLY_UNKNOWN || reply_type >= QUERY_REPLY_MAX)
 			{
 				logg("DB warn: REPLY value %i is invalid, %lli", reply_type, (long long)queryTimeStamp);
@@ -824,10 +824,12 @@ void DB_read_queries(void)
 		}
 
 		double reply_time = 0.0;
-		if(sqlite3_column_type(stmt, 8) == SQLITE_FLOAT)
+		bool reply_time_avail = false;
+		if(sqlite3_column_type(stmt, 9) == SQLITE_FLOAT)
 		{
 			// The field has been added for database version 12
-			reply_time = sqlite3_column_double(stmt, 8);
+			reply_time = sqlite3_column_double(stmt, 9);
+			reply_time_avail = true;
 			if(reply_time < 0.0)
 			{
 				logg("DB warn: REPLY_TIME value %f is invalid, %lli", reply_time, (long long)queryTimeStamp);
@@ -836,10 +838,10 @@ void DB_read_queries(void)
 		}
 
 		int dnssec = DNSSEC_UNSPECIFIED;
-		if(sqlite3_column_type(stmt, 9) == SQLITE_INTEGER)
+		if(sqlite3_column_type(stmt, 10) == SQLITE_INTEGER)
 		{
 			// The field has been added for database version 12
-			dnssec = sqlite3_column_int(stmt, 9);
+			dnssec = sqlite3_column_int(stmt, 10);
 			if(dnssec < DNSSEC_UNSPECIFIED || dnssec >= DNSSEC_ABANDONED)
 			{
 				logg("DB warn: DNSSEC value %i is invalid, %lli", dnssec, (long long)queryTimeStamp);
@@ -877,7 +879,7 @@ void DB_read_queries(void)
 		query->upstreamID = upstreamID;
 		query->id = 0;
 		query->response = 0;
-		query->flags.response_calculated = false;
+		query->flags.response_calculated = reply_time_avail;
 		query->dnssec = dnssec;
 		query->reply = reply_type;
 		query->response = reply_time * 1e4; // convert to tenth-millisecond unit

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -19,5 +19,6 @@ bool optimize_queries_table(sqlite3 *db);
 bool create_addinfo_table(sqlite3 *db);
 int DB_save_queries(sqlite3 *db);
 void DB_read_queries(void);
+bool add_query_storage_columns(sqlite3 *db);
 
 #endif //DATABASE_QUERY_TABLE_H

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -40,8 +40,8 @@ typedef struct {
 	// and straddle the individual bytes. It is useful to pack the memory as
 	// tightly as possible as there may be dozens of thousands of these
 	// objects in memory (one per query).
-	// C99 guarentees that bit-fields will be packed as tightly as possible,
-	// provided they don’t cross storageau unit boundaries (6.7.2.1 #10).
+	// C99 guarantees that bit-fields will be packed as tightly as possible,
+	// provided they don't cross storage unit boundaries (6.7.2.1 #10).
 	struct query_flags {
 		bool whitelisted :1;
 		bool complete :1;

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -594,7 +594,7 @@
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network\" (id INTEGER PRIMARY KEY NOT NULL, hwaddr TEXT UNIQUE NOT NULL, interface TEXT NOT NULL, firstSeen INTEGER NOT NULL, lastQuery INTEGER NOT NULL, numQueries INTEGER NOT NULL, macVendor TEXT, aliasclient_id INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network_addresses\" (network_id INTEGER NOT NULL, ip TEXT UNIQUE NOT NULL, lastSeen INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), name TEXT, nameUpdated INTEGER, FOREIGN KEY(network_id) REFERENCES network(id));"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE aliasclient (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, comment TEXT);"* ]]
-  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,12);"* ]] # Expecting FTL database version 11
+  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,12);"* ]] # Expecting FTL database version 12
   # vvv This has been added in version 10 vvv
   [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info, reply_type, reply_time, dnssec FROM query_storage q;"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE domain_by_id (id INTEGER PRIMARY KEY, domain TEXT NOT NULL);"* ]]

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -587,16 +587,16 @@
 @test "pihole-FTL.db schema is as expected" {
   run bash -c './pihole-FTL sqlite3 /etc/pihole/pihole-FTL.db .dump'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"query_storage\" (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain INTEGER NOT NULL, client INTEGER NOT NULL, forward INTEGER, additional_info INTEGER);"* ]]
+  [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"query_storage\" (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain INTEGER NOT NULL, client INTEGER NOT NULL, forward INTEGER, additional_info INTEGER, reply_type INTEGER, reply_time REAL, dnssec INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE INDEX idx_queries_timestamps ON \"query_storage\" (timestamp);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE ftl (id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE counters (id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network\" (id INTEGER PRIMARY KEY NOT NULL, hwaddr TEXT UNIQUE NOT NULL, interface TEXT NOT NULL, firstSeen INTEGER NOT NULL, lastQuery INTEGER NOT NULL, numQueries INTEGER NOT NULL, macVendor TEXT, aliasclient_id INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network_addresses\" (network_id INTEGER NOT NULL, ip TEXT UNIQUE NOT NULL, lastSeen INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), name TEXT, nameUpdated INTEGER, FOREIGN KEY(network_id) REFERENCES network(id));"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE aliasclient (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, comment TEXT);"* ]]
-  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,11);"* ]] # Expecting FTL database version 11
+  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,12);"* ]] # Expecting FTL database version 11
   # vvv This has been added in version 10 vvv
-  [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info FROM query_storage q;"* ]]
+  [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info, reply_type, reply_time, dnssec FROM query_storage q;"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE domain_by_id (id INTEGER PRIMARY KEY, domain TEXT NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE client_by_id (id INTEGER PRIMARY KEY, ip TEXT NOT NULL, name TEXT);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE forward_by_id (id INTEGER PRIMARY KEY, forward TEXT NOT NULL);"* ]]


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

When restarting FTL, it imports history from the database to repopulate the history. So far, this was only possible with a reduced set of variables to keep the database from growing forever. Recent database optimizations https://github.com/pi-hole/FTL/pull/1255 reduced the database size significantly allowing us to store more data in the database.

This PR adds storing all the details necessary for the query log so a restart goes (almost) invisible and without any data loss.

*) almost because some queries may not have been completed due to the forced restart and according service interruption.