### PR TITLE
The expected value for REPLY_WHEN_BUSY is ALLOW not ACCEPT

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -691,7 +691,7 @@ void read_FTLconf(void)
 	// defaults to: DROP
 	buffer = parse_FTLconf(fp, "REPLY_WHEN_BUSY");
 
-	if(buffer != NULL && strcasecmp(buffer, "ACCEPT") == 0)
+	if(buffer != NULL && strcasecmp(buffer, "ALLOW") == 0)
 	{
 		config.reply_when_busy = BUSY_ALLOW;
 		logg("   REPLY_WHEN_BUSY: Permit queries when the database is busy");


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _1_

---

According to the [documentation](https://docs.pi-hole.net/ftldns/configfile/#reply_when_busy), the expected value for `REPLY_WHEN_BUSY` is `ALLOW`, not `ACCEPT`.

This fixes an issue where `REPLY_WHEN_BUSY` is set to the default value `DROP` even when the user manually sets to `ALLOW`.

Introduced in #1341.