### PR TITLE
Fix for theoretical one byte buffer overflow

### DIFF
--- a/src/procps.c
+++ b/src/procps.c
@@ -17,7 +17,7 @@
 
 #define PROCESS_NAME   "pihole-FTL"
 
-static bool get_process_name(const pid_t pid, char name[128])
+static bool get_process_name(const pid_t pid, char name[16])
 {
 	if(pid == 0)
 	{
@@ -33,7 +33,7 @@ static bool get_process_name(const pid_t pid, char name[128])
 		return false;
 
 	// Read name from opened file
-	if(fscanf(f, "%128s", name) != 1)
+	if(fscanf(f, "%15s", name) != 1)
 		false;
 	fclose(f);
 
@@ -111,7 +111,7 @@ bool check_running_FTL(void)
 			continue;
 
 		// Get process name
-		char name[128] = { 0 };
+		char name[16] = { 0 };
 		if(!get_process_name(pid, name))
 			continue;
 
@@ -123,7 +123,7 @@ bool check_running_FTL(void)
 		pid_t ppid;
 		if(!get_process_ppid(pid, &ppid))
 			continue;
-		char ppid_name[128] = { 0 };
+		char ppid_name[16] = { 0 };
 		if(!get_process_name(ppid, ppid_name))
 			continue;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Reduce allocated memory when determining process names. This possible buffer overflow by one byte (which should, however, be impossible to exploit). Thanks to Raymond Weber for pointing this out!