### PR TITLE
Add stale bot to FTL repo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,6 @@ jobs:
         days-before-close: 5
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment or update this issue or it will be closed in 5 days.'
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'pinned, Fixed in next release, bug, never-stale, documentation, investigating'
+        exempt-issue-labels: 'Fixed in next release, Bug, documentation needed, internal'
         exempt-all-issue-assignees: true
         operations-per-run: 300

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues
+
+on:
+  schedule:
+  - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 30
+        days-before-close: 5
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment or update this issue or it will be closed in 5 days.'
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'pinned, Fixed in next release, bug, never-stale, documentation, investigating'
+        exempt-all-issue-assignees: true
+        operations-per-run: 300


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Internal housekeeping. Will become effective once this is merged and the next FTL version is released. I see no pressing need to merge this straight to `master`. This is a 1:1 copy of [pi-hole/docker-pi-hole//.github/workflows/stale.yml](https://github.com/pi-hole/docker-pi-hole/blob/279b206cdda562836c03ea7ff88cea2d9e23b047/.github/workflows/stale.yml).