### PR TITLE
Update embedded dnsmasq to v2.87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.87rc1)
+set(DNSMASQ_VERSION pi-hole-v2.87)
 
 add_subdirectory(src)

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -247,6 +247,14 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	  if (!daemon->free_frec_src)
 	    {
 	      query_full(now, NULL);
+	      /* This is tricky; if we're blasted with the same query
+		 over and over, we'll end up taking this path each time
+		 and never resetting until the frec gets deleted by
+		 aging followed by the receipt of a different query. This
+		 is a bit of a DoS vuln. Avoid by explicitly deleting the
+		 frec once it expires. */
+	      if (difftime(now, forward->time) >= TIMEOUT)
+		free_frec(forward);
 	      goto reply;
 	    }
 	  


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

`dnsmasq` v2.87 has been released today: https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2022q3/016599.html