### PR TITLE
Implement Query Log sorting (server-side pagination)

### DIFF
--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -390,15 +390,13 @@ int api_queries(struct ftl_conn *api)
 		if(get_int_var(api->request->query_string, "order%5B0%5D%5Bcolumn%5D", &sort_column) &&
 		   GET_STR("order%5B0%5D%5Bdir%5D", sort_dir, api->request->query_string) > 0)
 		{
-			log_debug(DEBUG_API, "Sorting by column %d (%s)", sort_column, sort_dir);
-
 			char sort_col_id[32] = { 0 };
 			snprintf(sort_col_id, sizeof(sort_col_id), "columns%%5B%d%%5D%%5Bdata%%5D",
 			         sort_column);
 
 			// Encoded URI string: %5B = [ and %5D = ]
 			if(GET_VAR(sort_col_id, sort_col, api->request->query_string) > 0)
-				log_info("Sorting by column %s (%s)", sort_col, sort_dir);
+				log_debug(DEBUG_API, "Sorting by column %s (%s)", sort_col, sort_dir);
 			else
 				log_warn("Sorting by column %d (%s) requested, but column name not found",
 				         sort_column, sort_dir);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -28,6 +28,12 @@ static unsigned int new_total = 0, new_blocked = 0;
 static unsigned long last_mem_db_idx = 0, last_disk_db_idx = 0;
 static unsigned int mem_db_num = 0, disk_db_num = 0;
 
+// Return the maximum ID of the in-memory database
+unsigned long __attribute__((pure)) get_max_db_idx(void)
+{
+	return last_mem_db_idx;
+}
+
 void db_counts(unsigned long *last_idx, unsigned long *mem_num, unsigned long *disk_num)
 {
 	*last_idx = last_mem_db_idx;

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -105,6 +105,7 @@ const char *index_creation[] = {
 };
 #endif
 
+unsigned long get_max_db_idx(void) __attribute__((pure));
 void db_counts(unsigned long *last_idx, unsigned long *mem_num, unsigned long *disk_num);
 bool init_memory_database(void);
 sqlite3 *get_memdb(void) __attribute__((pure));


### PR DESCRIPTION
# What does this implement/fix?

The PR adds the ability to sort the server-side prepared Query Log by all relevant columns. This PR works on its own, no `web` changes are required to get Query Log sorting.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.