### PR TITLE
Log reply forcing only in DEBUG_QUERIES mode

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1450,10 +1450,11 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 
 		// Debug output
 		if(config.debug & DEBUG_QUERIES)
+		{
 			logg("Blocking %s as %s is %s", domainstr, blockedDomain, blockingreason);
-
-		if(force_next_DNS_reply != 0)
-			logg("Forcing next reply to %s", get_query_reply_str(force_next_DNS_reply));
+			if(force_next_DNS_reply != 0)
+				logg("Forcing next reply to %s", get_query_reply_str(force_next_DNS_reply));
+		}
 	}
 	else if(db_okay)
 	{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Log "Forcing next reply to ..." only when DEBUG_QUERIES is enabled to avoid log flooding. Fixes #1339