### PR TITLE
DELAY_STARTUP only when booting

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -112,7 +112,7 @@
 
 // DELAY_STARTUP should only delay the startup of the resolver during a starting up system
 // This setting control how long after boot we consider a system to be in starting-up mode
-// Default: 600 [seconds]
+// Default: 60 [seconds]
 #define DELAY_UPTIME 60
 
 // Use out own syscalls handling functions that will detect possible errors

--- a/src/FTL.h
+++ b/src/FTL.h
@@ -110,6 +110,11 @@
 // Important: This number has to be smaller than 256 for this mechanism to work
 #define NUM_RECHECKS 3
 
+// DELAY_STARTUP should only delay the startup of the resolver during a starting up system
+// This setting control how long after boot we consider a system to be in starting-up mode
+// Default: 600 [seconds]
+#define DELAY_UPTIME 60
+
 // Use out own syscalls handling functions that will detect possible errors
 // and report accordingly in the log. This will make debugging FTL crash
 // caused by insufficient memory or by code bugs (not properly dealing

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -194,7 +194,7 @@ void delay_startup(void)
 	// Sleep if requested by DELAY_STARTUP
 	logg("Sleeping for %d seconds as requested by configuration ...", config.delay_startup);
 	sleep(config.delay_startup);
-	logg("Done sleeping, continuing startup of resolver...\n");
+	logg("Done sleeping, continuing startup of resolver...");
 }
 
 // Is this a fork?

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -24,6 +24,9 @@
 #include <sys/utsname.h>
 // killed
 #include "signals.h"
+// sysinfo()
+#include <sys/sysinfo.h>
+#include <errno.h>
 
 pthread_t threads[THREADS_MAX] = { 0 };
 pthread_t api_threads[MAX_API_THREADS] = { 0 };
@@ -173,9 +176,23 @@ void delay_startup(void)
 	if(config.delay_startup == 0u)
 		return;
 
+	// Get uptime of system
+	struct sysinfo info = { 0 };
+	if(sysinfo(&info) == 0)
+	{
+		if(info.uptime > DELAY_UPTIME)
+		{
+			logg("Not sleeping as system has finished booting");
+			return;
+		}
+	}
+	else
+	{
+		logg("Unable to obtain sysinfo: %s (%i)", strerror(errno), errno);
+	}
+
 	// Sleep if requested by DELAY_STARTUP
-	logg("Sleeping for %d seconds as requested by configuration ...",
-	     config.delay_startup);
+	logg("Sleeping for %d seconds as requested by configuration ...", config.delay_startup);
 	sleep(config.delay_startup);
 	logg("Done sleeping, continuing startup of resolver...\n");
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Apply `DELAY_STARTUP` only when the system is still booting. The amount of time we consider a system still booting is a compile-time constant. It defaults to 60 seconds.