### PR TITLE
Do not log unrealistic disk usage (docker + macOS bug)

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -86,9 +86,9 @@ static int check_space(const char *file, int LastUsage)
 	// exceeds the configured threshold and current usage is higher than
 	// usage in the last run (to prevent log spam)
 	perc = get_filepath_usage(file, buffer);
-	if(perc > config.check.disk && perc > LastUsage )
+	if(perc > config.check.disk && perc > LastUsage && perc <= 100.0)
 		log_resource_shortage(-1.0, 0, -1, perc, file, buffer);
-	
+
 	return perc;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Do not log running out of disk space when the disk occupation is > 100%. We are seeing this with docker deployments on macOS hosts. It is a band-aid fix, however, it also seem to be the only thing we can do given that docker didn't fix this in nearly two years now.

This PR seeks to fix https://github.com/pi-hole/docker-pi-hole/issues/951

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.