### PR TITLE
Always store time we start saving to the database

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -63,8 +63,7 @@ int DB_save_queries(sqlite3 *db)
 		return DB_FAILED;
 
 	// Start database timer
-	if(config.debug & DEBUG_DATABASE)
-		timer_start(DATABASE_WRITE_TIMER);
+	timer_start(DATABASE_WRITE_TIMER);
 
 	// Open pihole-FTL.db database file if needed
 	bool db_opened = false;


### PR DESCRIPTION
# What does this implement/fix?

Always store time we start to save to the database (not only in debug mode). This avoids erroneous timing reports in case of errors like seen here:
```
[2022-12-26 11:29:00.102 1204/T1220] Notice: Queries stored in long-term database: 166 (took 1672072140102.7 ms, last SQLite ID 4461823)
```

This bug has no other consequences else than the wrongly logged time.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable): N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
4. I have commented my proposed changes within the code.
6. I am willing to help maintain this change if there are issues with it later.
7. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
8. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.