### PR TITLE
Fix API parameter parsing on 32bit architectures

### DIFF
--- a/src/api/docs/content/specs/search.yaml
+++ b/src/api/docs/content/specs/search.yaml
@@ -147,6 +147,25 @@ components:
                     items:
                       type: integer
                     example: [0,1,2]
+            total:
+              type: integer
+              description: Total number of results
+              example: 2
+            parameters:
+              type: object
+              properties:
+                partial:
+                  type: boolean
+                  description: Whether partial matching was requested
+                  example: false
+                N:
+                  type: integer
+                  description: Maximum number of results to be returned (per type)
+                  example: 20
+                searchterm:
+                  type: string
+                  description: Search term
+                  example: "doubleclick.net"
   parameters:
     domain:
       name: domain

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -297,9 +297,9 @@ int api_queries(struct ftl_conn *api)
 		// Does the user request an offset from the cursor?
 		get_uint_var(api->request->query_string, "start", &start);
 
-		unsigned long unum = 0u;
+		unsigned long long unum = 0u;
 		const char *msg = NULL;
-		if(get_ulong_var_msg(api->request->query_string, "cursor", &unum, &msg) ||
+		if(get_ullong_var_msg(api->request->query_string, "cursor", &unum, &msg) ||
 		   msg != NULL)
 		{
 			// Do not start at the most recent, but at an older

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -297,9 +297,9 @@ int api_queries(struct ftl_conn *api)
 		// Does the user request an offset from the cursor?
 		get_uint_var(api->request->query_string, "start", &start);
 
-		unsigned long long unum = 0u;
+		uint64_t unum = 0u;
 		const char *msg = NULL;
-		if(get_ullong_var_msg(api->request->query_string, "cursor", &unum, &msg) ||
+		if(get_uint64_var_msg(api->request->query_string, "cursor", &unum, &msg) ||
 		   msg != NULL)
 		{
 			// Do not start at the most recent, but at an older

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -122,6 +122,9 @@ int api_search(struct ftl_conn *api)
 		get_bool_var(api->request->query_string, "partial", &partial);
 		get_uint_var(api->request->query_string, "N", &N);
 
+		log_debug(DEBUG_API, "Search for %s (partial=%s, N=%u)",
+		          api->item, partial ? "true" : "false", N);
+
 		// Check validity of N
 		if(N > MAX_SEARCH_RESULTS)
 		{

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -122,9 +122,6 @@ int api_search(struct ftl_conn *api)
 		get_bool_var(api->request->query_string, "partial", &partial);
 		get_uint_var(api->request->query_string, "N", &N);
 
-		log_debug(DEBUG_API, "Search for %s (partial=%s, N=%u)",
-		          api->item, partial ? "true" : "false", N);
-
 		// Check validity of N
 		if(N > MAX_SEARCH_RESULTS)
 		{
@@ -181,6 +178,12 @@ int api_search(struct ftl_conn *api)
 	cJSON *search = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(search, "domains", domains);
 	JSON_ADD_ITEM_TO_OBJECT(search, "gravity", gravity);
+	JSON_ADD_NUMBER_TO_OBJECT(search, "total", cJSON_GetArraySize(domains) + cJSON_GetArraySize(gravity));
+	cJSON *parameters = JSON_NEW_OBJECT();
+	JSON_ADD_NUMBER_TO_OBJECT(parameters, "N", N);
+	JSON_ADD_BOOL_TO_OBJECT(parameters, "partial", partial);
+	JSON_REF_STR_IN_OBJECT(parameters, "searchterm", api->item);
+	JSON_ADD_ITEM_TO_OBJECT(search, "parameters", parameters);
 	cJSON *json = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(json, "search", search);
 	JSON_SEND_OBJECT(json);

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -144,7 +144,7 @@ bool get_bool_var(const char *source, const char *var, bool *boolean)
 	return false;
 }
 
-static bool get_long_var_msg(const char *source, const char *var, long *num, const char **msg)
+static bool get_llong_var_msg(const char *source, const char *var, long long *num, const char **msg)
 {
 	if(!source)
 		return false;
@@ -165,10 +165,10 @@ static bool get_long_var_msg(const char *source, const char *var, long *num, con
 	// Try to get the value
 	char *endptr = NULL;
 	errno = 0;
-	const long val = strtol(buffer, &endptr, 10);
+	const long long val = strtoll(buffer, &endptr, 10);
 
 	// Error checking
-	if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) ||
+	if ((errno == ERANGE && (val == LLONG_MAX || val == LLONG_MIN)) ||
 	    (errno != 0 && val == 0))
 	{
 		*msg = strerror(errno);
@@ -186,7 +186,7 @@ static bool get_long_var_msg(const char *source, const char *var, long *num, con
 	return true;
 }
 
-bool get_ulong_var_msg(const char *source, const char *var, unsigned long *num, const char **msg)
+bool get_ullong_var_msg(const char *source, const char *var, unsigned long long *num, const char **msg)
 {
 	if(!source)
 		return false;
@@ -207,7 +207,7 @@ bool get_ulong_var_msg(const char *source, const char *var, unsigned long *num, 
 	// Try to get the value
 	char *endptr = NULL;
 	errno = 0;
-	const unsigned long val = strtoul(buffer, &endptr, 10);
+	const unsigned long long val = strtoull(buffer, &endptr, 10);
 
 	// Error checking
 	if ((errno == ERANGE && val == ULONG_MAX) ||
@@ -233,17 +233,17 @@ bool get_int_var_msg(const char *source, const char *var, int *num, const char *
 	if(!source)
 		return false;
 
-	long val = 0;
-	if(!get_long_var_msg(source, var, &val, msg))
+	long long val = 0;
+	if(!get_llong_var_msg(source, var, &val, msg))
 		return false;
 
-	if(val > (long)INT_MAX)
+	if(val > (long long)INT_MAX)
 	{
 		*msg = "Specified integer too large, maximum allowed number is "  xstr(INT_MAX);
 		return false;
 	}
 
-	if(val < (long)INT_MIN)
+	if(val < (long long)INT_MIN)
 	{
 		*msg = "Specified integer too negative, minimum allowed number is "  xstr(INT_MIN);
 		return false;
@@ -267,11 +267,11 @@ bool get_int_var(const char *source, const char *var, int *num)
 
 bool get_uint_var_msg(const char *source, const char *var, unsigned int *num, const char **msg)
 {
-	long val = 0;
-	if(!get_long_var_msg(source, var, &val, msg))
+	long long val = 0;
+	if(!get_llong_var_msg(source, var, &val, msg))
 		return false;
 
-	if(val > (long)UINT_MAX)
+	if(val > (long long)UINT_MAX)
 	{
 		*msg = "Specified integer too large, maximum allowed number is "  xstr(UINT_MAX);
 		return false;

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -85,7 +85,7 @@ bool http_get_cookie_str(struct ftl_conn *api, const char *cookieName, char *str
 
 // HTTP parameter routines
 bool get_bool_var(const char *source, const char *var, bool *boolean);
-bool get_ulong_var_msg(const char *source, const char *var, unsigned long *num, const char **msg);
+bool get_ullong_var_msg(const char *source, const char *var, unsigned long long *num, const char **msg);
 bool get_uint_var_msg(const char *source, const char *var, unsigned int *num, const char **msg);
 bool get_uint_var(const char *source, const char *var, unsigned int *num);
 bool get_int_var_msg(const char *source, const char *var, int *num, const char **msg);

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -85,7 +85,7 @@ bool http_get_cookie_str(struct ftl_conn *api, const char *cookieName, char *str
 
 // HTTP parameter routines
 bool get_bool_var(const char *source, const char *var, bool *boolean);
-bool get_ullong_var_msg(const char *source, const char *var, unsigned long long *num, const char **msg);
+bool get_uint64_var_msg(const char *source, const char *var, uint64_t *num, const char **msg);
 bool get_uint_var_msg(const char *source, const char *var, unsigned int *num, const char **msg);
 bool get_uint_var(const char *source, const char *var, unsigned int *num);
 bool get_int_var_msg(const char *source, const char *var, int *num, const char **msg);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

This PR seeks to fix the `search` and `taillog` API features on 32bit architectures and improve overall API parameter handling:

- Use explicitly sized integers (`u/int64_t`) to avoid overflowing `unsigned int`s not fitting within `long`s on 32bit.
- Log warnings when parameters of invalid type are passed to the API (e.g., a numeric parameter receiving an out-of-bounds or non-numeric argument).
- Include the specified parameters in the `search` response to ease working with the API