### PR TITLE
Fix forward percentages with all-servers

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -564,8 +564,8 @@ void getUpstreamDestinations(const char *client_message, const int *sock)
 			upstream_port = upstream->port;
 
 			// Get percentage
-			if(counters->queries > 0)
-				percentage = 1e2f * count / counters->queries;
+			if(totalqueries > 0)
+				percentage = 1e2f * count / totalqueries;
 		}
 
 		// Send data:


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The number of queries we are computing percentages against can be larger than the total number of queries. This can, e.g., happen when all-servers is in use as this generates more than one upstream query for every processed downstream query.

Fixes #1348 