### PR TITLE
Fix 404 for GET /api/info/sensors when hwmon isn't available

### DIFF
--- a/src/api/info.c
+++ b/src/api/info.c
@@ -258,7 +258,7 @@ static int read_hwmon_sensors(struct ftl_conn *api,
 	if(f_value == NULL)
 	{
 		log_warn("Cannot open %s: %s", value_path, strerror(errno));
-		return -1;
+		return 0;
 	}
 
 	int raw_temp = 0;
@@ -348,7 +348,8 @@ static int read_hwmon_sensors(struct ftl_conn *api,
 	return 0;
 }
 
-static int get_sensors(struct ftl_conn *api, cJSON *sensors)
+#define HWMON "/sys/class/hwmon"
+static int get_hwmon_sensors(struct ftl_conn *api, cJSON *sensors)
 {
 	int ret;
 	// Source available temperatures, we try to read temperature sensors from
@@ -360,11 +361,11 @@ static int get_sensors(struct ftl_conn *api, cJSON *sensors)
 	// https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-hwmon
 
 	// Iterate over content of /sys/class/hwmon
-	DIR *hwmon_dir = opendir("/sys/class/hwmon");
+	DIR *hwmon_dir = opendir(HWMON);
 	if(hwmon_dir == NULL)
 	{
-		log_warn("Cannot open /sys/class/hwmon: %s", strerror(errno));
-		return -1;
+		// Nothing to read here, leave array empty
+		return 0;
 	}
 
 	// Iterate over all hwmonX directories
@@ -637,7 +638,7 @@ int api_info_sensors(struct ftl_conn *api)
 
 	// Get sensors array
 	cJSON *list = JSON_NEW_ARRAY();
-	int ret = get_sensors(api, list);
+	int ret = get_hwmon_sensors(api, list);
 	if (ret != 0)
 		return ret;
 	JSON_ADD_ITEM_TO_OBJECT(sensors, "list", list);

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -348,7 +348,6 @@ static int read_hwmon_sensors(struct ftl_conn *api,
 	return 0;
 }
 
-#define HWMON "/sys/class/hwmon"
 static int get_hwmon_sensors(struct ftl_conn *api, cJSON *sensors)
 {
 	int ret;
@@ -361,10 +360,12 @@ static int get_hwmon_sensors(struct ftl_conn *api, cJSON *sensors)
 	// https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-hwmon
 
 	// Iterate over content of /sys/class/hwmon
-	DIR *hwmon_dir = opendir(HWMON);
+	const char *dirname = "/sys/class/hwmon";
+	DIR *hwmon_dir = opendir(dirname);
 	if(hwmon_dir == NULL)
 	{
 		// Nothing to read here, leave array empty
+		log_warn("Cannot open %s: %s", dirname, strerror(errno));
 		return 0;
 	}
 


### PR DESCRIPTION
# What does this implement/fix?

GET `/api/info/sensors` should return no error but simply no values when we cannot parse temperature sensors. So far, it returned error `404 Not Found` when FTL could not read `/sys/class/hwmon`. Technically, this does make some sense (`hwmon` could not be found in the end), however, it is not what we expect as we'd rather see a successful return with an empty set of sensors.

This has not been tested so far because the Linux kernel documentation states that `hwmon` is *the* default and go-to sensor management system. However, we've just learned that the Microsoft WSL2 provided kernel does not include this standard feature meaning we have to expect this to be missing. This is what is added in this PR.

Fixes #1614 

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.