### PR TITLE
Fix spelling in v6

### DIFF
--- a/.github/.codespellignore
+++ b/.github/.codespellignore
@@ -2,3 +2,4 @@ ssudo
 tre
 ede
 nd
+doubleclick

--- a/.github/.codespellignore_lines
+++ b/.github/.codespellignore_lines
@@ -1,0 +1,1 @@
+			self.errors.append("Exception when GETing from FTL: " + str(e))

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,5 @@ jobs:
       uses: codespell-project/actions-codespell@master
       with:
         ignore_words_file: .github/.codespellignore
-        skip: ./src/database/sqlite3.c,./src/database/sqlite3.h,./src/database/shell.c,./src/lua,./src/dnsmasq,./src/tre-regex,./.git,./test/libs
+        skip: ./src/database/sqlite3.c,./src/database/sqlite3.h,./src/database/shell.c,./src/lua,./src/dnsmasq,./src/tre-regex,./.git,./test/libs,./src/webserver/civetweb,./src/zip/miniz,./src/api/docs/content/external
+        exclude_file: .github/.codespellignore_lines

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -158,7 +158,7 @@ int api_handler(struct mg_connection *conn, void *ignored)
 				read_and_parse_payload(&api);
 			}
 
-			// Verify requesting client is allowed to see this ressource
+			// Verify requesting client is allowed to see this resource
 			if(api_request[i].require_auth && check_client_auth(&api) == API_AUTH_UNAUTHORIZED)
 			{
 				unauthorized = true;

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -148,7 +148,7 @@ int check_client_auth(struct ftl_conn *api)
 
 	if(!sid_avail)
 	{
-		log_debug(DEBUG_API, "API Authentification: FAIL (no SID provided)");
+		log_debug(DEBUG_API, "API Authentication: FAIL (no SID provided)");
 		return API_AUTH_UNAUTHORIZED;
 	}
 
@@ -170,7 +170,7 @@ int check_client_auth(struct ftl_conn *api)
 	}
 	if(user_id > API_AUTH_UNAUTHORIZED)
 	{
-		// Authentication succesful:
+		// Authentication successful:
 		// - We know this client
 		// - The session is (still) valid
 		// - The IP matches the one we know for this SID
@@ -199,7 +199,7 @@ int check_client_auth(struct ftl_conn *api)
 		}
 	}
 	else
-		log_debug(DEBUG_API, "API Authentification: FAIL (SID invalid/expired)");
+		log_debug(DEBUG_API, "API Authentication: FAIL (SID invalid/expired)");
 
 	api->user_id = user_id;
 

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -8,7 +8,7 @@ components:
           - Authentication
         operationId: "get_auth"
         description: |
-          The API may chose to reply with a valid session if no authentation is needed for this server.
+          The API may chose to reply with a valid session if no authentication is needed for this server.
         responses:
           '200':
             description: OK

--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -150,12 +150,12 @@ components:
           Clients may be described either by their IP addresses (IPv4 and IPv6 are supported),
           IP subnets (CIDR notation, like `192.168.2.0/24`), their MAC addresses (like `12:34:56:78:9A:BC`), by their hostnames (like `localhost`), or by the interface they are connected to (prefaced with a colon, like `:eth0`).</p>
 
-          Note that client recognition by IP addresses (incl. subnet ranges) is prefered over MAC address, host name or interface recognition as the two latter will only be available after some time.
+          Note that client recognition by IP addresses (incl. subnet ranges) is preferred over MAC address, host name or interface recognition as the two latter will only be available after some time.
           Furthermore, MAC address recognition only works for devices at most one networking hop away from your Pi-hole.
 
-          On success, a new ressource is created at `/clients/{client}`.
+          On success, a new resource is created at `/clients/{client}`.
 
-          The `database_error` with message `UNIQUE contraint failed` error indicates that this client already exists.
+          The `database_error` with message `UNIQUE constraint failed` error indicates that this client already exists.
         requestBody:
           description: Callback payload
           content:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -162,9 +162,9 @@ components:
           Both `{type}` and `{kind}` are mandatory for this endpoint.
           The `{domain}` itself is specified in the request body (POST JSON).
 
-          On success, a new ressource is created at `/domains/{type}/{kind}/{domain}`.
+          On success, a new resource is created at `/domains/{type}/{kind}/{domain}`.
 
