### PR TITLE
Remove PID and PORT file during shutdown

### DIFF
--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -54,8 +54,18 @@ void saveport(int port)
 	}
 	else
 	{
-		// FTL is terminating: Leave file truncated
+		// FTL is terminating: Truncate file and remove it (if possible)
 		fclose(f);
+		// We also try to remove the file. We still empty the file above
+		// to ensure it is at least empty when it cannot be removed.
+		// because removing files on Linux is actually unlinking them.
+		// If any processes still have the file open, it will remain
+		// in existence until the last file descriptor referring to
+		// it is closed.
+		if(remove(FTLfiles.port) != 0)
+		{
+			logg("WARNING: Unable to remove PORT file: %s", strerror(errno));
+		}
 	}
 }
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -121,6 +121,17 @@ static void removepid(void)
 		return;
 	}
 	fclose(f);
+
+	// We also try to remove the file. We still empty the file above
+	// to ensure it is at least empty when it cannot be removed.
+	// because removing files on Linux is actually unlinking them.
+	// If any processes still have the file open, it will remain
+	// in existence until the last file descriptor referring to
+	// it is closed.
+	if(remove(FTLfiles.pid) != 0)
+	{
+		logg("WARNING: Unable to remove PID file: %s", strerror(errno));
+	}
 }
 
 char *getUserName(void)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR tries to remove the PID file during shutdown. We still empty the file above to ensure it is at least empty when it cannot be removed. because removing files on Linux is actually `unlink`ing them. If any processes still have the file open, it will remain in existence until the last file descriptor referring to it is closed.