### PR TITLE
Improve deep CNAME inspection

### DIFF
--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -763,16 +763,6 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	    }
 #endif	  
 	  
-	// ****************************** Pi-hole modification ******************************
-	if(FTL_CNAME(name, cpp, daemon->log_display_id))
-	  {
-	    // Found while processing a reply from upstream. We prevent cache insertion here
-	    // This query is to be blocked as we found a blocked
-	    // domain while walking the CNAME path. Log to pihole.log here
-	    log_query(F_UPSTREAM, name, NULL, "blocked during CNAME inspection", 0);
-	    return 2;
-	  }
-	// **********************************************************************************
 
 	  if (aqtype == T_CNAME)
 	    {
@@ -804,6 +794,17 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	      if (!extract_name(header, qlen, &p1, name, 1, 0))
 		return 0;
 	      
+	      // ****************************** Pi-hole modification ******************************
+	      const char *src = cpp != NULL ? cpp->flags & F_BIGNAME ? cpp->name.bname->name : cpp->name.sname : NULL;
+	      if(FTL_CNAME(name, src, daemon->log_display_id))
+		{
+		  // Found while processing a reply from upstream. We prevent cache insertion here
+		  // This query is to be blocked as we found a blocked
+		  // domain while walking the CNAME path. Log to pihole.log here
+		  log_query(F_UPSTREAM, name, NULL, "blocked during CNAME inspection", 0);
+		  return 2;
+		}
+	      // **********************************************************************************
 	      if (qtype != T_CNAME)
 		goto cname_loop1;
 
@@ -1859,7 +1860,8 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 				log_query(crecp->flags & ~F_REVERSE, name, &crecp->addr,
 					  record_source(crecp->uid), 0);
 				// ****************************** Pi-hole modification ******************************
-				if(FTL_CNAME(name, crecp, daemon->log_display_id))
+				const char *src = crecp != NULL ? crecp->flags & F_BIGNAME ? crecp->name.bname->name : crecp->name.sname : NULL;
+				if(FTL_CNAME(name, src, daemon->log_display_id))
 				  {
 				    // Served from cache. This can happen if a domain hidden in the CNAME path
 				    // is only blocked for some but not all clients. In this case, the entire

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -34,8 +34,8 @@ void FTL_forwarding_retried(const struct server *server, const int oldID, const 
 #define FTL_make_answer(header, limit, len, ede) _FTL_make_answer(header, limit, len, ede, __FILE__, __LINE__)
 size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len, int *ede, const char* file, const int line);
 
-#define FTL_CNAME(domain, cpp, id) _FTL_CNAME(domain, cpp, id, __FILE__, __LINE__)
-bool _FTL_CNAME(const char *domain, const struct crec *cpp, const int id, const char* file, const int line);
+#define FTL_CNAME(dst, src, id) _FTL_CNAME(dst, src, id, __FILE__, __LINE__)
+bool _FTL_CNAME(const char *dst, const char *src, const int id, const char* file, const int line);
 
 unsigned int FTL_extract_question_flags(struct dns_header *header, const size_t qlen);
 void FTL_query_in_progress(const int id);

--- a/test/gravity.db.sql
+++ b/test/gravity.db.sql
@@ -212,8 +212,9 @@ INSERT INTO adlist VALUES(1,'https://hosts-file.net/ad_servers.txt',1,1559928803
 
 INSERT INTO gravity VALUES('whitelisted.ftl',1);
 INSERT INTO gravity VALUES('gravity.ftl',1);
+INSERT INTO gravity VALUES('gravity-aaaa.ftl',1);
 INSERT INTO gravity VALUES('gravity-whitelisted.ftl',1);
-INSERT INTO info VALUES('gravity_count',3);
+INSERT INTO info VALUES('gravity_count',4);
 
 INSERT INTO "group" VALUES(1,0,'Test group',1559928803,1559928803,'A disabled test group');
 INSERT INTO domainlist_by_group VALUES(15,1);

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -65,6 +65,7 @@ pdnsutil add-record ftl. regex-REPLYv4 AAAA fe80::2c01
 pdnsutil add-record ftl. regex-REPLYv6 AAAA fe80::2c02
 pdnsutil add-record ftl. regex-REPLYv46 AAAA fe80::2c03
 pdnsutil add-record ftl. any AAAA fe80::3c01
+pdnsutil add-record ftl. gravity-aaaa AAAA fe80::4c01
 
 # Create CNAME records
 pdnsutil add-record ftl. cname-1 CNAME gravity.ftl
@@ -78,6 +79,10 @@ pdnsutil add-record ftl. cname-ok CNAME a.ftl
 
 # Create CNAME for SOA test domain
 pdnsutil add-record ftl. soa CNAME ftl
+
+# Create CNAME for NODATA tests
+pdnsutil add-record ftl. aaaa-cname CNAME gravity-aaaa.ftl
+pdnsutil add-record ftl. a-cname CNAME gravity.ftl
 
 # Create PTR records
 pdnsutil add-record ftl. ptr PTR ptr.ftl.

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -384,6 +384,25 @@
   [[ ${lines[1]} == "" ]]
 }
 
+@test "CNAME inspection: NODATA CNAME targets are blocked" {
+  run bash -c "dig A a-cname.ftl @127.0.0.1 +short"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0.0.0.0" ]]
+  [[ ${lines[1]} == "" ]]
+  run bash -c "dig AAAA a-cname.ftl @127.0.0.1 +short"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "::" ]]
+  [[ ${lines[1]} == "" ]]
+  run bash -c "dig A aaaa-cname.ftl @127.0.0.1 +short"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0.0.0.0" ]]
+  [[ ${lines[1]} == "" ]]
+  run bash -c "dig AAAA aaaa-cname.ftl @127.0.0.1 +short"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "::" ]]
+  [[ ${lines[1]} == "" ]]
+}
+
 @test "DNSSEC: SECURE domain is resolved" {
   run bash -c "dig A sigok.verteiltesysteme.net @127.0.0.1"
   printf "%s\n" "${lines[@]}"
@@ -399,11 +418,11 @@
 @test "Statistics as expected" {
   run bash -c 'echo ">stats >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == "domains_being_blocked 3" ]]
-  [[ ${lines[2]} == "dns_queries_today 47" ]]
-  [[ ${lines[3]} == "ads_blocked_today 9" ]]
+  [[ ${lines[1]} == "domains_being_blocked 4" ]]
+  [[ ${lines[2]} == "dns_queries_today 51" ]]
+  [[ ${lines[3]} == "ads_blocked_today 13" ]]
   #[[ ${lines[4]} == "ads_percentage_today 7.792208" ]]
-  [[ ${lines[5]} == "unique_domains 35" ]]
+  [[ ${lines[5]} == "unique_domains 38" ]]
   [[ ${lines[6]} == "queries_forwarded 26" ]]
   [[ ${lines[7]} == "queries_cached 12" ]]
   # Clients ever seen is commented out as the CI may have
@@ -411,11 +430,11 @@
   # number of clients may not work in all cases
   #[[ ${lines[8]} == "clients_ever_seen 8" ]]
   #[[ ${lines[9]} == "unique_clients 8" ]]
-  [[ ${lines[10]} == "dns_queries_all_types 47" ]]
+  [[ ${lines[10]} == "dns_queries_all_types 51" ]]
   [[ ${lines[11]} == "reply_UNKNOWN 0" ]]
   [[ ${lines[12]} == "reply_NODATA 0" ]]
   [[ ${lines[13]} == "reply_NXDOMAIN 1" ]]
-  [[ ${lines[14]} == "reply_CNAME 3" ]]
+  [[ ${lines[14]} == "reply_CNAME 7" ]]
   [[ ${lines[15]} == "reply_IP 23" ]]
   [[ ${lines[16]} == "reply_DOMAIN 0" ]]
   [[ ${lines[17]} == "reply_RRNAME 5" ]]
@@ -426,7 +445,7 @@
   [[ ${lines[22]} == "reply_DNSSEC 5" ]]
   [[ ${lines[23]} == "reply_NONE 0" ]]
   [[ ${lines[24]} == "reply_BLOB 10" ]]
-  [[ ${lines[25]} == "dns_queries_all_replies 47" ]]
+  [[ ${lines[25]} == "dns_queries_all_replies 51" ]]
   [[ ${lines[26]} == "privacy_level 0" ]]
   [[ ${lines[27]} == "status enabled" ]]
   [[ ${lines[28]} == "" ]]
@@ -441,7 +460,7 @@
 @test "Top Clients" {
   run bash -c 'echo ">top-clients >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == "0 32 127.0.0.1 "* ]]
+  [[ ${lines[1]} == "0 36 127.0.0.1 "* ]]
   [[ ${lines[2]} == "1 5 :: "* ]]
   [[ ${lines[3]} == "2 4 127.0.0.3 "* ]]
   [[ ${lines[4]} == "3 3 127.0.0.2 "* ]]
@@ -484,7 +503,10 @@
 @test "Top Ads" {
   run bash -c 'echo ">top-ads (20) >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[@]}" == *" 4 gravity.ftl"* ]]
+  [[ "${lines[@]}" == *" 6 gravity.ftl"* ]]
+  [[ "${lines[@]}" == *" 2 a-cname.ftl"* ]]
+  [[ "${lines[@]}" == *" 2 aaaa-cname.ftl"* ]]
+  [[ "${lines[@]}" == *" 2 gravity-aaaa.ftl"* ]]
   [[ "${lines[@]}" == *" 1 blacklisted.ftl"* ]]
   [[ "${lines[@]}" == *" 1 whitelisted.ftl"* ]]
   [[ "${lines[@]}" == *" 1 regex5.ftl"* ]]
@@ -492,7 +514,7 @@
   [[ "${lines[@]}" == *" 1 cname-1.ftl"* ]]
   [[ "${lines[@]}" == *" 1 cname-7.ftl"* ]]
   [[ "${lines[@]}" == *" 1 use-application-dns.net"* ]]
-  [[ ${lines[9]} == "" ]]
+  [[ ${lines[12]} == "" ]]
 }
 
 @test "Domain auditing, approved domains are not shown" {
@@ -504,33 +526,33 @@
 @test "Upstream Destinations reported correctly" {
   run bash -c 'echo ">forward-dest >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == "-3 19.15 blocked blocked" ]]
-  [[ ${lines[2]} == "-2 25.53 cached cached" ]]
+  [[ ${lines[1]} == "-3 25.49 blocked blocked" ]]
+  [[ ${lines[2]} == "-2 23.53 cached cached" ]]
   [[ ${lines[3]} == "-1 0.00 other other" ]]
-  [[ ${lines[4]} == "0 51.06 127.0.0.1#5555 127.0.0.1#5555" ]]
-  [[ ${lines[5]} == "1 4.26 127.0.0.1#5554 127.0.0.1#5554" ]]
+  [[ ${lines[4]} == "0 47.06 127.0.0.1#5555 127.0.0.1#5555" ]]
+  [[ ${lines[5]} == "1 3.92 127.0.0.1#5554 127.0.0.1#5554" ]]
   [[ ${lines[6]} == "" ]]
 }
 
 @test "Query Types reported correctly" {
   run bash -c 'echo ">querytypes >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]}  == "A (IPv4): 51.06" ]]
-  [[ ${lines[2]}  == "AAAA (IPv6): 4.26" ]]
-  [[ ${lines[3]}  == "ANY: 2.13" ]]
-  [[ ${lines[4]}  == "SRV: 2.13" ]]
-  [[ ${lines[5]}  == "SOA: 2.13" ]]
-  [[ ${lines[6]}  == "PTR: 2.13" ]]
-  [[ ${lines[7]}  == "TXT: 12.77" ]]
-  [[ ${lines[8]}  == "NAPTR: 2.13" ]]
-  [[ ${lines[9]}  == "MX: 2.13" ]]
-  [[ ${lines[10]} == "DS: 4.26" ]]
+  [[ ${lines[1]}  == "A (IPv4): 50.98" ]]
+  [[ ${lines[2]}  == "AAAA (IPv6): 7.84" ]]
+  [[ ${lines[3]}  == "ANY: 1.96" ]]
+  [[ ${lines[4]}  == "SRV: 1.96" ]]
+  [[ ${lines[5]}  == "SOA: 1.96" ]]
+  [[ ${lines[6]}  == "PTR: 1.96" ]]
+  [[ ${lines[7]}  == "TXT: 11.76" ]]
+  [[ ${lines[8]}  == "NAPTR: 1.96" ]]
+  [[ ${lines[9]}  == "MX: 1.96" ]]
+  [[ ${lines[10]} == "DS: 3.92" ]]
   [[ ${lines[11]} == "RRSIG: 0.00" ]]
-  [[ ${lines[12]} == "DNSKEY: 6.38" ]]
-  [[ ${lines[13]} == "NS: 2.13" ]]
-  [[ ${lines[14]} == "OTHER: 2.13" ]]
-  [[ ${lines[15]} == "SVCB: 2.13" ]]
-  [[ ${lines[16]} == "HTTPS: 2.13" ]]
+  [[ ${lines[12]} == "DNSKEY: 5.88" ]]
+  [[ ${lines[13]} == "NS: 1.96" ]]
+  [[ ${lines[14]} == "OTHER: 1.96" ]]
+  [[ ${lines[15]} == "SVCB: 1.96" ]]
+  [[ ${lines[16]} == "HTTPS: 1.96" ]]
   [[ ${lines[17]} == "" ]]
 }
 
@@ -579,14 +601,18 @@
   [[ ${lines[38]} == *" HTTPS https.ftl 127.0.0.1 2 2 13 "*" N/A -1 127.0.0.1#5554 \"\" \"37\""* ]]
   [[ ${lines[39]} == *" A cname-1.ftl 127.0.0.1 9 2 3 "*" gravity.ftl -1 127.0.0.1#5555 \"\" \"38\""* ]]
   [[ ${lines[40]} == *" A cname-7.ftl 127.0.0.1 9 2 3 "*" gravity.ftl -1 127.0.0.1#5555 \"\" \"39\""* ]]
-  [[ ${lines[41]} == *" A sigok.verteiltesysteme.net 127.0.0.1 2 1 4 "*" N/A -1 127.0.0.1#5555 \"\" \"40\""* ]]
-  [[ ${lines[42]} == *" DS net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"41\""* ]]
-  [[ ${lines[43]} == *" DNSKEY . :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"42\""* ]]
-  [[ ${lines[44]} == *" DS verteiltesysteme.net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"43\""* ]]
-  [[ ${lines[45]} == *" DNSKEY net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"44\""* ]]
-  [[ ${lines[46]} == *" DNSKEY verteiltesysteme.net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"45\""* ]]
-  [[ ${lines[47]} == *" A sigfail.verteiltesysteme.net 127.0.0.1 2 3 4 "*" N/A -1 127.0.0.1#5555 \"DNSKEY missing\" \"46\""* ]]
-  [[ ${lines[48]} == "" ]]
+  [[ ${lines[41]} == *" A a-cname.ftl 127.0.0.1 9 2 3 "*" gravity.ftl -1 127.0.0.1#5555 \"\" \"40\""* ]]
+  [[ ${lines[42]} == *" AAAA a-cname.ftl 127.0.0.1 9 2 3 "*" gravity.ftl -1 127.0.0.1#5555 \"\" \"41\""* ]]
+  [[ ${lines[43]} == *" A aaaa-cname.ftl 127.0.0.1 9 2 3 "*" gravity-aaaa.ftl -1 127.0.0.1#5555 \"\" \"42\""* ]]
+  [[ ${lines[44]} == *" AAAA aaaa-cname.ftl 127.0.0.1 9 2 3 "*" gravity-aaaa.ftl -1 127.0.0.1#5555 \"\" \"43\""* ]]
+  [[ ${lines[45]} == *" A sigok.verteiltesysteme.net 127.0.0.1 2 1 4 "*" N/A -1 127.0.0.1#5555 \"\" \"44\""* ]]
+  [[ ${lines[46]} == *" DS net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"45\""* ]]
+  [[ ${lines[47]} == *" DNSKEY . :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"46\""* ]]
+  [[ ${lines[48]} == *" DS verteiltesysteme.net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"47\""* ]]
+  [[ ${lines[49]} == *" DNSKEY net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"48\""* ]]
+  [[ ${lines[50]} == *" DNSKEY verteiltesysteme.net :: 2 1 11 "*" N/A -1 127.0.0.1#5555 \"\" \"49\""* ]]
+  [[ ${lines[51]} == *" A sigfail.verteiltesysteme.net 127.0.0.1 2 3 4 "*" N/A -1 127.0.0.1#5555 \"DNSKEY missing\" \"50\""* ]]
+  [[ ${lines[52]} == "" ]]
 }
 
 @test "Get all queries (domain filtered) shows expected content" {
@@ -599,7 +625,7 @@
 @test "Recent blocked shows expected content" {
   run bash -c 'echo ">recentBlocked >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[1]} == "cname-7.ftl" ]]
+  [[ ${lines[1]} == "aaaa-cname.ftl" ]]
   [[ ${lines[2]} == "" ]]
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Improve deep `CNAME` inspection to also work on abandoned paths. The most obvious example for such a configuration is a `CNAME` child ending without a record (`NODATA`). See [FTL#1421](https://github.com/pi-hole/FTL/issues/1421).