### PR TITLE
Add Lua function pihole.https_port()

### DIFF
--- a/src/lua/ftl_lua.h
+++ b/src/lua/ftl_lua.h
@@ -10,8 +10,17 @@
 #ifndef FTL_LUA_H
 #define FTL_LUA_H
 
+#include "ftl_lua.h"
 #include "lua.h"
 #include <stdbool.h>
+
+#define MAXPORTS 8
+struct serverports
+{
+	bool is_secure;
+	unsigned char protocol; // 1 = IPv4, 2 = IPv4+IPv6, 3 = IPv6
+	unsigned short port;
+};
 
 #define LUA_HISTORY_FILE "~/.pihole_lua_history"
 
@@ -25,5 +34,7 @@ extern int dolibrary (lua_State *L, char *name);
 
 void print_embedded_scripts(void);
 void ftl_lua_init(lua_State *L);
+
+void store_server_ports(struct serverports ports[MAXPORTS]);
 
 #endif //FTL_LUA_H


### PR DESCRIPTION
# What does this implement/fix?

Add `pihole.https_port()` returning either `-1` (no HTTPS port defined or web server not running) or the port number of the first configured HTTPS port.

This is to be used in a future PR that makes the "consider using HTTPS" link on the login page conditional on HTTPS being actually enabled (it is by default). It can also be used to redirect to the correct port (in case this is not 443).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.