### PR TITLE
Always get max query ID from disk

### DIFF
--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -118,6 +118,7 @@ bool export_queries_to_disk(bool final);
 bool delete_old_queries_from_db(const bool use_memdb, const double mintime);
 bool add_additional_info_column(sqlite3 *db);
 void DB_read_queries(void);
+void update_disk_db_idx(void);
 bool queries_to_database(void);
 
 bool optimize_queries_table(sqlite3 *db);

--- a/src/main.c
+++ b/src/main.c
@@ -126,6 +126,10 @@ int main (int argc, char *argv[])
 		DB_read_queries();
 	}
 
+	// Initialize in-memory database starting index
+	update_disk_db_idx();
+
+	// Log some information about the imported queries (if any)
 	log_counter_info();
 
 	// Check for availability of capabilities in debug mode


### PR DESCRIPTION
# What does this implement/fix?

Fix an incorrect shortcut leading to FTL not being able to store queries in the long-term query database on disk if `database.DBimport` is `false`. The solution is to ensure we always get the `MAX(id)` from the on-disk database and never skip it. Otherwise, uniqueness constraint violations happen on the field `id` during query `INSERT`ion.

Reported and confirmed fixes in https://github.com/pi-hole/FTL/issues/1617 by @regae 

Note: The bug affected only users with `database.DBimport = false` (this option defaults to `true`) 

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.