### PR TITLE
Change generated elliptic curve from secp521r1 to secp384r1

### DIFF
--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -48,7 +48,7 @@ static int generate_private_key_rsa(mbedtls_pk_context *key,
 	return 0;
 }
 
-// Generate private EC key (secp521r1)
+// Generate private EC key
 static int generate_private_key_ec(mbedtls_pk_context *key,
                                    mbedtls_ctr_drbg_context *ctr_drbg,
                                    unsigned char key_buffer[])
@@ -61,8 +61,8 @@ static int generate_private_key_ec(mbedtls_pk_context *key,
 		return ret;
 	}
 
-	// Generate key
-	if((ret = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP521R1, mbedtls_pk_ec(*key),
+	// Generate key SECP384R1 key (NIST P-384)
+	if((ret = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP384R1, mbedtls_pk_ec(*key),
 	                              mbedtls_ctr_drbg_random, ctr_drbg)) != 0)
 	{
 		printf("ERROR: mbedtls_ecp_gen_key returned %d\n", ret);


### PR DESCRIPTION
# What does this implement/fix?

Change generated elliptic curve from secp521r1 to secp384r1 because the former is [not supported](https://boringssl.googlesource.com/boringssl/+/e9fc3e547e557492316932b62881c3386973ceb2) by current Google Chrome (and, presumably, Chromium-based browsers like Edge).

The reason for the removal is that NSA Suite B does not *mention* P-521 in the document, leading to Chrome removing support (even though Firefox keeps support for it, FIPS 140-2 also focuses on P-256 and P-384).

There is nothing wrong about this curve but with no support in Chrome, it doesn't make sense to still keep it for automatic certificate generation in Pi-hole. The reason why we currently have it in the v6.0 code is that I have never tried Chrome + Pi-hole TLS before and don't have a single Windows machine to try Edge.

There are debates on the web if P-256 wouldn't be enough as it is somewhat more efficient, but - at the end of the day - the difference is small and it still worth mentioning that even the largest standardized EC at this point is faster than any standardized and trusted non-EC cryptography used today.

Final words: If you dislike ECC, Pi-hole offers the generation of a 4096 bit RSA key, instead.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.