### PR TITLE
Add warning about inaccessible adlists to message table (Pi-hole diagnosis)

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1409,7 +1409,8 @@ bool gravityDB_get_regex_client_groups(clientsData* client, const unsigned int n
 	return true;
 }
 
-void check_inaccessible_adlists(void){
+void check_inaccessible_adlists(void)
+{
 
 	// check if any adlist was inaccessible in the last gravity run
 	// if so, gravity stored `status` in the adlist table with
@@ -1434,16 +1435,16 @@ void check_inaccessible_adlists(void){
 		return;
 	}
 
-    // Perform query
-    while((rc = sqlite3_step(query_stmt)) == SQLITE_ROW)
-    {
-        int id = sqlite3_column_int(query_stmt, 0);
-        const char *address = strdup((const char*)sqlite3_column_text(query_stmt, 1));
+	// Perform query
+	while((rc = sqlite3_step(query_stmt)) == SQLITE_ROW)
+	{
+		int id = sqlite3_column_int(query_stmt, 0);
+		const char *address = (const char*)sqlite3_column_text(query_stmt, 1);
 
-        // log to the message table
-        logg_inaccessible_adlist(id, address);
-    }
+		// log to the message table
+		logg_inaccessible_adlist(id, address);
+	}
 
-    // Finalize statement
-    sqlite3_finalize(query_stmt);
+	// Finalize statement
+	sqlite3_finalize(query_stmt);
 }

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1423,7 +1423,7 @@ void check_inaccessible_adlists(void){
 		return;
 	}
 
-	const char *querystr = "SELECT id, address FROM adlist WHERE status IN (3,4)";
+	const char *querystr = "SELECT id, address FROM adlist WHERE status IN (3,4) AND enabled=1";
 	
 	// Prepare query
 	sqlite3_stmt *query_stmt;

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -29,6 +29,7 @@ const char* gravityDB_getDomain(int *rowid);
 char* get_client_names_from_ids(const char *group_ids) __attribute__ ((malloc));
 void gravityDB_finalizeTable(void);
 int gravityDB_count(const enum gravity_tables list);
+void check_inaccessible_adlists(void);
 
 enum db_result in_gravity(const char *domain, clientsData *client);
 enum db_result in_blacklist(const char *domain, clientsData *client);

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -27,7 +27,7 @@
 #include "../gc.h"
 
 static const char *message_types[MAX_MESSAGE] =
-	{ "REGEX", "SUBNET", "HOSTNAME", "DNSMASQ_CONFIG", "RATE_LIMIT", "DNSMASQ_WARN", "LOAD", "SHMEM", "DISK" };
+	{ "REGEX", "SUBNET", "HOSTNAME", "DNSMASQ_CONFIG", "RATE_LIMIT", "DNSMASQ_WARN", "LOAD", "SHMEM", "DISK", "ADLIST" };
 
 static unsigned char message_blob_types[MAX_MESSAGE][5] =
 	{
@@ -93,6 +93,13 @@ static unsigned char message_blob_types[MAX_MESSAGE][5] =
 			SQLITE_NULL, // Not used
 			SQLITE_NULL, // Not used
 			SQLITE_NULL  // Not used
+		},
+		{	// INACCESSIBLE_ADLIST_MESSAGE: The message column contains the corresponding adlist URL
+			SQLITE_INTEGER, // database index of the adlist (so the dashboard can show a link)
+			SQLITE_NULL, // not used
+			SQLITE_NULL, // not used
+			SQLITE_NULL, // not used
+			SQLITE_NULL // not used
 		},
 	};
 // Create message table in the database
@@ -390,4 +397,13 @@ void log_resource_shortage(const double load, const int nprocs, const int shmem,
 		logg("WARNING: Disk shortage (%s) ahead: %d%% is used (%s)", path, disk, msg);
 		add_message(DISK_MESSAGE, true, path, 2, disk, msg);
 	}
