### PR TITLE
Fix upgrade of the password hash

### DIFF
--- a/src/config/password.c
+++ b/src/config/password.c
@@ -121,6 +121,10 @@ static char * __attribute__((malloc)) balloon_password(const char *password,
                                                        const uint8_t salt[SALT_LEN],
                                                        const bool phc_string)
 {
+	// Parameter check
+	if(password == NULL || salt == NULL)
+		return NULL;
+
 	struct timespec start, end;
 	// Record starting time
 	if(config.debug.api.v.b)
@@ -344,7 +348,7 @@ bool verify_password(const char *password, const char* pwhash)
 		// Upgrade double-hashed password to BALLOON hash
 		if(result)
 		{
-			char *new_hash = balloon_password(password, NULL, true);
+			char *new_hash = create_password(password);
 			if(new_hash != NULL)
 			{
 				log_info("Upgrading password from SHA256^2 to BALLOON-SHA256");


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the upgrade procedure of the "old" double SHA256 hash to the new BALLOON-based hash. Before, the code incorrectly relied on insufficient randomness possibly ending in spurious crashes. After this fix, it uses cryptographically secure random data for generating the hash's salt data.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.