-          The `database_error` with message `UNIQUE contraint failed` error indicates that the same entry (`domain`, `type`, `kind`) already exists.
+          The `database_error` with message `UNIQUE constraint failed` error indicates that the same entry (`domain`, `type`, `kind`) already exists.
 
           When adding a regular expression, ensure the request body is properly JSON-escaped.
         requestBody:

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -121,9 +121,9 @@ components:
         description: |
           Creates a new group in the `groups` object. The `{group}` itself is specified in the request body (POST JSON).
 
-          On success, a new ressource is created at `/groups/{name}`.
+          On success, a new resource is created at `/groups/{name}`.
 
-          The `database_error` with message `UNIQUE contraint failed` error indicates that a group with the same name already exists.
+          The `database_error` with message `UNIQUE constraint failed` error indicates that a group with the same name already exists.
         requestBody:
           description: Callback payload
           content:

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -123,12 +123,12 @@ components:
           lists may be described either by their IP addresses (IPv4 and IPv6 are supported),
           IP subnets (CIDR notation, like `192.168.2.0/24`), their MAC addresses (like `12:34:56:78:9A:BC`), by their hostnames (like `localhost`), or by the interface they are connected to (prefaced with a colon, like `:eth0`).</p>
 
-          Note that list recognition by IP addresses (incl. subnet ranges) is prefered over MAC address, host name or interface recognition as the two latter will only be available after some time.
+          Note that list recognition by IP addresses (incl. subnet ranges) is preferred over MAC address, host name or interface recognition as the two latter will only be available after some time.
           Furthermore, MAC address recognition only works for devices at most one networking hop away from your Pi-hole.
 
-          On success, a new ressource is created at `/lists/{list}`.
+          On success, a new resource is created at `/lists/{list}`.
 
-          The `database_error` with message `UNIQUE contraint failed` error indicates that this list already exists.
+          The `database_error` with message `UNIQUE constraint failed` error indicates that this list already exists.
         requestBody:
           description: Callback payload
           content:

--- a/src/api/docs/content/specs/search.yaml
+++ b/src/api/docs/content/specs/search.yaml
@@ -98,7 +98,7 @@ components:
                     example: "doubleclick.net"
                   address:
                     type: string
-                    description: Address of the adlist this domian was found on
+                    description: Address of the adlist this domain was found on
                     example: "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
                   comment:
                     type: string

--- a/src/api/docs/content/specs/stats.yaml
+++ b/src/api/docs/content/specs/stats.yaml
@@ -501,7 +501,7 @@ components:
                 example: "localhost"
               port:
                 type: integer
-                description: Upstream destination's destination port (-1 if not applicable, e.g., for the local chace)
+                description: Upstream destination's destination port (-1 if not applicable, e.g., for the local cache)
                 example: 53
               count:
                 type: integer

