### PR TITLE
Update embedded dnsmasq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.89)
+set(DNSMASQ_VERSION pi-hole-v2.89-9461807)
 
 add_subdirectory(src)

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -19,7 +19,7 @@
 #define CHILD_LIFETIME 300 /* secs 'till terminated (RFC1035 suggests > 120s) */
 #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
 #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
-#define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */
+#define EDNS_PKTSZ 1232 /* default max EDNS.0 UDP packet from from  /dnsflagday.net/2020 */
 #define SAFE_PKTSZ 1232 /* "go anywhere" UDP packet size, see https://dnsflagday.net/2020/ */
 #define KEYBLOCK_LEN 40 /* choose to minimise fragmentation when storing DNSSEC keys */
 #define DNSSEC_WORK 50 /* Max number of queries to validate one question */

--- a/src/dnsmasq/dbus.c
+++ b/src/dnsmasq/dbus.c
@@ -52,6 +52,12 @@ const char* introspection_xml_template =
 "    <method name=\"SetFilterWin2KOption\">\n"
 "      <arg name=\"filterwin2k\" direction=\"in\" type=\"b\"/>\n"
 "    </method>\n"
+"    <method name=\"SetFilterA\">\n"
+"      <arg name=\"filter-a\" direction=\"in\" type=\"b\"/>\n"
+"    </method>\n"
+"    <method name=\"SetFilterAAAA\">\n"
+"      <arg name=\"filter-aaaa\" direction=\"in\" type=\"b\"/>\n"
+"    </method>\n"
 "    <method name=\"SetLocaliseQueriesOption\">\n"
 "      <arg name=\"localise-queries\" direction=\"in\" type=\"b\"/>\n"
 "    </method>\n"
