### PR TITLE
Make REPLY_WHEN_BUSY=DROP the new default (was ALLOW)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -688,13 +688,13 @@ void read_FTLconf(void)
 
 	// REPLY_WHEN_BUSY
 	// How should FTL handle queries when the gravity database is not available?
-	// defaults to: BLOCK
+	// defaults to: DROP
 	buffer = parse_FTLconf(fp, "REPLY_WHEN_BUSY");
 
-	if(buffer != NULL && strcasecmp(buffer, "DROP") == 0)
+	if(buffer != NULL && strcasecmp(buffer, "ACCEPT") == 0)
 	{
-		config.reply_when_busy = BUSY_DROP;
-		logg("   REPLY_WHEN_BUSY: Drop queries when the database is busy");
+		config.reply_when_busy = BUSY_ALLOW;
+		logg("   REPLY_WHEN_BUSY: Permit queries when the database is busy");
 	}
 	else if(buffer != NULL && strcasecmp(buffer, "REFUSE") == 0)
 	{
@@ -708,8 +708,8 @@ void read_FTLconf(void)
 	}
 	else
 	{
-		config.reply_when_busy = BUSY_ALLOW;
-		logg("   REPLY_WHEN_BUSY: Permit queries when the database is busy");
+		config.reply_when_busy = BUSY_DROP;
+		logg("   REPLY_WHEN_BUSY: Drop queries when the database is busy");
 	}
 
 	// BLOCK_TTL


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The current default is in conflict with the description in https://github.com/pi-hole/FTL/pull/1156 which says we use `DROP` as the default. This is changed here.