### PR TITLE
Use EDE data when "proxy-dnssec" is used

### DIFF
--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -723,6 +723,10 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       /* Get extended RCODE. */
       rcode |= sizep[2] << 4;
 
+      // Pi-hole modification: Interpret the pseudoheader before
+      // it might get stripped off below (added_pheader == true)
+      FTL_parse_pseudoheaders(pheader, (size_t)plen);
+
       if (option_bool(OPT_CLIENT_SUBNET) && !check_source(header, plen, pheader, query_source))
 	{
 	  my_syslog(LOG_WARNING, _("discarding DNS reply: subnet option mismatch"));
@@ -782,7 +786,6 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       union all_addr a;
       a.log.rcode = rcode;
       a.log.ede = ede;
-      FTL_parse_pseudoheaders(pheader, (size_t)plen);
       log_query(F_UPSTREAM | F_RCODE, "error", &a, NULL, 0);
 
       return resize_packet(header, n, pheader, plen);

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1751,8 +1751,8 @@ void receive_query(struct listener *listen, time_t now)
     have_mark = get_incoming_mark(&source_addr, &dst_addr, /* istcp: */ 0, &mark);
 #endif
   //********************** Pi-hole modification **********************//
-  if ((pheader = find_pseudoheader(header, (size_t)n, NULL, &pheader, NULL, NULL)))
-      FTL_parse_pseudoheaders(pheader, (size_t)n);
+  pheader = find_pseudoheader(header, (size_t)n, NULL, &pheader, NULL, NULL);
+  FTL_parse_pseudoheaders(pheader, (size_t)n);
   //******************************************************************//
 	  
   if (extract_request(header, (size_t)n, daemon->namebuff, &type))
@@ -2299,8 +2299,8 @@ unsigned char *tcp_request(int confd, time_t now,
 
       //********************** Pi-hole modification **********************//
       unsigned char *pheader = NULL;
-      if ((pheader = find_pseudoheader(header, (size_t)size, NULL, &pheader, NULL, NULL)))
-        FTL_parse_pseudoheaders(pheader, (size_t)size);
+      pheader = find_pseudoheader(header, (size_t)size, NULL, &pheader, NULL, NULL);
+      FTL_parse_pseudoheaders(pheader, (size_t)size);
       //******************************************************************//
        
       if ((gotname = extract_request(header, (unsigned int)size, daemon->namebuff, &qtype)))

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -783,7 +783,8 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       a.log.rcode = rcode;
       a.log.ede = ede;
       log_query(F_UPSTREAM | F_RCODE, "error", &a, NULL, 0);
-      
+      FTL_parse_pseudoheaders(pheader, (size_t)plen);
+
       return resize_packet(header, n, pheader, plen);
     }
   
@@ -1750,9 +1751,8 @@ void receive_query(struct listener *listen, time_t now)
     have_mark = get_incoming_mark(&source_addr, &dst_addr, /* istcp: */ 0, &mark);
 #endif
   //********************** Pi-hole modification **********************//
-  ednsData edns = { 0 };
-  if (find_pseudoheader(header, (size_t)n, NULL, &pheader, NULL, NULL))
-    FTL_parse_pseudoheaders(header, n, &source_addr, &edns);
+  if ((pheader = find_pseudoheader(header, (size_t)n, NULL, &pheader, NULL, NULL)))
+      FTL_parse_pseudoheaders(pheader, (size_t)n);
   //******************************************************************//
 	  
   if (extract_request(header, (size_t)n, daemon->namebuff, &type))
@@ -1763,7 +1763,7 @@ void receive_query(struct listener *listen, time_t now)
       log_query_mysockaddr(F_QUERY | F_FORWARD, daemon->namebuff,
 			   &source_addr, auth_dns ? "auth" : "query", type);
       piholeblocked = FTL_new_query(F_QUERY | F_FORWARD , daemon->namebuff,
-				    &source_addr, auth_dns ? "auth" : "query", type, daemon->log_display_id, &edns, UDP);
+				    &source_addr, auth_dns ? "auth" : "query", type, daemon->log_display_id, UDP);
       
 #ifdef HAVE_CONNTRACK
       is_single_query = 1;
