### PR TITLE
Update embedded dnsmasq to v2.87rc1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-2.87test8)
+set(DNSMASQ_VERSION pi-hole-v2.87rc1)
 
 add_subdirectory(src)

--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -1683,10 +1683,8 @@ int cache_make_stat(struct txt_record *t)
 	      {
 		/* expand buffer if necessary */
 		newlen = bytes_needed + 1 + bufflen - bytes_avail;
-		if (!(new = whine_malloc(newlen)))
+		if (!(new = whine_realloc(buff, newlen)))
 		  return 0;
-		memcpy(new, buff, bufflen);
-		free(buff);
 		p = new + (p - buff);
 		lenp = p - 1;
 		buff = new;

--- a/src/dnsmasq/dbus.c
+++ b/src/dnsmasq/dbus.c
@@ -761,8 +761,11 @@ char *dbus_init(void)
 
   dbus_error_init (&dbus_error);
   if (!(connection = dbus_bus_get (DBUS_BUS_SYSTEM, &dbus_error)))
-    return NULL;
-    
+    {
+      dbus_error_free(&dbus_error);
+      return NULL;
+    }
+  
   dbus_connection_set_exit_on_disconnect(connection, FALSE);
   dbus_connection_set_watch_functions(connection, add_watch, remove_watch, 
 				      NULL, NULL, NULL);

--- a/src/dnsmasq/dhcp-common.c
+++ b/src/dnsmasq/dhcp-common.c
@@ -1017,7 +1017,10 @@ void log_relay(int family, struct dhcp_relay *relay)
 {
   int broadcast = relay->server.addr4.s_addr == 0;
   inet_ntop(family, &relay->local, daemon->addrbuff, ADDRSTRLEN);
-  inet_ntop(family, &relay->server, daemon->namebuff, ADDRSTRLEN); 
+  inet_ntop(family, &relay->server, daemon->namebuff, ADDRSTRLEN);
+
+  if (family == AF_INET && relay->port != DHCP_SERVER_PORT)
+    sprintf(daemon->namebuff + strlen(daemon->namebuff), "#%u", relay->port);
 
 #ifdef HAVE_DHCP6
   struct in6_addr multicast;
@@ -1025,7 +1028,11 @@ void log_relay(int family, struct dhcp_relay *relay)
   inet_pton(AF_INET6, ALL_SERVERS, &multicast);
 
   if (family == AF_INET6)
-    broadcast = IN6_ARE_ADDR_EQUAL(&relay->server.addr6, &multicast);
+    {
+      broadcast = IN6_ARE_ADDR_EQUAL(&relay->server.addr6, &multicast);
+      if (relay->port != DHCPV6_SERVER_PORT)
+	sprintf(daemon->namebuff + strlen(daemon->namebuff), "#%u", relay->port);
+    }
 #endif
   
   

--- a/src/dnsmasq/dhcp-common.c
+++ b/src/dnsmasq/dhcp-common.c
@@ -685,6 +685,7 @@ const struct opttab_t {
   { "client-machine-id", 97, 0 },
   { "posix-timezone", 100, OT_NAME }, /* RFC 4833, Sec. 2 */
   { "tzdb-timezone", 101, OT_NAME }, /* RFC 4833, Sec. 2 */
+  { "ipv6-only", 108, 4 | OT_DEC },  /* RFC 8925 */ 
   { "subnet-select", 118, OT_INTERNAL },
   { "domain-search", 119, OT_RFC1035_NAME },
   { "sip-server", 120, 0 },

--- a/src/dnsmasq/dhcp-protocol.h
+++ b/src/dnsmasq/dhcp-protocol.h
@@ -64,6 +64,7 @@
 #define OPTION_SIP_SERVER        120
 #define OPTION_VENDOR_IDENT      124
 #define OPTION_VENDOR_IDENT_OPT  125
+#define OPTION_MUD_URL_V4        161
 #define OPTION_END               255
 
 #define SUBOPT_CIRCUIT_ID        1

--- a/src/dnsmasq/dhcp.c
+++ b/src/dnsmasq/dhcp.c
@@ -1121,7 +1121,7 @@ static int relay_upstream4(int iface_index, struct dhcp_packet *mess, size_t sz)
 	
 	to.sa.sa_family = AF_INET;
 	to.in.sin_addr = relay->server.addr4;
-	to.in.sin_port = htons(daemon->dhcp_server_port);
+	to.in.sin_port = htons(relay->port);
 	
 	/* Broadcasting to server. */
 	if (relay->server.addr4.s_addr == 0)

--- a/src/dnsmasq/dhcp.c
+++ b/src/dnsmasq/dhcp.c
@@ -177,8 +177,7 @@ void dhcp_packet(time_t now, int pxe_fd)
     return;
   
 #ifdef HAVE_DUMPFILE
-  dump_packet(DUMP_DHCP, (void *)daemon->dhcp_packet.iov_base, sz, (union mysockaddr *)&dest, NULL,
-	      pxe_fd ? PXE_PORT : daemon->dhcp_server_port);
+  dump_packet_udp(DUMP_DHCP, (void *)daemon->dhcp_packet.iov_base, sz, (union mysockaddr *)&dest, NULL, fd);
 #endif
   
 #if defined (HAVE_LINUX_NETWORK)
@@ -464,8 +463,8 @@ void dhcp_packet(time_t now, int pxe_fd)
         dest.sin_addr = mess->yiaddr;
       dest.sin_port = htons(daemon->dhcp_client_port);
       
-      dump_packet(DUMP_DHCP, (void *)iov.iov_base, iov.iov_len, NULL,
-		  (union mysockaddr *)&dest, daemon->dhcp_server_port);
+      dump_packet_udp(DUMP_DHCP, (void *)iov.iov_base, iov.iov_len, NULL,
+		      (union mysockaddr *)&dest, fd);
 #endif
       
       send_via_bpf(mess, iov.iov_len, iface_addr, &ifr);
@@ -478,8 +477,8 @@ void dhcp_packet(time_t now, int pxe_fd)
 #endif
 
 #ifdef HAVE_DUMPFILE
-  dump_packet(DUMP_DHCP, (void *)iov.iov_base, iov.iov_len, NULL,
-	      (union mysockaddr *)&dest, daemon->dhcp_server_port);
+  dump_packet_udp(DUMP_DHCP, (void *)iov.iov_base, iov.iov_len, NULL,
+		  (union mysockaddr *)&dest, fd);
 #endif
   
   while(retry_send(sendmsg(fd, &msg, 0)));
@@ -1147,8 +1146,8 @@ static int relay_upstream4(int iface_index, struct dhcp_packet *mess, size_t sz)
 	  fromsock.in.sin_port = htons(daemon->dhcp_server_port);
 	  fromsock.in.sin_addr = from.addr4;
 	  fromsock.sa.sa_family = AF_INET;
-	  
-	  dump_packet(DUMP_DHCP, (void *)mess, sz, &fromsock, &to, 0);
+
+	  dump_packet_udp(DUMP_DHCP, (void *)mess, sz, &fromsock, &to, -1);
 	}
 #endif
 	

--- a/src/dnsmasq/dhcp6-protocol.h
+++ b/src/dnsmasq/dhcp6-protocol.h
@@ -63,6 +63,7 @@
 #define OPTION6_FQDN            39
 #define OPTION6_NTP_SERVER      56
 #define OPTION6_CLIENT_MAC      79
+#define OPTION6_MUD_URL         112
 
 #define NTP_SUBOPTION_SRV_ADDR  1
 #define NTP_SUBOPTION_MC_ADDR   2

--- a/src/dnsmasq/dhcp6.c
+++ b/src/dnsmasq/dhcp6.c
@@ -119,8 +119,8 @@ void dhcp6_packet(time_t now)
     return;
   
 #ifdef HAVE_DUMPFILE
-  dump_packet(DUMP_DHCPV6, (void *)daemon->dhcp_packet.iov_base, sz,
-	      (union mysockaddr *)&from, NULL, DHCPV6_SERVER_PORT);
+  dump_packet_udp(DUMP_DHCPV6, (void *)daemon->dhcp_packet.iov_base, sz,
+		  (union mysockaddr *)&from, NULL, daemon->dhcp6fd);
 #endif
   
   for (cmptr = CMSG_FIRSTHDR(&msg); cmptr; cmptr = CMSG_NXTHDR(&msg, cmptr))
@@ -142,8 +142,8 @@ void dhcp6_packet(time_t now)
   if (relay_reply6(&from, sz, ifr.ifr_name))
     {
 #ifdef HAVE_DUMPFILE
-      dump_packet(DUMP_DHCPV6, (void *)daemon->outpacket.iov_base, save_counter(-1), NULL,
-		  (union mysockaddr *)&from, DHCPV6_SERVER_PORT);
+      dump_packet_udp(DUMP_DHCPV6, (void *)daemon->outpacket.iov_base, save_counter(-1), NULL,
+		      (union mysockaddr *)&from, daemon->dhcp6fd);
 #endif
       
       while (retry_send(sendto(daemon->dhcp6fd, daemon->outpacket.iov_base, 
@@ -254,8 +254,8 @@ void dhcp6_packet(time_t now)
 	  from.sin6_port = htons(port);
 	  
 #ifdef HAVE_DUMPFILE
-	  dump_packet(DUMP_DHCPV6, (void *)daemon->outpacket.iov_base, save_counter(-1),
-		      NULL, (union mysockaddr *)&from, DHCPV6_SERVER_PORT);
+	  dump_packet_udp(DUMP_DHCPV6, (void *)daemon->outpacket.iov_base, save_counter(-1),
+			  NULL, (union mysockaddr *)&from, daemon->dhcp6fd);
 #endif 
 	  
 	  while (retry_send(sendto(daemon->dhcp6fd, daemon->outpacket.iov_base,

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1689,9 +1689,10 @@ static void poll_resolv(int force, int do_reload, time_t now)
     else
       {
 	res->logged = 0;
-	if (force || (statbuf.st_mtime != res->mtime))
+	if (force || (statbuf.st_mtime != res->mtime || statbuf.st_ino != res->ino))
           {
             res->mtime = statbuf.st_mtime;
+	    res->ino = statbuf.st_ino;
 	    if (difftime(statbuf.st_mtime, last_change) > 0.0)
 	      {
 		last_change = statbuf.st_mtime;

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1097,6 +1097,7 @@ struct dhcp_relay {
   union all_addr local, server;
   char *interface; /* Allowable interface for replies from server, and dest for IPv6 multicast */
   int iface_index; /* working - interface in which requests arrived, for return */
+  int port;        /* Port of relay we forward to. */
 #ifdef HAVE_SCRIPT
   struct snoop_record {
     struct in6_addr client, prefix;

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1425,6 +1425,7 @@ void *safe_malloc(size_t size);
 void safe_strncpy(char *dest, const char *src, size_t size);
 void safe_pipe(int *fd, int read_noblock);
 void *whine_malloc(size_t size);
+void *whine_realloc(void *ptr, size_t size);
 int sa_len(union mysockaddr *addr);
 int sockaddr_isequal(const union mysockaddr *s1, const union mysockaddr *s2);
 int hostname_order(const char *a, const char *b);

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -677,6 +677,7 @@ struct resolvc {
   struct resolvc *next;
   int is_default, logged;
   time_t mtime;
+  ino_t ino;
   char *name;
 #ifdef HAVE_INOTIFY
   int wd; /* inotify watch descriptor */

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1843,8 +1843,10 @@ int do_arp_script_run(void);
 /* dump.c */
 #ifdef HAVE_DUMPFILE
 void dump_init(void);
-void dump_packet(int mask, void *packet, size_t len, union mysockaddr *src,
-		 union mysockaddr *dst, int port);
+void dump_packet_udp(int mask, void *packet, size_t len, union mysockaddr *src,
+		     union mysockaddr *dst, int fd);
+void dump_packet_icmp(int mask, void *packet, size_t len, union mysockaddr *src,
+		      union mysockaddr *dst);
 #endif
 
 /* domain-match.c */

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -987,6 +987,8 @@ struct dhcp_bridge {
 
 struct cond_domain {
   char *domain, *prefix; /* prefix is text-prefix on domain name */
+  char *interface;       /* These two set when domain comes from interface. */
+  struct addrlist *al;
   struct in_addr start, end;
   struct in6_addr start6, end6;
   int is6, indexed, prefixlen;

--- a/src/dnsmasq/dnssec.c
+++ b/src/dnsmasq/dnssec.c
@@ -1851,7 +1851,7 @@ static int zone_status(char *name, int class, char *keyname, time_t now)
    STAT_NEED_DS  need DS to complete validation (name is returned in keyname)
 
    daemon->rr_status points to a char array which corressponds to the RRs in the 
-   answer and auth sections. This is set to 1 for each RR which is validated, and 0 for any which aren't.
+   answer and auth sections. This is set to >1 for each RR which is validated, and 0 for any which aren't.
 
    When validating replies to DS records, we're only interested in the NSEC{3} RRs in the auth section.
    Other RRs in that section missing sigs will not cause am INSECURE reply. We determine this mode

--- a/src/dnsmasq/domain-match.c
+++ b/src/dnsmasq/domain-match.c
@@ -213,9 +213,13 @@ int lookup_domain(char *domain, int flags, int *lowout, int *highout)
 	       to continue generalising */
 	    {
 	      /* We've matched a setting which says to use servers without a domain.
-		 Continue the search with empty query */
+		 Continue the search with empty query. We set the F_SERVER flag
+		 so that --address=/#/... doesn't match. */
 	      if (daemon->serverarray[nlow]->flags & SERV_USE_RESOLV)
-		crop_query = qlen;
+		{
+		  crop_query = qlen;
+		  flags |= F_SERVER;
+		}
 	      else
 		break;
 	    }
@@ -299,7 +303,7 @@ int filter_servers(int seed, int flags, int *lowout, int *highout)
       
       for (i = nlow; i < nhigh && (daemon->serverarray[i]->flags & SERV_6ADDR); i++);
       
-      if (i != nlow && (flags & F_IPV6))
+      if (!(flags & F_SERVER) && i != nlow && (flags & F_IPV6))
 	nhigh = i;
       else
 	{
@@ -307,7 +311,7 @@ int filter_servers(int seed, int flags, int *lowout, int *highout)
 	  
 	  for (i = nlow; i < nhigh && (daemon->serverarray[i]->flags & SERV_4ADDR); i++);
 	  
-	  if (i != nlow && (flags & F_IPV4))
+	  if (!(flags & F_SERVER) && i != nlow && (flags & F_IPV4))
 	    nhigh = i;
 	  else
 	    {
@@ -315,7 +319,7 @@ int filter_servers(int seed, int flags, int *lowout, int *highout)
 	      
 	      for (i = nlow; i < nhigh && (daemon->serverarray[i]->flags & SERV_ALL_ZEROS); i++);
 	      
-	      if (i != nlow && (flags & (F_IPV4 | F_IPV6)))
+	      if (!(flags & F_SERVER) && i != nlow && (flags & (F_IPV4 | F_IPV6)))
 		nhigh = i;
 	      else
 		{

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1166,6 +1166,13 @@ void reply_query(int fd, time_t now)
     }
 
   forward->sentto = server;
+
+  /* We have a good answer, and will now validate it or return it. 
+     It may be some time before this the validation completes, but we don't need
+     any more answers, so close the socket(s) on which we were expecting
+     answers, to conserve file descriptors, and to save work reading and
+     discarding answers for other upstreams. */
+  free_rfds(&forward->rfds);
   
 #ifdef HAVE_DNSSEC
   if ((forward->sentto->flags & SERV_DO_DNSSEC) && 

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -537,8 +537,8 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 		}
 #ifdef HAVE_DNSSEC
 	      else
-		log_query_mysockaddr(F_NOEXTRA | F_DNSSEC, daemon->namebuff, &srv->addr,
-				     "dnssec-retry", (forward->flags & FREC_DNSKEY_QUERY) ? T_DNSKEY : T_DS);
+		log_query_mysockaddr(F_NOEXTRA | F_DNSSEC | F_SERVER, daemon->namebuff, &srv->addr,
+				     (forward->flags & FREC_DNSKEY_QUERY) ? "dnssec-retry[DNSKEY]" : "dnssec-retry[DS]", 0);
 #endif
 
 	      srv->queries++;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1095,12 +1095,15 @@ void reply_query(int fd, time_t now)
       size_t nn = 0;
       
 #ifdef HAVE_DNSSEC
-      /* DNSSEC queries have a copy of the original query stashed. 
-	 The query MAY have got a good answer, and be awaiting
+      /* The query MAY have got a good answer, and be awaiting
 	 the results of further queries, in which case
 	 The Stash contains something else and we don't need to retry anyway. */
-      if ((forward->flags & (FREC_DNSKEY_QUERY | FREC_DS_QUERY)) && !forward->blocking_query)
+      if (forward->blocking_query)
+	return;
+      
+      if (forward->flags & (FREC_DNSKEY_QUERY | FREC_DS_QUERY))
 	{
+	  /* DNSSEC queries have a copy of the original query stashed. */
 	  blockdata_retrieve(forward->stash, forward->stash_len, (void *)header);
 	  nn = forward->stash_len;
 	  udp_size = daemon->edns_pktsz;

--- a/src/dnsmasq/hash-questions.c
+++ b/src/dnsmasq/hash-questions.c
@@ -23,7 +23,7 @@
 
    The hash used is SHA-256. If we're building with DNSSEC support,
    we use the Nettle cypto library. If not, we prefer not to
-   add a dependency on Nettle, and use a stand-alone implementaion. 
+   add a dependency on Nettle, and use a stand-alone implementation. 
 */
 
 #include "dnsmasq.h"

--- a/src/dnsmasq/helper.c
+++ b/src/dnsmasq/helper.c
@@ -642,6 +642,7 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 	      buf = grab_extradata(buf, end, "DNSMASQ_CIRCUIT_ID", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_SUBSCRIBER_ID", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_REMOTE_ID", &err);
+	      buf = grab_extradata(buf, end, "DNSMASQ_MUD_URL", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_REQUESTED_OPTIONS", &err);
 	    }
 	  

--- a/src/dnsmasq/helper.c
+++ b/src/dnsmasq/helper.c
@@ -430,6 +430,9 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 	      
 	      end = extradata + data.ed_len;
 	      buf = extradata;
+
+	      lua_pushnumber(lua, data.ed_len == 0 ? 1 : 0);
+	      lua_setfield(lua, -2, "data_missing");
 	      
 	      if (!is6)
 		buf = grab_extradata_lua(buf, end, "vendor_class");
@@ -608,6 +611,9 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 	  
 	  end = extradata + data.ed_len;
 	  buf = extradata;
+
+	  if (data.ed_len == 0)
+	    my_setenv("DNSMASQ_DATA_MISSING", "1", &err);
 	  
 	  if (!is6)
 	    buf = grab_extradata(buf, end, "DNSMASQ_VENDOR_CLASS", &err);

--- a/src/dnsmasq/helper.c
+++ b/src/dnsmasq/helper.c
@@ -459,9 +459,9 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 		  buf = grab_extradata_lua(buf, end, "circuit_id");
 		  buf = grab_extradata_lua(buf, end, "subscriber_id");
 		  buf = grab_extradata_lua(buf, end, "remote_id");
-		  buf = grab_extradata_lua(buf, end, "requested_options");
 		}
-	      
+
+	      buf = grab_extradata_lua(buf, end, "requested_options");
 	      buf = grab_extradata_lua(buf, end, "mud_url");
 	      buf = grab_extradata_lua(buf, end, "tags");
 	      
@@ -644,9 +644,9 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 	      buf = grab_extradata(buf, end, "DNSMASQ_CIRCUIT_ID", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_SUBSCRIBER_ID", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_REMOTE_ID", &err);
-	      buf = grab_extradata(buf, end, "DNSMASQ_REQUESTED_OPTIONS", &err);
 	    }
 	  
+	  buf = grab_extradata(buf, end, "DNSMASQ_REQUESTED_OPTIONS", &err);
 	  buf = grab_extradata(buf, end, "DNSMASQ_MUD_URL", &err);
 	  buf = grab_extradata(buf, end, "DNSMASQ_TAGS", &err);
 	  	  

--- a/src/dnsmasq/helper.c
+++ b/src/dnsmasq/helper.c
@@ -459,8 +459,10 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 		  buf = grab_extradata_lua(buf, end, "circuit_id");
 		  buf = grab_extradata_lua(buf, end, "subscriber_id");
 		  buf = grab_extradata_lua(buf, end, "remote_id");
+		  buf = grab_extradata_lua(buf, end, "requested_options");
 		}
 	      
+	      buf = grab_extradata_lua(buf, end, "mud_url");
 	      buf = grab_extradata_lua(buf, end, "tags");
 	      
 	      if (is6)
@@ -642,16 +644,14 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 	      buf = grab_extradata(buf, end, "DNSMASQ_CIRCUIT_ID", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_SUBSCRIBER_ID", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_REMOTE_ID", &err);
-	      buf = grab_extradata(buf, end, "DNSMASQ_MUD_URL", &err);
 	      buf = grab_extradata(buf, end, "DNSMASQ_REQUESTED_OPTIONS", &err);
 	    }
 	  
+	  buf = grab_extradata(buf, end, "DNSMASQ_MUD_URL", &err);
 	  buf = grab_extradata(buf, end, "DNSMASQ_TAGS", &err);
-
-	  if (is6) {
-	       buf = grab_extradata(buf, end, "DNSMASQ_RELAY_ADDRESS", &err);
-	       buf = grab_extradata(buf, end, "DNSMASQ_MUD_URL", &err);
-	     }
+	  	  
+	  if (is6)
+	    buf = grab_extradata(buf, end, "DNSMASQ_RELAY_ADDRESS", &err);
 	  else
 	    {
 	      const char *giaddr = NULL;

--- a/src/dnsmasq/helper.c
+++ b/src/dnsmasq/helper.c
@@ -647,8 +647,10 @@ int create_helper(int event_fd, int err_fd, uid_t uid, gid_t gid, long max_fd)
 	  
 	  buf = grab_extradata(buf, end, "DNSMASQ_TAGS", &err);
 
-	  if (is6)
-	    buf = grab_extradata(buf, end, "DNSMASQ_RELAY_ADDRESS", &err);
+	  if (is6) {
+	       buf = grab_extradata(buf, end, "DNSMASQ_RELAY_ADDRESS", &err);
+	       buf = grab_extradata(buf, end, "DNSMASQ_MUD_URL", &err);
+	     }
 	  else
 	    {
 	      const char *giaddr = NULL;

--- a/src/dnsmasq/lease.c
+++ b/src/dnsmasq/lease.c
@@ -1180,17 +1180,11 @@ void lease_add_extradata(struct dhcp_lease *lease, unsigned char *data, unsigned
   if ((lease->extradata_size - lease->extradata_len) < (len + 1))
     {
       size_t newsz = lease->extradata_len + len + 100;
-      unsigned char *new = whine_malloc(newsz);
+      unsigned char *new = whine_realloc(lease->extradata, newsz);
   
       if (!new)
 	return;
       
-      if (lease->extradata)
-	{
-	  memcpy(new, lease->extradata, lease->extradata_len);
-	  free(lease->extradata);
-	}
-
       lease->extradata = new;
       lease->extradata_size = newsz;
     }

--- a/src/dnsmasq/netlink.c
+++ b/src/dnsmasq/netlink.c
@@ -258,7 +258,16 @@ int iface_enumerate(int family, void *parm, int (*callback)())
 		    
 		    while (RTA_OK(rta, len1))
 		      {
-			if (rta->rta_type == IFA_ADDRESS)
+			/*
+			 * Important comment: (from if_addr.h)
+			 * IFA_ADDRESS is prefix address, rather than local interface address.
+			 * It makes no difference for normally configured broadcast interfaces,
+			 * but for point-to-point IFA_ADDRESS is DESTINATION address,
+			 * local address is supplied in IFA_LOCAL attribute.
+			 */
+			if (rta->rta_type == IFA_LOCAL)
+			  addrp = ((struct in6_addr *)(rta+1));
+			else if (rta->rta_type == IFA_ADDRESS && !addrp)
 			  addrp = ((struct in6_addr *)(rta+1)); 
 			else if (rta->rta_type == IFA_CACHEINFO)
 			  {

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -4337,6 +4337,11 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	  {
 	    if (inet_pton(AF_INET, arg, &new->local))
 	      {
+		char *hash = split_chr(two, '#');
+
+		if (!hash || !atoi_check16(hash, &new->port))
+		  new->port = DHCP_SERVER_PORT;
+		
 		if (!inet_pton(AF_INET, two, &new->server))
 		  {
 		    new->server.addr4.s_addr = 0;
@@ -4355,6 +4360,11 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 #ifdef HAVE_DHCP6
 	    else if (inet_pton(AF_INET6, arg, &new->local))
 	      {
+		char *hash = split_chr(two, '#');
+
+		if (!hash || !atoi_check16(hash, &new->port))
+		  new->port = DHCPV6_SERVER_PORT;
+
 		if (!inet_pton(AF_INET6, two, &new->server))
 		  {
 		    inet_pton(AF_INET6, ALL_SERVERS, &new->server.addr6);

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -2496,9 +2496,15 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 			  else if (!inet_pton(AF_INET6, arg, &new->end6))
 			    ret_err_free(gen_err, new);
 			}
-		      else 
+		      else if (option == 's')
+			{
+			  /* subnet from interface. */
+			  new->interface = opt_string_alloc(comma);
+			  new->al = NULL;
+			}
+		      else
 			ret_err_free(gen_err, new);
-
+		      
 		      if (option != 's' && prefstr)
 			{
 			  if (!(new->prefix = canonicalise_opt(prefstr)) ||

--- a/src/dnsmasq/poll.c
+++ b/src/dnsmasq/poll.c
@@ -96,9 +96,7 @@ void poll_listen(int fd, short event)
      pollfds[i].events |= event;
    else
      {
-       if (arrsize != nfds)
-	 memmove(&pollfds[i+1], &pollfds[i], (nfds - i) * sizeof(struct pollfd));
-       else
+       if (arrsize == nfds)
 	 {
 	   /* Array too small, extend. */
 	   struct pollfd *new;
@@ -108,17 +106,11 @@ void poll_listen(int fd, short event)
 	   if (!(new = whine_realloc(pollfds, arrsize * sizeof(struct pollfd))))
 	     return;
 
-	   if (pollfds)
-	     {
-	       memmove(&new[i+1], &new[i], (nfds - i) * sizeof(struct pollfd));
-	       /* clear remaining space with zeroes. */
-	       if (nfds+1 < arrsize)
-	         memset(new+nfds+1, 0, arrsize-nfds-1);
-	     }
-	   
 	   pollfds = new;
 	 }
-       
+
+       memmove(&pollfds[i+1], &pollfds[i], (nfds - i) * sizeof(struct pollfd));
+
        pollfds[i].fd = fd;
        pollfds[i].events = event;
        nfds++;

--- a/src/dnsmasq/poll.c
+++ b/src/dnsmasq/poll.c
@@ -105,14 +105,15 @@ void poll_listen(int fd, short event)
 
 	   arrsize = (arrsize == 0) ? 64 : arrsize * 2;
 
-	   if (!(new = whine_malloc(arrsize * sizeof(struct pollfd))))
+	   if (!(new = whine_realloc(pollfds, arrsize * sizeof(struct pollfd))))
 	     return;
 
 	   if (pollfds)
 	     {
-	       memcpy(new, pollfds, i * sizeof(struct pollfd));
-	       memcpy(&new[i+1], &pollfds[i], (nfds - i) * sizeof(struct pollfd));
-	       free(pollfds);
+	       memmove(&new[i+1], &new[i], (nfds - i) * sizeof(struct pollfd));
+	       /* clear remaining space with zeroes. */
+	       if (nfds+1 < arrsize)
+	         memset(new+nfds+1, 0, arrsize-nfds-1);
 	     }
 	   
 	   pollfds = new;

--- a/src/dnsmasq/radv.c
+++ b/src/dnsmasq/radv.c
@@ -203,7 +203,7 @@ void icmp6_packet(time_t now)
       int opt_sz;
       
 #ifdef HAVE_DUMPFILE
-      dump_packet(DUMP_RA, (void *)packet, sz, (union mysockaddr *)&from, NULL, -1);
+      dump_packet_icmp(DUMP_RA, (void *)packet, sz, (union mysockaddr *)&from, NULL);
 #endif           
       
       /* look for link-layer address option for logging */
@@ -560,7 +560,7 @@ static void send_ra_alias(time_t now, int iface, char *iface_name, struct in6_ad
     }
   
 #ifdef HAVE_DUMPFILE
-  dump_packet(DUMP_RA, (void *)daemon->outpacket.iov_base, save_counter(-1), NULL, (union mysockaddr *)&addr, -1);
+  dump_packet_icmp(DUMP_RA, (void *)daemon->outpacket.iov_base, save_counter(-1), NULL, (union mysockaddr *)&addr);
 #endif
 
   while (retry_send(sendto(daemon->icmp6fd, daemon->outpacket.iov_base, 

--- a/src/dnsmasq/radv.c
+++ b/src/dnsmasq/radv.c
@@ -560,7 +560,13 @@ static void send_ra_alias(time_t now, int iface, char *iface_name, struct in6_ad
     }
   
 #ifdef HAVE_DUMPFILE
-  dump_packet_icmp(DUMP_RA, (void *)daemon->outpacket.iov_base, save_counter(-1), NULL, (union mysockaddr *)&addr);
+  {
+    struct sockaddr_in6 src;
+    src.sin6_family = AF_INET6;
+    src.sin6_addr = parm.link_local;
+    
+    dump_packet_icmp(DUMP_RA, (void *)daemon->outpacket.iov_base, save_counter(-1), (union mysockaddr *)&src, (union mysockaddr *)&addr);
+  }
 #endif
 
   while (retry_send(sendto(daemon->icmp6fd, daemon->outpacket.iov_base, 

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1609,7 +1609,7 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 		    
 		    if (addrlist)
 		      break;
-		    else
+		    else if (!(intr->flags & INP4))
 		      while (intr->next && strcmp(intr->intr, intr->next->intr) == 0)
 			intr = intr->next;
 		  }
@@ -1624,7 +1624,7 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 		    
 		    if (addrlist)
 		      break;
-		    else
+		    else if (!(intr->flags & INP6))
 		      while (intr->next && strcmp(intr->intr, intr->next->intr) == 0)
 			intr = intr->next;
 		  }

--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -1418,14 +1418,8 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
 		    }
 
 		  if ((opt = option_find(mess, sz, OPTION_MUD_URL_V4, 1)))
-		  {
-			add_extradata_opt(lease, opt);
-		  }
-		  else
-		  {
-			add_extradata_opt(lease, NULL);
-		  }
-
+		    add_extradata_opt(lease, opt);
+		  
 		  /* DNSMASQ_REQUESTED_OPTIONS */
 		  if ((opt = option_find(mess, sz, OPTION_REQUESTED_OPTIONS, 1)))
 		    {

--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -1417,9 +1417,6 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
 		      add_extradata_opt(lease, NULL);
 		    }
 
-		  if ((opt = option_find(mess, sz, OPTION_MUD_URL_V4, 1)))
-		    add_extradata_opt(lease, opt);
-		  
 		  /* DNSMASQ_REQUESTED_OPTIONS */
 		  if ((opt = option_find(mess, sz, OPTION_REQUESTED_OPTIONS, 1)))
 		    {
@@ -1437,7 +1434,9 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
 		    {
 		      add_extradata_opt(lease, NULL);
 		    }
-
+		  
+		  add_extradata_opt(lease, option_find(mess, sz, OPTION_MUD_URL_V4, 1));
+		  
 		  /* space-concat tag set */
 		  if (!tagif_netid)
 		    add_extradata_opt(lease, NULL);

--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -1420,20 +1420,15 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
 		  /* DNSMASQ_REQUESTED_OPTIONS */
 		  if ((opt = option_find(mess, sz, OPTION_REQUESTED_OPTIONS, 1)))
 		    {
-		      int len = option_len(opt);
+		      int i, len = option_len(opt);
 		      unsigned char *rop = option_ptr(opt, 0);
-		      char *q = daemon->namebuff;
-		      int i;
+		      
 		      for (i = 0; i < len; i++)
-		        {
-		          q += snprintf(q, MAXDNAME - (q - daemon->namebuff), "%d%s", rop[i], i + 1 == len ? "" : ",");
-		        }
-		      lease_add_extradata(lease, (unsigned char *)daemon->namebuff, (q - daemon->namebuff), 0); 
+			lease_add_extradata(lease, (unsigned char *)daemon->namebuff,
+					    sprintf(daemon->namebuff, "%u", rop[i]), (i + 1) == len ? 0 : ',');
 		    }
 		  else
-		    {
-		      add_extradata_opt(lease, NULL);
-		    }
+		    lease_add_extradata(lease, NULL, 0, 0);
 		  
 		  add_extradata_opt(lease, option_find(mess, sz, OPTION_MUD_URL_V4, 1));
 		  

--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -1417,6 +1417,15 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
 		      add_extradata_opt(lease, NULL);
 		    }
 
+		  if ((opt = option_find(mess, sz, OPTION_MUD_URL_V4, 1)))
+		  {
+			add_extradata_opt(lease, opt);
+		  }
+		  else
+		  {
+			add_extradata_opt(lease, NULL);
+		  }
+
 		  /* DNSMASQ_REQUESTED_OPTIONS */
 		  if ((opt = option_find(mess, sz, OPTION_REQUESTED_OPTIONS, 1)))
 		    {

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -1905,6 +1905,11 @@ static void update_leases(struct state *state, struct dhcp_context *context, str
 	  lease_add_extradata(lease, (unsigned char *)state->client_hostname, 
 			      state->client_hostname ? strlen(state->client_hostname) : 0, 0);				
 	  
+	  if ((opt = opt6_find(state->packet_options, state->end, OPTION6_MUD_URL, 1)))
+	    lease_add_extradata(lease, opt6_ptr(opt, 0), opt6_len(opt), 0);
+	  else
+	    lease_add_extradata(lease, NULL, 0, 0);
+
 	  /* space-concat tag set */
 	  if (!tagif && !context->netid.net)
 	    lease_add_extradata(lease, NULL, 0, 0);
@@ -1933,11 +1938,6 @@ static void update_leases(struct state *state, struct dhcp_context *context, str
 	    inet_ntop(AF_INET6, state->link_address, daemon->addrbuff, ADDRSTRLEN);
 	  
 	  lease_add_extradata(lease, (unsigned char *)daemon->addrbuff, state->link_address ? strlen(daemon->addrbuff) : 0, 0);
-	  
-	  if ((opt = opt6_find(state->packet_options, state->end, OPTION6_MUD_URL, 1)))
-	    lease_add_extradata(lease, opt6_ptr(opt, 0), opt6_len(opt), 0);
-	  else
-	    lease_add_extradata(lease, NULL, 0, 0);
 	  
 	  if ((opt = opt6_find(state->packet_options, state->end, OPTION6_USER_CLASS, 2)))
 	    {

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -1934,6 +1934,16 @@ static void update_leases(struct state *state, struct dhcp_context *context, str
 	  
 	  lease_add_extradata(lease, (unsigned char *)daemon->addrbuff, state->link_address ? strlen(daemon->addrbuff) : 0, 0);
 	  
+	  void *mud_opt;
+	  if ((mud_opt = opt6_find(state->packet_options, state->end, OPTION6_MUD_URL, 1)))
+	    {
+	      lease_add_extradata(lease, opt6_ptr(mud_opt, 0), opt6_len(mud_opt), NULL);
+	    }
+	  else
+	    {
+	      lease_add_extradata(lease, NULL, 0, 0);
+	    }
+	  
 	  if ((class_opt = opt6_find(state->packet_options, state->end, OPTION6_USER_CLASS, 2)))
 	    {
 	      void *enc_opt, *enc_end = opt6_ptr(class_opt, opt6_len(class_opt));

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -2170,7 +2170,7 @@ int relay_upstream6(int iface_index, ssize_t sz,
 	
 	to.sa.sa_family = AF_INET6;
 	to.in6.sin6_addr = relay->server.addr6;
-	to.in6.sin6_port = htons(DHCPV6_SERVER_PORT);
+	to.in6.sin6_port = htons(relay->port);
 	to.in6.sin6_flowinfo = 0;
 	to.in6.sin6_scope_id = 0;
 	

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -2214,7 +2214,7 @@ int relay_upstream6(int iface_index, ssize_t sz,
 	  fromsock.in6.sin6_flowinfo = 0;
 	  fromsock.in6.sin6_scope_id = 0;
 	  
-	  dump_packet(DUMP_DHCPV6, (void *)daemon->outpacket.iov_base, save_counter(-1), &fromsock, &to, 0);
+	  dump_packet_udp(DUMP_DHCPV6, (void *)daemon->outpacket.iov_base, save_counter(-1), &fromsock, &to, -1);
 	}
 #endif
 	send_from(daemon->dhcp6fd, 0, daemon->outpacket.iov_base, save_counter(-1), &to, &from, 0);

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -33,9 +33,9 @@ struct state {
   unsigned int mac_len, mac_type;
 };
 
-static int dhcp6_maybe_relay(struct state *state, void *inbuff, size_t sz, 
+static int dhcp6_maybe_relay(struct state *state, unsigned char *inbuff, size_t sz, 
 			     struct in6_addr *client_addr, int is_unicast, time_t now);
-static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_t sz, int is_unicast, time_t now);
+static int dhcp6_no_relay(struct state *state, int msg_type, unsigned char *inbuff, size_t sz, int is_unicast, time_t now);
 static void log6_opts(int nest, unsigned int xid, void *start_opts, void *end_opts);
 static void log6_packet(struct state *state, char *type, struct in6_addr *addr, char *string);
 static void log6_quiet(struct state *state, char *type, struct in6_addr *addr, char *string);
@@ -104,12 +104,12 @@ unsigned short dhcp6_reply(struct dhcp_context *context, int interface, char *if
 }
 
 /* This cost me blood to write, it will probably cost you blood to understand - srk. */
-static int dhcp6_maybe_relay(struct state *state, void *inbuff, size_t sz, 
+static int dhcp6_maybe_relay(struct state *state, unsigned char *inbuff, size_t sz, 
 			     struct in6_addr *client_addr, int is_unicast, time_t now)
 {
   void *end = inbuff + sz;
   void *opts = inbuff + 34;
-  int msg_type = *((unsigned char *)inbuff);
+  int msg_type = *inbuff;
   unsigned char *outmsgtypep;
   void *opt;
   struct dhcp_vendor *vendor;
@@ -259,15 +259,15 @@ static int dhcp6_maybe_relay(struct state *state, void *inbuff, size_t sz,
   return 1;
 }
 
-static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_t sz, int is_unicast, time_t now)
+static int dhcp6_no_relay(struct state *state, int msg_type, unsigned char *inbuff, size_t sz, int is_unicast, time_t now)
 {
   void *opt;
-  int i, o, o1, start_opts;
+  int i, o, o1, start_opts, start_msg;
   struct dhcp_opt *opt_cfg;
   struct dhcp_netid *tagif;
   struct dhcp_config *config = NULL;
   struct dhcp_netid known_id, iface_id, v6_id;
-  unsigned char *outmsgtypep;
+  unsigned char outmsgtype;
   struct dhcp_vendor *vendor;
   struct dhcp_context *context_tmp;
   struct dhcp_mac *mac_opt;
@@ -296,12 +296,13 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
   v6_id.next = state->tags;
   state->tags = &v6_id;
 
-  /* copy over transaction-id, and save pointer to message type */
-  if (!(outmsgtypep = put_opt6(inbuff, 4)))
+  start_msg = save_counter(-1);
+  /* copy over transaction-id */
+  if (!put_opt6(inbuff, 4))
     return 0;
   start_opts = save_counter(-1);
-  state->xid = outmsgtypep[3] | outmsgtypep[2] << 8 | outmsgtypep[1] << 16;
-   
+  state->xid = inbuff[3] | inbuff[2] << 8 | inbuff[1] << 16;
+    
   /* We're going to be linking tags from all context we use. 
      mark them as unused so we don't link one twice and break the list */
   for (context_tmp = state->context; context_tmp; context_tmp = context_tmp->current)
@@ -347,7 +348,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
       (msg_type == DHCP6REQUEST || msg_type == DHCP6RENEW || msg_type == DHCP6RELEASE || msg_type == DHCP6DECLINE))
     
     {  
-      *outmsgtypep = DHCP6REPLY;
+      outmsgtype = DHCP6REPLY;
       o1 = new_opt6(OPTION6_STATUS_CODE);
       put_opt6_short(DHCP6USEMULTI);
       put_opt6_string("Use multicast");
@@ -619,11 +620,11 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 	struct dhcp_netid *solicit_tags;
 	struct dhcp_context *c;
 	
-	*outmsgtypep = DHCP6ADVERTISE;
+	outmsgtype = DHCP6ADVERTISE;
 	
 	if (opt6_find(state->packet_options, state->end, OPTION6_RAPID_COMMIT, 0))
 	  {
-	    *outmsgtypep = DHCP6REPLY;
+	    outmsgtype = DHCP6REPLY;
 	    state->lease_allocate = 1;
 	    o = new_opt6(OPTION6_RAPID_COMMIT);
 	    end_opt6(o);
@@ -809,7 +810,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 	int start = save_counter(-1);
 
 	/* set reply message type */
-	*outmsgtypep = DHCP6REPLY;
+	outmsgtype = DHCP6REPLY;
 	state->lease_allocate = 1;
 
 	log6_quiet(state, "DHCPREQUEST", NULL, ignore ? _("ignored") : NULL);
@@ -924,7 +925,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 	int address_assigned = 0;
 
 	/* set reply message type */
-	*outmsgtypep = DHCP6REPLY;
+	outmsgtype = DHCP6REPLY;
 	
 	log6_quiet(state, msg_type == DHCP6RENEW ? "DHCPRENEW" : "DHCPREBIND", NULL, NULL);
 
@@ -1057,7 +1058,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 	int good_addr = 0;
 
 	/* set reply message type */
-	*outmsgtypep = DHCP6REPLY;
+	outmsgtype = DHCP6REPLY;
 	
 	log6_quiet(state, "DHCPCONFIRM", NULL, NULL);
 	
@@ -1121,7 +1122,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 	log6_quiet(state, "DHCPINFORMATION-REQUEST", NULL, ignore ? _("ignored") : state->hostname);
 	if (ignore)
 	  return 0;
-	*outmsgtypep = DHCP6REPLY;
+	outmsgtype = DHCP6REPLY;
 	tagif = add_options(state, 1);
 	break;
       }
@@ -1130,7 +1131,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
     case DHCP6RELEASE:
       {
 	/* set reply message type */
-	*outmsgtypep = DHCP6REPLY;
+	outmsgtype = DHCP6REPLY;
 
 	log6_quiet(state, "DHCPRELEASE", NULL, NULL);
 
@@ -1195,7 +1196,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
     case DHCP6DECLINE:
       {
 	/* set reply message type */
-	*outmsgtypep = DHCP6REPLY;
+	outmsgtype = DHCP6REPLY;
 	
 	log6_quiet(state, "DHCPDECLINE", NULL, NULL);
 
@@ -1275,7 +1276,12 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
       }
 
     }
-  
+
+  /* Fill in the message type. Note that we store the offset,
+     not a direct pointer, since the packet memory may have been 
+     reallocated. */
+  ((unsigned char *)(daemon->outpacket.iov_base))[start_msg] = outmsgtype;
+
   log_tags(tagif, state->xid);
   log6_opts(0, state->xid, daemon->outpacket.iov_base + start_opts, daemon->outpacket.iov_base + save_counter(-1));
   

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -1879,23 +1879,23 @@ static void update_leases(struct state *state, struct dhcp_context *context, str
 #ifdef HAVE_SCRIPT
       if (daemon->lease_change_command)
 	{
-	  void *class_opt;
+	  void *opt;
 	  lease->flags |= LEASE_CHANGED;
 	  free(lease->extradata);
 	  lease->extradata = NULL;
 	  lease->extradata_size = lease->extradata_len = 0;
 	  lease->vendorclass_count = 0; 
 	  
-	  if ((class_opt = opt6_find(state->packet_options, state->end, OPTION6_VENDOR_CLASS, 4)))
+	  if ((opt = opt6_find(state->packet_options, state->end, OPTION6_VENDOR_CLASS, 4)))
 	    {
-	      void *enc_opt, *enc_end = opt6_ptr(class_opt, opt6_len(class_opt));
+	      void *enc_opt, *enc_end = opt6_ptr(opt, opt6_len(opt));
 	      lease->vendorclass_count++;
 	      /* send enterprise number first  */
-	      sprintf(daemon->dhcp_buff2, "%u", opt6_uint(class_opt, 0, 4));
+	      sprintf(daemon->dhcp_buff2, "%u", opt6_uint(opt, 0, 4));
 	      lease_add_extradata(lease, (unsigned char *)daemon->dhcp_buff2, strlen(daemon->dhcp_buff2), 0);
 	      
-	      if (opt6_len(class_opt) >= 6) 
-		for (enc_opt = opt6_ptr(class_opt, 4); enc_opt; enc_opt = opt6_next(enc_opt, enc_end))
+	      if (opt6_len(opt) >= 6) 
+		for (enc_opt = opt6_ptr(opt, 4); enc_opt; enc_opt = opt6_next(enc_opt, enc_end))
 		  {
 		    lease->vendorclass_count++;
 		    lease_add_extradata(lease, opt6_ptr(enc_opt, 0), opt6_len(enc_opt), 0);
@@ -1934,20 +1934,15 @@ static void update_leases(struct state *state, struct dhcp_context *context, str
 	  
 	  lease_add_extradata(lease, (unsigned char *)daemon->addrbuff, state->link_address ? strlen(daemon->addrbuff) : 0, 0);
 	  
-	  void *mud_opt;
-	  if ((mud_opt = opt6_find(state->packet_options, state->end, OPTION6_MUD_URL, 1)))
-	    {
-	      lease_add_extradata(lease, opt6_ptr(mud_opt, 0), opt6_len(mud_opt), NULL);
-	    }
+	  if ((opt = opt6_find(state->packet_options, state->end, OPTION6_MUD_URL, 1)))
+	    lease_add_extradata(lease, opt6_ptr(opt, 0), opt6_len(opt), 0);
 	  else
-	    {
-	      lease_add_extradata(lease, NULL, 0, 0);
-	    }
+	    lease_add_extradata(lease, NULL, 0, 0);
 	  
-	  if ((class_opt = opt6_find(state->packet_options, state->end, OPTION6_USER_CLASS, 2)))
+	  if ((opt = opt6_find(state->packet_options, state->end, OPTION6_USER_CLASS, 2)))
 	    {
-	      void *enc_opt, *enc_end = opt6_ptr(class_opt, opt6_len(class_opt));
-	      for (enc_opt = opt6_ptr(class_opt, 0); enc_opt; enc_opt = opt6_next(enc_opt, enc_end))
+	      void *enc_opt, *enc_end = opt6_ptr(opt, opt6_len(opt));
+	      for (enc_opt = opt6_ptr(opt, 0); enc_opt; enc_opt = opt6_next(enc_opt, enc_end))
 		lease_add_extradata(lease, opt6_ptr(enc_opt, 0), opt6_len(enc_opt), 0);
 	    }
 	}

--- a/src/dnsmasq/rrfilter.c
+++ b/src/dnsmasq/rrfilter.c
@@ -159,7 +159,7 @@ static int check_rrs(unsigned char *p, struct dns_header *header, size_t plen, i
 /* mode may be remove EDNS0 or DNSSEC RRs or remove A or AAAA from answer section. */
 size_t rrfilter(struct dns_header *header, size_t plen, int mode)
 {
-  static unsigned char **rrs;
+  static unsigned char **rrs = NULL;
   static int rr_sz = 0;
 
   unsigned char *p = (unsigned char *)(header+1);
@@ -339,15 +339,11 @@ int expand_workspace(unsigned char ***wkspc, int *szp, int new)
     return 0;
 
   new += 5;
-  
-  if (!(p = whine_malloc(new * sizeof(unsigned char *))))
-    return 0;  
-  
-  if (old != 0 && *wkspc)
-    {
-      memcpy(p, *wkspc, old * sizeof(unsigned char *));
-      free(*wkspc);
-    }
+
+  if (!(p = whine_realloc(*wkspc, new * sizeof(unsigned char *))))
+    return 0;
+
+  memset(p+old, 0, new-old);
   
   *wkspc = p;
   *szp = new;

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -97,7 +97,7 @@ void tftp_request(struct listener *listen, time_t now)
     return;
 
 #ifdef HAVE_DUMPFILE
-  dump_packet(DUMP_TFTP, (void *)packet, len, (union mysockaddr *)&peer, NULL, TFTP_PORT);
+  dump_packet_udp(DUMP_TFTP, (void *)packet, len, (union mysockaddr *)&peer, NULL, listen->tftpfd);
 #endif
   
   /* Can always get recvd interface for IPv6 */
@@ -488,7 +488,7 @@ void tftp_request(struct listener *listen, time_t now)
   send_from(transfer->sockfd, !option_bool(OPT_SINGLE_PORT), packet, len, &peer, &addra, if_index);
 
 #ifdef HAVE_DUMPFILE
-  dump_packet(DUMP_TFTP, (void *)packet, len, NULL, (union mysockaddr *)&peer, TFTP_PORT);
+  dump_packet_udp(DUMP_TFTP, (void *)packet, len, NULL, (union mysockaddr *)&peer, transfer->sockfd);
 #endif
   
   if (is_err)
@@ -610,7 +610,7 @@ void check_tftp_listeners(time_t now)
 		  while(retry_send(sendto(transfer->sockfd, daemon->packet, len, 0, &peer.sa, sa_len(&peer))));
 
 #ifdef HAVE_DUMPFILE
-		  dump_packet(DUMP_TFTP, (void *)daemon->packet, len, NULL, (union mysockaddr *)&peer, TFTP_PORT);
+		  dump_packet_udp(DUMP_TFTP, (void *)daemon->packet, len, NULL, (union mysockaddr *)&peer, transfer->sockfd);
 #endif
 		}
 	    }
@@ -650,7 +650,7 @@ void check_tftp_listeners(time_t now)
 	      send_from(transfer->sockfd, !option_bool(OPT_SINGLE_PORT), daemon->packet, len,
 			&transfer->peer, &transfer->source, transfer->if_index);
 #ifdef HAVE_DUMPFILE
-	      dump_packet(DUMP_TFTP, (void *)daemon->packet, len, NULL, (union mysockaddr *)&transfer->peer, TFTP_PORT);
+	      dump_packet_udp(DUMP_TFTP, (void *)daemon->packet, len, NULL, (union mysockaddr *)&transfer->peer, transfer->sockfd);
 #endif
 	    }
 	  

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -336,6 +336,16 @@ void *whine_malloc(size_t size)
   return ret;
 }
 
+void *whine_realloc(void *ptr, size_t size)
+{
+  void *ret = realloc(ptr, size);
+
+  if (!ret)
+    my_syslog(LOG_ERR, _("failed to reallocate %d bytes"), (int) size);
+
+  return ret;
+}
+
 int sockaddr_isequal(const union mysockaddr *s1, const union mysockaddr *s2)
 {
   if (s1->sa.sa_family == s2->sa.sa_family)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

CHANGELOG entries since our last `dnsmasq` update:
```
	Enhance --domain to accept, for instance,
	--domain=net2.thekelleys.org.uk,eth2 so that hosts get a domain
	which relects the interface they are attached to in a way which
	doesn't require hard-coding addresses. Thanks to Sten Spans for
	the idea.

	Fix write-after-free error in DHCPv6 server code.
	CVE-2022-0934 refers.
	
	Add the ability to specify destination port in
	DHCP-relay mode. This change also removes a previous bug
	where --dhcp-alternate-port would affect the port used
	to relay _to_ as well as the port being listened on.
	The new feature allows configuration to provide bug-for-bug
	compatibility, if required. Thanks to Damian Kaczkowski 
	for the feature suggestion.

	Bound the value of UDP packet size in the EDNS0 header of
	forwarded queries to the configured or default value of
	edns-packet-max. There's no point letting a client set a larger
	value if we're unable to return the answer. Thanks to Bertie
	Taylor for pointing out the problem and supplying the patch.
	
	Fix problem with the configuration
	
	--server=/some.domain/# --address=/#/<ip> --server=<server_ip>

	This would return <ip> for queries in some.domain, rather than
	forwarding the query via the default server.

	Tweak DHCPv6 relay code so that packets relayed towards a server
	have source address on the server-facing network, not the
	client facing network. Thanks to Luis Thomas for spotting this
	and initial patch.
```

Plus some bug fixes.