### PR TITLE
Allow generating X.509 TLS certificates for arbitrary domain names

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -311,18 +311,20 @@ void parse_args(int argc, char* argv[])
 
 	if(argc > 1 && strcmp(argv[1], "--gen-x509") == 0)
 	{
-		if(argc != 3 && argc != 4)
+		if(argc < 3 || argc > 5)
 		{
-			printf("Usage: %s --gen-x509 <output file> [rsa]\n", argv[0]);
-			printf("Example: %s --gen-x509 /etc/pihole/tls.pem\n", argv[0]);
-			printf("     or: %s --gen-x509 /etc/pihole/tls.pem rsa\n", argv[0]);
+			printf("Usage: %s --gen-x509 <output file> [<domain>] [rsa]\n", argv[0]);
+			printf("Example:          %s --gen-x509 /etc/pihole/tls.pem\n", argv[0]);
+			printf(" with domain:     %s --gen-x509 /etc/pihole/tls.pem pi.hole\n", argv[0]);
+			printf(" RSA with domain: %s --gen-x509 /etc/pihole/tls.pem nanopi.lan rsa\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
 		// Enable stdout printing
 		cli_mode = true;
 		log_ctrl(false, true);
-		const bool rsa = argc == 4 && strcasecmp(argv[3], "rsa") == 0;
-		exit(generate_certificate(argv[2], rsa) ? EXIT_SUCCESS : EXIT_FAILURE);
+		const char *domain = argc > 3 ? argv[3] : "pi.hole";
+		const bool rsa = argc > 4 && strcasecmp(argv[4], "rsa") == 0;
+		exit(generate_certificate(argv[2], rsa, domain) ? EXIT_SUCCESS : EXIT_FAILURE);
 	}
 
 	// If the first argument is "gravity" (e.g., /usr/bin/pihole-FTL gravity),

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -278,7 +278,7 @@ void http_init(void)
 	{
 		// Try to generate certificate if not present
 		if(!file_readable(config.webserver.tls.cert.v.s) &&
-		   !generate_certificate(config.webserver.tls.cert.v.s, false))
+		   !generate_certificate(config.webserver.tls.cert.v.s, false, config.webserver.domain.v.s))
 		{
 			log_err("Generation of SSL/TLS certificate %s failed!",
 			        config.webserver.tls.cert.v.s);
@@ -288,6 +288,9 @@ void http_init(void)
 		{
 			options[++next_option] = "ssl_certificate";
 			options[++next_option] = config.webserver.tls.cert.v.s;
+
+			log_info("Created SSL/TLS certificate for %s at %s",
+			         config.webserver.domain.v.s, config.webserver.tls.cert.v.s);
 		}
 		else
 		{

--- a/src/webserver/x509.h
+++ b/src/webserver/x509.h
@@ -13,6 +13,6 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 
-bool generate_certificate(const char* certfile, bool rsa);
+bool generate_certificate(const char* certfile, bool rsa, const char *domain);
 
 #endif // X509_H


### PR DESCRIPTION
# What does this implement/fix?

Allow generating X.509 TLS certificates for arbitrary domain names.
When auto-generated, FTL uses the config value `webserver.domain` defaulting to `"pi.hole"`.

The generated certificate may be checked using, e.g.
``` bash
openssl x509 -in /etc/pihole/tls.pem -text -noout
```

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.