### PR TITLE
Print more details in CLI regex-test

### DIFF
--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -588,3 +588,41 @@ void _query_set_status(queriesData *query, const enum query_status new_status, c
 	// Update status
 	query->status = new_status;
 }
+
+const char * __attribute__ ((const)) get_query_reply_str(const enum reply_type reply)
+{
+	switch(reply)
+	{
+		case REPLY_UNKNOWN:
+			return "UNKNOWN";
+		case REPLY_NODATA:
+			return "NODATA";
+		case REPLY_NXDOMAIN:
+			return "NXDOMAIN";
+		case REPLY_CNAME:
+			return "CNAME";
+		case REPLY_IP:
+			return "IP";
+		case REPLY_DOMAIN:
+			return "DOMAIN";
+		case REPLY_RRNAME:
+			return "RRNAME";
+		case REPLY_SERVFAIL:
+			return "SERVFAIL";
+		case REPLY_REFUSED:
+			return "REFUSED";
+		case REPLY_NOTIMP:
+			return "NOTIMP";
+		case REPLY_OTHER:
+			return "OTHER";
+		case REPLY_DNSSEC:
+			return "DNSSEC";
+		case REPLY_NONE:
+			return "NONE";
+		case REPLY_BLOB:
+			return "BLOB";
+		default:
+		case QUERY_REPLY_MAX:
+			return "INVALID";
+	}
+}

--- a/src/regex.c
+++ b/src/regex.c
@@ -410,25 +410,50 @@ int match_regex(const char *input, DNSCacheData* dns_cache, const int clientID,
 				     input, regex[index].string);
 			}
 
-			if(regextest && regexid == REGEX_CLI)
+			if(regextest)
 			{
-				// CLI provided regular expression
-				logg("    %s%s%s matches",
-				     cli_bold(), regex[index].string, cli_normal());
-			}
-			else if(regextest && regexid == REGEX_BLACKLIST)
-			{
-				// Database-sourced regular expression
-				logg("    %s%s%s matches (regex blacklist, DB ID %i)",
-				     cli_bold(), regex[index].string, cli_normal(),
-				     regex[index].database_id);
-			}
-			else if(regextest && regexid == REGEX_WHITELIST)
-			{
-				// Database-sourced regular expression
-				logg("    %s%s%s matches (regex whitelist, DB ID %i)",
-				     cli_bold(), regex[index].string, cli_normal(),
-				     regex[index].database_id);
+				if(regexid == REGEX_CLI)
+				{
+					// CLI provided regular expression
+					logg("    %s%s%s matches",
+					cli_bold(), regex[index].string, cli_normal());
+				}
+				else if(regextest && regexid == REGEX_BLACKLIST)
+				{
+					// Database-sourced regular expression
+					logg("    %s%s%s matches (regex blacklist, DB ID %i)",
+					cli_bold(), regex[index].string, cli_normal(),
+					regex[index].database_id);
+				}
+				else if(regextest && regexid == REGEX_WHITELIST)
+				{
+					// Database-sourced regular expression
+					logg("    %s%s%s matches (regex whitelist, DB ID %i)",
+					cli_bold(), regex[index].string, cli_normal(),
+					regex[index].database_id);
+				}
+
+				// Check query type filtering
+				if(regex[index].ext.query_type != 0)
+				{
+					logg("    Hint: This regex %s type %s queries",
+					     regex[index].ext.query_type_inverted ? "does not match" : "matches only",
+					     querytypes[regex[index].ext.query_type]);
+				}
+
+				// Check inversion
+				if(regex[index].ext.inverted)
+				{
+					logg("    Hint: This regex is inverted");
+				}
+
+				// Check special reply type
+				if(regex[index].ext.reply != REPLY_UNKNOWN)
+				{
+					logg("    Hint: This regex forces reply type %s",
+					     get_query_reply_str(regex[index].ext.reply));
+				}
+
 			}
 			else
 			{

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -986,6 +986,34 @@
   [[ ${lines[0]} == "fe80::1234" ]]
 }
 
+@test "Regex Test 47: Option \";querytype=A\" reported on CLI" {
+  run bash -c './pihole-FTL regex-test "f" f\;querytype=A'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  [[ ${lines[4]} == "    Hint: This regex matches only type A queries" ]]
+}
+
+@test "Regex Test 48: Option \";querytype=!TXT\" reported on CLI" {
+  run bash -c './pihole-FTL regex-test "f" f\;querytype=!TXT'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  [[ ${lines[4]} == "    Hint: This regex does not match type TXT queries" ]]
+}
+
+@test "Regex Test 49: Option \";reply=NXDOMAIN\" reported on CLI" {
+  run bash -c './pihole-FTL regex-test "f" f\;reply=NXDOMAIN'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  [[ ${lines[4]} == "    Hint: This regex forces reply type NXDOMAIN" ]]
+}
+
+@test "Regex Test 50: Option \";invert\" reported on CLI" {
+  run bash -c './pihole-FTL regex-test "f" g\;invert'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  [[ ${lines[4]} == "    Hint: This regex is inverted" ]]
+}
+
 # x86_64-musl is built on busybox which has a slightly different
 # variant of ls displaying three, instead of one, spaces between the
 # user and group names.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Prints details about parsed Pi-hole regex extensions changing the effect of regular expressions.

Examples:
```
./pihole-FTL regex-test "f" 'f;querytype=AAAA'

[i] Compiling regex filter...
    Compiled regex filter in 0.646 msec

Checking domain...
    f;querytype=AAAA matches
    Hint: This regex matches only type AAAA queries   <-----------
   Time: 0.449 msec
```
```
./pihole-FTL regex-test "f" 'f;querytype=!TXT'

[i] Compiling regex filter...
    Compiled regex filter in 0.646 msec

Checking domain...
    f;querytype=!TXT matches
    Hint: This regex never matches type TXT queries   <-----------
   Time: 0.449 msec
```
```
./pihole-FTL regex-test "f" 'g;invert'

[i] Compiling regex filter...
    Compiled regex filter in 0.050 msec

Checking domain...
    g;invert matches
    Hint: This regex matches inverted   <-----------
   Time: 0.046 msec
```
```
./pihole-FTL regex-test "f" 'f;reply=NXDOMAIN'

[i] Compiling regex filter...
    Compiled regex filter in 0.030 msec

Checking domain...
    f;reply=NXDOMAIN matches
    Hint: This regex forces reply type NXDOMAIN   <-----------
   Time: 0.019 msec
```