### PR TITLE
Increase SQLite3's cache size

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 # SQLITE_ENABLE_DBPAGE_VTAB: Enables the SQLITE_DBPAGE virtual table. Warning: writing to the SQLITE_DBPAGE virtual table can very easily cause unrecoverably database corruption.
 # SQLITE_OMIT_DESERIALIZE: This option causes the the sqlite3_serialize() and sqlite3_deserialize() interfaces to be omitted from the build (was the default before 3.36.0)
 # HAVE_READLINE: Enable readline support to allow easy editing, history and auto-completion
-set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_DEFAULT_FOREIGN_KEYS=1 -DSQLITE_DQS=0 -DSQLITE_ENABLE_DBPAGE_VTAB -DSQLITE_OMIT_DESERIALIZE -DHAVE_READLINE")
+# SQLITE_DEFAULT_CACHE_SIZE=-16384: Allow up to 16 MiB of cache to be used by SQLite3 (default is 2000 kiB)
+set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_DEFAULT_FOREIGN_KEYS=1 -DSQLITE_DQS=0 -DSQLITE_ENABLE_DBPAGE_VTAB -DSQLITE_OMIT_DESERIALIZE -DHAVE_READLINE -DSQLITE_DEFAULT_CACHE_SIZE=-16384")
 
 # Code hardening and debugging improvements
 # -fstack-protector-strong: The program will be resistant to having its stack overflowed


### PR DESCRIPTION
# What does this implement/fix?

Increase default SQLite3 cache size from ~2 MiB to 16 MiB

FTL heavily relies on the [B-tree](https://en.wikipedia.org/wiki/B-tree) of the databases to be able to make extremely fast decisions if a domain is to be blocked. The speed-up between a B-tree and a conventional lookup is on the order of `O(N/log(N))` so something like 7,000x for 120,000 gravity-blocked domains or roughly 100,000x for two million domains.

For this to be efficient, FTL needs to have sufficiently fast access to the B-tree. By default, SQLite3 uses an upper limit for the cache of roughly 2 [MiB](https://en.wiktionary.org/wiki/mebibyte). This PR increases this limit to 16 [MiB](https://en.wiktionary.org/wiki/mebibyte). Given how much memory FTL uses overall, this seems an acceptable amount.

One further technical detail here: One domain takes roughly 32 bytes of memory in the index (it's a bit more because of bookkeeping things). So the default cache is only sufficient for about 60,000 domains. Increasing this to 16 MiB will make enough room for at least 480,000 domains.

You may ask "but can FTL be as fast with a cache is too small at the moment?" and this is indeed a very good question. Even when the cache is too small to keep the entire tree in memory, the kernel sees that you're reading from the file `gravity.db` really really often and decides to [cache](https://medium.com/geekculture/linux-memory-buffer-vs-cache-44d8a187f310) the file for you. It's the kernel's way to make intelligent use of "free" memory. So - in a way - the table already completely resides in memory just now.
So what is this PR going to change? Well, when the entire file is kept in the kernel's cache, we still have to interact with the database file and read the file and do all the interactions using I/O whereas, when the cache is sufficiently large, SQLite3 will be able to cache the tree itself and does not need to read the file ever and ever again.

What's the benefit? It's really hard to measure. It can surely be seen as a kind of micro-optimization but it something that basically comes for free and allows us to notably reduce I/O that has to go through the kernel and, hence, reduces syscalls and overall latency.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))


## Checklist:
- [x] The code change is tested and works locally.
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_