### PR TITLE
Remove gray color in help output

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -65,7 +65,6 @@ const char** argv_dnsmasq = NULL;
 #define COL_ULINE	"\x1b[4m"  // underline font
 #define COL_GREEN	"\x1b[32m" // normal foreground color
 #define COL_YELLOW	"\x1b[33m" // normal foreground color
-#define COL_GRAY	"\x1b[90m" // bright foreground color
 #define COL_RED		"\x1b[91m" // bright foreground color
 #define COL_BLUE	"\x1b[94m" // bright foreground color
 #define COL_PURPLE	"\x1b[95m" // bright foreground color
@@ -431,7 +430,6 @@ void parse_args(int argc, char* argv[])
 			const char *normal = cli_normal();
 			const char *blue = cli_color(COL_BLUE);
 			const char *cyan = cli_color(COL_CYAN);
-			const char *gray = cli_color(COL_GRAY);
 			const char *green = cli_color(COL_GREEN);
 			const char *yellow = cli_color(COL_YELLOW);
 			const char *purple = cli_color(COL_PURPLE);
@@ -458,8 +456,8 @@ void parse_args(int argc, char* argv[])
 
 			printf("    Example: %spihole-FTL regex-test %ssomebad.domain %sbad%s\n", green, blue, cyan, normal);
 			printf("    to test %ssomebad.domain%s against %sbad%s\n\n", blue, normal, cyan, normal);
-			printf("    An optional %s-q%s prevents any output (exit code testing):\n", gray, normal);
-			printf("    %spihole-FTL %s-q%s regex-test %ssomebad.domain %sbad%s\n\n", green, gray, green, blue, cyan, normal);
+			printf("    An optional %s-q%s prevents any output (exit code testing):\n", purple, normal);
+			printf("    %spihole-FTL %s-q%s regex-test %ssomebad.domain %sbad%s\n\n", green, purple, green, blue, cyan, normal);
 
 			printf("%sEmbedded Lua engine:%s\n", yellow, normal);
 			printf("\t%s--lua%s, %slua%s          FTL's lua interpreter\n", green, normal, green, normal);
@@ -476,10 +474,10 @@ void parse_args(int argc, char* argv[])
 			printf("      the script.\n\n");
 
 			printf("%sEmbedded SQLite3 shell:%s\n", yellow, normal);
-			printf("\t%ssql %s[-h]%s, %ssqlite3 %s[-h]%s        FTL's SQLite3 shell\n", green, gray, normal, green, gray, normal);
-			printf("\t%s-h%s starts a special %shuman-readable mode%s\n\n", gray, normal, bold, normal);
+			printf("\t%ssql %s[-h]%s, %ssqlite3 %s[-h]%s        FTL's SQLite3 shell\n", green, purple, normal, green, purple, normal);
+			printf("\t%s-h%s starts a special %shuman-readable mode%s\n\n", purple, normal, bold, normal);
 
-			printf("    Usage: %spihole-FTL sqlite3 %s[-h] %s[OPTIONS] [FILENAME] [SQL]%s\n\n", green, gray, cyan, normal);
+			printf("    Usage: %spihole-FTL sqlite3 %s[-h] %s[OPTIONS] [FILENAME] [SQL]%s\n\n", green, purple, cyan, normal);
 			printf("    Options:\n\n");
 			printf("    - %s[OPTIONS]%s is an optional set of options. All available\n", cyan, normal);
 			printf("      options can be found in %spihole-FTL sqlite3 --help%s\n", green, normal);


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

PR https://github.com/pi-hole/FTL/pull/1501 added a colorful output for `pihole-FTL -h`. 
For some items it uses a `gray` color - but this is hardly readable when the terminal background is not pitch black. 
 
![Screenshot at 2023-01-08 22-18-44](https://user-images.githubusercontent.com/26622301/211219962-4365c59d-2419-444c-a375-860e4cc026d6.png)

This PR removed the `gray` and switches colors of those items to `purple`

![Screenshot at 2023-01-08 22-25-59](https://user-images.githubusercontent.com/26622301/211219980-30108fa3-2341-4cad-8083-cab7067e012b.png)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
