### PR TITLE
Fix comment on `gravity-db.c`

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -152,7 +152,7 @@ bool gravityDB_open(void)
 	//            BUT NOT google.de itself
 	// Example 3: *google.de
 	//            matches 'google.de' and all of its subdomains but
-	//            also other domains starting in google.de, like
+	//            also other domains ending in google.de, like
 	//            abcgoogle.de
 	rc = sqlite3_prepare_v3(gravity_db,
 	        "SELECT domain, "
@@ -1398,7 +1398,7 @@ void check_inaccessible_adlists(void)
 	// check if any adlist was inaccessible in the last gravity run
 	// if so, gravity stored `status` in the adlist table with
 	// "3": List unavailable, Pi-hole used a local copy
-	// "4": List unavailable, there is no local copy available 
+	// "4": List unavailable, there is no local copy available
 
 	// Do not proceed when database is not available
 	if(!gravityDB_opened && !gravityDB_open())
@@ -1408,7 +1408,7 @@ void check_inaccessible_adlists(void)
 	}
 
 	const char *querystr = "SELECT id, address FROM adlist WHERE status IN (3,4) AND enabled=1";
-	
+
 	// Prepare query
 	sqlite3_stmt *query_stmt;
 	int rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &query_stmt, NULL);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
5

---

In `gravity-db.c`, the comment explaining how the wildcard character works when adding audit domains is wrong. 

The text says `*google.de` matches other domains **starting** in `google.de`, like `abcgoogle.de`.
This is clearly wrong, since `abcgoogle.de` **ends** with the matching text.
The PR fixes the comment.

 
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
