### PR TITLE
Added support for compilation on MIPS platform

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/src/static_assert.h
+++ b/src/static_assert.h
@@ -18,14 +18,10 @@
 #if defined(__x86_64__) || defined(__aarch64__)
 #define ASSERT_SIZEOF(OBJECT, SIZE64, SIZE32, SIZEARM) \
 	STATIC_ASSERT(OBJECT, SIZE64)
-#elif defined(__i386__)
+#elif defined(__i386__) || defined(__mips__) // issue #290
 #define ASSERT_SIZEOF(OBJECT, SIZE64, SIZE32, SIZEARM) \
 	STATIC_ASSERT(OBJECT, SIZE32)
 #elif defined(__arm__)
 #define ASSERT_SIZEOF(OBJECT, SIZE64, SIZE32, SIZEARM) \
 	STATIC_ASSERT(OBJECT, SIZEARM)
-// Added support for compilation on MIPS platforms. See issue #290
-#elif defined(__mips__)
-#define ASSERT_SIZEOF(OBJECT, SIZE64, SIZE32, SIZEARM) \
-	STATIC_ASSERT(OBJECT, SIZE32)
 #endif

--- a/src/static_assert.h
+++ b/src/static_assert.h
@@ -24,4 +24,8 @@
 #elif defined(__arm__)
 #define ASSERT_SIZEOF(OBJECT, SIZE64, SIZE32, SIZEARM) \
 	STATIC_ASSERT(OBJECT, SIZEARM)
+// Added support for compilation on MIPS platforms. See issue #290
+#elif defined(__mips__)
+#define ASSERT_SIZEOF(OBJECT, SIZE64, SIZE32, SIZEARM) \
+	STATIC_ASSERT(OBJECT, SIZE32)
 #endif


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 3 (I looked only at what was required to pass the build on mips).

---

Compiling FTL on MIPS platform would fail with the following error (repeated multiple times).
```
/path/to/FTL/src/database/../shmem.h:57:41: error: expected declaration specifiers or ‘...’ before numeric constant
   57 | ASSERT_SIZEOF(countersStruct, 240, 240, 240);
```
This error originates from `static_assert.h`, where there are no definition of `ASSERT_SIZEOF` and `STATIC_ASSERT` for the mips architecture.
This PR does not constitute a support for MIPS, only an assistance for people who want to build FTL on MIPS, and do not want to track down the compilation error.
Support added in this PR, as per [DL6ER recommendation](https://github.com/pi-hole/FTL/issues/290#issuecomment-1066162813).


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