@@ -2298,9 +2298,9 @@ unsigned char *tcp_request(int confd, time_t now,
 	no_cache_dnssec = 1;
 
       //********************** Pi-hole modification **********************//
-      ednsData edns = { 0 };
-      if (find_pseudoheader(header, (size_t)size, NULL, &pheader, NULL, NULL))
-        FTL_parse_pseudoheaders(header, size, &peer_addr, &edns);
+      unsigned char *pheader = NULL;
+      if ((pheader = find_pseudoheader(header, (size_t)size, NULL, &pheader, NULL, NULL)))
+        FTL_parse_pseudoheaders(pheader, (size_t)size);
       //******************************************************************//
        
       if ((gotname = extract_request(header, (unsigned int)size, daemon->namebuff, &qtype)))
@@ -2320,7 +2320,7 @@ unsigned char *tcp_request(int confd, time_t now,
 				   &peer_addr, auth_dns ? "auth" : "query", qtype);
 	      
 	      piholeblocked = FTL_new_query(F_QUERY | F_FORWARD, daemon->namebuff,
-					    &peer_addr, auth_dns ? "auth" : "query", qtype, daemon->log_display_id, &edns, TCP);
+					    &peer_addr, auth_dns ? "auth" : "query", qtype, daemon->log_display_id, TCP);
 
 #ifdef HAVE_AUTH
 	      /* find queries for zones we're authoritative for, and answer them directly */

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -782,8 +782,8 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       union all_addr a;
       a.log.rcode = rcode;
       a.log.ede = ede;
-      log_query(F_UPSTREAM | F_RCODE, "error", &a, NULL, 0);
       FTL_parse_pseudoheaders(pheader, (size_t)plen);
+      log_query(F_UPSTREAM | F_RCODE, "error", &a, NULL, 0);
 
       return resize_packet(header, n, pheader, plen);
     }

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -128,8 +128,6 @@ void FTL_hook(unsigned int flags, const char *name, union all_addr *addr, char *
 		if(!config.show_dnssec)
 			return;
 
-		const ednsData edns = { 0 };
-
 		// Type is overloaded with port since 2d65d55, so we have to
 		// derive the real query type from the arg string
 		unsigned short qtype = type;
@@ -158,7 +156,7 @@ void FTL_hook(unsigned int flags, const char *name, union all_addr *addr, char *
 			arg = (char*)"dnssec-unknown";
 		}
 
-		_FTL_new_query(flags, name, NULL, arg, qtype, id, &edns, INTERNAL, file, line);
+		_FTL_new_query(flags, name, NULL, arg, qtype, id, INTERNAL, file, line);
 		// forwarded upstream (type is used to store the upstream port)
 		FTL_forwarded(flags, name, addr, type, id, path, line);
 	}
@@ -464,7 +462,7 @@ static bool is_pihole_domain(const char *domain)
 bool _FTL_new_query(const unsigned int flags, const char *name,
                     union mysockaddr *addr, char *arg,
                     const unsigned short qtype, const int id,
-                    const ednsData *edns, const enum protocol proto,
+                    const enum protocol proto,
                     const char* file, const int line)
 {
 	// Create new query in data structure
@@ -596,6 +594,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	in_port_t clientPort = daemon->port;
 	bool internal_query = false;
 	char clientIP[ADDRSTRLEN+1] = { 0 };
+	ednsData *edns = getEDNS();
 	if(config.edns0_ecs && edns && edns->client_set)
 	{
 		// Use ECS provided client
@@ -3345,7 +3344,7 @@ int check_struct_sizes(void)
 	result += check_one_struct("clientsData", sizeof(clientsData), 672, 648);
 	result += check_one_struct("domainsData", sizeof(domainsData), 24, 20);
 	result += check_one_struct("DNSCacheData", sizeof(DNSCacheData), 16, 16);
-	result += check_one_struct("ednsData", sizeof(ednsData), 72, 72);
+	result += check_one_struct("ednsData", sizeof(ednsData), 76, 76);
 	result += check_one_struct("overTimeData", sizeof(overTimeData), 32, 24);
 	result += check_one_struct("regexData", sizeof(regexData), 64, 48);
 	result += check_one_struct("SharedMemory", sizeof(SharedMemory), 24, 12);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -743,10 +743,6 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	counters->reply[REPLY_UNKNOWN]++;
 	// Store DNSSEC result for this domain
 	query->dnssec = DNSSEC_UNSPECIFIED;
-	// Every domain is insecure in the beginning. It can get secure or bogus
-	// only if validation reveals this. If DNSSEC validation is not used, the
-	// original status (DNSSEC_UNSPECIFIED) is not changed.
-	query_set_dnssec(query, DNSSEC_INSECURE);
 	query->CNAME_domainID = -1;
 	// This query is not yet known ad forwarded or blocked
 	query->flags.blocked = false;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2105,6 +2105,10 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 		// Save reply type and update individual reply counters
 		query_set_reply(flags, 0, addr, query, response);
 
+		// Set DNSSEC status to INSECURE if it is still unknown
+		if(query->dnssec == DNSSEC_UNSPECIFIED)
+			query_set_dnssec(query, DNSSEC_INSECURE);
+
 		// Hereby, this query is now fully determined
 		query->flags.complete = true;
 	}
@@ -2143,6 +2147,12 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 				// to store NODATA for this query
 				reply_flags = F_NEG;
 			}
