### PR TITLE
Stale exempt

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,6 @@ jobs:
         days-before-close: 5
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment or update this issue or it will be closed in 5 days.'
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'Fixed in next release, Bug, documentation needed, internal'
+        exempt-issue-labels: 'Fixed in next release, Bug, Bug:Confirmed, documentation needed, internal'
         exempt-all-issue-assignees: true
         operations-per-run: 300

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,6 @@ jobs:
         days-before-close: 5
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment or update this issue or it will be closed in 5 days.'
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'Fixed in next release, Bug, Bug:Confirmed, documentation needed, internal'
+        exempt-issue-labels: 'Fixed in next release, Bug, Bug:Confirmed, Bugfix in progress, documentation needed, internal'
         exempt-all-issue-assignees: true
         operations-per-run: 300


### PR DESCRIPTION
Adds `Bug:Confirmed` and `Bugfix in progress` to `exempt-issue-labels` of the stale action. Those two labels are used quite regularly and should prevent issues from going stale.

**Target: Master branch.**