### PR TITLE
Improve web theme handling

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -28,6 +28,8 @@ set(sources
         stats_database.c
         stats.c
         teleporter.c
+        theme.c
+        theme.h
         )
 
 add_library(api OBJECT ${sources})

--- a/src/api/theme.c
+++ b/src/api/theme.c
@@ -1,0 +1,89 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2023 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Theme-related routines
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+// NULL
+#include <stddef.h>
+// strcasecmp()
+#include <string.h>
+
+#include "theme.h"
+
+struct web_themes webthemes[THEME_MAX] = {
+	{
+		/* id */ THEME_DEFAULT_AUTO,
+		/* name */ "default-auto",
+		/* description */ "Pi-hole auto",
+		/* dark */ true,
+		/* color */ "#367fa9"
+	},
+	{
+		/* id */ THEME_DEFAULT_LIGHT,
+		/* name */ "default-light",
+		/* description */ "Pi-hole day",
+		/* dark */ false,
+		/* color */ "#367fa9"
+	},
+	{
+		/* id */ THEME_DEFAULT_DARK,
+		/* name */ "default-dark",
+		/* description */ "Pi-hole midnight",
+		/* dark */ true,
+		/* color */ "#272c30"
+	},
+	{
+		/* id */ THEME_DEFAULT_DARKER,
+		/* name */ "default-darker",
+		/* description */ "Pi-hole deep-midnight",
+		/* dark */ true,
+		/* color */ "#2e6786"
+	},
+	{
+		/* id */ THEME_HIGH_CONTRAST,
+		/* name */ "high-contrast",
+		/* description */ "High-contrast light",
+		/* dark */ false,
+		/* color */ "#0078a0"
+	},
+	{
+		/* id */ THEME_HIGH_CONTRAST_DARK,
+		/* name */ "high-contrast-dark",
+		/* description */ "High-contrast dark",
+		/* dark */ true,
+		/* color */ "#0077c7"
+	},
+	{
+		/* id */ THEME_LCARS,
+		/* name */ "lcars",
+		/* description */ "Star Trek LCARS",
+		/* dark */ true,
+		/* color */ "#4488FF"
+	},
+};
+
+const char * __attribute__ ((pure)) get_web_theme_str(const enum web_theme web_theme)
+{
+	for(enum web_theme i = 0; i < THEME_MAX; i++)
+		if(webthemes[i].id == web_theme)
+			return webthemes[i].name;
+	return NULL;
+}
+
+int __attribute__ ((pure)) get_web_theme_val(const char *web_theme)
+{
+	// Iterate over all possible theme values
+	for(enum web_theme i = 0; i < THEME_MAX; i++)
+	{
+		if(strcasecmp(web_theme, webthemes[i].name) == 0)
+			return i;
+	}
+
+	// Invalid value
+	return -1;
+}

--- a/src/api/theme.h
+++ b/src/api/theme.h
@@ -1,0 +1,41 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  API route prototypes
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+#ifndef THEME_H
+#define THEME_H
+
+#include <stdbool.h>
+
+enum web_theme {
+	THEME_DEFAULT_AUTO = 0,
+	THEME_DEFAULT_LIGHT,
+	THEME_DEFAULT_DARK,
+	THEME_DEFAULT_DARKER,
+	THEME_HIGH_CONTRAST,
+	THEME_HIGH_CONTRAST_DARK,
+	THEME_LCARS,
+	THEME_MAX // This needs to be the last element in this enum
+} __attribute__ ((packed));
+
+struct web_themes{
+	const enum web_theme id;
+	const char *name;
+	const char *description;
+	const bool dark;
+	const char *color;
+};
+
+// defined in theme.c
+extern struct web_themes webthemes[THEME_MAX];
+
+// Prototypes
+const char * __attribute__ ((pure)) get_web_theme_str(const enum web_theme web_theme);
+int __attribute__ ((pure)) get_web_theme_val(const char *web_theme);
+
+#endif // THEME_H

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -873,17 +873,12 @@ void initConfig(struct config *conf)
 	conf->webserver.interface.theme.k = "webserver.interface.theme";
 	conf->webserver.interface.theme.h = "Theme used by the Pi-hole web interface";
 	{
-		struct enum_options themes[] =
+		struct enum_options themes[THEME_MAX];
+		for(unsigned int i = 0; i < THEME_MAX; i++)
 		{
-			// Remember to adjust enum web_theme when adding more themes!
-			{ "default-auto", "Pi-hole auto theme (light/dark, default)" },
-			{ "default-light", "Pi-hole day theme (light)" },
-			{ "default-dark", "Pi-hole midnight theme (dark)" },
-			{ "default-darker", "Pi-hole deep-midnight theme (dark)" },
-			{ "high-contrast", "High Contrast theme (light)" },
-			{ "high-contrast-dark", "High Contrast theme (dark)" },
-			{ "lcars", "Star Trek LCARS theme (dark)" }
-		};
+			themes[i].item = webthemes[i].name;
+			themes[i].description = webthemes[i].description;
+		}
 		CONFIG_ADD_ENUM_OPTIONS(conf->webserver.interface.theme.a, themes);
 	}
 	conf->webserver.interface.theme.t = CONF_ENUM_WEB_THEME;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -25,6 +25,8 @@
 #include <stdio.h>
 // type cJSON
 #include "webserver/cJSON/cJSON.h"
