### PR TITLE
perf improvements for findDomainID()

### DIFF
--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -40,6 +40,24 @@ void strtolower(char *str)
 	while(str[i]){ str[i] = tolower(str[i]); i++; }
 }
 
+// creates a simple hash of a string that fits into a uint32_t
+uint32_t hashStr(const char *s)
+{
+        uint32_t hash = 0;
+        // Jenkins' One-at-a-Time hash (http://www.burtleburtle.net/bob/hash/doobs.html)
+        for(; *s; ++s)
+        {
+                hash += *s;
+                hash += hash << 10;
+                hash ^= hash >> 6;
+        }
+
+        hash += hash << 3;
+        hash ^= hash >> 11;
+        hash += hash << 15;
+        return hash;
+}
+
 int findQueryID(const int id)
 {
 	// Loop over all queries - we loop in reverse order (start from the most recent query and
@@ -121,6 +139,7 @@ int findUpstreamID(const char * upstreamString, const in_port_t port)
 
 int findDomainID(const char *domainString, const bool count)
 {
+	uint32_t domainHash = hashStr(domainString);
 	for(int domainID = 0; domainID < counters->domains; domainID++)
 	{
 		// Get domain pointer
@@ -130,8 +149,8 @@ int findDomainID(const char *domainString, const bool count)
 		if(domain == NULL)
 			continue;
 
-		// Quick test: Does the domain start with the same character?
-		if(getstr(domain->domainpos)[0] != domainString[0])
+		// Quicker test: Does the domain match the pre-computed hash?
+		if(domain->domainhash != domainHash)
 			continue;
 
 		// If so, compare the full domain using strcmp
@@ -164,6 +183,8 @@ int findDomainID(const char *domainString, const bool count)
 	domain->blockedcount = 0;
 	// Store domain name - no need to check for NULL here as it doesn't harm
 	domain->domainpos = addstr(domainString);
+	// Store pre-computed hash of domain for faster lookups later on
+	domain->domainhash = hashStr(domainString);
 	// Increase counter by one
 	counters->domains++;
 

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -97,9 +97,10 @@ typedef struct {
 	unsigned char magic;
 	int count;
 	int blockedcount;
+	uint32_t domainhash;
 	size_t domainpos;
 } domainsData;
-ASSERT_SIZEOF(domainsData, 24, 16, 16);
+ASSERT_SIZEOF(domainsData, 24, 20, 20);
 
 typedef struct {
 	unsigned char magic;
@@ -113,6 +114,7 @@ typedef struct {
 ASSERT_SIZEOF(DNSCacheData, 16, 16, 16);
 
 void strtolower(char *str);
+uint32_t hashStr(const char *s) __attribute__((const));
 int findQueryID(const int id);
 int findUpstreamID(const char * upstream, const in_port_t port);
 int findDomainID(const char *domain, const bool count);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 
2

---

The function findDomainID() is called a lot and contains a simple test to avoid
further iteration and more expensive calls within.  This commit improves the
performance overall by optimizing the simple test to match more frequently and
perform the actual comparison quicker too.

The original code will try a quick match on the first char of the domain before
continuing, which from my testing actually appears to match more regularly
than expected, and therefor, continue with more expensive calls and further iteration.

This is because common "domains" tend to start with things like 'www.' or
'mail. or 'img.' (etc., etc.) and also the frequency of the first letters in
domains generally seems to be fairly common too.

This patch implements an approach to test whether 4 chars are the
same, offset 4 chars within the domain (to avoid 'www.' and similar), unless
the length of the domain is less than 4 chars and we revert to the original
first char only test.

The 4 chars are also packed into an int sized register for comparison which
means the comparison is just as fast as the single char test.

My testing of these two changes on my modest Pi 3 Model B Rev 2 (the 1GB RAM,
non-GbE Quad-core 1.2 GHz kind) showed an average 20% improvement in dns lookup
latency (namebench showed 103ms to 83ms improvement using Alexa Top 200
domains).