### PR TITLE
Rename upstream 'blocklist' => 'blocked' and 'cache' => 'cached'

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -548,7 +548,7 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 		else if(i == -2)
 		{
 			// Local cache
-			ip = "cache";
+			ip = "cached";
 			name = ip;
 
 			if(counters->queries > 0)
@@ -590,7 +590,7 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 		}
 
 		// Send data:
-		// - always if i < 0 (special upstreams: blocked and cache)
+		// - always if i < 0 (special upstreams: blocked and cached)
 		// - only if percentage > 0.0 for all others (i > 0)
 		if(percentage > 0.0f || i < 0)
 		{
@@ -733,7 +733,7 @@ void getAllQueries(const char *client_message, const int *sock)
 
 		if(strcmp(forwarddest, "blocked") == 0)
 			forwarddestid = -3;
-		else if(strcmp(forwarddest, "cache") == 0)
+		else if(strcmp(forwarddest, "cached") == 0)
 			forwarddestid = -2;
 		else if(strcmp(forwarddest, "other") == 0)
 			forwarddestid = -1;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -538,7 +538,7 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 		if(i == -3)
 		{
 			// Blocked queries (local lists)
-			ip = "blocklist";
+			ip = "blocked";
 			name = ip;
 
 			if(counters->queries > 0)
@@ -590,7 +590,7 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 		}
 
 		// Send data:
-		// - always if i < 0 (special upstreams: blocklist and cache)
+		// - always if i < 0 (special upstreams: blocked and cache)
 		// - only if percentage > 0.0 for all others (i > 0)
 		if(percentage > 0.0f || i < 0)
 		{
@@ -731,7 +731,7 @@ void getAllQueries(const char *client_message, const int *sock)
 		sscanf(client_message, ">getallqueries-forward %255s", forwarddest);
 		filterforwarddest = true;
 
-		if(strcmp(forwarddest, "blocklist") == 0)
+		if(strcmp(forwarddest, "blocked") == 0)
 			forwarddestid = -3;
 		else if(strcmp(forwarddest, "cache") == 0)
 			forwarddestid = -2;

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -493,7 +493,7 @@
 @test "Upstream Destinations reported correctly" {
   run bash -c 'echo ">forward-dest >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == "-3 17.02 blocklist blocklist" ]]
+  [[ ${lines[1]} == "-3 17.02 blocked blocked" ]]
   [[ ${lines[2]} == "-2 27.66 cache cache" ]]
   [[ ${lines[3]} == "-1 0.00 other other" ]]
   [[ ${lines[4]} == "0 51.06 127.0.0.1#5555 127.0.0.1#5555" ]]

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -494,7 +494,7 @@
   run bash -c 'echo ">forward-dest >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[1]} == "-3 17.02 blocked blocked" ]]
-  [[ ${lines[2]} == "-2 27.66 cache cache" ]]
+  [[ ${lines[2]} == "-2 27.66 cached cached" ]]
   [[ ${lines[3]} == "-1 0.00 other other" ]]
   [[ ${lines[4]} == "0 51.06 127.0.0.1#5555 127.0.0.1#5555" ]]
   [[ ${lines[5]} == "1 4.26 127.0.0.1#5554 127.0.0.1#5554" ]]


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

---

Renames the Upstream server name for blocked queries from "blocklist" to "blocked".
The term "blocklist" was omitted in v5 by "adlist" but this would still not be comprehensively enough. This special upstream server includes queries blocked by gravity, regex or domainlist. Therefore I suggest to just name it "blocked".

Fixes https://github.com/pi-hole/AdminLTE/issues/1468

Accompanied by https://github.com/pi-hole/AdminLTE/pull/2119

![Bildschirmfoto zu 2022-02-12 10-12-59](https://user-images.githubusercontent.com/26622301/153705614-9b8bc2de-db69-43df-9e94-b9891ce48adc.png)



_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
