### PR TITLE
Prevent excessive reply times in the Query Log after restarting

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -431,8 +431,11 @@ int DB_save_queries(sqlite3 *db)
 		// REPLY_TYPE
 		sqlite3_bind_int(query_stmt, 10, query->reply);
 
-		// REPLY_TIME (stored in units of seconds)
-		sqlite3_bind_double(query_stmt, 11, 1e-4*query->response);
+		// REPLY_TIME (stored in units of seconds) if available, NULL otherwise
+		if(query->flags.response_calculated)
+			sqlite3_bind_double(query_stmt, 11, 1e-4*query->response);
+		else
+			sqlite3_bind_null(query_stmt, 11);
 
 		// DNSSEC
 		sqlite3_bind_int(query_stmt, 12, query->dnssec);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The `query->reply_time` variable serves two purposes: (1) When sending a query upstream, we store the current time in this field. (2) When the reply arrives, we compute the difference and store it in the same field. We memorize the transition from (1) to (2) by setting the flag `query->flags.response_calculated` to `true`.

Currently (broken in `development`, not in `master`), we store the reply_time field unconditionally, hence, for a few queries which are still being processed upstream at restart, we store the real time instead of the response. FTL incorrectly interprets the (homogeneous!) timestamp as difference and telly you the query needed quadrillions of milliseconds to get answered.

We fix this small bug by instead storing `NULL` in the `REPLY_TIME` column when the reply time is not available. FTL already handles this case well when loading from the database: the default of `query->flags.response_calculated` is `false`. A `NULL` value in this field does not change this default.