--- a/src/api/docs/docs.c
+++ b/src/api/docs/docs.c
@@ -12,7 +12,7 @@
 
 int api_docs(struct ftl_conn *api)
 {
-	// Handle ressource request by redirecting to "/"
+	// Handle resource request by redirecting to "/"
 	if(strcmp(api->request->request_uri, "/api/docs") == 0)
 	{
 		mg_send_http_redirect(api->conn, "/api/docs/", 301);

--- a/src/api/network.c
+++ b/src/api/network.c
@@ -14,7 +14,7 @@
 #include "api/api.h"
 // Routing information and flags
 #include <net/route.h>
-// Interate through directories
+// Iterate through directories
 #include <dirent.h>
 // networkrecord
 #include "database/network-table.h"
@@ -43,7 +43,7 @@ static bool getDefaultInterface(char iface[IF_NAMESIZE], in_addr_t *gw)
 			if(sscanf(buf, "%s %lx %lx %x %*i %*i %i", iface_r, &dest_r, &gw_r, &flags, &metric) != 5)
 				continue;
 
-			// Only anaylze routes which are UP and whose
+			// Only analyze routes which are UP and whose
 			// destinations are a gateway
 			if(!(flags & RTF_UP) || !(flags & RTF_GATEWAY))
 				continue;

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -29,7 +29,7 @@
 // sqrt()
 #include <math.h>
 
-/* qsort comparision function (count field), sort ASC
+/* qsort comparison function (count field), sort ASC
 static int __attribute__((pure)) cmpasc(const void *a, const void *b)
 {
 	const int *elem1 = (int*)a;
@@ -461,7 +461,7 @@ int api_stats_upstreams(struct ftl_conn *api)
 		}
 		else
 		{
-			// Regular upstream destionation
+			// Regular upstream destination
 			// Get sorted indices
 			const int upstreamID = temparray[2*i + 0];
 
@@ -583,7 +583,7 @@ int api_stats_recentblocked(struct ftl_conn *api)
 
 			JSON_REF_STR_IN_ARRAY(blocked, domain);
 
-			// Only count when added succesfully
+			// Only count when added successfully
 			found++;
 		}
 

--- a/src/api/stats_database.c
+++ b/src/api/stats_database.c
@@ -192,7 +192,7 @@ int api_stats_database_top_items(struct ftl_conn *api)
 
 		// Get blocked queries not only for .../top_blocked
 		// but also for .../top_domains?blocked=true
-		// Note: this may overwrite the blocked propery from the URL
+		// Note: this may overwrite the blocked property from the URL
 		get_bool_var(api->request->query_string, "blocked", &blocked);
 
 		// Does the user request a non-default number of replies?

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -32,7 +32,7 @@ static int api_teleporter_GET(struct ftl_conn *api)
 		                       NULL);
 
 	// Add header indicating that this is a file to be downloaded and stored as
-	// teleporter.zip (rather than showing the binary data in teh browser
+	// teleporter.zip (rather than showing the binary data in the browser
 	// window). This client is free to ignore and do whatever it wants with this
 	// data stream.
 	snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -70,7 +70,7 @@ void set_all_debug(struct config *conf, const bool status)
 	const bool all_set = elements_set == DEBUG_ELEMENTS-1;
 
 	// If ALL is false and not all debug flags are set, we do not manipulate
-	// the debug flags at all. This is necessary to avoid overwriting inidividual
+	// the debug flags at all. This is necessary to avoid overwriting individual
 	// debug flag settings when the user has set some of them to true and
 	// "ALL" to false.
 	if(status == false && !all_set)
@@ -129,7 +129,7 @@ char **gen_config_path(const char *pathin, const char delim)
 		// Advance to next path element
 		pathlen++;
 
-		// Safetly measure: Exit if this path is too deep
+		// Safety measure: Exit if this path is too deep
 		if(pathlen > MAX_CONFIG_PATH_DEPTH-1)
 			break;
 	}
@@ -691,7 +691,7 @@ void initConfig(struct config *conf)
 	conf->dhcp.end.d.s = (char*)"";
 
 	conf->dhcp.router.k = "dhcp.router";
-	conf->dhcp.router.h = "Address of the gateway to be used (typicaly the address of your router in a home installation)";
+	conf->dhcp.router.h = "Address of the gateway to be used (typically the address of your router in a home installation)";
 	conf->dhcp.router.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.1\"");
 	conf->dhcp.router.t = CONF_STRING;
 	conf->dhcp.router.f = FLAG_RESTART_DNSMASQ;
@@ -794,7 +794,7 @@ void initConfig(struct config *conf)
 
 	// sub-struct database.network
 	conf->database.network.parseARPcache.k = "database.network.parseARPcache";
-	conf->database.network.parseARPcache.h = "Should FTL anaylze the local ARP cache? When disabled, client identification and the network table will stop working reliably.";
+	conf->database.network.parseARPcache.h = "Should FTL analyze the local ARP cache? When disabled, client identification and the network table will stop working reliably.";
 	conf->database.network.parseARPcache.t = CONF_BOOL;
 	conf->database.network.parseARPcache.f = FLAG_ADVANCED_SETTING;
 	conf->database.network.parseARPcache.d.b = true;

--- a/src/config/legacy_reader.c
+++ b/src/config/legacy_reader.c
@@ -284,7 +284,7 @@ const char *readFTLlegacy(struct config *conf)
 	// put on the list of IP addresses which have access to our
 	// web server.
 	// The ACL is a comma separated list of IP subnets, where
-	// each subnet is pre-pended by either a - or a + sign.
+	// each subnet is prepended by either a - or a + sign.
 	// A plus sign means allow, where a minus sign means deny.
 	// If a subnet mask is omitted, such as -1.2.3.4, this means
 	// to deny only that single IP address.

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -261,7 +261,7 @@ void print_toml_allowed_values(cJSON *allowed_values, FILE *fp, const unsigned i
 			}
 			else if(item->valueint < 100)
 			{
-				// Interger value
+				// Integer value
 				char itemname[3];
 				snprintf(itemname, sizeof(itemname), "%d", item->valueint);
 				// Print item name

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1560,7 +1560,7 @@ bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
 	else
 	{	// Create new or replace existing entry, no error if existing
 		// We have to use a subquery here to avoid violating FOREIGN KEY
-		// contraints (REPLACE recreates (= new ID) entries instead of updating them)
+		// constraints (REPLACE recreates (= new ID) entries instead of updating them)
 		if(listtype == GRAVITY_GROUPS)
 			if(row->name == NULL)
 			{

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -89,7 +89,7 @@ bool init_memory_database(void)
 	}
 
 	// Add indices on all columns of the in-memory database
-	// as well as index on auxilliary tables
+	// as well as index on auxiliary tables
 	for(unsigned int i = 0; i < ArraySize(index_creation); i++)
 	{
 		log_debug(DEBUG_DATABASE, "init_memory_database(): Executing %s", index_creation[i]);
@@ -467,7 +467,7 @@ bool import_queries_from_disk(void)
 }
 
 // Export in-memory queries to disk - either due to periodic dumping (final =
-// false) or because of a sutdown (final = true)
+// false) or because of a shutdown (final = true)
 bool export_queries_to_disk(bool final)
 {
 	bool okay = false;
@@ -1251,7 +1251,7 @@ bool queries_to_database(void)
 			continue;
 
 		// Update max_iter in case we have changes queries very close to
-		// the end of the interation interval
+		// the end of the iteration interval
 		if(min_iter - max_iter < 10)
 			max_iter = max_iter > DB_QUERY_MAX_ITER ? max_iter - DB_QUERY_MAX_ITER : 0;
 

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -60,7 +60,7 @@ static int redirect_root_handler(struct mg_connection *conn, void *input)
 			}
 			else
 			{
-				// Host header only contains the host name iteself
+				// Host header only contains the host name itself
 				host_len = strlen(host);
 			}
 		}
@@ -292,7 +292,7 @@ void http_init(void)
 	// Register handler for the rest
 	mg_set_request_handler(ctx, "**", request_handler, NULL);
 
-	// Prepare prerequesites for Lua
+	// Prepare prerequisites for Lua
 	allocate_lua();
 }
 
@@ -321,7 +321,7 @@ void FTL_rewrite_pattern(char *filename, size_t filename_buf_len)
 	log_debug(DEBUG_API, "Not rewriting %s ==> %s, no such file",
 	          filename, filename_lp);
 
-	// Change last occurence of "/" to "-" (if any)
+	// Change last occurrence of "/" to "-" (if any)
 	char *last_slash = strrchr(filename_lp, '/');
 	if(last_slash != NULL)
 	   *last_slash = '-';

--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -231,7 +231,7 @@ bool generate_certificate(const char* certfile, bool rsa)
 	fclose(f);
 	free(certfile2);
 
-	// Free ressources
+	// Free resources
 	mbedtls_x509write_crt_free(&crt);
 	mbedtls_pk_free(&key);
 	mbedtls_ctr_drbg_free(&ctr_drbg);

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -82,7 +82,7 @@ class ResponseVerifyer():
 			elif 'application/zip' in content:
 				expected_mimetype = 'application/zip'
 				jsonData = content[expected_mimetype]
-				# Thie endpoint requires HEADER authentication
+				# The endpoint requires HEADER authentication
 				authentication_method = AuthenticationMethods.HEADER
 				YAMLresponseSchema = None
 				YAMLresponseExamples = None
@@ -126,7 +126,7 @@ class ResponseVerifyer():
 					for prop in YAMLresponseSchema['allOf'][i]['properties']:
 						self.verify_property(YAMLresponseSchema['allOf'][i]['properties'], YAMLresponseExamples, FTLresponse, [prop])
 
-			# If neither of the above is true, thie definition is invalid
+			# If neither of the above is true, the definition is invalid
 			else:
 				self.errors.append("Top-level response should be either an object or a non-empty allOf/anyOf/oneOf")
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -358,7 +358,7 @@
   #     <ip-addr>, e.g., "192.168.0.250"
   end = ""
 
-  # Address of the gateway to be used (typicaly the address of your router in a home
+  # Address of the gateway to be used (typically the address of your router in a home
   # installation)
   #
   # Possible values are:
@@ -455,7 +455,7 @@
   DBinterval = 60
 
   [database.network]
-    # Should FTL anaylze the local ARP cache? When disabled, client identification and the
+    # Should FTL analyze the local ARP cache? When disabled, client identification and the
     # network table will stop working reliably.
     parseARPcache = true
 


### PR DESCRIPTION
Satisfy `codespell` in `FTLv6`.

Fix sepelling and set some external resources to be excluded from checking