### PR TITLE
Clear web session on external password change

### DIFF
--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -345,11 +345,8 @@ static void delete_session(const int user_id)
 	if(user_id < 0 || user_id >= API_MAX_CLIENTS)
 		return;
 
-	auth_data[user_id].used = false;
-	auth_data[user_id].valid_until = 0;
-	memset(auth_data[user_id].sid, 0, sizeof(auth_data[user_id].sid));
-	memset(auth_data[user_id].remote_addr, 0, sizeof(auth_data[user_id].remote_addr));
-	memset(auth_data[user_id].user_agent, 0, sizeof(auth_data[user_id].user_agent));
+	// Zero out this session (also sets valid to false == 0)
+	memset(&auth_data[user_id], 0, sizeof(auth_data[user_id]));
 }
 
 void delete_all_sessions(void)

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -21,8 +21,6 @@
 // toml_table_t
 #include "tomlc99/toml.h"
 
-// delete_all_sessions()
-#include "api/api.h"
 // hash_password()
 #include "config/password.h"
 

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -422,12 +422,6 @@ int set_config_from_CLI(const char *key, const char *value)
 			write_custom_list();
 		}
 
-
-		// Check if this item changed the password, if so, we need to
-		// invalidate all currently active sessions
-		if(conf_item->f & FLAG_INVALIDATE_SESSIONS)
-			delete_all_sessions();
-
 		// Install new configuration
 		replace_config(&newconf);
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -25,6 +25,8 @@
 #include "shmem.h"
 // dnsmasq_failed
 #include "daemon.h"
+// delete_all_sessions()
+#include "api/api.h"
 
 struct config config = { 0 };
 static bool config_initialized = false;
@@ -1473,6 +1475,17 @@ void reread_config(void)
 	{
 		// Install new configuration
 		log_debug(DEBUG_CONFIG, "Loaded configuration is valid, installing it");
+
+		// Check if the web password has changed. If so, we invalidate
+		// all currently active web interface sessions
+		if(conf_copy.webserver.api.password.v.s != NULL &&
+		   config.webserver.api.password.v.s != NULL &&
+		   strcmp(conf_copy.webserver.api.password.v.s, config.webserver.api.password.v.s) != 0)
+			delete_all_sessions();
+
+		// Replace config struct used by FTL by newly loaded
+		// configuration. This swpas the pointers and frees
+		// the old config structure altogether
 		replace_config(&conf_copy);
 	}
 	else

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1476,11 +1476,11 @@ void reread_config(void)
 		// Install new configuration
 		log_debug(DEBUG_CONFIG, "Loaded configuration is valid, installing it");
 
-		// Check if the web password has changed. If so, we invalidate
+		// Check if the web pwhash has changed. If so, we invalidate
 		// all currently active web interface sessions
-		if(conf_copy.webserver.api.password.v.s != NULL &&
-		   config.webserver.api.password.v.s != NULL &&
-		   strcmp(conf_copy.webserver.api.password.v.s, config.webserver.api.password.v.s) != 0)
+		if(conf_copy.webserver.api.pwhash.v.s != NULL &&
+		   config.webserver.api.pwhash.v.s != NULL &&
+		   strcmp(conf_copy.webserver.api.pwhash.v.s, config.webserver.api.pwhash.v.s) != 0)
 			delete_all_sessions();
 
 		// Replace config struct used by FTL by newly loaded

--- a/src/gc.c
+++ b/src/gc.c
@@ -375,7 +375,7 @@ void *GC_thread(void *val)
 		{
 			// Reload config
 			log_info("Reloading config due to pihole.toml change");
-			kill(0, SIGHUP);
+			raise(SIGHUP);
 		}
 
 		thread_sleepms(GC, 1000);

--- a/src/signals.c
+++ b/src/signals.c
@@ -292,7 +292,7 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *unused)
 	{
 		// Terminate FTL indicating failure
 		exit_code = EXIT_FAILURE;
-		kill(0, SIGTERM);
+		raise(SIGTERM);
 	}
 	else if(rtsig == 3)
 	{


### PR DESCRIPTION
# What does this implement/fix?

Ensure that all web sessions are invalidated when the password hash is changed. This is already the case when the password is changed through the API but it hasn't been done when the hash has been changed on-disk (e.g., by calling `pihole -a -p`) and, subsequently, reread by FTL. This is fixed in this PR.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.