### PR TITLE
Add separator for dependebot PR names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: development
+  pull-request-branch-name:
+    separator: _
   reviewers:
     - "pi-hole/ftl-maintainers"


### PR DESCRIPTION
Changes the separator for dependabot PRs from`/` to `_` to allow CI transfer via `sftp`.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator

**Target: master branch**