### PR TITLE
Update CI to ftl-build:v1.23 containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
     needs: smoke-tests
 
-    container: ghcr.io/pi-hole/ftl-build:v1.22-${{ matrix.arch }}
+    container: ghcr.io/pi-hole/ftl-build:v1.23-${{ matrix.arch }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,9 @@ jobs:
         include:
           - arch: x86_64
             bin_name: pihole-FTL-linux-x86_64
+          - arch: x86_64
+            arch_extra: _full
+            bin_name: pihole-FTL-linux-x86_64_full
           - arch: x86_64-musl
             bin_name: pihole-FTL-musl-linux-x86_64
           - arch: x86_32
@@ -80,7 +83,7 @@ jobs:
             bin_name: pihole-FTL-aarch64-linux-gnu
 
     env:
-      CI_ARCH: ${{ matrix.arch }}
+      CI_ARCH: ${{ matrix.arch }}${{ matrix.arch_extra }}
 
     steps:
       -

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,6 +217,22 @@ else()
     message(STATUS "Building FTL with readline support: NO")
 endif()
 
+# Do we want to compile an all-in FTL version?
+if($ENV{CI_ARCH} STREQUAL "x86_64_full")
+    add_definitions(-DDNSMASQ_ALL_OPTS)
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
+    find_package(DBus REQUIRED)
+    # Use results of find_package() call.
+    include_directories(${DBUS_INCLUDE_DIRS})
+    target_link_libraries(pihole-FTL ${DBUS_LIBRARIES})
+    find_library(LIBMNL mnl)
+    find_library(LIBNFTNL nftnl)
+    find_library(LIBNFTABLES nftables)
+    find_library(LIBNFNETLINK nfnetlink)
+    find_library(LIBNETFILTER_CONNTRACK netfilter_conntrack)
+    target_link_libraries(pihole-FTL ${LIBMNL} ${LIBNFTABLES} ${LIBNFTNL} ${LIBNFNETLINK} ${LIBNETFILTER_CONNTRACK})
+endif()
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "..." FORCE)
 endif()

--- a/src/FindDBus.cmake
+++ b/src/FindDBus.cmake
@@ -1,0 +1,59 @@
+# - Try to find DBus
+# Once done, this will define
+#
+#  DBUS_FOUND - system has DBus
+#  DBUS_INCLUDE_DIRS - the DBus include directories
+#  DBUS_LIBRARIES - link these to use DBus
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FIND_PACKAGE(PkgConfig)
+PKG_CHECK_MODULES(PC_DBUS QUIET dbus-1)
+
+FIND_LIBRARY(DBUS_LIBRARIES
+    NAMES dbus-1
+    HINTS ${PC_DBUS_LIBDIR}
+          ${PC_DBUS_LIBRARY_DIRS}
+)
+
+FIND_PATH(DBUS_INCLUDE_DIR
+    NAMES dbus/dbus.h
+    HINTS ${PC_DBUS_INCLUDEDIR}
+          ${PC_DBUS_INCLUDE_DIRS}
+)
+
+GET_FILENAME_COMPONENT(_DBUS_LIBRARY_DIR ${DBUS_LIBRARIES} PATH)
+FIND_PATH(DBUS_ARCH_INCLUDE_DIR
+    NAMES dbus/dbus-arch-deps.h
+    HINTS ${PC_DBUS_INCLUDEDIR}
+          ${PC_DBUS_INCLUDE_DIRS}
+          ${_DBUS_LIBRARY_DIR}
+          ${DBUS_INCLUDE_DIR}
+    PATH_SUFFIXES include
+)
+
+SET(DBUS_INCLUDE_DIRS ${DBUS_INCLUDE_DIR} ${DBUS_ARCH_INCLUDE_DIR})
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DBUS REQUIRED_VARS DBUS_INCLUDE_DIRS DBUS_LIBRARIES)

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -200,6 +200,17 @@ RESOLVFILE
 /* #define HAVE_DNSSEC */
 /* #define HAVE_NFTSET */
 
