### PR TITLE
Add performance tests and prevent online-brute forcing

### DIFF
--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -509,7 +509,8 @@ int api_auth(struct ftl_conn *api)
 	// else: Login attempt
 	// - Client tries to authenticate using a password, or
 	// - There no password on this machine
-	if(empty_password ? true : verify_password(password, config.webserver.api.pwhash.v.s))
+	const enum password_result result = empty_password ? true : verify_password(password, config.webserver.api.pwhash.v.s, true);
+	if(result == PASSWORD_CORRECT)
 	{
 		// Accepted
 
@@ -603,6 +604,15 @@ int api_auth(struct ftl_conn *api)
 		{
 			log_warn("No free API seats available, not authenticating client");
 		}
+	}
+	else if(result == PASSWORD_RATE_LIMITED)
+	{
+		// Rate limited
+		log_debug(DEBUG_API, "API: Login attempt rate-limited");
+		return send_json_error(api, 429,
+					"too_many_requests",
+					"Too many requests",
+					NULL);
 	}
 	else
 	{

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -608,11 +608,10 @@ int api_auth(struct ftl_conn *api)
 	else if(result == PASSWORD_RATE_LIMITED)
 	{
 		// Rate limited
-		log_debug(DEBUG_API, "API: Login attempt rate-limited");
 		return send_json_error(api, 429,
 					"too_many_requests",
 					"Too many requests",
-					NULL);
+					"login rate limiting");
 	}
 	else
 	{

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -287,7 +287,7 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 			char *pwhash = strlen(elem->valuestring) > 0 ? create_password(elem->valuestring) : strdup("");
 
 			// Verify that the password hash is valid
-			const bool verfied = verify_password(elem->valuestring, pwhash);
+			const bool verfied = verify_password(elem->valuestring, pwhash, false) == PASSWORD_CORRECT;
 
 			if(!verfied)
 			{

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -79,6 +79,14 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
+          '429':
+            description: Too Many Requests
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'common.yaml#/components/errors/too_many_requests'
+                    - $ref: 'common.yaml#/components/schemas/took'
       delete:
         summary: Delete session
         tags:

--- a/src/api/docs/content/specs/common.yaml
+++ b/src/api/docs/content/specs/common.yaml
@@ -53,6 +53,26 @@ components:
               nullable: true
               description: "No additional data available"
               example: null
+    too_many_requests:
+      type: object
+      description: "Too many requests (rate limiting)"
+      properties:
+        error:
+          type: object
+          properties:
+            key:
+              type: string
+              description: "Machine-readable error type"
+              example: "too_many_requests"
+            message:
+              type: string
+              description: "Human-readable error message"
+              example: "Too many requests"
+            hint:
+              type: string
+              nullable: true
+              description: "No additional data available"
+              example: null
   headers:
     Location:
       description: Location of created resource

--- a/src/args.c
+++ b/src/args.c
@@ -58,6 +58,8 @@
 #include "tools/dhcp-discover.h"
 // run_arp_scan()
 #include "tools/arp-scan.h"
+// run_performance_test()
+#include "config/password.h"
 
 // defined in dnsmasq.c
 extern void print_dnsmasq_version(const char *yellow, const char *green, const char *bold, const char *normal);
@@ -353,6 +355,14 @@ void parse_args(int argc, char* argv[])
 		// Enable stdout printing
 		cli_mode = true;
 		exit(run_dhcp_discover());
+	}
+
+	// Password hashing performance test
+	if(argc > 1 && (strcmp(argv[1], "--perf") == 0 || strcmp(argv[1], "performance") == 0))
+	{
+		// Enable stdout printing
+		cli_mode = true;
+		exit(run_performance_test());
 	}
 
 	// ARP scanning mode
@@ -817,6 +827,8 @@ void parse_args(int argc, char* argv[])
 			printf("\t                    interfaces and scan 10x more often\n");
 			printf("\t%s--totp%s              Generate valid TOTP token for 2FA\n", green, normal);
 			printf("\t                    authentication (if enabled)\n");
+			printf("\t%s--perf%s              Run performance-tests based on the\n", green, normal);
+			printf("\t                    BALLOON password-hashing algorithm\n");
 			printf("\t%s--%s [OPTIONS]%s        Pass OPTIONS to internal dnsmasq resolver\n", green, cyan, normal);
 			printf("\t%s-h%s, %shelp%s            Display this help and exit\n\n", green, normal, green, normal);
 			exit(EXIT_SUCCESS);

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -162,7 +162,7 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 			char *pwhash = strlen(value) > 0 ? create_password(value) : strdup("");
 
 			// Verify that the password hash is valid
-			const bool verfied = verify_password(value, pwhash);
+			const bool verfied = verify_password(value, pwhash, false) == PASSWORD_CORRECT;
 
 			if(!verfied)
 			{

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -400,7 +400,7 @@ static double sqroot(double square)
 }
 
 static int performance_test_task(const size_t s_cost, const size_t t_cost, const uint8_t password[],
-                                 const size_t pwlen, uint8_t salt[SALT_LEN], const size_t rel,
+                                 const size_t pwlen, uint8_t salt[SALT_LEN],
                                  double *elapsed1, double *elapsed2)
 {
 		struct timespec start, end, end2;
@@ -445,8 +445,8 @@ static int performance_test_task(const size_t s_cost, const size_t t_cost, const
 		format_memory_size(prefix, (unsigned long long)scratch_size, &formatted);
 		const double avg = (*elapsed1 + *elapsed2)/2;
 		const double stdev = sqroot(((*elapsed1 - avg)*(*elapsed1 - avg) + (*elapsed2 - avg)*(*elapsed2 - avg))/2);
-		printf("s = %zu, t = %zu took %.1f +/- %.1f ms (scratch buffer %.1f%sB) -> %.1f\n",
-		       s_cost, t_cost, 1e3*avg, 1e3*stdev, formatted, prefix, 1.0*rel/avg);
+		printf("s = %5zu, t = %5zu took %6.1f +/- %4.1f ms (scratch buffer %6.1f%1sB) -> %.0f\n",
+		       s_cost, t_cost, 1e3*avg, 1e3*stdev, formatted, prefix, 1.0*(s_cost*t_cost)/avg);
 
 		// Break if test took longer than two seconds
 		if(avg > 2)
@@ -482,7 +482,7 @@ int run_performance_test(void)
 	{
 		double elapsed1 = 0.0, elapsed2 = 0.0;
 		const int ret = performance_test_task(t_s_cost, t_t_cost, password, sizeof(password), salt,
-		                                      t_t_cost, &elapsed1, &elapsed2);
+		                                      &elapsed1, &elapsed2);
 
 		if(ret == -1)
 			return EXIT_FAILURE;
@@ -491,8 +491,8 @@ int run_performance_test(void)
 		{
 			// We do not want to include the first test in the
 			// average as the first call is slower
-			cJSON_AddItemToArray(time_test, cJSON_CreateNumber(1.0*t_t_cost/elapsed1));
-			cJSON_AddItemToArray(time_test, cJSON_CreateNumber(1.0*t_t_cost/elapsed2));
+			cJSON_AddItemToArray(time_test, cJSON_CreateNumber(1.0*(t_s_cost*t_t_cost)/elapsed1));
+			cJSON_AddItemToArray(time_test, cJSON_CreateNumber(1.0*(t_s_cost*t_t_cost)/elapsed2));
 		}
 
 		if(ret == 1)
@@ -511,10 +511,10 @@ int run_performance_test(void)
 	{
 		double elapsed1 = 0.0, elapsed2 = 0.0;
 		const int ret = performance_test_task(s_s_cost, s_t_cost, password, sizeof(password), salt,
-		                                      s_s_cost, &elapsed1, &elapsed2);
+		                                      &elapsed1, &elapsed2);
 
-		cJSON_AddItemToArray(space_test, cJSON_CreateNumber(1.0*s_s_cost/elapsed1));
-		cJSON_AddItemToArray(space_test, cJSON_CreateNumber(1.0*s_s_cost/elapsed2));
+		cJSON_AddItemToArray(space_test, cJSON_CreateNumber(1.0*(s_t_cost*s_s_cost)/elapsed1));
+		cJSON_AddItemToArray(space_test, cJSON_CreateNumber(1.0*(s_t_cost*s_s_cost)/elapsed2));
 
 		if(ret == -1)
 			return EXIT_FAILURE;
@@ -564,8 +564,8 @@ int run_performance_test(void)
 	cJSON_Delete(space_test);
 
 	// Print results
-	printf("\nAverage time-performance index:  %8.1f +/- %.1f (s = %zu)\n", t_avg_sum1, t_stdev_sum1, t_s_cost);
-	printf("Average space-performance index: %8.1f +/- %.1f (t = %zu)\n", s_avg_sum1, s_stdev_sum1, s_t_cost);
+	printf("\nAverage time-performance index:  %9.0f +/- %.0f (s = %zu)\n", t_avg_sum1, t_stdev_sum1, t_s_cost);
+	printf("Average space-performance index: %9.0f +/- %.0f (t = %zu)\n", s_avg_sum1, s_stdev_sum1, s_t_cost);
 	printf("\nTotal test time: %.1f seconds\n\n", elapsed);
 
 	return EXIT_SUCCESS;

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -461,19 +461,6 @@ int run_performance_test(void)
 	// Record starting time
 	clock_gettime(CLOCK_MONOTONIC, &start);
 
-	// The space parameter s_cost determines how many blocks of working
-	// space the algorithm will require during its computation.  It is
-	// common to set s_cost to a high value in order to increase the cost of
-	// hardware accelerators built by the adversary.
-	// The algorithm will need (s_cost + 1) * digest_size
-	size_t s_t_cost, s_s_cost;
-
-	// The time parameter t_cost determines the number of rounds of
-	// computation that the algorithm will perform. This can be used to
-	// further increase the cost of computation without raising the memory
-	// requirement.
-	size_t t_t_cost, t_s_cost;
-
 	// Test password
 	const uint8_t password[] = "abcdefghijklmnopqrstuvwxyz0123456789!\"§$%&/()=?";
 
@@ -487,8 +474,8 @@ int run_performance_test(void)
 	}
 
 	printf("Running time-performance test:\n");
-	t_t_cost = 1;
-	t_s_cost = 1024;
+	size_t t_t_cost = 1;
+	const size_t t_s_cost = 1024;
 	size_t t_t_costs = 0, t_s_costs = 0;
 	double t_avg_sum = 0.0;
 	while(true)
@@ -505,8 +492,8 @@ int run_performance_test(void)
 	}
 
 	printf("\nRunning space-performance test:\n");
-	s_t_cost = 256;
-	s_s_cost = 1;
+	const size_t s_t_cost = 256;
+	size_t s_s_cost = 1;
 	size_t s_t_costs = 0, s_s_costs = 0;
 	double s_avg_sum = 0.0;
 	while(true)

--- a/src/config/password.h
+++ b/src/config/password.h
@@ -17,5 +17,6 @@
 void sha256_raw_to_hex(uint8_t *data, char *buffer);
 char *create_password(const char *password) __attribute__((malloc));
 bool verify_password(const char *password, const char *pwhash);
+int run_performance_test(void);
 
 #endif //PASSWORD_H

--- a/src/config/password.h
+++ b/src/config/password.h
@@ -16,7 +16,16 @@
 
 void sha256_raw_to_hex(uint8_t *data, char *buffer);
 char *create_password(const char *password) __attribute__((malloc));
-bool verify_password(const char *password, const char *pwhash);
+char verify_password(const char *password, const char *pwhash, const bool rate_limiting);
 int run_performance_test(void);
+
+enum password_result {
+	PASSWORD_INCORRECT = 0,
+	PASSWORD_CORRECT = 1,
+	PASSWORD_RATE_LIMITED = -1
+} __attribute__((packed));
+
+// The maximum number of password attempts per second
+#define MAX_PASSWORD_ATTEMPTS_PER_SECOND 3
 
 #endif //PASSWORD_H

--- a/test/api/libs/FTLAPI.py
+++ b/test/api/libs/FTLAPI.py
@@ -43,9 +43,10 @@ class FTLAPI():
 		self.verbose = False
 
 		# Login to FTL API
-		self.login(password)
-		if self.session is None or 'valid' not in self.session or not self.session['valid']:
-			raise Exception("Could not login to FTL API")
+		if password is not None:
+			self.login(password)
+			if self.session is None or 'valid' not in self.session or not self.session['valid']:
+				raise Exception("Could not login to FTL API")
 
 	def login(self, password: str = None):
 		# Check if we even need to login
@@ -65,6 +66,8 @@ class FTLAPI():
 			return
 
 		response = self.POST("/api/auth", {"password": password})
+		if "error" in response:
+			raise Exception("FTL returned error: " + json.dumps(response["error"]))
 		if 'session' not in response:
 			raise Exception("FTL returned invalid response item")
 		self.session = response["session"]

--- a/test/api/test-rate-limit.py
+++ b/test/api/test-rate-limit.py
@@ -1,0 +1,24 @@
+# Script that sends a number of randomly generated passwords to the
+# /api/auth endpoint checking that rate limiting is enforced
+import random
+import string
+from libs.FTLAPI import FTLAPI
+
+if __name__ == "__main__":
+	# Create FTLAPI object
+	ftl = FTLAPI("http://127.0.0.1:8080")
+
+	# Try to login with random passwords
+	for i in range(0, 100):
+		pw = "".join(random.choices(string.printable, k=random.randint(1, 64)))
+		try:
+			ftl.login(pw)
+		except Exception as e:
+			if "too_many_requests" in str(e):
+				print("Rate-limited on attempt no. "  + str(i))
+				exit(0)
+			else:
+				print("Unexpected error: " + str(e))
+				exit(1)
+	print("Rate-limiting was not enforced")
+	exit(1)

--- a/test/run.sh
+++ b/test/run.sh
@@ -130,6 +130,11 @@ kill "$(pidof pihole-FTL)"
 # Restore umask
 umask "$OLDUMASK"
 
+# Run performance tests
+if ! su pihole -s /bin/sh -c "/home/pihole/pihole-FTL --perf"; then
+  echo "pihole-FTL --perf failed to start"
+fi
+
 # Remove copied file
 rm /home/pihole/pihole-FTL
 


### PR DESCRIPTION
# What does this implement/fix?

Add `pihole-FTL --perf` suitable to measure both memory- as well as compute-performance in the context of password hashing.

Context (source [Wikipedia EN](https://en.wikipedia.org/wiki/Balloon_hashing)):
> Balloon hashing is a [key derivation function](https://en.wikipedia.org/wiki/Key_derivation_function) presenting proven memory-hard password-hashing and modern design. It was created by [Dan Boneh](https://en.wikipedia.org/wiki/Dan_Boneh), Henry Corrigan-Gibbs (both at [Stanford University](https://en.wikipedia.org/wiki/Stanford_University)) and Stuart Schechter ([Microsoft Research](https://en.wikipedia.org/wiki/Microsoft_Research)) in 2016. It is a recommended function in [NIST password guidelines](https://en.wikipedia.org/wiki/Password_policy#NIST_guidelines).
>
> The authors claim that Balloon:
>
> - has proven [memory-hardness](https://en.wikipedia.org/wiki/Memory-hard_function) properties,
> - is built from standard primitives: it can use any standards non-space-hard [cryptographic hash function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) as a sub-algorithm (e.g., [SHA-3](https://en.wikipedia.org/wiki/SHA-3), [SHA-512](https://en.wikipedia.org/wiki/SHA-512)),
 > - is resistant to [side-channel attacks](https://en.wikipedia.org/wiki/Side-channel_attack): the memory access pattern is independent of the data to be hashed,
 > - is easy to implement and matches the performance of similar algorithms.

Pi-hole FTL uses **BALLOON** starting in version v6.0 in combination with
- salting of **128 bits cryptographically-secure randomness** to prevent any rainbow tables, and
- the well-known **secure hashing algorithm 2** with 256 bits (SHA256) to ensure the one-way character of the resulting hash.

Even the best designed algorithm has the issue than an attacker - having once gotten his hands on the stored hash - can offline* brute-force the password until he finds a match. This new feature may be used to find the sweat-spot among the variety of devices on which users are running Pi-hole.

The current default values (s = 1024, t = 32) takes roughly 42 milliseconds on my x86_64 microserver.

*) Online brute-forcing is prevented in FTL due to (a) a certain amount of time spent in the BALLOON routine and (b) a limited number of concurrent API threads. To be on the safe side, FTL furthermore rate-limits login attempts (read as: password validation attempts) to at most 3 per second (compile-time constant).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.