### PR TITLE
Switch SSH deploy action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,10 +142,10 @@ jobs:
         working-directory: ${{steps.download.outputs.download-path}}
       -
         name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: benoitchantre/setup-ssh-authentication-action@1.0.0
         with:
-          key: ${{ secrets.SSH_KEY }}
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          private-key: ${{ secrets.SSH_KEY }}
+          known-hosts: ${{ secrets.KNOWN_HOSTS }}
       -
         name: Transfer Builds to Pi-hole server for pihole checkout
         env:


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** _{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar} 10

---

Switch from https://github.com/shimataro/ssh-key-action to https://github.com/benoitchantre/setup-ssh-authentication-action

Reason: the current action uses `Node.js 12` which is not supported by GH anymore, makes the deploy workflow failing. Also, the action repo looks a bit abandoned, last release 1 year ago with some open issues and pull requests. One issue is about Nodejs (https://github.com/shimataro/ssh-key-action/issues/207) where the author of the new action introduced it. 
The new action is much simpler and uses a pure `bash` approach making it less error-prone.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
