### PR TITLE
prevent free() after alloca()

### DIFF
--- a/src/tre-regex/tre-match-backtrack.c
+++ b/src/tre-regex/tre-match-backtrack.c
@@ -118,10 +118,12 @@ typedef struct tre_backtrack_struct {
 #define tre_bt_mem_new		  tre_mem_newa
 #define tre_bt_mem_alloc	  tre_mem_alloca
 #define tre_bt_mem_destroy(obj)	  do { } while (0,0)
+#define tre_bt_mem_free(ptr)	  do { } while (0,0)
 #else /* !TRE_USE_ALLOCA */
 #define tre_bt_mem_new		  tre_mem_new
 #define tre_bt_mem_alloc	  tre_mem_alloc
 #define tre_bt_mem_destroy	  tre_mem_destroy
+#define tre_bt_mem_free(ptr)	  if (ptr) xfree(ptr)
 #endif /* !TRE_USE_ALLOCA */
 
 
@@ -136,12 +138,9 @@ typedef struct tre_backtrack_struct {
 	  if (!s)							      \
 	    {								      \
 	      tre_bt_mem_destroy(mem);					      \
-	      if (tags)							      \
-		xfree(tags);						      \
-	      if (pmatch)						      \
-		xfree(pmatch);						      \
-	      if (states_seen)						      \
-		xfree(states_seen);					      \
+	      tre_bt_mem_free(tags);					      \
+	      tre_bt_mem_free(pmatch);					      \
+	      tre_bt_mem_free(states_seen);				      \
 	      return REG_ESPACE;					      \
 	    }								      \
 	  s->prev = stack;						      \
@@ -151,12 +150,9 @@ typedef struct tre_backtrack_struct {
 	  if (!s->item.tags)						      \
 	    {								      \
 	      tre_bt_mem_destroy(mem);					      \
-	      if (tags)							      \
-		xfree(tags);						      \
-	      if (pmatch)						      \
-		xfree(pmatch);						      \
-	      if (states_seen)						      \
-		xfree(states_seen);					      \
+	      tre_bt_mem_free(tags);					      \
+	      tre_bt_mem_free(pmatch);					      \
+	      tre_bt_mem_free(states_seen);				      \
 	      return REG_ESPACE;					      \
 	    }								      \
 	  stack->next = s;						      \


### PR DESCRIPTION
Signed-off-by: catch-error <mirko.kraft@gmx.ch>

**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 3

---

alloca() allocates memory from the stack. Passing a pointer returned by alloca() to free() results in undefined behavior. This patch ensures that whenever TRE_USE_ALLOCA is active, free() never gets called by the BT_STACK_PUSH macro.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