+		}
+		else
+		{
+			// Set DNSSEC status to INSECURE if it is still unknown
+			if(query->dnssec == DNSSEC_UNSPECIFIED)
+				query_set_dnssec(query, DNSSEC_INSECURE);
 		}
 
 		// Save reply type and update individual reply counters

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2021,7 +2021,8 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 	if(edns != NULL && edns->ede != EDE_UNSET)
 	{
 		query->ede = edns->ede;
-		log_debug(DEBUG_QUERIES, "     EDE: %s (%d)", edestr(edns->ede), edns->ede);
+		if(config.debug & DEBUG_QUERIES)
+			logg("     EDE: %s (%d)", edestr(edns->ede), edns->ede);
 	}
 
 	// Update upstream server (if applicable)
@@ -2501,7 +2502,7 @@ static void FTL_upstream_error(const union all_addr *addr, const unsigned int fl
 		if(edns != NULL && edns->ede != EDE_UNSET)
 		{
 			query->ede = edns->ede;
-			log_debug(DEBUG_QUERIES, "     EDE: %s (%d)", edestr(edns->ede), edns->ede);
+			logg("     EDE: %s (%d)", edestr(edns->ede), edns->ede);
 		}
 	}
 	if(option_bool(OPT_DNSSEC_PROXY) && edns->ede >= EDE_DNSSEC_BOGUS && edns->ede <= EDE_NO_NSEC)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2505,11 +2505,13 @@ static void FTL_upstream_error(const union all_addr *addr, const unsigned int fl
 			logg("     EDE: %s (%d)", edestr(edns->ede), edns->ede);
 		}
 	}
-	if(option_bool(OPT_DNSSEC_PROXY) && edns->ede >= EDE_DNSSEC_BOGUS && edns->ede <= EDE_NO_NSEC)
+	// Check EDNS EDE for DNSSEC status in DNSSEC proxy mode
+	if(option_bool(OPT_DNSSEC_PROXY) &&
+	   edns && edns->ede >= EDE_DNSSEC_BOGUS && edns->ede <= EDE_NO_NSEC)
 	{
-		// DNSSEC proxy mode is enabled and we received a DNSSEC status
-		// from the upstream server. We need to update the DNSSEC status
-		// of the corresponding query.
+		// DNSSEC proxy mode is enabled and we received a valid DNSSEC
+		// status from the upstream server through ENDS EDE. We need to
+		// update the DNSSEC status of the corresponding query.
 		query_set_dnssec(query, DNSSEC_BOGUS);
 	}
 	// Set query reply

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2497,7 +2497,10 @@ static void FTL_upstream_error(const union all_addr *addr, const unsigned int fl
 		}
 
 		if(addr->log.ede != EDE_UNSET) // This function is only called if (flags & F_RCODE)
