### PR TITLE
Fix shown upstream for internally generated DNSSEC-queries being wrong in certain configurations

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -837,9 +837,6 @@ static char *parse_FTLconf(FILE *fp, const char *key)
 	// Go to beginning of file
 	fseek(fp, 0L, SEEK_SET);
 
-	if(config.debug & DEBUG_EXTRA)
-		logg("initial: conflinebuffer = %p, keystr = %p, size = %zu", conflinebuffer, keystr, size);
-
 	// Set size to zero if conflinebuffer is not available here
 	// This causes getline() to allocate memory for the buffer itself
 	if(conflinebuffer == NULL && size != 0)
@@ -848,11 +845,6 @@ static char *parse_FTLconf(FILE *fp, const char *key)
 	errno = 0;
 	while(getline(&conflinebuffer, &size, fp) != -1)
 	{
-		if(config.debug & DEBUG_EXTRA)
-		{
-			logg("conflinebuffer = %p, keystr = %p, size = %zu", conflinebuffer, keystr, size);
-			logg("  while reading line \"%s\" looking for \"%s\"", conflinebuffer, keystr);
-		}
 		// Check if memory allocation failed
 		if(conflinebuffer == NULL)
 			break;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -2089,6 +2089,8 @@ static int tcp_key_recurse(time_t now, int status, struct dns_header *header, si
   unsigned char *packet = NULL;
   struct dns_header *new_header = NULL;
   
+  FTL_header_analysis(header->hb4, 0, server, daemon->log_display_id);
+
   while (1)
     {
       size_t m;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -2089,7 +2089,7 @@ static int tcp_key_recurse(time_t now, int status, struct dns_header *header, si
   unsigned char *packet = NULL;
   struct dns_header *new_header = NULL;
   
-  FTL_header_analysis(header->hb4, 0, server, daemon->log_display_id);
+  FTL_header_analysis(header->hb4, RCODE(header), server, daemon->log_display_id);
 
   while (1)
     {

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1170,6 +1170,8 @@ void reply_query(int fd, time_t now)
 
   server = daemon->serverarray[c];
 
+  FTL_header_analysis(header->hb4, RCODE(header), server, daemon->log_display_id);
+
   if (RCODE(header) != REFUSED)
     daemon->serverarray[first]->last_server = c;
   else if (daemon->serverarray[first]->last_server == c)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1877,6 +1877,8 @@ static void update_upstream(queriesData *query, const int id)
 					id, oldaddr, oldport, ip, port);
 			}
 		}
+
+		// Update upstream server ID
 		query->upstreamID = upstreamID;
 	}
 }
@@ -2024,6 +2026,10 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 	// Update upstream server (if applicable)
 	if(!cached)
 		update_upstream(query, id);
+
+	// Reset last_server to avoid possibly changing the upstream server
+	// again in the next query
+	memset(&last_server, 0, sizeof(last_server));
 
 	// Save response time
 	// Skipped internally if already computed
@@ -2529,6 +2535,9 @@ static void FTL_upstream_error(const union all_addr *addr, const unsigned int fl
 	}
 	// Set query reply
 	query_set_reply(0, reply, addr, query, response);
+
+	// Reset last_server
+	memset(&last_server, 0, sizeof(last_server));
 
 	// Unlock shared memory
 	unlock_shm();

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2614,7 +2614,12 @@ void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode,
 	{
 		memcpy(&last_server, &server->addr, sizeof(last_server));
 		if(config.debug & DEBUG_EXTRA)
-			logg("Got forward address: YES");
+		{
+			char ip[ADDRSTRLEN+1] = { 0 };
+			in_port_t port = 0;
+			mysockaddr_extract_ip_port(&last_server, ip, &port);
+			logg("Got forward address: %s#%u (%s:%i)", ip, port, short_path(file), line);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
# What does this implement/fix?

When multiple upstream servers are defined (can also be the case with enabled "conditional forwarding"), it can happen that the upstream destination display for DNSSEC-related queries is incorrect.

This is fixed by this PR in two independent ways:

1. Ensure we are analyzing also the DNSSEC-related replies
2. Ensure we are not invalidating upstream responses after analysis to avoid possible confusion in subsequent queries

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
3. I have commented my proposed changes within the code.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.