### PR TITLE
Improve shared memory protection

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -190,7 +190,12 @@ void delay_startup(void)
 
 	// Sleep if requested by DELAY_STARTUP
 	logg("Sleeping for %d seconds as requested by configuration ...", config.delay_startup);
-	sleep(config.delay_startup);
+	if(sleep(config.delay_startup) != 0)
+	{
+		logg("FATAL: Sleeping was interrupted by an external signal");
+		cleanup(EXIT_FAILURE);
+		exit(EXIT_FAILURE);
+	}
 	logg("Done sleeping, continuing startup of resolver...");
 }
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3339,7 +3339,7 @@ int check_struct_sizes(void)
 	result += check_one_struct("overTimeData", sizeof(overTimeData), 32, 24);
 	result += check_one_struct("regexData", sizeof(regexData), 56, 44);
 	result += check_one_struct("SharedMemory", sizeof(SharedMemory), 24, 12);
-	result += check_one_struct("ShmSettings", sizeof(ShmSettings), 12, 12);
+	result += check_one_struct("ShmSettings", sizeof(ShmSettings), 16, 16);
 	result += check_one_struct("countersStruct", sizeof(countersStruct), 244, 244);
 	result += check_one_struct("sqlite3_stmt_vec", sizeof(sqlite3_stmt_vec), 32, 16);
 

--- a/src/main.c
+++ b/src/main.c
@@ -55,6 +55,9 @@ int main (int argc, char* argv[])
 	logg("########## FTL started on %s! ##########", hostname());
 	log_FTL_version(false);
 
+	// Process pihole-FTL.conf
+	read_FTLconf();
+
 	// Catch signals not handled by dnsmasq
 	// We configure real-time signals later (after dnsmasq has forked)
 	handle_signals();
@@ -67,9 +70,6 @@ int main (int argc, char* argv[])
 		check_running_FTL();
 		return EXIT_FAILURE;
 	}
-
-	// Process pihole-FTL.conf
-	read_FTLconf();
 
 	// pihole-FTL should really be run as user "pihole" to not mess up with file permissions
 	// print warning otherwise

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ int main (int argc, char* argv[])
 	handle_signals();
 
 	// Initialize shared memory
-	if(!init_shmem(true))
+	if(!init_shmem())
 	{
 		logg("Initialization of shared memory failed.");
 		// Check if there is already a running FTL process

--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,10 @@ int main (int argc, char* argv[])
 	if(strcmp(username, "pihole") != 0)
 		logg("WARNING: Starting pihole-FTL as user %s is not recommended", username);
 
+	// Write PID early on so systemd cannot be fooled during DELAY_STARTUP
+	// times. The PID in this file will later be overwritten after forking
+	savepid();
+
 	// Delay startup (if requested)
 	// Do this before reading the database to make this option not only
 	// useful for interfaces that aren't ready but also for fake-hwclocks

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -429,134 +429,118 @@ bool is_our_lock(void)
 	return false;
 }
 
