### PR TITLE
Fix initOverTime's calculation of last slot timestamp

### DIFF
--- a/src/overTime.c
+++ b/src/overTime.c
@@ -70,23 +70,22 @@ void initOverTime(void)
 	// Get current timestamp
 	time_t now = time(NULL);
 
-	// The last timestamp (overTime[149]) should be the last interval of this hour
-	// If the current time is 09:35, the last interval is 09:50 - 10:00 (centered at 09:55)
-	time_t timestamp = now - now % 3600 + 3600 - (OVERTIME_INTERVAL / 2);
+	// Get the centered timestamp of the current timestamp
+	time_t first_slot_ts = now - now % OVERTIME_INTERVAL + (OVERTIME_INTERVAL / 2);
+	time_t last_slot_ts = first_slot_ts + (OVERTIME_SLOTS-1) * OVERTIME_INTERVAL;
 
 	if(config.debug & DEBUG_OVERTIME)
 		logg("initOverTime(): Initializing %i slots from %llu to %llu",
 		     OVERTIME_SLOTS,
-		     (long long)timestamp-OVERTIME_SLOTS*OVERTIME_INTERVAL,
-		     (long long)timestamp);
+		     (long long)first_slot_ts,
+		     (long long)last_slot_ts);
 
 	// Iterate over overTime
-	for(int i = OVERTIME_SLOTS-1; i >= 0 ; i--)
+	for(int i = 0; i < OVERTIME_SLOTS; i++)
 	{
-		// Initialize onerTime slot
-		initSlot(i, timestamp);
-		// Prepare for next iteration
-		timestamp -= OVERTIME_INTERVAL;
+		time_t this_slot_ts = first_slot_ts + OVERTIME_INTERVAL * i;
+		// Initialize overTime slot
+		initSlot(i, this_slot_ts);
 	}
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 2

---

initOverTime calculate's the last slot timestamp with the assumption that `OVERTIME_INTERVAL` will
allow atleast `OVERTIME_SLOTS` number of slots between now and the last slot in the current
hour. This leads it to calculate the timestamp of the last slot, and then assign timestamps to each
slot counting down from that timestamp.

This logic is not compatible with changes in the OVERTIME_INTERVAL and the MAXLOGAGE variables. Here is a demonstration of a case where this can be shown clearly:

```
OVERTIME_INTERVAL = 60s (Each slot stores 1 minute of data)
MAXLOGAGE = 600s (Store date for only 10 minutes)
OVERTIME_SLOTS = 11 (MAXLOGAGE/OVERTIME_INTERVAL)

GCInterval = 90 (Any value less than MAXLOGAGE is okay)
```

**Current logic:**

- Current time: 10:35:04
- First slot time: 10:48:30
- Last slot time: 10:59:30

**This PR's proposal:**

- Current time: 10:35:04
- First slot time: 10:35:30
- Last slot time: 10:46:30

Note that this logic *does* work as expected with the default minimum of 1 hour for the MAXLOGAGE
configuration variable.

However, I believe that there is no need to make this part of the code dependent on this minimum. If this part of the code is changed, the macros for OVERTIME_INTERVAL and MAXLOGAGE can be freely changed by users.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
