### PR TITLE
Extend regex extension ;querytype=...

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3347,7 +3347,7 @@ int check_struct_sizes(void)
 	result += check_one_struct("DNSCacheData", sizeof(DNSCacheData), 16, 16);
 	result += check_one_struct("ednsData", sizeof(ednsData), 72, 72);
 	result += check_one_struct("overTimeData", sizeof(overTimeData), 32, 24);
-	result += check_one_struct("regexData", sizeof(regexData), 56, 44);
+	result += check_one_struct("regexData", sizeof(regexData), 64, 48);
 	result += check_one_struct("SharedMemory", sizeof(SharedMemory), 24, 12);
 	result += check_one_struct("ShmSettings", sizeof(ShmSettings), 16, 16);
 	result += check_one_struct("countersStruct", sizeof(countersStruct), 248, 248);

--- a/src/regex.c
+++ b/src/regex.c
@@ -203,7 +203,7 @@ static bool compile_regex(const char *regexin, const enum regex_type regexid, co
 					// Get next token
 					token = strtok_r(NULL, ",", &saveptr2);
 				}
-				if(regex[index].ext.query_type != 0)
+				if(regex[index].ext.query_type != 0 && config.debug & DEBUG_REGEX)
 				{
 					logg("    Hint: This regex matches only specific query types:");
 					for(int i = TYPE_A; i < TYPE_MAX; i++)

--- a/src/regex_r.h
+++ b/src/regex_r.h
@@ -30,13 +30,12 @@ typedef struct {
 	bool available :1;
 	struct {
 		bool inverted :1;
-		bool query_type_inverted :1;
 		bool custom_ip4 :1;
 		bool custom_ip6 :1;
-		enum query_types query_type;
 		enum reply_type reply;
 		struct in_addr addr4;
 		struct in6_addr addr6;
+		uint32_t query_type;
 	} ext;
 	int database_id;
 	char *string;

--- a/test/gravity.db.sql
+++ b/test/gravity.db.sql
@@ -208,9 +208,11 @@ INSERT INTO domainlist VALUES(11,3,'^regex-REPLYv6$;reply=fe80::1234',1,15599288
 INSERT INTO domainlist VALUES(12,3,'^regex-REPLYv46$;reply=1.2.3.4;reply=fe80::1234',1,1559928803,1559928803,'');
 INSERT INTO domainlist VALUES(13,3,'^regex-A$;querytype=A',1,1559928803,1559928803,'');
 INSERT INTO domainlist VALUES(14,3,'^regex-notA$;querytype=!A',1,1559928803,1559928803,'');
+INSERT INTO domainlist VALUES(15,3,'^regex-multiple.ftl$;querytype=ANY,HTTPS,SVCB;reply=refused',1,1559928803,1559928803,'');
+INSERT INTO domainlist VALUES(16,3,'^regex-notMultiple.ftl$;querytype=!ANY,HTTPS,SVCB;reply=refused',1,1559928803,1559928803,'');
 
 /* Other special domains */
-INSERT INTO domainlist VALUES(15,1,'blacklisted-group-disabled.com',1,1559928803,1559928803,'Entry disabled by a group');
+INSERT INTO domainlist VALUES(17,1,'blacklisted-group-disabled.com',1,1559928803,1559928803,'Entry disabled by a group');
 
 INSERT INTO adlist VALUES(1,'https://hosts-file.net/ad_servers.txt',1,1559928803,1559928803,'Migrated from /etc/pihole/adlists.list',1559928803,2000,2,1);
 

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -98,9 +98,19 @@ pdnsutil add-record ftl. mx MX "50 ns1.ftl."
 
 # SVCB + HTTPS
 pdnsutil add-record ftl. svcb SVCB '1 port="80"'
+pdnsutil add-record ftl. regex-multiple SVCB '1 port="80"'
+pdnsutil add-record ftl. regex-notMultiple SVCB '1 port="80"'
 
 # HTTPS
 pdnsutil add-record ftl. https HTTPS '1 . alpn="h3,h2"'
+pdnsutil add-record ftl. regex-multiple HTTPS '1 . alpn="h3,h2"'
+pdnsutil add-record ftl. regex-notMultiple HTTPS '1 . alpn="h3,h2"'
+
+# ANY
+pdnsutil add-record ftl. regex-multiple A 192.168.3.12
+pdnsutil add-record ftl. regex-multiple AAAA fe80::3f41
+pdnsutil add-record ftl. regex-notMultiple A 192.168.3.12
+pdnsutil add-record ftl. regex-notMultiple AAAA fe80::3f41
 
 # Create reverse lookup zone
 pdnsutil create-zone arpa ns1.ftl

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -58,7 +58,7 @@
 @test "Number of compiled regex filters as expected" {
   run bash -c 'grep "Compiled [0-9]* whitelist" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == *"Compiled 2 whitelist and 9 blacklist regex filters"* ]]
+  [[ ${lines[0]} == *"Compiled 2 whitelist and 11 blacklist regex filters"* ]]
 }
 
 @test "Blacklisted domain is blocked" {
@@ -196,7 +196,7 @@
   [[ ${lines[0]} == "2" ]]
   run bash -c "grep -c 'Regex blacklist ([[:digit:]]*, DB ID [[:digit:]]*) .* NOT ENABLED for client 127.0.0.4' /var/log/pihole/FTL.log"
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "9" ]]
+  [[ ${lines[0]} == "11" ]]
 }
 
 @test "Client 5: Client is recognized by MAC address" {
@@ -228,7 +228,7 @@
   [[ ${lines[0]} == "2" ]]
   run bash -c "grep -c 'Regex blacklist ([[:digit:]]*, DB ID [[:digit:]]*) .* NOT ENABLED for client 127.0.0.5' /var/log/pihole/FTL.log"
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "9" ]]
+  [[ ${lines[0]} == "11" ]]
 }
 
 @test "Client 6: Client is recognized by interface name" {
@@ -266,7 +266,7 @@
   [[ ${lines[0]} == "2" ]]
   run bash -c "grep -c 'Regex blacklist ([[:digit:]]*, DB ID [[:digit:]]*) .* NOT ENABLED for client 127.0.0.6' /var/log/pihole/FTL.log"
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "9" ]]
+  [[ ${lines[0]} == "11" ]]
 }
 
 @test "Normal query (A) is not blocked" {
@@ -1080,6 +1080,42 @@
   [[ $status == 0 ]]
   [[ "${lines[@]}" == *"- A"* ]]
   [[ "${lines[@]}" == *"- HTTPS"* ]]
+}
+
+@test "Regex Test 52: Option \";querytype=ANY,HTTPS,SVCB;reply=refused\" working as expected (ONLY matching ANY, HTTPS or SVCB queries)" {
+  run bash -c 'dig A regex-multiple.ftl @127.0.0.1'
+  printf "dig A: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: NOERROR"* ]]
+  run bash -c 'dig AAAA regex-multiple.ftl @127.0.0.1'
+  printf "dig AAAA: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: NOERROR"* ]]
+  run bash -c 'dig SVCB regex-multiple.ftl @127.0.0.1'
+  printf "dig SVCB: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: REFUSED"* ]]
+  run bash -c 'dig HTTPS regex-multiple.ftl @127.0.0.1'
+  printf "dig HTTPS: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: REFUSED"* ]]
+  run bash -c 'dig ANY regex-multiple.ftl @127.0.0.1'
+  printf "dig ANY: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: REFUSED"* ]]
+}
+
+@test "Regex Test 53: Option \";querytype=!ANY,HTTPS,SVCB;reply=refused\" working as expected (NOT matching ANY, HTTPS or SVCB queries)" {
+  run bash -c 'dig A regex-notMultiple.ftl @127.0.0.1'
+  printf "dig A: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: REFUSED"* ]]
+  run bash -c 'dig AAAA regex-notMultiple.ftl @127.0.0.1'
+  printf "dig AAAA: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: REFUSED"* ]]
+  run bash -c 'dig SVCB regex-notMultiple.ftl @127.0.0.1'
+  printf "dig SVCB: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: NOERROR"* ]]
+  run bash -c 'dig HTTPS regex-notMultiple.ftl @127.0.0.1'
+  printf "dig HTTPS: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: NOERROR"* ]]
+  run bash -c 'dig ANY regex-notMultiple.ftl @127.0.0.1'
+  printf "dig ANY: %s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"status: NOERROR"* ]]
 }
 
 # x86_64-musl is built on busybox which has a slightly different

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -998,7 +998,7 @@
   run bash -c './pihole-FTL regex-test "f" g\;querytype=!A\;querytype=A'
   printf "%s\n" "${lines[@]}"
   [[ $status == 2 ]]
