### PR TITLE
Exit immediately after running dnsmasq-test

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -137,8 +137,7 @@ void parse_args(int argc, char* argv[])
 			const char *arg[2];
 			arg[0] = "";
 			arg[1] = "--test";
-			main_dnsmasq(2, arg);
-			ok = true;
+			exit(main_dnsmasq(2, arg));
 		}
 
 		// If we find "--" we collect everything behind that for dnsmasq


### PR DESCRIPTION
# What does this implement/fix?

FTL should exit immediately after running the config check when being invoked as `pihole-FTL dnsmasq-test`. This was not the case leading to possible (but harmless) side-effects further down the line (SEGFAULT). Hence, I'm marking this PR as bugfix.
 
---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
4. I have commented my proposed changes within the code.
6. I am willing to help maintain this change if there are issues with it later.
7. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
8. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.