### PR TITLE
Add new config option webserver.api.searchAPIauth

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -164,15 +164,14 @@ int api_handler(struct mg_connection *conn, void *ignored)
 			if(api_request[i].func == api_search)
 			{
 				// Handle /api/search special as it may be allowed for local users due to webserver.api.searchAPIauth
-				if(config.webserver.api.searchAPIauth.v.b && check_client_auth(&api, true) == API_AUTH_UNAUTHORIZED)
+				if(!config.webserver.api.searchAPIauth.v.b && is_local_api_user(api.request->remote_addr))
 				{
-					// Local users need to authenticate, too
-					unauthorized = true;
-					break;
+					// Local users does not need to authenticate when searchAPIauth is false
+					;
 				}
-				else if(!is_local_api_user(api.request->remote_addr))
+				else if(api_request[i].require_auth && check_client_auth(&api, true) == API_AUTH_UNAUTHORIZED)
 				{
-					// Remote users need to authenticate
+					// Users need to authenticate but authentication failed
 					unauthorized = true;
 					break;
 				}

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -16,7 +16,7 @@
 #include "webserver/cJSON/cJSON.h"
 #include "webserver/http-common.h"
 
-// Commo definitions
+// Common definitions
 #define LOCALHOSTv4 "127.0.0.1"
 #define LOCALHOSTv6 "::1"
 
@@ -87,6 +87,7 @@ int api_auth(struct ftl_conn *api);
 void delete_all_sessions(void);
 int api_auth_sessions(struct ftl_conn *api);
 int api_auth_session_delete(struct ftl_conn *api);
+bool is_local_api_user(const char *remote_addr) __attribute__((pure));
 
 // 2FA methods
 bool verifyTOTP(const uint32_t code);

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -83,6 +83,13 @@ static void add_request_info(struct ftl_conn *api, const char *csrf)
 	memset((int*)&api->request->is_authenticated, 1, sizeof(api->request->is_authenticated));
 }
 
+// Is this client connecting from localhost?
+bool __attribute__((pure)) is_local_api_user(const char *remote_addr)
+{
+	return strcmp(remote_addr, LOCALHOSTv4) == 0 ||
+	       strcmp(remote_addr, LOCALHOSTv6) == 0;
+}
+
 // Can we validate this client?
 // Returns -1 if not authenticated or expired
 // Returns >= 0 for any valid authentication
@@ -90,8 +97,7 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 {
 	// Is the user requesting from localhost?
 	// This may be allowed without authentication depending on the configuration
-	if(!config.webserver.api.localAPIauth.v.b && (strcmp(api->request->remote_addr, LOCALHOSTv4) == 0 ||
-	                                              strcmp(api->request->remote_addr, LOCALHOSTv6) == 0))
+	if(!config.webserver.api.localAPIauth.v.b && is_local_api_user(api->request->remote_addr))
 	{
 		add_request_info(api, NULL);
 		return API_AUTH_LOCALHOST;

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -379,6 +379,8 @@ components:
                   properties:
                     localAPIauth:
                       type: boolean
+                    searchAPIauth:
+                      type: boolean
                     prettyJSON:
                       type: boolean
                     password:
@@ -652,6 +654,7 @@ components:
               theme: "default-darker"
             api:
               localAPIauth: false
+              searchAPIauth: false
               prettyJSON: false
               password: "********"
               pwhash: ''

--- a/src/api/docs/content/specs/search.yaml
+++ b/src/api/docs/content/specs/search.yaml
@@ -17,6 +17,7 @@ components:
           Search for domains in Pi-hole's list. The optional parameters `N` and `partial` limit the maximum number of returned records and whether partial matches should be returned, respectively.
           There is a hard upper limit of `N` defined in FTL (currently set to 10,000) to ensure that the response is not too large.
           ABP matches are not returned when partial matching is requested.
+          Depending on the value of the config option webserver.api.searchAPIauth, local clients may not need to authenticate for this endpoint.
         responses:
           '200':
             description: OK

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -886,8 +886,13 @@ void initConfig(struct config *conf)
 	conf->webserver.interface.theme.d.web_theme = THEME_DEFAULT_AUTO;
 
 	// sub-struct api
+	conf->webserver.api.searchAPIauth.k = "webserver.api.searchAPIauth";
+	conf->webserver.api.searchAPIauth.h = "Do local clients need to authenticate to access the search API? This settings allows local clients to use pihole -q ... without authentication. Note that \"local\" in the sense of the option means only 127.0.0.1 and [::1]";
+	conf->webserver.api.searchAPIauth.t = CONF_BOOL;
+	conf->webserver.api.searchAPIauth.d.b = false;
+
 	conf->webserver.api.localAPIauth.k = "webserver.api.localAPIauth";
-	conf->webserver.api.localAPIauth.h = "Do local clients need to authenticate to access the API?";
+	conf->webserver.api.localAPIauth.h = "Do local clients need to authenticate to access the API? This settings allows local clients to use the API without authentication.";
 	conf->webserver.api.localAPIauth.t = CONF_BOOL;
 	conf->webserver.api.localAPIauth.d.b = true;
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -220,6 +220,7 @@ struct config {
 		} interface;
 		struct {
 			struct conf_item localAPIauth;
+			struct conf_item searchAPIauth;
 			struct conf_item prettyJSON;
 			struct conf_item pwhash;
 			struct conf_item password; // This is a pseudo-item

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -594,6 +594,11 @@
     # Does local clients need to authenticate to access the API?
     localAPIauth = true
 
+    # Do local clients need to authenticate to access the search API? This settings allows
+    # local clients to use pihole -q ... without authentication. Note that "local" in the
+    # sense of the option means only 127.0.0.1 and [::1]
+    searchAPIauth = false
+
     # Should FTL prettify the API output (add extra spaces, newlines and indentation)?
     prettyJSON = false
 


### PR DESCRIPTION
# What does this implement/fix?

Add new config option `webserver.api.searchAPIauth` defaulting to `false` to aid https://github.com/pi-hole/pi-hole/pull/5361

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.