-  [[ ${lines[1]} == *"Overwriting previous querytype setting" ]]
+  [[ "${lines[@]}" == *"Overwriting previous querytype setting"* ]]
 }
 
 @test "Regex Test 41: Option \"^;reply=NXDOMAIN\" working as expected" {
@@ -1050,14 +1050,14 @@
   run bash -c './pihole-FTL regex-test "f" f\;querytype=A'
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
-  [[ ${lines[4]} == "    Hint: This regex matches only type A queries" ]]
+  [[ "${lines[@]}" == *"- A"* ]]
 }
 
 @test "Regex Test 48: Option \";querytype=!TXT\" reported on CLI" {
   run bash -c './pihole-FTL regex-test "f" f\;querytype=!TXT'
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
-  [[ ${lines[4]} == "    Hint: This regex does not match type TXT queries" ]]
+  [[ "${lines[@]}" != *"- TXT"* ]]
 }
 
 @test "Regex Test 49: Option \";reply=NXDOMAIN\" reported on CLI" {
@@ -1072,6 +1072,14 @@
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
   [[ ${lines[4]} == "    Hint: This regex is inverted" ]]
+}
+
+@test "Regex Test 51: Option \";querytype=A,HTTPS\" reported on CLI" {
+  run bash -c './pihole-FTL regex-test "f" f\;querytype=A,HTTPS'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  [[ "${lines[@]}" == *"- A"* ]]
+  [[ "${lines[@]}" == *"- HTTPS"* ]]
 }
 
 # x86_64-musl is built on busybox which has a slightly different


### PR DESCRIPTION
# What does this implement/fix?

`;querytype=...A` accepts now also a list (like `;querytype=A,AAAA,MX`). You can use the exclamation mark as before for inversion (`querytype=!A`) matches everything BUT type `A` queries. This has now been extended to be able to invert a list, too (like `;querytype=!A,AAAA` matching everything BUT `A` and `AAAA` queries).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** TODO, extend description of Pi-hole regex extensions at https://docs.pi-hole.net/regex/pi-hole/#only-match-specific-query-types

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
4. I have commented my proposed changes within the code.
6. I am willing to help maintain this change if there are issues with it later.
7. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
8. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.