-bool init_shmem(bool create_new)
+bool init_shmem()
 {
 	// Get kernel's page size
 	pagesize = getpagesize();
 
 	/****************************** shared memory lock ******************************/
 	// Try to create shared memory object
-	shm_lock = create_shm(SHARED_LOCK_NAME, sizeof(ShmLock), create_new);
+	shm_lock = create_shm(SHARED_LOCK_NAME, sizeof(ShmLock));
 	if(shm_lock.ptr == NULL)
 		return false;
-	shmLock = (ShmLock*) shm_lock.ptr;
-	if(create_new)
-	{
-		shmLock->lock.outer = create_mutex();
-		shmLock->lock.inner = create_mutex();
-	}
+
+	shmLock = (ShmLock*)shm_lock.ptr;
+	shmLock->lock.outer = create_mutex();
+	shmLock->lock.inner = create_mutex();
 
 	/****************************** shared counters struct ******************************/
 	// Try to create shared memory object
-	shm_counters = create_shm(SHARED_COUNTERS_NAME, sizeof(countersStruct), create_new);
+	shm_counters = create_shm(SHARED_COUNTERS_NAME, sizeof(countersStruct));
 	if(shm_counters.ptr == NULL)
 		return false;
+
 	counters = (countersStruct*)shm_counters.ptr;
 
 	/****************************** shared settings struct ******************************/
 	// Try to create shared memory object
-	shm_settings = create_shm(SHARED_SETTINGS_NAME, sizeof(ShmSettings), create_new);
+	shm_settings = create_shm(SHARED_SETTINGS_NAME, sizeof(ShmSettings));
 	if(shm_settings.ptr == NULL)
 		return false;
+
 	shmSettings = (ShmSettings*)shm_settings.ptr;
-	if(create_new)
-	{
-		shmSettings->version = SHARED_MEMORY_VERSION;
-		shmSettings->global_shm_counter = 0;
-	}
-	else
-	{
-		if(shmSettings->version != SHARED_MEMORY_VERSION)
-		{
-			logg("Shared memory version mismatch, found %d, expected %d!",
-			     shmSettings->version, SHARED_MEMORY_VERSION);
-			return false;
-		}
-	}
+	shmSettings->version = SHARED_MEMORY_VERSION;
+	shmSettings->global_shm_counter = 0;
 
 	/****************************** shared strings buffer ******************************/
 	// Try to create shared memory object
-	shm_strings = create_shm(SHARED_STRINGS_NAME, STRINGS_ALLOC_STEP, create_new);
+	shm_strings = create_shm(SHARED_STRINGS_NAME, STRINGS_ALLOC_STEP);
 	if(shm_strings.ptr == NULL)
 		return false;
-	if(create_new)
-	{
-		counters->strings_MAX = shm_strings.size;
 
-		// Initialize shared string object with an empty string at position zero
-		((char*)shm_strings.ptr)[0] = '\0';
-		shmSettings->next_str_pos = 1;
-	}
+	counters->strings_MAX = shm_strings.size;
+
+	// Initialize shared string object with an empty string at position zero
+	((char*)shm_strings.ptr)[0] = '\0';
+	shmSettings->next_str_pos = 1;
 
 	/****************************** shared domains struct ******************************/
 	size_t size = get_optimal_object_size(sizeof(domainsData), 1);
 	// Try to create shared memory object
-	shm_domains = create_shm(SHARED_DOMAINS_NAME, size*sizeof(domainsData), create_new);
+	shm_domains = create_shm(SHARED_DOMAINS_NAME, size*sizeof(domainsData));
 	if(shm_domains.ptr == NULL)
 		return false;
+
 	domains = (domainsData*)shm_domains.ptr;
-	if(create_new)
-		counters->domains_MAX = size;
+	counters->domains_MAX = size;
 
 	/****************************** shared clients struct ******************************/
 	size = get_optimal_object_size(sizeof(clientsData), 1);
 	// Try to create shared memory object
-	shm_clients = create_shm(SHARED_CLIENTS_NAME, size*sizeof(clientsData), create_new);
+	shm_clients = create_shm(SHARED_CLIENTS_NAME, size*sizeof(clientsData));
 	if(shm_clients.ptr == NULL)
 		return false;
+
 	clients = (clientsData*)shm_clients.ptr;
-	if(create_new)
-		counters->clients_MAX = size;
+	counters->clients_MAX = size;
 
 	/****************************** shared upstreams struct ******************************/
 	size = get_optimal_object_size(sizeof(upstreamsData), 1);
 	// Try to create shared memory object
-	shm_upstreams = create_shm(SHARED_UPSTREAMS_NAME, size*sizeof(upstreamsData), create_new);
+	shm_upstreams = create_shm(SHARED_UPSTREAMS_NAME, size*sizeof(upstreamsData));
 	if(shm_upstreams.ptr == NULL)
 		return false;
 	upstreams = (upstreamsData*)shm_upstreams.ptr;
-	if(create_new)
-		counters->upstreams_MAX = size;
+
+	counters->upstreams_MAX = size;
 
 	/****************************** shared queries struct ******************************/
 	// Try to create shared memory object
-	shm_queries = create_shm(SHARED_QUERIES_NAME, pagesize*sizeof(queriesData), create_new);
+	shm_queries = create_shm(SHARED_QUERIES_NAME, pagesize*sizeof(queriesData));
 	if(shm_queries.ptr == NULL)
 		return false;
 	queries = (queriesData*)shm_queries.ptr;
-	if(create_new)
-		counters->queries_MAX = pagesize;
+
+	counters->queries_MAX = pagesize;
 
 	/****************************** shared overTime struct ******************************/
 	size = get_optimal_object_size(sizeof(overTimeData), OVERTIME_SLOTS);
 	// Try to create shared memory object
-	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size*sizeof(overTimeData), create_new);
+	shm_overTime = create_shm(SHARED_OVERTIME_NAME, size*sizeof(overTimeData));
 	if(shm_overTime.ptr == NULL)
 		return false;
