### PR TITLE
Tweak build and deploy process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
     types: [published]
 
 jobs:
-  build:
+  smoke-tests:
     if: |
       github.event_name == 'push'
       || github.event_name == 'release'
@@ -24,6 +24,37 @@ jobs:
       OUTPUT_DIR: ${{ steps.variables.outputs.OUTPUT_DIR }}
 
     runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
+        name: "Calculate required variables"
+        id: variables
+        run: |
+          GIT_TAG=${{ github.event.release.tag_name }}
+          # If GIT_TAG is set then GIT BRANCH should be "master", else set it from GITHUB_REF
+          GIT_BRANCH=$([ -n "${GIT_TAG}" ] && echo "master" || echo "${GITHUB_REF#refs/*/}")
+          echo ::set-output name=GIT_BRANCH::${GIT_BRANCH}
+          echo ::set-output name=GIT_TAG::${GIT_TAG}
+          echo ::set-output name=OUTPUT_DIR::${GIT_TAG:-${GIT_BRANCH}}
+      -
+        name: "Check git branch name depth"
+        env:
+          GIT_BRANCH: ${{ steps.variables.outputs.GIT_BRANCH }}
+        run: |
+          IFS='/';
+          read -r -a branch <<<"${GIT_BRANCH}";
+          if [[ "${#branch[@]}" -gt 2 ]]; then echo "Error: Your branch name contains more than one subdir, which will cause issues with the build process." && FAIL=1; fi;
+          unset IFS;
+          # If FAIL is 1 then we fail.
+          [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
+        shell: bash
+
+  build:
+    runs-on: ubuntu-latest
+
+    needs: smoke-tests
 
     container: ghcr.io/pi-hole/ftl-build:v1.18-${{ matrix.arch }}
 
@@ -59,23 +90,16 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v3.0.2
       -
-        name: Calculate required build variables
-        id: variables
-        run: |
-          GIT_TAG=${{ github.event.release.tag_name }}
-          # If GIT_TAG is set then GIT BRANCH should be "master", else set it from GITHUB_REF
-          GIT_BRANCH=$([ -n "${GIT_TAG}" ] && echo "master" || echo "${GITHUB_REF#refs/*/}")
-          echo ::set-output name=GIT_BRANCH::${GIT_BRANCH}
-          echo ::set-output name=GIT_TAG::${GIT_TAG}
-          echo ::set-output name=OUTPUT_DIR::${GIT_TAG:-${GIT_BRANCH}}
+        name: "Fix ownership of repository"
+        run: chown -R root .
       -
         name: "Fix ownership of repository"
         run: chown -R root .
       -
         name: "Build"
         env:
-          GIT_BRANCH: ${{ steps.variables.outputs.GIT_BRANCH }}
-          GIT_TAG: ${{ steps.variables.outputs.GIT_TAG }}
+          GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
+          GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
         run: |
           bash build.sh "-DSTATIC=${STATIC}"
       -
@@ -102,17 +126,23 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
-    needs: build
+    needs: [smoke-tests, build]
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
         name: Get Binaries built in previous jobs
         uses: actions/download-artifact@v3.0.0
+        id: download
         with:
           name: tmp-binary-storage
+          path: ftl-builds/
       -
         name: Display structure of downloaded files
         run: ls -R
+        working-directory: ${{steps.download.outputs.download-path}}
       -
         name: Install SSH Key
         uses: shimataro/ssh-key-action@v2.3.1
@@ -121,9 +151,13 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
       -
         name: Transfer Builds to Pi-hole server for pihole checkout
+        env:
+          USER: ${{ secrets.SSH_USER }}
+          HOST: ${{ secrets.SSH_HOST }}
+          TARGET_DIR: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
+          SOURCE_DIR: ${{ steps.download.outputs.download-path }}
         run: |
-          sftp -b - ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} <<< "-mkdir ${{ needs.build.outputs.OUTPUT_DIR }}
-          put * ${{ needs.build.outputs.OUTPUT_DIR }}"
+          bash ./deploy.sh
       -
         name: Attach binaries to release
         if: github.event_name == 'release'

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,8 +37,20 @@ unset IFS
 old_path="."
 
 for dir in "${path[@]}"; do
-    sftp -b - "${USER}"@"${HOST}" <<< "cd ${old_path}
-    -mkdir ${dir}"
+    mapfile -t dir_content <<< "$(
+        sftp -b - "${USER}"@"${HOST}" <<< "cd ${old_path}
+        ls -1"
+    )"
+
+    # Only try to create the subdir if does not already exist
+    if [[ "${dir_content[*]}" =~ "${dir}" ]]; then
+        echo "Dir: ${old_path}/${dir} already exists"
+    else
+        echo "Creating dir: ${old_path}/${dir}"
+        sftp -b - "${USER}"@"${HOST}" <<< "cd ${old_path}
+        -mkdir ${dir}"
+    fi
+
     old_path="${old_path}/${dir}"
 done
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2022 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# FTL Engine
+# Deploy script for FTL
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+
+# Transfer Builds to Pi-hole server for pihole checkout
+# We use sftp for secure transfer and use the branch name as dir on the server.
+# The branch name could contain slashes, creating hierarchical dirs. However,
+# this is not supported by sftp's `mkdir` (option -p) is not available. Therefore,
+# we need to loop over each dir level and create them one by one.
+
+
+# Safeguard: do not deploy if TARGET_DIR is empty
+if [[ -z ${TARGET_DIR} ]]; then
+    echo "Error: Empty target dir."
+    exit 1
+fi
+
+IFS='/'
+read -r -a path <<<"${TARGET_DIR}"
+
+# Safeguard: do not deploy if more than one subdir (eg. /tweak/feature/subfeature) needs to be created
+if [[ "${#path[@]}" -gt 2 ]]; then
+    echo "Error: Your branch name contains more then one subdir. We won't deploy that."
+    exit 1
+fi
+
+unset IFS
+
+old_path="."
+
+for dir in "${path[@]}"; do
+    sftp -b - "${USER}"@"${HOST}" <<< "cd ${old_path}
+    -mkdir ${dir}"
+    old_path="${old_path}/${dir}"
+done
+
+sftp -r -b - "${USER}"@"${HOST}" <<< "cd ${old_path}
+put ${SOURCE_DIR}/* ./"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

This PR improves the build&deploy process in two ways:

1) It adds a pre-build smoke-test that checks the depth of the git branch name. Everything with more than one subdir won't pass. E.g. `tweak/smoke-test` will pass, but `tweak/smoke-test/subfeature` won't.
2) It allows to create subdirs during the deploy process when transferring the binary to our `ftl` server. We use `sftp` to transfer the files securely, but `sftp's` `mkdir` does not have a `-p` option to create subdirs. Therefore, we loop over the target branch and create each subdir one-by-one.

This test will pass the GH action. The same code of the branch`twek/sftp/mkdir` won't pass - action output here: https://github.com/pi-hole/FTL/runs/7309991123?check_suite_focus=true
