### PR TITLE
Minor integrated docs changes

### DIFF
--- a/src/api/docs/content/index.css
+++ b/src/api/docs/content/index.css
@@ -1,16 +1,13 @@
 
 .btn {
-  width: 90px;
-  height: 32px;
-  padding:2px;
+  padding: 6px 12px;
   font-size:13px;
-  background-color: #47AFE8;
+  background-color: var(--primary-color);
   color: #fff;
   border: none;
   margin: 0 2px;
   border-radius: 2px;
   cursor:pointer;
-  outline:none;
 }
 .btn.large {
   width: 120px;
@@ -29,4 +26,48 @@
 }
 .btn.red {
   background-color: #ff4500;
+}
+
+.btn:hover {
+  background: #fff;
+  color: var(--primary-color);
+}
+
+.logo-slot {
+  padding: 10px 0 10px 16px;
+  width: 50px;
+}
+
+.header-slot {
+  margin: 0 15px 0 0;
+  width: 100%;
+  display: flex;
+  gap: 6px 32px;
+  flex-wrap: wrap;
+  justify-content: start;
+}
+.header-title {
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1;
+}
+
+.password-controls {
+  display: flex;
+  align-items: stretch;
+}
+
+.footer-slot {
+  margin:0;
+  padding:16px;
+  display: flex;
+  gap: 16px 36px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  color:#fff;
+  text-align:center;
+  background-color:#222;
+}
+.footer-slot > div {
+  flex: 0 0 auto;
 }

--- a/src/api/docs/content/index.html
+++ b/src/api/docs/content/index.html
@@ -10,14 +10,14 @@
         <script type='text/javascript' src='external/rapidoc-min.js'></script>
         <script type="text/javascript" src="pi-hole.js"></script>
         <link href='index.css' rel='stylesheet'>
-        <link rel="apple-touch-icon" href="<?=pihole.webhome()?>/img/favicons/apple-touch-icon.png" sizes="180x180">
-        <link rel="icon" href="<?=pihole.webhome()?>/img/favicons/favicon-32x32.png" sizes="32x32" type="image/png">
-        <link rel="icon" href="<?=pihole.webhome()?>/img/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
-        <link rel="manifest" href="<?=pihole.webhome()?>/img/favicons/manifest.json">
-        <link rel="mask-icon" href="<?=pihole.webhome()?>/img/favicons/safari-pinned-tab.svg" color="#367fa9">
-        <link rel="shortcut icon" href="<?=pihole.webhome()?>/img/favicons/favicon.ico">
+        <link rel="apple-touch-icon" href="/admin/img/favicons/apple-touch-icon.png" sizes="180x180">
+        <link rel="icon" href="/admin/img/favicons/favicon-32x32.png" sizes="32x32" type="image/png">
+        <link rel="icon" href="/admin/img/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
+        <link rel="manifest" href="/admin/img/favicons/manifest.json">
+        <link rel="mask-icon" href="/admin/img/favicons/safari-pinned-tab.svg" color="#367fa9">
+        <link rel="shortcut icon" href="/admin/img/favicons/favicon.ico">
         <meta name="msapplication-TileColor" content="#367fa9">
-        <meta name="msapplication-TileImage" content="<?=pihole.webhome()?>/img/favicons/mstile-150x150.png">
+        <meta name="msapplication-TileImage" content="/admin/img/favicons/mstile-150x150.png">
         <meta name="theme-color" content="#367fa9">
     </head>
     <body>

--- a/src/api/docs/content/index.html
+++ b/src/api/docs/content/index.html
@@ -36,27 +36,31 @@
           schema-style = "tree"
           render-style = "view"
           primary-color = "#2d87e2"
-          header-color = "#2d87e2"
+          header-color = "#222"
           api-key-name = "sid"
           api-key-location = "header"
           api-key-value = "-"
           show-method-in-nav-bar="as-colored-block"
           allow-search = "false">
-            <img slot="logo" style="padding-left: 10px;" src="images/logo.svg" width="40px" />
-            <div slot='header' style="font-weight:700; font-size:32px">
-              <div>Pi-hole API Documentation</div>
-              <div>
-                <input id='loginpw' type='password' size="4">
-                <button class='btn' id='loginbtn' onclick='loginout()'>Login</button>
-              </div>
+            <img slot="logo" class="logo-slot" src="images/logo.svg">
+            <div slot="header" class="header-slot">
+                <div class="header-title">Pi-hole API Documentation</div>
+                <div class="password-controls">
+                    <input id="loginpw" type="password" placeholder="password">
+                    <button class="btn" id="loginbtn" onclick="loginout()">Login</button>
+                </div>
             </div>
             <!-- content at the bottom -->
-            <div slot="footer" style="margin:0; padding:16px 36px; background-color:#2d87e2; color:#fff; text-align:center;">
-                <button class='btn' onclick="document.getElementById('thedoc').setAttribute('theme', 'dark')" >Dark Theme</button>
-                <button class='btn' onclick="document.getElementById('thedoc').setAttribute('theme', 'light')" >Light Theme</button>
-                <button class='btn large' onclick="setStyle('view')" >Default</button>
-                <button class='btn large' onclick="setStyle('read')" >Reader</button>
-                <button class='btn large' onclick="setStyle('focused')" >Focused reader</button>
+            <div slot="footer" class="footer-slot">
+                <div>
+                    <button onclick="document.getElementById('thedoc').setAttribute('theme', 'dark')" class="btn">Dark Theme</button>
+                    <button onclick="document.getElementById('thedoc').setAttribute('theme', 'light')" class="btn">Light Theme</button>
+                </div>
+                <div>
+                    <button onclick="setStyle('view')" class="btn">Default</button>
+                    <button onclick="setStyle('read')" class="btn">Reader</button>
+                    <button onclick="setStyle('focused')" class="btn">Focused reader</button>
+                </div>
             </div>
         </rapi-doc>
     </body>

--- a/src/api/docs/content/specs/main.yaml
+++ b/src/api/docs/content/specs/main.yaml
@@ -15,17 +15,6 @@ info:
     Most (but not all) endpoints require authentication.
     API endpoints requiring authentication will fail with code `401 Unauthorized` when used outside a valid session.
 servers:
-  - url: 'http://{url}:{port}/{path}'
-    variables:
-      url:
-        description: URL or address of your Pi-hole
-        default: pi.hole
-      port:
-        description: Port of your Pi-hole's API
-        default: "8080"
-      path:
-        description: Path where your Pi-hole's API is hosted
-        default: api
   - url: 'https://{url}:{port}/{path}'
     variables:
       url:
@@ -34,6 +23,17 @@ servers:
       port:
         description: Port of your Pi-hole's API (HTTPS)
         default: "443"
+      path:
+        description: Path where your Pi-hole's API is hosted
+        default: api
+  - url: 'http://{url}:{port}/{path}'
+    variables:
+      url:
+        description: URL or address of your Pi-hole
+        default: pi.hole
+      port:
+        description: Port of your Pi-hole's API
+        default: "80"
       path:
         description: Path where your Pi-hole's API is hosted
         default: api


### PR DESCRIPTION
# What does this implement/fix?

Make HTTPS scheme the default case, change the default port from 8080 to 80 for the HTTP case, and make docs index page a Lua page to allow loading of the favicon

![Screenshot from 2023-10-15 12-54-53](https://github.com/pi-hole/FTL/assets/16748619/a90fa325-9659-4aba-ab34-f6c1d05cefbe)
![Screenshot from 2023-10-15 12-55-00](https://github.com/pi-hole/FTL/assets/16748619/713e807d-5194-41d4-99fb-6b3aeea515b4)


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.