### PR TITLE
Separate dependabot branch names with a hypthen to work around the dir depth restriction in the build workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
   target-branch: development
   reviewers:
     - "pi-hole/ftl-maintainers"
+  pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      separator: "-"


### PR DESCRIPTION
Our build workflow restricts the dir depth of the branch names to one subdir. This makes the built fail for dependabot as it creates deeper subdirs.

Working around this by:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator
