### PR TITLE
 Replace reference to hard-coded default GCinterval value

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -156,10 +156,10 @@ void *GC_thread(void *val)
 			// Get minimum timestamp to keep (this can be set with MAXLOGAGE)
 			time_t mintime = (now - GCdelay) - config.maxlogage;
 
-			// Align to the start of the next hour. This will also align with
-			// the oldest overTime interval after GC is done.
-			mintime -= mintime % 3600;
-			mintime += 3600;
+			// Align the start time of this GC run to the GCinterval. This will also align with the
+			// oldest overTime interval after GC is done.
+			mintime -= mintime % GCinterval;
+			mintime += GCinterval;
 
 			if(config.debug & DEBUG_GC)
 			{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 2

---

This hard-coded GCinterval value makes any change to the macro defining the GCinterval ineffective
when the GC runs.

For e.g., if I reduce the GC from once an hour to once every 3 minutes, the GC runs every 3 minutes,
but the mintime is set to the start of the next hour, which wipes everything from the overTime data.

I believe that this change is safe and can be merged and shipped to existing users because the
GCinterval value is not configurable and users who don't build the PiHole version that they are
running will not be affected by this change.

Signed-off-by: Siddharth Kannan <mail@siddharthkannan.in>

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
