### PR TITLE
Do not run built workflow on dependabot pushes and PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - '**'
+      - '!dependabot/**'
   pull_request:
+    branches-ignore:
+      - 'dependabot/**'
   release:
     types: [published]
 


### PR DESCRIPTION
Don't run built workflow on dependabot PRs and pushes.

**Target: master branch**