### PR TITLE
Hard limit for searching the adlists is 10,000

### DIFF
--- a/src/api/docs/content/specs/search.yaml
+++ b/src/api/docs/content/specs/search.yaml
@@ -14,7 +14,7 @@ components:
           - $ref: 'search.yaml#/components/parameters/N'
         description: |
           Search for domains in Pi-hole's list. The optional parameters `N` and `partial` limit the maximum number of returned records and whether only exact matches or also partial matches should be returned, respectively.
-          There is a hard upper limit of `N` defined in FTL (currently set to 40,000) to ensure that the response is not too large.
+          There is a hard upper limit of `N` defined in FTL (currently set to 10,000) to ensure that the response is not too large.
         responses:
           '200':
             description: OK


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

`MAX_SEARCH_RESULTS` for searching the adlists is `10,000`

https://github.com/pi-hole/FTL/blob/9c4e132bd6bf18524a7948c208bec67d776ca28c/src/api/search.c#L19

Documentation is changed accordingly.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
