### PR TITLE
Use github cli to sync master back to development

### DIFF
--- a/.github/workflows/sync-back-to-dev.yml
+++ b/.github/workflows/sync-back-to-dev.yml
@@ -13,15 +13,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Opening pull request
-        id: pull
-        uses: tretuna/sync-branches@1.4.0
-        with:
+        run: gh pr create -B development -H master --title 'Sync master back into development' --body 'Created by Github action' --label 'internal'
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FROM_BRANCH: 'master'
-          TO_BRANCH: 'development'
-      - name: Label the pull request to ignore for release note generation
-        uses: actions-ecosystem/action-add-labels@v1.1.3
-        with:
-          labels: internal
-          repo: ${{ github.repository }}
-          number: ${{ steps.pull.outputs.PULL_REQUEST_NUMBER }}


### PR DESCRIPTION
**PR to master branch**
___

**What does this PR aim to accomplish?:**

After we merged PRs to `master` we use a workflow to sync back to `development`. Currently we use https://github.com/TreTuna/sync-branches , but it looks a bit abandoned and triggers warnings (https://github.com/pi-hole/FTL/actions/runs/3488422011)

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

While looking for a replacement, I stumbled across https://stackoverflow.com/a/73340290 which suggest to use Githubs CLI to create pull requests (https://cli.github.com/manual/gh_pr_create). This looks like an elegant solution as it does not depend on outside actions to maintain this workflow. 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
