### PR TITLE
Fix overtime computation logic broken in PR #1312

### DIFF
--- a/src/overTime.c
+++ b/src/overTime.c
@@ -71,8 +71,8 @@ void initOverTime(void)
 	time_t now = time(NULL);
 
 	// Get the centered timestamp of the current timestamp
-	time_t first_slot_ts = now - now % OVERTIME_INTERVAL + (OVERTIME_INTERVAL / 2);
-	time_t last_slot_ts = first_slot_ts + (OVERTIME_SLOTS-1) * OVERTIME_INTERVAL;
+	const time_t last_slot_ts = now - now % OVERTIME_INTERVAL + (OVERTIME_INTERVAL / 2);
+	const time_t first_slot_ts = last_slot_ts - (OVERTIME_SLOTS-1) * OVERTIME_INTERVAL;
 
 	if(config.debug & DEBUG_OVERTIME)
 		logg("initOverTime(): Initializing %i slots from %llu to %llu",


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

See title, fixes a logic quirk introduced in #1312. `master` isn't affected.