+		{
+			query->ede = addr->log.ede;
 			logg("     EDE: %s (%d)", edestr(addr->log.ede), addr->log.ede);
+		}
 
 		if(edns != NULL && edns->ede != EDE_UNSET)
 		{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2184,6 +2184,10 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 		//   name = google-public-dns-a.google.com
 		// Hence, isExactMatch is always false
 
+		// Set DNSSEC status to INSECURE if it is still unknown
+		if(query->dnssec == DNSSEC_UNSPECIFIED)
+			query_set_dnssec(query, DNSSEC_INSECURE);
+
 		// Save reply type and update individual reply counters
 		query_set_reply(flags, 0, addr, query, response);
 	}

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -23,8 +23,8 @@ void FTL_hook(unsigned int flags, const char *name, union all_addr *addr, char *
 #define FTL_iface(iface, addr, addrfamily) _FTL_iface(iface, addr, addrfamily, __FILE__, __LINE__)
 void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_family_t addrfamily, const char* file, const int line);
 
-#define FTL_new_query(flags, name, addr, arg, qtype, id, edns, proto) _FTL_new_query(flags, name, addr, arg, qtype, id, edns, proto, __FILE__, __LINE__)
-bool _FTL_new_query(const unsigned int flags, const char *name, union mysockaddr *addr, char *arg, const unsigned short qtype, const int id, const ednsData *edns, enum protocol proto, const char* file, const int line);
+#define FTL_new_query(flags, name, addr, arg, qtype, id, proto) _FTL_new_query(flags, name, addr, arg, qtype, id, proto, __FILE__, __LINE__)
+bool _FTL_new_query(const unsigned int flags, const char *name, union mysockaddr *addr, char *arg, const unsigned short qtype, const int id, enum protocol proto, const char* file, const int line);
 
 #define FTL_header_analysis(header4, rcode, server, id) _FTL_header_analysis(header4, rcode, server, id, __FILE__, __LINE__)
 void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode, const struct server *server, const int id, const char* file, const int line);

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -372,18 +372,35 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 			// Advance working pointer
 			p += optlen;
 		}
-		else if(code == EDNS0_OPTION_EDE && optlen == 2)
+		else if(code == EDNS0_OPTION_EDE && optlen >= 2)
 		{
 			// EDNS(0) EDE
 			// https://datatracker.ietf.org/doc/rfc8914/
-
+			//
+			//                                                1   1   1   1   1   1
+			//        0   1   2   3   4   5   6   7   8   9   0   1   2   3   4   5
+			//      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			//   0: |                            OPTION-CODE                        |
+			//      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			//   2: |                           OPTION-LENGTH                       |
+			//      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			//   4: | INFO-CODE                                                     |
+			edns.ede = ntohs(((int)p[1] << 8) | p[0]);
+			//      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			//   6: / EXTRA-TEXT ...                                                /
+			//      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			//
 			// The INFO-CODE from the EDE EDNS option is used to
 			// serve as an index into the "Extended DNS Error" IANA
 			// registry, the initial values for which are defined in
 			// this document. The value of the INFO-CODE is encoded
 			// as a two-octet unsigned integer in network byte
 			// order.
-			edns.ede = ntohs(((int)p[1] << 8) | p[0]);
+			//
+			// The EXTRA-TEXT from the EDE EDNS option is ignored by
+			// FTL
+
+			// Debug output
 			if(config.debug & DEBUG_EDNS0)
 				logg("EDNS(0) EDE: %s (code %d)", edestr(edns.ede), edns.ede);
 

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -166,7 +166,7 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 
 	// Reset EDNS(0) data
 	memset(&edns, 0, sizeof(ednsData));
-	edns.ede = -1;
+	edns.ede = EDE_UNSET;
 	edns.valid = true;
 
 	size_t offset; // The header is 11 bytes before the beginning of OPTION-DATA
@@ -379,7 +379,10 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 
 			// The INFO-CODE from the EDE EDNS option is used to
 			// serve as an index into the "Extended DNS Error" IANA
-			// registry, the initial values for which are defined in 
+			// registry, the initial values for which are defined in
+			// this document. The value of the INFO-CODE is encoded
+			// as a two-octet unsigned integer in network byte
+			// order.
 			edns.ede = ntohs(((int)p[1] << 8) | p[0]);
 			if(config.debug & DEBUG_EDNS0)
 				logg("EDNS(0) EDE: %s (code %d)", edestr(edns.ede), edns.ede);

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -372,6 +372,21 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 			// Advance working pointer
 			p += optlen;
 		}
