### PR TITLE
Run stale workflow at 8:00 once per day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues
 
 on:
   schedule:
-  - cron: '0 * * * *'
+  - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Do not run `stale` workflow once an hour, but once a day (randomly picked 8:00).