### PR TITLE
Add support for TRUNCATED DNSSEC status

### DIFF
--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -675,6 +675,8 @@ const char * __attribute__ ((const)) get_query_dnssec_str(const enum dnssec_stat
 			return "BOGUS";
 		case DNSSEC_ABANDONED:
 			return "ABANDONED";
+		case DNSSEC_TRUNCATED:
+			return "TRUNCATED";
 		case DNSSEC_MAX:
 		default:
 			return "N/A";

--- a/src/enums.h
+++ b/src/enums.h
@@ -26,6 +26,7 @@ enum dnssec_status {
 	DNSSEC_INSECURE,
 	DNSSEC_BOGUS,
 	DNSSEC_ABANDONED,
+	DNSSEC_TRUNCATED,
 	DNSSEC_MAX
 } __attribute__ ((packed));
 


### PR DESCRIPTION
# What does this implement/fix?

Add `TRUNCATED` status to enumeration of valid DNSSEC status codes. Truncated answer can't be validated. If this is an answer to a DNSSEC-generated query, we still need to get the client to retry over TCP, so we return an answer with the `TC` bit set, even if the actual answer fits into buffer. All the other code is already there, just the parsing code needs a minor tweak.

I have never seen a truncated DNSSEC message with my local `unbound`, however, I have recently received comments about this status popping up quite often with certain online resolvers (Quad9 or DNS.Watch IIRC) putting too much optional content into the DNSSEC reply causing fragmentation (= truncation). The only way to remedy is retrying over TCP which then does support fragmentation (as said above).

This fix is merely cosmetic, FTL already behaves correctly but is needlessly complaining about an unknown status in its log file.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.