+}
+
+void logg_inaccessible_adlist(const int dbindex, const char *address)
+{
+	// Log to FTL.log
+	logg("Adlist warning: Adlist with ID %d (%s) was inaccessible during last gravity run", dbindex, address);
+
+	// Log to database
+	add_message(INACCESSIBLE_ADLIST_MESSAGE, false, address, 1, dbindex);
 }

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -23,5 +23,6 @@ void logg_fatal_dnsmasq_message(const char *message);
 void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit_count);
 void logg_warn_dnsmasq_message(char *message);
 void log_resource_shortage(const double load, const int nprocs, const int shmem, const int disk, const char *path, const char *msg);
+void logg_inaccessible_adlist(const int dbindex, const char *address);
 
 #endif //MESSAGETABLE_H

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -506,6 +506,9 @@ void FTL_reload_all_domainlists(void)
 	// only after having called gravityDB_open()
 	read_regex_from_database();
 
+	// Check for inaccessible adlist URLs
+	check_inaccessible_adlists();
+
 	// Reset FTL's internal DNS cache storing whether a specific domain
 	// has already been validated for a specific user
 	FTL_reset_per_client_domain_data();

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1788,6 +1788,7 @@ void FTL_dnsmasq_reload(void)
 	// Gravity database updates
 	// - (Re-)open gravity database connection
 	// - Get number of blocked domains
+	// - check adlist table for inaccessible adlists
 	// - Read and compile regex filters (incl. per-client)
 	// - Flush FTL's DNS cache
 	set_event(RELOAD_GRAVITY);

--- a/src/enums.h
+++ b/src/enums.h
@@ -209,7 +209,8 @@ enum message_type {
 	LOAD_MESSAGE,
 	SHMEM_MESSAGE,
 	DISK_MESSAGE,
-	MAX_MESSAGE
+	INACCESSIBLE_ADLIST_MESSAGE,
+	MAX_MESSAGE,
 } __attribute__ ((packed));
 
 enum ptr_type {

--- a/test/gravity.db.sql
+++ b/test/gravity.db.sql
@@ -25,12 +25,16 @@ CREATE TABLE domainlist
 
 CREATE TABLE adlist
 (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
-	address TEXT UNIQUE NOT NULL,
-	enabled BOOLEAN NOT NULL DEFAULT 1,
-	date_added INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)),
-	date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)),
-	comment TEXT
+  id INTEGER PRIMARY KEY AUTOINCREMENT, 
+  address TEXT UNIQUE NOT NULL, 
+  enabled BOOLEAN NOT NULL DEFAULT 1, 
+  date_added INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), 
+  date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), 
+  comment TEXT,
+  date_updated INTEGER, 
+  number INTEGER NOT NULL DEFAULT 0, 
+  invalid_domains INTEGER NOT NULL DEFAULT 0, 
+  status INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE adlist_by_group
@@ -208,7 +212,7 @@ INSERT INTO domainlist VALUES(14,3,'^regex-notA$;querytype=!A',1,1559928803,1559
 /* Other special domains */
 INSERT INTO domainlist VALUES(15,1,'blacklisted-group-disabled.com',1,1559928803,1559928803,'Entry disabled by a group');
 
-INSERT INTO adlist VALUES(1,'https://hosts-file.net/ad_servers.txt',1,1559928803,1559928803,'Migrated from /etc/pihole/adlists.list');
+INSERT INTO adlist VALUES(1,'https://hosts-file.net/ad_servers.txt',1,1559928803,1559928803,'Migrated from /etc/pihole/adlists.list',1559928803,2000,2,1);
 
 INSERT INTO gravity VALUES('whitelisted.ftl',1);
 INSERT INTO gravity VALUES('gravity.ftl',1);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _10_

---

Adds a warning to the `message` table (Pi-hole diagnosis) if adlists have been inaccessible during the last gravity run. We already save `status` in the `adlists` table in the `gravity.db`. This status is set during the gravity run and indicates if the "download" was successful (https://docs.pi-hole.net/database/gravity/#adlist-table-adlist). Status type `3` and `4` indicate that the adlist was inaccessible. 
This PR checks on each `FTL` reload if `gravity.db` contains adlists with `status=[3,4]` (and are enabled) and adds a warning if applicable.


Corresponding web interface PR: https://github.com/pi-hole/AdminLTE/pull/2320

Discourse thread: https://discourse.pi-hole.net/t/gravity-update-timeout/57391
