### PR TITLE
Fix compatibility with gcc 12.2.0

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1550,7 +1550,7 @@ static bool listInterfaces(struct if_info **head, char default_iface[IF_NAMESIZE
 	while ((dp = readdir(dfd)) != NULL)
 	{
 		// Skip "." and ".."
-		if(!dp->d_name || strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
+		if(strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
 			continue;
 
 		// Create new interface record

--- a/src/args.c
+++ b/src/args.c
@@ -403,26 +403,26 @@ void parse_args(int argc, char* argv[])
 #define COL_PURPLE	"\x1b[95m" // bright foreground color
 #define COL_CYAN	"\x1b[96m" // bright foreground color
 
-static inline bool __attribute__ ((const)) is_term(void)
+static inline bool __attribute__ ((pure)) is_term(void)
 {
 	// test whether STDOUT refers to a terminal
 	return isatty(fileno(stdout)) == 1;
 }
 
 // Returns green [✓]
-const char __attribute__ ((const)) *cli_tick(void)
+const char __attribute__ ((pure)) *cli_tick(void)
 {
 	return is_term() ? "["COL_GREEN"✓"COL_NC"]" : "[✓]";
 }
 
 // Returns red [✗]
-const char __attribute__ ((const)) *cli_cross(void)
+const char __attribute__ ((pure)) *cli_cross(void)
 {
 	return is_term() ? "["COL_RED"✗"COL_NC"]" : "[✗]";
 }
 
 // Returns [i]
-const char __attribute__ ((const)) *cli_info(void)
+const char __attribute__ ((pure)) *cli_info(void)
 {
 	return is_term() ? COL_BOLD"[i]"COL_NC : "[i]";
 }
@@ -434,19 +434,19 @@ const char __attribute__ ((const)) *cli_qst(void)
 }
 
 // Returns green "done!""
-const char __attribute__ ((const)) *cli_done(void)
+const char __attribute__ ((pure)) *cli_done(void)
 {
 	return is_term() ? COL_GREEN"done!"COL_NC : "done!";
 }
 
 // Sets font to bold
-const char __attribute__ ((const)) *cli_bold(void)
+const char __attribute__ ((pure)) *cli_bold(void)
 {
 	return is_term() ? COL_BOLD : "";
 }
 
 // Resets font to normal
-const char __attribute__ ((const)) *cli_normal(void)
+const char __attribute__ ((pure)) *cli_normal(void)
 {
 	return is_term() ? COL_NC : "";
 }

--- a/src/args.h
+++ b/src/args.h
@@ -16,13 +16,13 @@ extern bool daemonmode, cli_mode, dnsmasq_debug;
 extern int argc_dnsmasq;
 extern const char ** argv_dnsmasq;
 
-const char *cli_tick(void) __attribute__ ((const));
-const char *cli_cross(void) __attribute__ ((const));
-const char *cli_info(void) __attribute__ ((const));
+const char *cli_tick(void) __attribute__ ((pure));
+const char *cli_cross(void) __attribute__ ((pure));
+const char *cli_info(void) __attribute__ ((pure));
 const char *cli_qst(void) __attribute__ ((const));
-const char *cli_done(void) __attribute__ ((const));
-const char *cli_bold(void) __attribute__ ((const));
-const char *cli_normal(void) __attribute__ ((const));
+const char *cli_done(void) __attribute__ ((pure));
+const char *cli_bold(void) __attribute__ ((pure));
+const char *cli_normal(void) __attribute__ ((pure));
 
 // defined in dnsmasq_interface.c
 int check_struct_sizes(void);

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -41,7 +41,7 @@ void strtolower(char *str)
 }
 
 // creates a simple hash of a string that fits into a uint32_t
-uint32_t hashStr(const char *s)
+uint32_t __attribute__ ((pure)) hashStr(const char *s)
 {
         uint32_t hash = 0;
         // Jenkins' One-at-a-Time hash (http://www.burtleburtle.net/bob/hash/doobs.html)

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -108,7 +108,7 @@ typedef struct {
 } DNSCacheData;
 
 void strtolower(char *str);
-uint32_t hashStr(const char *s) __attribute__((const));
+uint32_t hashStr(const char *s) __attribute__((pure));
 int findQueryID(const int id);
 int findUpstreamID(const char * upstream, const in_port_t port);
 int findDomainID(const char *domain, const bool count);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

`gcc 12.1.0` has a [known bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=18487) with incorrect attribute suggestions preventing FTL to compile correctly. This has been reported for Alpine before (#1424). This bug made it also into  `gcc 12.2.0` which is the default compiler on Ubuntu 22.10 preventing FTL to compile successfully on the latest Ubuntu release. Herein, we add a suitable workaround needed to ensure compatibility with this `gcc` version. There are no functional changes whatsoever in this PR. I tested with a few older versions of `gcc` and found no difference in compatibility due to these changes.