-	if(create_new)
-	{
-		// set global pointer in overTime.c
-		overTime = (overTimeData*)shm_overTime.ptr;
-	}
+
+	// set global pointer in overTime.c
+	overTime = (overTimeData*)shm_overTime.ptr;
 
 	/****************************** shared DNS cache struct ******************************/
 	size = get_optimal_object_size(sizeof(DNSCacheData), 1);
 	// Try to create shared memory object
-	shm_dns_cache = create_shm(SHARED_DNS_CACHE, size*sizeof(DNSCacheData), create_new);
+	shm_dns_cache = create_shm(SHARED_DNS_CACHE, size*sizeof(DNSCacheData));
 	if(shm_dns_cache.ptr == NULL)
 		return false;
+
 	dns_cache = (DNSCacheData*)shm_dns_cache.ptr;
-	if(create_new)
-		counters->dns_cache_MAX = size;
+	counters->dns_cache_MAX = size;
 
 	/****************************** shared per-client regex buffer ******************************/
 	size = pagesize; // Allocate one pagesize initially. This may be expanded later on
 	// Try to create shared memory object
-	shm_per_client_regex = create_shm(SHARED_PER_CLIENT_REGEX, size, create_new);
+	shm_per_client_regex = create_shm(SHARED_PER_CLIENT_REGEX, size);
 	if(shm_per_client_regex.ptr == NULL)
 		return false;
-	if(create_new)
-		counters->per_client_regex_MAX = size;
+
+	counters->per_client_regex_MAX = size;
 
 	return true;
 }
@@ -588,10 +572,9 @@ void destroy_shmem(void)
 ///
 /// \param name the name of the shared memory
 /// \param size the size to allocate
-/// \param create_new true = delete old file, create new, false = connect to existing object or fail
 /// \return a structure with a pointer to the mounted shared memory. The pointer
 /// will always be valid, because if it failed FTL will have exited.