@@ -816,6 +822,14 @@ DBusHandlerResult message_handler(DBusConnection *connection,
   else if (strcmp(method, "SetFilterWin2KOption") == 0)
     {
       reply = dbus_set_bool(message, OPT_FILTER, "filterwin2k");
+    }
+  else if (strcmp(method, "SetFilterA") == 0)
+    {
+      reply = dbus_set_bool(message, OPT_FILTER_A, "filter-A");
+    }
+  else if (strcmp(method, "SetFilterAAAA") == 0)
+    {
+      reply = dbus_set_bool(message, OPT_FILTER_AAAA, "filter-AAAA");
     }
   else if (strcmp(method, "SetLocaliseQueriesOption") == 0)
     {

--- a/src/dnsmasq/dhcp-common.c
+++ b/src/dnsmasq/dhcp-common.c
@@ -838,7 +838,7 @@ char *option_string(int prot, unsigned int opt, unsigned char *val, int opt_len,
 		for (i = 0, j = 0; i < opt_len && j < buf_len ; i++)
 		  {
 		    char c = val[i];
-		    if (isprint((int)c))
+		    if (isprint((unsigned char)c))
 		      buf[j++] = c;
 		  }
 #ifdef HAVE_DHCP6
@@ -852,7 +852,7 @@ char *option_string(int prot, unsigned int opt, unsigned char *val, int opt_len,
 		    for (k = i + 1; k < opt_len && k < l && j < buf_len ; k++)
 		     {
 		       char c = val[k];
-		       if (isprint((int)c))
+		       if (isprint((unsigned char)c))
 			 buf[j++] = c;
 		     }
 		    i = l;
@@ -873,7 +873,7 @@ char *option_string(int prot, unsigned int opt, unsigned char *val, int opt_len,
 		    for (k = 0; k < len && j < buf_len; k++)
 		      {
 		       char c = *p++;
-		       if (isprint((int)c))
+		       if (isprint((unsigned char)c))
 			 buf[j++] = c;
 		     }
 		    i += len +2;

--- a/src/dnsmasq/dhcp.c
+++ b/src/dnsmasq/dhcp.c
@@ -916,14 +916,14 @@ void dhcp_read_ethers(void)
       
       lineno++;
       
-      while (strlen(buff) > 0 && isspace((int)buff[strlen(buff)-1]))
+      while (strlen(buff) > 0 && isspace((unsigned char)buff[strlen(buff)-1]))
 	buff[strlen(buff)-1] = 0;
       
       if ((*buff == '#') || (*buff == '+') || (*buff == 0))
 	continue;
       
-      for (ip = buff; *ip && !isspace((int)*ip); ip++);
-      for(; *ip && isspace((int)*ip); ip++)
+      for (ip = buff; *ip && !isspace((unsigned char)*ip); ip++);
+      for(; *ip && isspace((unsigned char)*ip); ip++)
 	*ip = 0;
       if (!*ip || parse_hex(buff, hwaddr, ETHER_ADDR_LEN, NULL, NULL) != ETHER_ADDR_LEN)
 	{

--- a/src/dnsmasq/domain-match.c
+++ b/src/dnsmasq/domain-match.c
@@ -253,9 +253,10 @@ int lookup_domain(char *domain, int flags, int *lowout, int *highout)
   if (highout)
     *highout = nhigh;
 
-  if (nlow == nhigh)
+  /* qlen == -1 when we failed to match even an empty query, if there are no default servers. */
+  if (nlow == nhigh || qlen == -1)
     return 0;
-
+  
   return 1;
 }
 

--- a/src/dnsmasq/loop.c
+++ b/src/dnsmasq/loop.c
@@ -92,7 +92,7 @@ int detect_loop(char *query, int type)
     return 0;
 
   for (i = 0; i < 8; i++)
-    if (!isxdigit(query[i]))
+    if (!isxdigit((unsigned char)query[i]))
       return 0;
 
   uid = strtol(query, NULL, 16);

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -361,13 +361,8 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
 		struct in_addr newaddr = addr->in.sin_addr;
 		
 		if (int_name->flags & INP4)
-		  {
-		    if (netmask.s_addr == 0xffffffff)
-		      continue;
-
-		    newaddr.s_addr = (addr->in.sin_addr.s_addr & netmask.s_addr) |
-		      (int_name->proto4.s_addr & ~netmask.s_addr);
-		  }
+		  newaddr.s_addr = (addr->in.sin_addr.s_addr & netmask.s_addr) |
+		    (int_name->proto4.s_addr & ~netmask.s_addr);
 		
 		/* check for duplicates. */
 		for (lp = int_name->addr; lp; lp = lp->next)
@@ -400,10 +395,6 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
 		  {
 		    int i;
 
-		    /* No sense in doing /128. */
-		    if (prefixlen == 128)
-		      continue;
-		    
 		    for (i = 0; i < 16; i++)
 		      {
 			int bits = ((i+1)*8) - prefixlen;

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1163,6 +1163,9 @@ static char *domain_rev4(int from_file, char *server, struct in_addr *addr4, int
 	}
       else
 	{
+	  /* Always reset server as valid here, so we can add the same upstream
+	     server address multiple times for each x.y.z.in-addr.arpa  */
+	  sdetails.valid = 1;
 	  while (parse_server_next(&sdetails))
 	    {
 	      if ((string = parse_server_addr(&sdetails)))
@@ -1248,6 +1251,9 @@ static char *domain_rev6(int from_file, char *server, struct in6_addr *addr6, in
 	}
       else
 	{
+	  /* Always reset server as valid here, so we can add the same upstream
+	     server address multiple times for each x.y.z.ip6.arpa  */
+	  sdetails.valid = 1;
 	  while (parse_server_next(&sdetails))
 	    {
 	      if ((string = parse_server_addr(&sdetails)))

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -2755,7 +2755,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 		ret_err(gen_err);
 	      
 	      for (p = arg; *p; p++)
-		if (!isxdigit((int)*p))
+		if (!isxdigit((unsigned char)*p))
 		  ret_err(gen_err);
 	      
 	      set_option_bool(OPT_UMBRELLA_DEVID);
@@ -4840,7 +4840,7 @@ err:
 	    new->target = target;
 	    new->ttl = ttl;
 
-	    for (arg += arglen+1; *arg && isspace(*arg); arg++);
+	    for (arg += arglen+1; *arg && isspace((unsigned char)*arg); arg++);
 	  }
       
 	break;
@@ -5231,7 +5231,7 @@ err:
 	unhide_metas(keyhex);
 	/* 4034: "Whitespace is allowed within digits" */
 	for (cp = keyhex; *cp; )
-	  if (isspace(*cp))
+	  if (isspace((unsigned char)*cp))
 	    for (cp1 = cp; *cp1; cp1++)
 	      *cp1 = *(cp1+1);
 	  else
@@ -5319,7 +5319,7 @@ static void read_file(char *file, FILE *f, int hard_opt, int from_script)
 	      memmove(p, p+1, strlen(p+1)+1);
 	    }
 
-	  if (isspace(*p))
+	  if (isspace((unsigned char)*p))
 	    {
 	      *p = ' ';
 	      white = 1;

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -520,7 +520,7 @@ static int print_txt(struct dns_header *header, const size_t qlen, char *name,
       /* make counted string zero-term and sanitise */
       for (i = 0; i < len; i++)
 	{
-	  if (!isprint((int)*(p3+1)))
+	  if (!isprint((unsigned char)*(p3+1)))
 	    break;
 	  *p3 = *(p3+1);
 	  p3++;

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -907,9 +907,8 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	    {
 	      flags &= ~(F_IPV4 | F_IPV6 | F_SRV);
 	      
-	      /* Can store NXDOMAIN reply to CNAME or ANY query. */
-	      if (qtype == T_CNAME || qtype == T_ANY)
-		insert = 1;
+	      /* Can store NXDOMAIN reply for any qtype. */
+	      insert = 1;
 	    }
 	  
 	  log_query(F_UPSTREAM | F_FORWARD | F_NEG | flags | (secure ? F_DNSSECOK : 0), name, NULL, NULL, 0);
@@ -2109,7 +2108,22 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 	}
 
       if (!ans)
-	return 0; /* failed to answer a question */
+	{
+	  /* We may know that the domain doesn't exist for any RRtype. */
+	  if ((crecp = cache_find_by_name(NULL, name, now, F_NXDOMAIN)))
+	    {
+	      ans = nxdomain = 1;
+	      auth = 0;
+
+	      if (!(crecp->flags & F_DNSSECOK)) 
+		sec_data = 0;
+	      
+	      if (!dryrun)
+		log_query(F_NXDOMAIN | F_NEG, name, NULL, NULL, 0);
+	    }
+	  else
+	    return 0; /* failed to answer a question */
+	}
     }
   
   if (dryrun)

--- a/src/dnsmasq/rfc2131.c
+++ b/src/dnsmasq/rfc2131.c
@@ -1678,7 +1678,7 @@ static int sanitise(unsigned char *opt, char *buf)
   for (i = option_len(opt); i > 0; i--)
     {
       char c = *p++;
-      if (isprint((int)c))
+      if (isprint((unsigned char)c))
 	*buf++ = c;
     }
   *buf = 0; /* add terminator */

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -353,7 +353,7 @@ static int dhcp6_no_relay(struct state *state, int msg_type, unsigned char *inbu
       put_opt6_short(DHCP6USEMULTI);
       put_opt6_string("Use multicast");
       end_opt6(o1);
-      return 1;
+      goto done;
     }
 
   /* match vendor and user class options */
@@ -1277,12 +1277,14 @@ static int dhcp6_no_relay(struct state *state, int msg_type, unsigned char *inbu
 
     }
 
+  log_tags(tagif, state->xid);
+
+ done:
   /* Fill in the message type. Note that we store the offset,
      not a direct pointer, since the packet memory may have been 
      reallocated. */
   ((unsigned char *)(daemon->outpacket.iov_base))[start_msg] = outmsgtype;
 
-  log_tags(tagif, state->xid);
   log6_opts(0, state->xid, daemon->outpacket.iov_base + start_opts, daemon->outpacket.iov_base + save_counter(-1));
   
   return 1;

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -405,7 +405,7 @@ void tftp_request(struct listener *listen, time_t now)
 	if (*p == '\\')
 	  *p = '/';
 	else if (option_bool(OPT_TFTP_LC))
-	  *p = tolower(*p);
+	  *p = tolower((unsigned char)*p);
 		
       strcpy(daemon->namebuff, "/");
       if (prefix)


### PR DESCRIPTION
Merge bug fixes and improvements

Related changelog:
```
	Fix reversion in --rev-server introduced in 2.88 which
	caused breakage if the prefix length is not exactly divisible
	by 8 (IPv4) or 4 (IPv6).

	Fix possible SEGV when there server(s) for a particular
	domain are configured, but no server which is not qualified
	for a particular domain. Thanks to Daniel Danzberger for
	spotting this bug.

	Set the default maximum DNS UDP packet sice to 1232. This
	has been the recommended value since 2020 because it's the
	largest value that avoid fragmentation, and fragmentation
	is just not reliable on the modern internet, especially
	for IPv6. It's still possible to override this with
	--edns-packet-max for special circumstances.
```