### PR TITLE
Log new and terminating telnet connections only when debug flag is set

### DIFF
--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -519,8 +519,8 @@ void *telnet_listening_thread_IPv4(void *args)
 			logg("WARNING: Unable to open telnet processing thread: %s", strerror(errno));
 		}
 	}
-
-	logg("Terminating IPv4 telnet thread");
+	if(config.debug & DEBUG_API)
+		logg("Terminating IPv4 telnet thread");
 	return NULL;
 }
 

--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -502,7 +502,8 @@ void *telnet_listening_thread_IPv4(void *args)
 			continue;
 		}
 
-		logg("Accepting new telnet connection at socket %d", csck);
+		if(config.debug & DEBUG_API)
+			logg("Accepting new telnet connection at socket %d", csck);
 
 		// Allocate memory used to transport client socket ID to client listening thread
 		int *newsock;


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

5

PR https://github.com/pi-hole/FTL/pull/1370 changed the telnet API error handling. It also logs when new telnet connections were made. However, the web interface makes a lot of connections via the API, all of them get logged. This creates logspam. 

This PR changes the behavior to only log if the debug flag is set.