+// enum web_theme
+#include "api/theme.h"
 
 #define GLOBALTOMLPATH "/etc/pihole/pihole.toml"
 

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -1070,41 +1070,6 @@ int __attribute__ ((pure)) get_listeningMode_val(const char *listeningMode)
 	return -1;
 }
 
-const char * __attribute__ ((const)) get_web_theme_str(const enum web_theme web_theme)
-{
-	switch(web_theme)
-	{
-		case THEME_DEFAULT_AUTO:
-			return "default-auto";
-		case THEME_DEFAULT_LIGHT:
-			return "default-light";
-		case THEME_DEFAULT_DARK:
-			return "default-dark";
-		case THEME_DEFAULT_DARKER:
-			return "default-darker";
-		case THEME_HIGH_CONTRAST:
-			return "high-contrast";
-		case THEME_HIGH_CONTRAST_DARK:
-			return "high-contrast-dark";
-		case THEME_LCARS:
-			return "lcars";
-		case THEME_MAX:
-			return NULL;
-	}
-	return NULL;
-}
-
-int __attribute__ ((pure)) get_web_theme_val(const char *web_theme)
-{
-	// Iterate over all possible theme values
-	for(enum web_theme i = 0; i < THEME_MAX; i++)
-		if(strcasecmp(web_theme, get_web_theme_str(i)) == 0)
-			return i;
-
-	// Invalid value
-	return -1;
-}
-
 const char * __attribute__ ((const)) get_temp_unit_str(const enum temp_unit temp_unit)
 {
 	switch(temp_unit)

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -160,8 +160,6 @@ const char *get_busy_reply_str(const enum busy_reply replyWhenBusy) __attribute_
 int get_busy_reply_val(const char *replyWhenBusy) __attribute__ ((pure));
 const char * get_listeningMode_str(const enum listening_mode listeningMode) __attribute__ ((const));
 int get_listeningMode_val(const char *listeningMode) __attribute__ ((pure));
-const char * __attribute__ ((const)) get_web_theme_str(const enum web_theme web_theme);
-int __attribute__ ((pure)) get_web_theme_val(const char *web_theme);
 const char * __attribute__ ((const)) get_temp_unit_str(const enum temp_unit temp_unit);
 int __attribute__ ((pure)) get_temp_unit_val(const char *temp_unit);
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -297,17 +297,6 @@ enum fifo_logs {
 	FIFO_MAX
 } __attribute__ ((packed));
 
-enum web_theme {
-	THEME_DEFAULT_AUTO = 0,
-	THEME_DEFAULT_LIGHT,
-	THEME_DEFAULT_DARK,
-	THEME_DEFAULT_DARKER,
-	THEME_HIGH_CONTRAST,
-	THEME_HIGH_CONTRAST_DARK,
-	THEME_LCARS,
-	THEME_MAX
-} __attribute__ ((packed));
-
 enum temp_unit {
 	TEMP_UNIT_C = 0,
 	TEMP_UNIT_F,

--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -171,10 +171,28 @@ static int pihole_fileversion(lua_State *L) {
 
 // pihole.webtheme()
 static int pihole_webtheme(lua_State *L) {
-	// Get name of currently set webtheme
-	const char *name = get_web_theme_str(config.webserver.interface.theme.v.web_theme);
-	lua_pushstring(L, name);
-	return 1; // number of results
+	// Get currently configured webtheme
+	const struct web_themes this_theme = webthemes[config.webserver.interface.theme.v.web_theme];
+	// Create a Lua table
+	lua_newtable(L);
+
+	// Set table["name"] = this_theme.name (string)
+	lua_pushstring(L, "name");
+	lua_pushstring(L, this_theme.name);
+	lua_settable(L, -3);
+
+	// Set table["dark"] = this_theme.dark (boolean)
+	lua_pushstring(L, "dark");
+	lua_pushboolean(L, this_theme.dark);
+	lua_settable(L, -3);
+
+	// Set table["color"] = this_theme.color (string)
+	lua_pushstring(L, "color");
+	lua_pushstring(L, this_theme.color);
+	lua_settable(L, -3);
+
+	// Return there is one result on the stack
+	return 1;
 }
 
 // pihole.webhome()


### PR DESCRIPTION
# What does this implement/fix?

Provide theme details through Lua function `pihole.webtheme()` now returning a full table instead of only a string. Everything concerning theme definition is moved into `api/themes.{c,h}` and simplified to remove duplication as good as possible (the `enum` is defined separately for efficiency reasons, everything else is in `theme.c`).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.