+/* Pi-hole definitions */
+#define HAVE_LUASCRIPT
+#define HAVE_IDN
+#define HAVE_DNSSEC
+#ifdef DNSMASQ_ALL_OPTS
+  #define HAVE_DBUS
+  #define HAVE_CONNTRACK
+  #define HAVE_NFTSET
+#endif
+/***********************/
+
 /* Default locations for important system files. */
 
 #ifndef LEASEFILE

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -14,13 +14,6 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* Pi-hole definitions */
-#define HAVE_DNSSEC
-#define HAVE_DNSSEC_STATIC
-#define HAVE_IDN
-#define HAVE_LUASCRIPT
-/***********************/
-
 #define COPYRIGHT "Copyright (c) 2000-2022 Simon Kelley"
 
 /* We do defines that influence behavior of stdio.h, so complain

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -73,10 +73,10 @@ check_static() {
   echo "Static executable check: OK"
 }
 
-if [[ "${CI_ARCH}" == "x86_64" ]]; then
+if [[ "${CI_ARCH}" == "x86_64" || "${CI_ARCH}" == "x86_64_full" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
-  if [[ "${GIT_TAG}" == "all-dependencies-test-build" ]]; then
+  if [[ "${CI_ARCH}" == "x86_64_full" ]]; then
     check_libs "[libm.so.6] [librt.so.1] [libdbus-1.so.3] [libmnl.so.0] [libnftables.so.1] [libnftnl.so.11] [libnfnetlink.so.0] [libnetfilter_conntrack.so.3] [libpthread.so.0] [libc.so.6]"
   else
     check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -76,7 +76,11 @@ check_static() {
 if [[ "${CI_ARCH}" == "x86_64" ]]; then
 
   check_machine "ELF64" "Advanced Micro Devices X86-64"
-  check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"
+  if [[ "${GIT_TAG}" == "all-dependencies-test-build" ]]; then
+    check_libs "[libm.so.6] [librt.so.1] [libdbus-1.so.3] [libmnl.so.0] [libnftables.so.1] [libnftnl.so.11] [libnfnetlink.so.0] [libnetfilter_conntrack.so.3] [libpthread.so.0] [libc.so.6]"
+  else
+    check_libs "[libm.so.6] [librt.so.1] [libpthread.so.0] [libc.so.6]"
+  fi
   check_file "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped"
 
 elif [[ "${CI_ARCH}" == "x86_64-musl" ]]; then

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Only run tests on x86_64, x86_64-musl, and x86_32 targets
-if [[ ${CI} == "true" && "${CI_ARCH}" != "x86_64" &&  "${CI_ARCH}" != "x86_64-musl" && "${CI_ARCH}" != "x86_32" ]]; then
+# Only run tests on x86_* targets (where the CI can natively run the binaries)
+if [[ ${CI} == "true" && "${CI_ARCH}" != "x86_"* ]]; then
   echo "Skipping tests (CI_ARCH: ${CI_ARCH})!"
   exit 0
 fi

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -11,6 +11,17 @@
   [[ ${lines[6]} == "" ]]
 }
 
+@test "dnsmasq options as expected" {
+  run bash -c './pihole-FTL -vv | grep "cryptohash"'
+  printf "%s\n" "${lines[@]}"
+  if [[ "${CI_ARCH}" == "x86_64_full" ]]; then
+    [[ ${lines[0]} == "Compile options: IPv6 GNU-getopt DBus no-UBus no-i18n IDN DHCP DHCPv6 Lua TFTP conntrack ipset nftset auth cryptohash DNSSEC loop-detect inotify dumpfile" ]]
+  else
+    [[ ${lines[0]} == "Compile options: IPv6 GNU-getopt no-DBus no-UBus no-i18n IDN DHCP DHCPv6 Lua TFTP no-conntrack ipset no-nftset auth cryptohash DNSSEC loop-detect inotify dumpfile" ]]
+  fi
+  [[ ${lines[1]} == "" ]]
+}
+
 @test "DNS server port is reported over Telnet API" {
   run bash -c 'echo ">dns-port >quit" | nc -v 127.0.0.1 4711'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

Update CI to use [`ftl-build:v1.23`](https://github.com/pi-hole/docker-base-images/releases/tag/v1.23) containers. This includes two changes:

- Update statically linked `nettle` from version 3.8 to 3.8.1
- Include an "all-options" test build for `dnsmasq` (DBus, `conntrack`, `nftset`)