### PR TITLE
Simplify/fix redirection rules

### DIFF
--- a/patch/civetweb.sh
+++ b/patch/civetweb.sh
@@ -7,5 +7,6 @@ patch -p1 < patch/civetweb/0001-Always-Kepler-syntax-for-Lua-server-pages.patch
 patch -p1 < patch/civetweb/0001-Add-FTL-URI-rewriting-changes-to-CivetWeb.patch
 patch -p1 < patch/civetweb/0001-Add-mbedTLS-debug-logging-hook.patch
 patch -p1 < patch/civetweb/0001-Register-CSRF-token-in-conn-request_info.patch
+patch -p1 < patch/civetweb/0001-Do-not-try-to-guess-server-hostname-in-Civetweb-when.patch
 
 echo "ALL PATCHES APPLIED OKAY"

--- a/patch/civetweb/0001-Do-not-try-to-guess-server-hostname-in-Civetweb-when.patch
+++ b/patch/civetweb/0001-Do-not-try-to-guess-server-hostname-in-Civetweb-when.patch
@@ -1,0 +1,29 @@
+From e41d902b5b01896360e1235aebabd3eb352158aa Mon Sep 17 00:00:00 2001
+From: DL6ER <dl6er@dl6er.de>
+Date: Sun, 8 Oct 2023 14:31:20 +0200
+Subject: [PATCH] Do not try to guess server hostname in Civetweb when
+ redirecting directory URIs to end with a slash
+
+Signed-off-by: DL6ER <dl6er@dl6er.de>
+---
+ src/webserver/civetweb/civetweb.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/webserver/civetweb/civetweb.c b/src/webserver/civetweb/civetweb.c
+index f44b17ba..3df8eab9 100644
+--- a/src/webserver/civetweb/civetweb.c
++++ b/src/webserver/civetweb/civetweb.c
+@@ -15306,7 +15306,9 @@ handle_request(struct mg_connection *conn)
+ 		if (!new_path) {
+ 			mg_send_http_error(conn, 500, "out or memory");
+ 		} else {
+-			mg_get_request_link(conn, new_path, buflen - 1);
++			/* Pi-hole modification */
++			//mg_get_request_link(conn, new_path, buflen - 1);
++			strcpy(new_path, ri->local_uri_raw);
+ 			strcat(new_path, "/");
+ 			if (ri->query_string) {
+ 				/* Append ? and query string */
+-- 
+2.34.1
+

--- a/src/api/docs/docs.c
+++ b/src/api/docs/docs.c
@@ -15,6 +15,7 @@ int api_docs(struct ftl_conn *api)
 	// Handle resource request by redirecting to "/"
 	if(strcmp(api->request->request_uri, "/api/docs") == 0)
 	{
+		log_debug(DEBUG_API, "Redirecting /api/docs --301--> /api/docs/");
 		mg_send_http_redirect(api->conn, "/api/docs/", 301);
 	}
 

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -15306,7 +15306,9 @@ handle_request(struct mg_connection *conn)
 		if (!new_path) {
 			mg_send_http_error(conn, 500, "out or memory");
 		} else {
-			mg_get_request_link(conn, new_path, buflen - 1);
+			/* Pi-hole modification */
+			//mg_get_request_link(conn, new_path, buflen - 1);
+			strcpy(new_path, ri->local_uri_raw);
 			strcat(new_path, "/");
 			if (ri->query_string) {
 				/* Append ? and query string */

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -86,6 +86,8 @@ static int redirect_root_handler(struct mg_connection *conn, void *input)
 		// 308 Permanent Redirect from http://pi.hole -> http://pi.hole/admin
 		if(strcmp(uri, "/") == 0)
 		{
+			log_debug(DEBUG_API, "Redirecting / --308--> %s",
+			          config.webserver.paths.webhome.v.s);
 			mg_send_http_redirect(conn, config.webserver.paths.webhome.v.s, 308);
 			return 1;
 		}
@@ -108,44 +110,6 @@ static int redirect_lp_handler(struct mg_connection *conn, void *input)
 	char *new_uri = calloc(strlen(uri) + query_len, sizeof(char));
 	// Copy everything from before the ".lp" to the new URI
 	strncpy(new_uri, uri, pos - uri);
-
-	// Append query string to the new URI if present
-	if(query_len > 0)
-	{
-		strcat(new_uri, "?");
-		strcat(new_uri, query_string);
-	}
-
-	// Send a 301 redirect to the new URI
-	log_debug(DEBUG_API, "Redirecting %s?%s ==301==> %s",
-	          uri, query_string, new_uri);
-	mg_send_http_redirect(conn, new_uri, 301);
-	free(new_uri);
-
-	return 1;
-}
-
-static int redirect_slash_handler(struct mg_connection *conn, void *input)
-{
-	// Get requested URI
-	const struct mg_request_info *request = mg_get_request_info(conn);
-	const char *uri = request->local_uri_raw;
-	const char *query_string = request->query_string;
-	const size_t query_len = query_string != NULL ? strlen(query_string) : 0;
-
-	// Do not redirect if the new URI is the webhome
-	if(strcmp(uri, config.webserver.paths.webhome.v.s) == 0)
-	{
-		log_debug(DEBUG_API, "Not redirecting %s?%s",
-		          uri, query_string);
-
-		// Handle as a normal request
-		return request_handler(conn, input);
-	}
-
-	// Remove the trailing slash from the URI
-	char *new_uri = strdup(uri);
-	new_uri[strlen(new_uri) - 1] = '\0';
 
 	// Append query string to the new URI if present
 	if(query_len > 0)
@@ -329,9 +293,6 @@ void http_init(void)
 
 	// Register **.lp -> ** redirect handler
 	mg_set_request_handler(ctx, "**.lp$", redirect_lp_handler, NULL);
-
-	// Register **/ -> ** redirect handler
-	mg_set_request_handler(ctx, "**/$", redirect_slash_handler, NULL);
 
 	// Register handler for the rest
 	mg_set_request_handler(ctx, "**", request_handler, NULL);


### PR DESCRIPTION
# What does this implement/fix?

The PR has two connected goals:

1. Simplify redirection rules.
   Before we had an explicit rule to redirect rules ending in slashes to strip the slash, e.g. `pi.hole/admin/` to `pi.hole/admin`. However, as both URLs will work equally well, there is no need for this redirection.
2. When directly trying to access a directory, CivetWeb tries to determine the server hostname so it can send an **absolute** redirect (301). Especially when being behind a proxy, this will always fail and cause dead-end redirections.
   We solve this by patching CivetWeb to use **relative** redirections instead. This fully resolves this issue. The patch is added to our existing series of patches to ensure it can be re-applied in future CivetWeb upgrades.
   You can try this with, e.g. http://pi.hole/admin/scripts/ - the expected outcome is:
   ```
   Error 403: Forbidden
   Error: Directory listing denied
   ```
   The bug is: Redirection to *somewhere* (may be the IPv4 or IPv6 address of your Pi-hole).

As you can guess, these two were even able to play some weird ping-pong sending users with non-default deployments into the wild.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
4. I have commented my proposed changes within the code.
5. I am willing to help maintain this change if there are issues with it later.
6. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
7. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.