### PR TITLE
Be more precise about escaping invalid characters in queries

### DIFF
--- a/src/shmem.c
+++ b/src/shmem.c
@@ -255,7 +255,7 @@ size_t addstr(const char *input)
 	char *str = str_escape(input, &N);
 
 	if(N > 0)
-		logg("INFO: FTL escaped %u characters in \"%s\"", N, str);
+		logg("INFO: FTL replaced %u invalid characters with ~ in the query \"%s\"", N, str);
 
 	// Debugging output
 	if(config.debug & DEBUG_SHMEM)


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

---

When FTL encounters invalid characters within a query, it will escape them with `~`.
From the logging it was not clear which character was the replacement. This PR makes the logging more precise.

Example:
```
[2022-03-09 06:37:56.649 528M] INFO: FTL escaped 1 characters in "150.109.179.161Æz¡hÌz¡~ob¡"
[2022-03-09 06:37:56.676 528M] INFO: FTL escaped 1 characters in "150.109.179.161Æz¡hÌz¡~ob¡"
[2022-03-09 06:37:56.701 528M] INFO: FTL escaped 1 characters in "150.109.179.161Æz¡hÌz¡~ob¡"
[2022-03-09 06:37:56.719 528M] INFO: FTL escaped 1 characters in "150.109.179.161Æz¡hÌz¡~ob¡"
```


See this discourse thread: https://discourse.pi-hole.net/t/pihole-log-fill-up-with-strange-letter/54154
