### PR TITLE
Slash the slash

### DIFF
--- a/src/api/docs/content/specs/queries.yaml
+++ b/src/api/docs/content/specs/queries.yaml
@@ -210,8 +210,8 @@ components:
                     description: Time until the response was received (ms, negative if N/A)
               ttl:
                 type: integer
-                description: Remaining Time-To-Live (0 if N/A)
-              regex:
+                description: Query's Time-To-Live (TTL) value (`-1` if N/A)
+              regex_id:
                 type: integer
                 description: ID of blocking regex (`-1` if N/A)
               upstream:
@@ -231,7 +231,8 @@ components:
               reply:
                 type: "IP"
                 time: 19
-              regex_idx: -1
+              ttl: -1
+              regex_id: -1
               upstream: "localhost#5353"
               dbid: 112421354
             - time: 1581907871.583821
@@ -246,8 +247,8 @@ components:
               reply:
                 type: "IP"
                 time: 12.3
-              response_time: 7
-              regex_idx: -1
+              ttl: 7
+              regex_id: -1
               upstream: "localhost#5353"
               dbid: 112421355
         cursor:

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -105,8 +105,8 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	// Check if the request is for the login page
 	const bool login = (strcmp(req_info->local_uri_raw, login_uri) == 0);
 
-	// Check if the request is for a LUA page (every *.lp has already been
-	// rewritten at this point to *)
+	// Check if the request is for a LUA page (every XYZ.lp has already been
+	// rewritten at this point to XYZ)
 	if(!no_dot)
 	{
 		// Not a LUA page - fall back to CivetWeb's default handler

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -108,9 +108,38 @@ static int redirect_lp_handler(struct mg_connection *conn, void *input)
 	char *new_uri = calloc(strlen(uri) + query_len, sizeof(char));
 	// Copy everything from before the ".lp" to the new URI
 	strncpy(new_uri, uri, pos - uri);
+
+	// Append query string to the new URI if present
 	if(query_len > 0)
 	{
-		// Append query string ".lp" to the new URI if present
+		strcat(new_uri, "?");
+		strcat(new_uri, query_string);
+	}
+
+	// Send a 301 redirect to the new URI
+	log_debug(DEBUG_API, "Redirecting %s?%s ==301==> %s",
+	          uri, query_string, new_uri);
+	mg_send_http_redirect(conn, new_uri, 301);
+	free(new_uri);
+
+	return 1;
+}
+
+static int redirect_slash_handler(struct mg_connection *conn, void *input)
+{
+	// Get requested URI
+	const struct mg_request_info *request = mg_get_request_info(conn);
+	const char *uri = request->local_uri_raw;
+	const char *query_string = request->query_string;
+	const size_t query_len = query_string != NULL ? strlen(query_string) : 0;
+
+	// Remove the trailing slash from the URI
+	char *new_uri = strdup(uri);
+	new_uri[strlen(new_uri) - 1] = '\0';
+
+	// Append query string to the new URI if present
+	if(query_len > 0)
+	{
 		strcat(new_uri, "?");
 		strcat(new_uri, query_string);
 	}
@@ -290,6 +319,9 @@ void http_init(void)
 
 	// Register **.lp -> ** redirect handler
 	mg_set_request_handler(ctx, "**.lp$", redirect_lp_handler, NULL);
+
+	// Register **/ -> ** redirect handler
+	mg_set_request_handler(ctx, "**/$", redirect_slash_handler, NULL);
 
 	// Register handler for the rest
 	mg_set_request_handler(ctx, "**", request_handler, NULL);


### PR DESCRIPTION
# What does this implement/fix?

As a consequence of https://github.com/pi-hole/AdminLTE/pull/2655, redirection from the login page to any other page than the dashboard is broken.

This PR fixes this in the proper way by redirecting from URLs with *trailing slashes* such as `/admin/queries/"` to `/admin/queries` which is where the actual scripts are (they'd have to be in `/admin/queries/index.html` otherwise)

---
**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.