### PR TITLE
Add capabilities check for feature dhcp-discover

### DIFF
--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -17,6 +17,8 @@
 #include "log.h"
 // read_FTLconf()
 #include "config.h"
+// check_capability()
+#include "capabilities.h"
 
 #include <sys/time.h>
 // SIOCGIFHWADDR
@@ -691,6 +693,14 @@ static void *dhcp_discover_iface(void *args)
 
 int run_dhcp_discover(void)
 {
+	// Check if we are capable of binding to port 67 (DHCP)
+	// DHCP uses normal UDP datagrams, so we cdon't need CAP_NET_RAW
+	if(!check_capability(CAP_NET_BIND_SERVICE))
+	{
+		puts("Error: Insufficient permissions or capabilities (needs CAP_NET_BIND_SERVICE). Try running as root (sudo)");
+		return EXIT_FAILURE;
+	}
+
 	// Disable terminal output during config config file parsing
 	log_ctrl(false, false);
 	// Process pihole-FTL.conf to get gravity.db


### PR DESCRIPTION
# What does this implement/fix?

Add capabilities check for feature `pihole-FTL dhcp-discover` in the same way we already have it for `pihole-FTL arp-scan`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.