### PR TITLE
Add interface info for PADD

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1567,17 +1567,6 @@ static bool listInterfaces(struct if_info **head, char default_iface[IF_NAMESIZE
 		if((f = fopen(fname, "r")) == NULL || fscanf(f, "%i", &(new->speed)) != 1)
 			new->speed = -1;
 
-		// Extract hardware address
-		snprintf(fname, sizeof(fname)-1, "/sys/class/net/%s/address", new->name);
-		if((f = fopen(fname, "r")) != NULL && fgets(readbuffer, sizeof(readbuffer)-1, f) != NULL)
-		{
-			const size_t len = strlen(readbuffer);
-			if(len > 0 && readbuffer[len-1] == '\n')
-				readbuffer[len-1] = '\0';
-			if(len > 1)
-				new->addr = strdup(readbuffer);
-		}
-
 		// Get total transmitted bytes
 		snprintf(fname, sizeof(fname)-1, "/sys/class/net/%s/statistics/tx_bytes", new->name);
 		if((f = fopen(fname, "r")) == NULL || fscanf(f, "%zi", &(new->tx_bytes)) != 1)
@@ -1622,8 +1611,8 @@ static void send_iface(const int *sock, struct if_info *iface)
 	char txp[2] = { 0 }, rxp[2] = { 0 };
 	format_memory_size(txp, iface->tx_bytes, &tx);
 	format_memory_size(rxp, iface->rx_bytes, &rx);
-	ssend(*sock, "%s %s %s %i %.1f%sB %.1f%sB\n",
-	      iface->name, iface->addr,
+	ssend(*sock, "%s %s %i %.1f%sB %.1f%sB\n",
+	      iface->name,
 	      iface->carrier ? "UP" : "DOWN",
 	      iface->speed,
 	      tx, txp, rx, rxp);

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -29,6 +29,7 @@ void getDBstats(const int *sock);
 void getUnknownQueries(const int *sock);
 void getMAXLOGAGE(const int *sock);
 void getGateway(const int *sock);
+void getInterfaces(const int *sock);
 
 // DNS resolver methods (dnsmasq_interface.c)
 void getCacheInformation(const int *sock);

--- a/src/api/request.c
+++ b/src/api/request.c
@@ -179,6 +179,11 @@ void process_request(const char *client_message, int *sock)
 		processed = true;
 		getGateway(sock);
 	}
+	else if(command(client_message, ">interfaces"))
+	{
+		processed = true;
+		getInterfaces(sock);
+	}
 
 	// Test only at the end if we want to quit or kill
 	// so things can be processed before

--- a/src/log.c
+++ b/src/log.c
@@ -208,7 +208,7 @@ void format_memory_size(char prefix[2], const unsigned long long int bytes,
 			break;
 		*formatted /= 1e3;
 	}
-	const char prefixes[8] = { ' ', 'K', 'M', 'G', 'T', 'P', 'E', '?' };
+	const char prefixes[8] = { '\0', 'K', 'M', 'G', 'T', 'P', 'E', '?' };
 	// Chose matching SI prefix
 	prefix[0] = prefixes[i];
 	prefix[1] = '\0';

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1343,3 +1343,30 @@
   printf "Checking IF: %s == %s\n" "$ftlif" "$interf"
   [[ "$ftlif" == "$interf" ]]
 }
+
+@test "Reported interface statistics are as expected" {
+  routes="$(ip -4 route show default)"
+  interf="$(awk '{print $5}' <<< $routes)"
+  printf "ip -4 route show default: %s\n" "${routes}"
+  run bash -c 'echo ">interfaces >quit" | nc 127.0.0.1 4711'
+  firstiface="$(awk '{print $1}' <<< "${lines[0]}")"
+  firstcarrier="$(awk '{print $2}' <<< "${lines[0]}")"
+  firstnum="$(awk '{print NF}' <<< "${lines[0]}")"
+  lastiface="$(awk '{print $1}' <<< "${lines[-1]}")"
+  lastcarrier="$(awk '{print $2}' <<< "${lines[-1]}")"
+  lastspeed="$(awk '{print $3}' <<< "${lines[-1]}")"
+  lastnum="$(awk '{print NF}' <<< "${lines[-1]}")"
+  printf "%s\n" "${lines[@]}"
+  # Check default interface is reported in first line
+  printf "Checking IF: %s == %s\n" "$firstiface" "$interf"
+  [[ "$firstiface" == "$interf" ]]
+  # Check default interface is reported as being UP
+  [[ "$firstcarrier" == "UP" ]]
+  # Check last reported record is the sum
+  [[ "$lastiface" == "sum" ]]
+  [[ "$lastcarrier" == "UP" ]]
+  [[ "$lastspeed" == "0" ]]
+  # Check we are reporting five quantities for the interfaces
+  [[ "$firstnum" == 5 ]]
+  [[ "$lastnum" == 5 ]]
+}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1366,7 +1366,7 @@
   [[ "$lastiface" == "sum" ]]
   [[ "$lastcarrier" == "UP" ]]
   [[ "$lastspeed" == "0" ]]
-  # Check we are reporting five quantities for the interfaces
-  [[ "$firstnum" == 5 ]]
-  [[ "$lastnum" == 5 ]]
+  # Check we are reporting seven quantities for the interfaces
+  [[ "$firstnum" == 7 ]]
+  [[ "$lastnum" == 7 ]]
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Adds a bit of network information to be used in [PADD](https://github.com/pi-hole/PADD).

```
$ echo ">interfaces" | ncat 127.0.0.1 4711
enp2s0 UP 1000 3.4GB 5.1GB
lo UP -1 54.4MB 54.4MB
docker0 DOWN -1 0.0B 0.0B
wg0 UP -1 855.6MB 137.4MB
sum UP 0 4.3GB 5.3GB
---EOM---
```

Column definitions are:
1. Interface name
2. UP/DOWN status
3. Link speed in MBit/s (-1 means "Not available" (like link down) or "Not applicable" (like virtual interface))
4. TX bytes
5. RX bytes

The default interface (the one connected to the (favorite) gateway) will always be the first one so PADD can just `head -n1` it. The `sum` will always be the last one - even if you have (for whatever reason) an interface called `sum`.

Caveat about link speed: It won't work for most WiFi interfaces are the speed is not known at the kernel level. Instead, the drivers manage them dynamically depending on package loss, signal strength, etc. - in this case, you'll see link speed `-1` as well.