### PR TITLE
Ensure compatibility with gcc 11.2.0 (Ubuntu 11.2.0-19ubuntu1)

### DIFF
--- a/src/syscalls/fopen.c
+++ b/src/syscalls/fopen.c
@@ -15,7 +15,7 @@
 static uint8_t already_writing = 0;
 
 #undef fopen
-FILE *FTLfopen(const char *pathname, const char *mode, const char *file, const char *func, const int line)
+FILE * __attribute__ ((__malloc__)) FTLfopen(const char *pathname, const char *mode, const char *file, const char *func, const int line)
 {
 	FILE *file_ptr = 0;
 	do

--- a/src/syscalls/syscalls.h
+++ b/src/syscalls/syscalls.h
@@ -45,7 +45,7 @@ ssize_t FTLsendto(int sockfd, void *buf, size_t len, int flags, const struct soc
 int FTLpthread_mutex_lock(pthread_mutex_t *__mutex, const char *file, const char *func, const int line);
 
 // Interrupt-safe file routines
-FILE *FTLfopen(const char *pathname, const char *mode, const char *file, const char *func, const int line);
+FILE *FTLfopen(const char *pathname, const char *mode, const char *file, const char *func, const int line) __attribute__ ((__malloc__));
 
 // Syscall helpers
 void syscalls_report_error(const char *error, FILE *stream, const int _errno, const char *format, const char *func, const char *file, const int line);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Add missing function attribute to syscall to ensure compatibility with gcc 11.2.0 (Ubuntu 11.2.0-19ubuntu1) which was installed on my main development system after the upgrade from Ubuntu 20.04.4 LTS to Ubuntu 22.04.1 LTS.

The function `FTLfopen()` is a wrapper around `fopen()` which is, in turn, equipped with the very same attribute:

![Screenshot from 2022-08-21 12-02-51](https://user-images.githubusercontent.com/16748619/185785890-e3a86a83-0268-491a-9955-d0e166495410.png)

https://github.com/bminor/glibc/blob/f7b0fc5cc61301461e3c1a278240ce78701bb9a8/libio/stdio.h#L256-L260

![Screenshot from 2022-08-21 12-03-03](https://user-images.githubusercontent.com/16748619/185785900-a7153521-2061-4005-a38f-c6c9d465f454.png)

https://github.com/bminor/glibc/blob/d055481ce39d03652ac60de5078889e15b6917ff/misc/sys/cdefs.h#L277-L284