### PR TITLE
Attach binaries to release from the correct path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,4 +164,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            *
+            ${{ steps.download.outputs.download-path }}/*


### PR DESCRIPTION
title. Otherwise we need to manually attach from ftl.pi-hole.net