### PR TITLE
Use cmake --install . instead of make install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ cmake --build . -- -j $(nproc)
 if [[ -n "${install}" ]]; then
     echo "Installing pihole-FTL"
     SUDO=$(which sudo)
-    ${SUDO} make install
+    ${SUDO} cmake --install .
 else
     echo "Copying compiled pihole-FTL binary to repository root"
     cp pihole-FTL ../


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Use `cmake --install` instead of `make install` to only copy the binary to its destination instead of running a second compilation when installing. The latter was caused because the scripts generated a new version (compilation timestamp) when installing so the binary had to be regenerated.