### PR TITLE
Fix wording of info message concerning self-generated TLS certificate

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -296,11 +296,18 @@ void http_init(void)
 	   strlen(config.webserver.tls.cert.v.s) > 0)
 	{
 		// Try to generate certificate if not present
-		if(!file_readable(config.webserver.tls.cert.v.s) &&
-		   !generate_certificate(config.webserver.tls.cert.v.s, false, config.webserver.domain.v.s))
+		if(!file_readable(config.webserver.tls.cert.v.s))
 		{
-			log_err("Generation of SSL/TLS certificate %s failed!",
-			        config.webserver.tls.cert.v.s);
+			if(generate_certificate(config.webserver.tls.cert.v.s, false, config.webserver.domain.v.s))
+			{
+				log_info("Created SSL/TLS certificate for %s at %s",
+				         config.webserver.domain.v.s, config.webserver.tls.cert.v.s);
+			}
+			else
+			{
+				log_err("Generation of SSL/TLS certificate %s failed!",
+				        config.webserver.tls.cert.v.s);
+			}
 		}
 
 		if(file_readable(config.webserver.tls.cert.v.s))
@@ -308,8 +315,8 @@ void http_init(void)
 			options[++next_option] = "ssl_certificate";
 			options[++next_option] = config.webserver.tls.cert.v.s;
 
-			log_info("Created SSL/TLS certificate for %s at %s",
-			         config.webserver.domain.v.s, config.webserver.tls.cert.v.s);
+			log_info("Using SSL/TLS certificate file %s",
+			         config.webserver.tls.cert.v.s);
 		}
 		else
 		{


### PR DESCRIPTION
# What does this implement/fix?

Fix wording of info message concerning self-generated TLS certificate. Before this commit, we incorrectly logged that we created a TLS certificate not only when we really did this but also after each restart when simply using it.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.