### PR TITLE
Fix handling of dnssec-retry queries.

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -134,10 +134,29 @@ void FTL_hook(unsigned int flags, const char *name, union all_addr *addr, char *
 		// derive the real query type from the arg string
 		unsigned short qtype = type;
 		if(strcmp(arg, "dnssec-query[DNSKEY]") == 0)
+		{
 			qtype = T_DNSKEY;
+			arg = (char*)"dnssec-query";
+		}
 		else if(strcmp(arg, "dnssec-query[DS]") == 0)
+		{
 			qtype = T_DS;
-		arg = (char*)"dnssec-query";
+			arg = (char*)"dnssec-query";
+		}
+		else if(strcmp(arg, "dnssec-retry[DNSKEY]") == 0)
+		{
+			qtype = T_DNSKEY;
+			arg = (char*)"dnssec-retry";
+		}
+		else if(strcmp(arg, "dnssec-retry[DS]") == 0)
+		{
+			qtype = T_DS;
+			arg = (char*)"dnssec-retry";
+		}
+		else
+		{
+			arg = (char*)"dnssec-unknown";
+		}
 
 		_FTL_new_query(flags, name, NULL, arg, qtype, id, &edns, INTERNAL, file, line);
 		// forwarded upstream (type is used to store the upstream port)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

The most recent FTL release contains `dnsmasq v2.87rc1` which causes a regression for `dnssec-retry` queries leading to a bug where FTL isn't able to interpret the query type as `DS`/`DNSKEY` and incorrectly infers `TYPE<upstream-port>` as query type:

![6df9d0a56d2a13a43de97e71de42629b5706b5c5](https://user-images.githubusercontent.com/16748619/190896765-da963a4a-54d5-4191-9cc5-27fad4be0ca1.png)
(picture taken from related [Discourse topic](https://discourse.pi-hole.net/t/log-entry-for-dns-type-type5335-with-reply-of-blob/57908))

Subsequently, FTL fails to analyze the content of this query (as it doesn't know how to handle, e.g. `TYPE5335`) and simply logs `BLOB` as return type (= some unknown binary stuff).

It is worth pointing out that DNS blocking and internal DNSSEC verification still works fine making this a displaying bug only.