### PR TITLE
Revert "Do not run built workflow on dependabot pushes and PRs"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - '**'
-      - '!dependabot/**'
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
   release:
     types: [published]
 


### PR DESCRIPTION
Reverts PR https://github.com/pi-hole/FTL/pull/1367 after discussion here: https://github.com/pi-hole/FTL/pull/1436.

We decided after all it would be a good idea to check dependabot PR.
