### PR TITLE
Add automatic database optimization 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 # SQLITE_ENABLE_DBPAGE_VTAB: Enables the SQLITE_DBPAGE virtual table. Warning: writing to the SQLITE_DBPAGE virtual table can very easily cause unrecoverably database corruption.
 # SQLITE_OMIT_DESERIALIZE: This option causes the the sqlite3_serialize() and sqlite3_deserialize() interfaces to be omitted from the build (was the default before 3.36.0)
 # HAVE_READLINE: Enable readline support to allow easy editing, history and auto-completion
-set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_DEFAULT_FOREIGN_KEYS=1 -DSQLITE_DQS=0 -DSQLITE_ENABLE_DBPAGE_VTAB -DSQLITE_OMIT_DESERIALIZE -DHAVE_READLINE")
+# SQLITE_ENABLE_STAT4: This option adds additional logic to the ANALYZE command and to the query planner that can help SQLite to chose a better query plan under certain situations. The ANALYZE command is enhanced to collect histogram data from all columns of every index and store that data in the sqlite_stat4 table. The query planner will then use the histogram data to help it make better index choices.
+set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_DEFAULT_FOREIGN_KEYS=1 -DSQLITE_DQS=0 -DSQLITE_ENABLE_DBPAGE_VTAB -DSQLITE_OMIT_DESERIALIZE -DHAVE_READLINE -DSQLITE_ENABLE_STAT4")
 
 # Code hardening and debugging improvements
 # -fstack-protector-strong: The program will be resistant to having its stack overflowed

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 # SQLITE_OMIT_PROGRESS_CALLBACK: The progress handler callback counter must be checked in the inner loop of the bytecode engine. By omitting this interface, a single conditional is removed from the inner loop of the bytecode engine, helping SQL statements to run slightly faster.
 # SQLITE_DEFAULT_FOREIGN_KEYS=1: This macro determines whether enforcement of foreign key constraints is enabled or disabled by default for new database connections.
 # SQLITE_DQS=0: This setting disables the double-quoted string literal misfeature.
-# SQLITE_ENABLE_DBPAGE_VTAB: Enables the SQLITE_DBPAGE virtual table. Warning: writing to the SQLITE_DBPAGE virtual table can very easily cause unrecoverably database corruption.
+# SQLITE_ENABLE_DBPAGE_VTAB: Enables the SQLITE_DBPAGE virtual table. Warning: writing to the SQLITE_DBPAGE virtual table can very easily cause unrecoverably database corruption. This option is necessary for the .recover operation.
 # SQLITE_OMIT_DESERIALIZE: This option causes the the sqlite3_serialize() and sqlite3_deserialize() interfaces to be omitted from the build (was the default before 3.36.0)
 # HAVE_READLINE: Enable readline support to allow easy editing, history and auto-completion
 # SQLITE_ENABLE_STAT4: This option adds additional logic to the ANALYZE command and to the query planner that can help SQLite to chose a better query plan under certain situations. The ANALYZE command is enhanced to collect histogram data from all columns of every index and store that data in the sqlite_stat4 table. The query planner will then use the histogram data to help it make better index choices.

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -679,8 +679,6 @@ static void optimize_database(sqlite3 *db, const bool debug)
 {
 	double start = double_time();
 	sqlite3_stmt *stmt;
-	if(debug)
-		logg("Performing database optimization dry-run:");
 
 	// Prepare optimization statement
 	const char *querystr = debug ? "PRAGMA optimize(0x03)" : "PRAGMA optimize(0x02)";
@@ -705,19 +703,19 @@ static void optimize_database(sqlite3 *db, const bool debug)
 			return;
 		}
 
-		instructions ++;
+
+		if(debug && instructions == 0)
+			logg("Performing database optimization dry-run:");
 		const char *zSubSql = (char*)sqlite3_column_text(stmt, 0);
 		logg("  %s", zSubSql);
+		instructions++;
 	}
 	sqlite3_finalize(stmt);
-
-	if(debug)
-		logg(instructions > 0 ? "  COMMIT" : "  ---");
 
 	if(config.debug & DEBUG_DATABASE)
 	{
 		logg("Database optimization %s took %.4f seconds",
-		     debug ? "simulation" : "execution",
+		     debug ? "dry-run" : "execution",
 		     (double_time() - start));
 	}
 

--- a/src/log.c
+++ b/src/log.c
@@ -51,6 +51,18 @@ void init_FTL_log(void)
 	fclose(logfile);
 }
 
+// Return time(NULL) but with (up to) nanosecond accuracy
+// The resolution of clock depends on the hardware implementation and cannot be
+// changed by a particular process
+double double_time(void)
+{
+	struct timespec tp;
+	// POSIX.1-2008: "Applications should use the clock_gettime() function instead
+	// of the obsolescent gettimeofday() function"
+	clock_gettime(CLOCK_REALTIME, &tp);
+	return tp.tv_sec + 1e-9*tp.tv_nsec;
+}
+
 // The size of 84 bytes has been carefully selected for all possible timestamps
 // to always fit into the available space without buffer overflows
 void get_timestr(char * const timestring, const time_t timein, const bool millis)

--- a/src/log.h
+++ b/src/log.h
@@ -20,6 +20,7 @@ void format_memory_size(char prefix[2], unsigned long long int bytes,
 void format_time(char buffer[42], unsigned long seconds, double milliseconds);
 const char *get_FTL_version(void) __attribute__ ((malloc));
 void log_FTL_version(bool crashreport);
+double double_time(void);
 void get_timestr(char * const timestring, const time_t timein, const bool millis);
 const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));
 void print_FTL_version(void);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add automatic database optimization using `PRAGMA optimize` before closing database connections as recommended by the SQLite3 maintainers: 

> To achieve the best long-term query performance without the need to do a detailed engineering analysis of the application schema and SQL, it is recommended that applications run "PRAGMA optimize" (with no arguments) just before closing each [database connection](https://www.sqlite.org/c3ref/sqlite3.html). Long-running applications might also benefit from setting a timer to run "PRAGMA optimize" every few hours.
> 
> This pragma is usually a no-op or nearly so and is very fast. However if SQLite feels that performing database optimizations (such as running [ANALYZE](https://www.sqlite.org/lang_analyze.html) or creating new indexes) will improve the performance of future queries, then some database I/O may be done.