### PR TITLE
Add dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: development
+  reviewers:
+    - "pi-hole/ftl-maintainers"


### PR DESCRIPTION
Adds a dependabot for `github/actions` to keep things up-to-date.

**Target: Master branch**
