### PR TITLE
Fix storing of API thread IDs

### DIFF
--- a/src/api/socket.c
+++ b/src/api/socket.c
@@ -263,7 +263,6 @@ void listen_telnet(const enum telnet_type type)
 	for(unsigned int i = 0; i < MAX_API_THREADS; i++)
 	{
 		// Spawn telnet thread
-		pthread_t telnet_connection_thread;
 		// Create a private copy of the socket fd for the child thread
 		struct thread_info *tinfo = calloc(1, sizeof(struct thread_info));
 		if(!tinfo)
@@ -273,7 +272,7 @@ void listen_telnet(const enum telnet_type type)
 		tinfo->tid = i;
 		tinfo->istelnet = (type == TELNETv4 || type == TELNETv6);
 		tinfo->stype = stype;
-		if(pthread_create(&telnet_connection_thread, &attr, telnet_connection_handler_thread, (void*) tinfo) != 0)
+		if(pthread_create(&api_threads[i], &attr, telnet_connection_handler_thread, (void*) tinfo) != 0)
 		{
 			// Log the error code description
 			logg("WARNING: Unable to open telnet processing thread: %s", strerror(errno));

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -13,7 +13,7 @@
 #include "enums.h"
 extern pthread_t threads[THREADS_MAX];
 #define MAX_API_THREADS 5
-extern pthread_t api_threads[TELNET_MAX][MAX_API_THREADS];
+extern pthread_t api_threads[MAX_API_THREADS];
 
 void go_daemon(void);
 void savepid(void);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Fixes calls to `pthread_cancel(0)` causing `musl`-based binaries to crash during shutdown. Fixes https://github.com/pi-hole/FTL/issues/1405