+		else if(code == EDNS0_OPTION_EDE && optlen == 2)
+		{
+			// EDNS(0) EDE
+			// https://datatracker.ietf.org/doc/rfc8914/
+
+			// The INFO-CODE from the EDE EDNS option is used to
+			// serve as an index into the "Extended DNS Error" IANA
+			// registry, the initial values for which are defined in 
+			edns.ede = ntohs(((int)p[1] << 8) | p[0]);
+			if(config.debug & DEBUG_EDNS0)
+				logg("EDNS(0) EDE: %s (code %d)", edestr(edns.ede), edns.ede);
+
+			// Advance working pointer
+			p += optlen;
+		}
 		else
 		{
 			if(config.debug & DEBUG_EDNS0)

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -41,14 +41,26 @@
 // dnsmasq option: --add-cpe-id=...
 #define EDNS0_CPE_ID EDNS0_OPTION_NOMCPEID
 
-void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockaddr *peer, ednsData *edns)
-{
-	int is_sign;
-	size_t plen;
-	unsigned char *pheader, *sizep;
+static ednsData edns = { 0 };
 
-	// Extract additional record A.K.A. pseudoheader
-	if (!(pheader = find_pseudoheader(header, n, &plen, &sizep, &is_sign, NULL)))
+ednsData *getEDNS(void)
+{
+	if(edns.valid)
+	{
+		// Return pointer to ednsData structure and reset it for the
+		// next query
+		edns.valid = false;
+		return &edns;
+	}
+
+	// No valid EDNS data available
+	return NULL;
+}
+
+void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
+{
+	// Return early if we have no pseudoheader (a.k.a. additional records)
+	if (!pheader)
 		return;
 
 	// Debug logging
@@ -152,6 +164,11 @@ void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockad
 	if(edns0_version != 0x00)
 		return;
 
+	// Reset EDNS(0) data
+	memset(&edns, 0, sizeof(ednsData));
+	edns.ede = -1;
+	edns.valid = true;
+
 	size_t offset; // The header is 11 bytes before the beginning of OPTION-DATA
 	while ((offset = (p - pheader - 11u)) < rdlen && rdlen < UINT16_MAX)
 	{
@@ -225,8 +242,8 @@ void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockad
 			}
 
 			// Copy data to edns struct
-			strncpy(edns->client, ipaddr, ADDRSTRLEN);
-			edns->client[ADDRSTRLEN-1] = '\0';
+			strncpy(edns.client, ipaddr, ADDRSTRLEN);
+			edns.client[ADDRSTRLEN-1] = '\0';
 
 			// Only set the address as useful when it is not the
 			// loopback address of the distant machine (127.0.0.0/8 or ::1)
@@ -239,7 +256,7 @@ void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockad
 			}
 			else
 			{
-				edns->client_set = true;
+				edns.client_set = true;
 				if(config.debug & DEBUG_EDNS0)
 					logg("EDNS(0) CLIENT SUBNET: %s/%u - OK (IPv%u)",
 					     ipaddr, source_netmask, family == 1 ? 4 : 6);
@@ -292,11 +309,11 @@ void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockad
 		else if(code == EDNS0_MAC_ADDR_BYTE && optlen == 6)
 		{
 			// EDNS(0) MAC address (BYTE format)
-			memcpy(edns->mac_byte, p, sizeof(edns->mac_byte));
-			print_mac(edns->mac_text, (unsigned char*)edns->mac_byte, sizeof(edns->mac_byte));
-			edns->mac_set = true;
+			memcpy(edns.mac_byte, p, sizeof(edns.mac_byte));
+			print_mac(edns.mac_text, (unsigned char*)edns.mac_byte, sizeof(edns.mac_byte));
+			edns.mac_set = true;
 			if(config.debug & DEBUG_EDNS0)
-				logg("EDNS(0) MAC address (BYTE format): %s", edns->mac_text);
+				logg("EDNS(0) MAC address (BYTE format): %s", edns.mac_text);
 
 			// Advance working pointer
 			p += 6;
@@ -304,19 +321,19 @@ void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockad
 		else if(code == EDNS0_MAC_ADDR_TEXT && optlen == 17)
 		{
 			// EDNS(0) MAC address (TEXT format)
-			memcpy(edns->mac_text, p, 17);
-			edns->mac_text[17] = '\0';
-			if(sscanf(edns->mac_text, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-			          &edns->mac_byte[0],
-			          &edns->mac_byte[1],
-			          &edns->mac_byte[2],
-			          &edns->mac_byte[3],
-			          &edns->mac_byte[4],
-			          &edns->mac_byte[5]) == 6)
+			memcpy(edns.mac_text, p, 17);
+			edns.mac_text[17] = '\0';
+			if(sscanf(edns.mac_text, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+			          (unsigned char*)&edns.mac_byte[0],
+			          (unsigned char*)&edns.mac_byte[1],
+			          (unsigned char*)&edns.mac_byte[2],
+			          (unsigned char*)&edns.mac_byte[3],
+			          (unsigned char*)&edns.mac_byte[4],
+			          (unsigned char*)&edns.mac_byte[5]) == 6)
 			{
-				edns->mac_set = true;
+				edns.mac_set = true;
 				if(config.debug & DEBUG_EDNS0)
-					logg("EDNS(0) MAC address (TEXT format): %s", edns->mac_text);
+					logg("EDNS(0) MAC address (TEXT format): %s", edns.mac_text);
 			}
 			else if(config.debug & DEBUG_EDNS0)
 			{
@@ -358,7 +375,7 @@ void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockad
 		else
 		{
 			if(config.debug & DEBUG_EDNS0)
-				logg("EDNS(0):n option %u with length %u", code, optlen);
+				logg("EDNS(0): option %u with length %u", code, optlen);
 			// Not implemented, skip this record
 
 			// Advance working pointer

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -61,7 +61,11 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 {
 	// Return early if we have no pseudoheader (a.k.a. additional records)
 	if (!pheader)
+	{
+		if(config.debug & DEBUG_EDNS0)
+			logg("EDNS(0) pheader is NULL");
 		return;
+	}
 
 	// Debug logging
 	if(config.debug & DEBUG_EDNS0)

--- a/src/edns0.h
+++ b/src/edns0.h
@@ -11,13 +11,16 @@
 #define EDNS0_HEADER
 
 typedef struct {
-	bool client_set;
-	bool mac_set;
+	bool client_set :1;
+	bool mac_set :1;
+	bool valid :1;
 	char client[ADDRSTRLEN];
 	char mac_byte[6];
 	char mac_text[18];
+	int ede;
 } ednsData;
 
-void FTL_parse_pseudoheaders(struct dns_header *header, size_t n, union mysockaddr *peer, ednsData *edns);
+ednsData *getEDNS(void);
+void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen);
 
 #endif // EDNS0_HEADER


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

When the `dnsmasq` option `proxy-dnssec`

> **proxy-dnssec**
> Copy the DNSSEC Authenticated Data bit from upstream servers to downstream clients. This is an alternative to having dnsmasq validate DNSSEC, but it depends on the security of the network between dnsmasq and the upstream servers, and the trustworthiness of the upstream servers. Note that caching the Authenticated Data bit correctly in all cases is not technically possible. If the AD bit is to be relied upon when using this option, then the cache should be disabled using `--cache-size=0`. In most cases, enabling DNSSEC validation within dnsmasq is a better option. See `--dnssec` for details. 

is used, FTL uses the AD bit to determine the `INSECURE`/`SECURE` status of queries. In cases where the upstream resolver includes EDE data for errors (e.g. `unbound 1.16.0+`), FTL also analyses this data to tell apart `SERVFAIL`s caused by a "real" server failure from crafted `SERVFAIL`s due to failed DNSSEC validation.

See linked Discourse Discussion for further details and extensive testing done by @jpgpi250 

---

To get `proxy-dnssec` working, you'll need to add
```
edns: yes
```
to `unbound`s `server` section and
```
proxy-dnssec
add-cpe-id=01234
```
to a custom `dnsmasq` config file. The `add-cpe-id` options is necessary to query EDE data from the upstream destination in case a client does not signal EDNS0 support.

---

All in all, this PR also improves the internal handling of DNSSEC status and, e.g., ensures ignored queries (because they are duplicated) are not stamped `INSECURE` when this is not actually true (they are actually "nothing" as they are ignored). This makes this PR an enhancement even for the vast majority that will never use `proxy-dnssec`.