### PR TITLE
Add config option to enable packet dumping to PCAP file

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -421,6 +421,8 @@ components:
                   type: string
                 setupVars:
                   type: string
+                pcap:
+                  type: string
                 log:
                   type: object
                   properties:
@@ -667,6 +669,7 @@ components:
             gravity: "/etc/pihole/gravity.db"
             macvendor: "/etc/pihole/macvendor.db"
             setupVars: "/etc/pihole/setupVars.conf"
+            pcap: ""
             log:
               ftl: "/var/log/pihole/FTL.log"
               dnsmasq: "/var/log/pihole/pihole.log"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -999,6 +999,13 @@ void initConfig(struct config *conf)
 	conf->files.setupVars.f = FLAG_ADVANCED_SETTING;
 	conf->files.setupVars.d.s = (char*)"/etc/pihole/setupVars.conf";
 
+	conf->files.pcap.k = "files.pcap";
+	conf->files.pcap.h = "An optional file containing a pcap capture of the network traffic. This file is used for debugging purposes only. If you don't know what this is, you don't need it.\n Setting this to an empty string disables pcap recording. The file must be writable by the user running FTL (typically pihole). Failure to write to this file will prevent the DNS resolver from starting. The file is appended to if it already exists.";
+	conf->files.pcap.a = cJSON_CreateStringReference("<any writable pcap file>");
+	conf->files.pcap.t = CONF_STRING;
+	conf->files.pcap.f = FLAG_ADVANCED_SETTING;
+	conf->files.pcap.d.s = (char*)"";
+
 	conf->files.log.webserver.k = "files.log.webserver";
 	conf->files.log.webserver.h = "The log file used by the webserver";
 	conf->files.log.webserver.a = cJSON_CreateStringReference("<any writable file>");

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -239,6 +239,7 @@ struct config {
 		struct conf_item gravity;
 		struct conf_item macvendor;
 		struct conf_item setupVars;
+		struct conf_item pcap;
 		struct {
 			struct conf_item ftl;
 			struct conf_item dnsmasq;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -511,6 +511,22 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 	fputs("# Cache all DNS records\n", pihole_conf);
 	fputs("cache-rr=ANY\n\n", pihole_conf);
 
+	// Add option for PCAP file recording
+	if(strlen(conf->files.pcap.v.s) > 0)
+	{
+		if(file_writeable(conf->files.pcap.v.s))
+		{
+			fputs("# PCAP network traffic recording\n", pihole_conf);
+			fprintf(pihole_conf, "dumpmask=0xFFFF\n");
+			fprintf(pihole_conf, "dumpfile=%s\n", conf->files.pcap.v.s);
+			fputs("\n", pihole_conf);
+		}
+		else
+		{
+			log_err("Cannot write to %s, disabling PCAP recording", conf->files.pcap.v.s);
+		}
+	}
+
 	// Add additional config lines to disk (if present)
 	if(conf->misc.dnsmasq_lines.v.json != NULL &&
 	   cJSON_GetArraySize(conf->misc.dnsmasq_lines.v.json) > 0)

--- a/src/files.c
+++ b/src/files.c
@@ -94,6 +94,28 @@ bool file_readable(const char *filename)
 }
 
 /**
+ * Function to check whether a file is writable or not.
+ * This function also returns success when a file does not exist yet but could
+ * be created and written to.
+ */
+bool file_writeable(const char *filename)
+{
+	// Check if file is writable
+	FILE *fp = fopen(filename, "ab");
+	if(fp == NULL)
+	{
+		// File is not writable
+		return false;
+	}
+
+	// Close file
+	fclose(fp);
+
+	// File is writable
+	return true;
+}
+
+/**
  * Function to check whether a directory exists or not.
  * It returns true if given path is a directory and exists
  * otherwise returns false.

--- a/src/files.h
+++ b/src/files.h
@@ -21,6 +21,7 @@
 bool chmod_file(const char *filename, const mode_t mode);
 bool file_exists(const char *filename);
 bool file_readable(const char *filename);
+bool file_writeable(const char *filename);
 bool get_database_stat(struct stat *st);
 unsigned long long get_FTL_db_filesize(void);
 void get_permission_string(char permissions[10], struct stat *st);

--- a/test/hostnames.sh
+++ b/test/hostnames.sh
@@ -13,8 +13,8 @@ getIPs() {
     if [ -n "${addresses}" ]; then
         while IFS= read -r addr ; do
             # Check if Pi-hole can use itself to block a domain
-            dig_result=$(dig +tries=1 +time=2 -"${protocol}" -x "${addr}" @127.0.0.1 +short)
-            if [[ $addr == "127.0.0.1" && $dig_result == "localhost." ]] || [[ $addr == "::1" &&  $dig_result == "ip6-localhost." ]] || [[ $dig_result == "pi.hole." ]]; then
+            dig_result=$(dig +tries=1 +time=2 -x "${addr}" @127.0.0.1 +short)
+            if [[ $addr == "127.0.0.1" && $dig_result == "localhost." ]] || [[ $addr == "::1" && [[ $dig_result == "localhost." || $dig_result == "ip6-localhost." ]] ]] || [[ $dig_result == "pi.hole." ]]; then
                 echo "${addr} is \"${dig_result}\": OK"
             else
                 # Otherwise, show a failure

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -676,6 +676,17 @@
   #     <any Pi-hole setupVars file>
   setupVars = "/etc/pihole/setupVars.conf"
 
+  # An optional file containing a pcap capture of the network traffic. This file is used
+  # for debugging purposes only. If you don't know what this is, you don't need it.
+  # Setting this to an empty string disables pcap recording. The file must be writable
+  # by the user running FTL (typically pihole). Failure to write to this file will
+  # prevent the DNS resolver from starting. The file is appended to if it already
+  # exists.
+  #
+  # Possible values are:
+  #     <any writable pcap file>
+  pcap = ""
+
   [files.log]
     # The location of FTL's log file
     #


### PR DESCRIPTION
# What does this implement/fix?

Add new config option `files.pcap` to expose integrated packet (PCAP) dumping to a file. This PR also fixes a small issue with the hostname test failing in the most recent `ftl-build` containers.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.