-static SharedMemory create_shm(const char *name, const size_t size, bool create_new)
+static SharedMemory create_shm(const char *name, const size_t size)
 {
 	char df[64] =  { 0 };
 	const int percentage = get_dev_shm_usage(df);
@@ -608,21 +591,19 @@ static SharedMemory create_shm(const char *name, const size_t size, bool create_
 		.ptr = NULL
 	};
 
-	// O_RDWR: Open the object for read-write access (we need to be able to modify the locks)
-	// When creating a new shared memory object, we add to this
-	//   - O_CREAT: Create the shared memory object if it does not exist.
-	//   - O_EXCL: Return an error if a shared memory object with the given name already exists.
-	const int shm_oflags = create_new ? O_RDWR | O_CREAT | O_EXCL : O_RDWR;
-
-	// Create the shared memory file in read/write mode with 600 permissions
+	// Create the shared memory file in read/write mode with 600 (u+rw) permissions
+	// and the following open flags:
+	// - O_RDWR: Open the object for read-write access (we need to be able to modify the locks)
+	// - O_CREAT: Create the shared memory object if it does not exist.
+	// - O_EXCL: Return an error if a shared memory object with the given name already exists.
 	errno = 0;
-	const int fd = shm_open(sharedMemory.name, shm_oflags, S_IRUSR | S_IWUSR);
+	const int fd = shm_open(sharedMemory.name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 
 	// Check for `shm_open` error
 	if(fd == -1)
 	{
-		logg("FATAL: create_shm(): Failed to %s shared memory object \"%s\": %s",
-		     create_new ? "create" : "open", name, strerror(errno));
+		logg("FATAL: create_shm(): Failed to create shared memory object \"%s\": %s",
+		     name, strerror(errno));
 		return sharedMemory;
 	}
 

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -26,6 +26,7 @@ typedef struct {
 
 typedef struct {
 	int version;
+	pid_t pid;
 	unsigned int global_shm_counter;
 	unsigned int next_str_pos;
 } ShmSettings;

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -57,10 +57,9 @@ extern countersStruct *counters;
 ///
 /// \param name the name of the shared memory
 /// \param size the size to allocate
-/// \param create_new true = delete old file, create new, false = connect to existing object or fail
 /// \return a structure with a pointer to the mounted shared memory. The pointer
 /// will always be valid, because if it failed FTL will have exited.
-static SharedMemory create_shm(const char *name, const size_t size, bool create_new);
+static SharedMemory create_shm(const char *name, const size_t size);
 
 /// Reallocate shared memory
 ///
@@ -99,7 +98,7 @@ void _unlock_log(const char* func, const int line, const char * file);
 
 /// Block until a lock can be obtained
 
-bool init_shmem(bool create_new);
+bool init_shmem(void);
 void destroy_shmem(void);
 size_t addstr(const char *str);
 #define getstr(pos) _getstr(pos, __FUNCTION__, __LINE__, __FILE__)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -28,8 +28,8 @@
 @test "Running a second instance is detected and prevented" {
   run bash -c 'su pihole -s /bin/sh -c "/home/pihole/pihole-FTL -f"'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[9]} == *"Initialization of shared memory failed." ]]
-  [[ ${lines[10]} == *"HINT: pihole-FTL is already running!"* ]]
+  [[ "${lines[@]}" == *"Initialization of shared memory failed."* ]]
+  [[ "${lines[@]}" == *"HINT: pihole-FTL is already running!"* ]]
 }
 
 @test "Starting tests without prior history" {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

**Store and check shared memory ownership before resizing shared memory objects.**

The scenario we are resolving here is the following: FTL is already running and someone(/-thing) deletes all the shared memory objects. If another instance of FTL is then started, it doesn't know a previous process is running and creates new SHM objects for itself. Both processes can - in theory - run just fine without touching each other as they are both actually using *different* shared memory objects. You are right when you think this is bizarre. The reason is that the first one has the shared memory objects still mapped into memory, i.e., "deleting" them from disk only removes the visible file handles. The next FTL instance creates files with the very same name, however, they are also new and distinct files, i.e., their memory will point elsewhere. Both instances can now run in parallel just fine *until* one of them needs to resize a shared memory objects. If one of the shared memory events now gets resized to a size larger than it was before BUT smaller than what the other FTL instance is expecting, the other instance will instantaneously crash with a `SIGSEGV` (a bus error to be precise).

This PR resolves this by storing the PID of the SHM object creator in the settings object.

Each FTL instance reloads this shared memory instance now before performing any potentially dangerous operation and checks if the shared memory files on disk are still owned by this process. If this is not the case, we are in serious trouble and exit immediately. This should allow the second instance (you could call it the "rightful owner" of the current existing SHM objects) a fairly good chance to never even notice this and continue to operate just fine.

Resolves the root causes behind #1463, #1448 and possibly other similar issues in the past by preventing a certain "mis"configuration to have the bad effect it had for these users.