### PR TITLE
Only log disk space warning when usage increased

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -146,12 +146,8 @@ void *GC_thread(void *val)
 		if(now - lastResourceCheck >= RCinterval)
 		{
 			check_load();
-			int DBStorageUsage = check_space(FTLfiles.FTL_db, LastDBStorageUsage);
-			int LogStorageUsage = check_space(FTLfiles.log, LastLogStorageUsage);
-			
-			LastLogStorageUsage = LogStorageUsage;
-			LastDBStorageUsage = DBStorageUsage;
-
+			LastDBStorageUsage = check_space(FTLfiles.FTL_db, LastDBStorageUsage);
+			LastLogStorageUsage = check_space(FTLfiles.log, LastLogStorageUsage);
 			lastResourceCheck = now;
 		}
 


### PR DESCRIPTION
***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**  5

---

We check two locations for free disk space and warn if disk usage >90% (https://github.com/pi-hole/FTL/pull/1249). Warning consists of adding a message in the `message_table` and logging to `FTL.log`
One location we monitor is the filesystem where the log files are located. We already ensure that we only log to the message table once, however, we continue to log to `FTL.log` every time we check (300 sec). This leads to log spam which further decreases the available space for the log files. 
See this discourse thread with a log warning every 5 minutes: https://discourse.pi-hole.net/t/disk-shortage-var-log-pihole-ftl-log-ahead-99-used/57905/10?u=yubiuser

This PR adds a check that the available disk space is less then during the previous check and only executes the logging in such a case.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
