### PR TITLE
Update SQLite3 from 3.39.0 to 3.39.2

### DIFF
--- a/src/database/shell.c
+++ b/src/database/shell.c
@@ -4411,7 +4411,7 @@ static const char *re_compile(ReCompiled **ppRe, const char *zIn, int noCase){
         pRe->zInit[j++] = (unsigned char)(0xc0 | (x>>6));
         pRe->zInit[j++] = 0x80 | (x&0x3f);
       }else if( x<=0xffff ){
-        pRe->zInit[j++] = (unsigned char)(0xd0 | (x>>12));
+        pRe->zInit[j++] = (unsigned char)(0xe0 | (x>>12));
         pRe->zInit[j++] = 0x80 | ((x>>6)&0x3f);
         pRe->zInit[j++] = 0x80 | (x&0x3f);
       }else{
@@ -23080,7 +23080,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
   char **argv;
 #endif
 #ifdef SQLITE_DEBUG
-  sqlite3_uint64 mem_main_enter = sqlite3_memory_used();
+  sqlite3_int64 mem_main_enter = sqlite3_memory_used();
 #endif
   char *zErrMsg = 0;
 #ifdef SQLITE_SHELL_WASM_MODE

--- a/src/database/sqlite3.h
+++ b/src/database/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.0"
-#define SQLITE_VERSION_NUMBER 3039000
-#define SQLITE_SOURCE_ID      "2022-06-25 14:57:57 14e166f40dbfa6e055543f8301525f2ca2e96a02a57269818b9e69e162e98918"
+#define SQLITE_VERSION        "3.39.2"
+#define SQLITE_VERSION_NUMBER 3039002
+#define SQLITE_SOURCE_ID      "2022-07-21 15:24:47 698edb77537b67c41adc68f9b892db56bcf9a55e00371a61420f3ddd668e6603"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -6282,7 +6282,7 @@ SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 **
 ** ^The sqlite3_db_name(D,N) interface returns a pointer to the schema name
 ** for the N-th database on database connection D, or a NULL pointer of N is
-** out of range.  An N alue of 0 means the main database file.  An N of 1 is
+** out of range.  An N value of 0 means the main database file.  An N of 1 is
 ** the "temp" schema.  Larger values of N correspond to various ATTACH-ed
 ** databases.
 **


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

From the SQLite3 CHANGELOG:

### 2022-07-13 (3.39.1)

1. Fix an incorrect result from a query that uses a view that contains a compound SELECT in which only one arm contains a RIGHT JOIN and where the view is not the first FROM clause term of the query that contains the view. [forum post 174afeae5734d42d](https://sqlite.org/forum/forumpost/174afeae5734d42d). 
2. Fix some harmless compiler warnings. 
3. Fix a long-standing problem with [ALTER TABLE RENAME](https://sqlite.org/lang_altertable.html#altertabrename) that can only arise if the [sqlite3_limit](https://sqlite.org/c3ref/limit.html)([SQLITE_LIMIT_SQL_LENGTH](https://sqlite.org/c3ref/c_limit_attached.html#sqlitelimitsqllength)) is set to a very small value. 
4. Fix a long-standing problem in [FTS3](https://sqlite.org/fts3.html) that can only arise when compiled with the [SQLITE_ENABLE_FTS3_PARENTHESIS](https://sqlite.org/compile.html#enable_fts3_parenthesis) compile-time option. 
5. Fix the build so that is works when the [SQLITE_DEBUG](https://sqlite.org/compile.html#debug) and [SQLITE_OMIT_WINDOWFUNC](https://sqlite.org/compile.html#omit_windowfunc) compile-time options are both provided at the same time. 
6. Fix the initial-prefix optimization for the [REGEXP](https://sqlite.org/lang_expr.html#regexp) extension so that it works correctly even if the prefix contains characters that require a 3-byte UTF8 encoding. 
7. Enhance the [sqlite_stmt](https://sqlite.org/stmt.html) virtual table so that it buffers all of its output. 

### 2022-07-21 (3.39.2)
1. Fix a performance regression in the query planner associated with rearranging the order of FROM clause terms in the presences of a LEFT JOIN. 
2. Apply fixes for CVE-2022-35737, Chromium bugs 1343348 and 1345947, [forum post 3607259d3c](https://sqlite.org/forum/forumpost/3607259d3c), and other minor problems discovered by internal testing. 

---

Nothing very important in here.