### PR TITLE
Skip empty elements in config arrays both when reading and writing

### DIFF
--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -389,12 +389,18 @@ void writeTOMLvalue(FILE * fp, const int indent, const enum conf_type t, union c
 				fputc(' ', fp);
 			for(unsigned int i = 0; i < elems; i++)
 			{
+				// Get the element
+				cJSON *item = cJSON_GetArrayItem(v->json, i);
+
+				// Skip empty elements
+				if(strlen(item->valuestring) == 0)
+					continue;
+
 				// Add intendation (if we are indenting)
 				if(indent > -1)
 					indentTOML(fp, indent + 1);
 
-				// Get and print the element
-				cJSON *item = cJSON_GetArrayItem(v->json, i);
+				// Print the element
 				printTOMLstring(fp, item->valuestring, toml);
 
 				// Add a comma if there is one more element to come
@@ -683,10 +689,14 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 						log_debug(DEBUG_CONFIG, "%s is an invalid array (found at index %u)", conf_item->k, i);
 						break;
 					}
-					// Add string to our JSON array
-					cJSON *item = cJSON_CreateString(d.u.s);
+					// Only import non-empty entries
+					if(strlen(d.u.s) > 0)
+					{
+						// Add string to our JSON array
+						cJSON *item = cJSON_CreateString(d.u.s);
+						cJSON_AddItemToArray(conf_item->v.json, item);
+					}
 					free(d.u.s);
-					cJSON_AddItemToArray(conf_item->v.json, item);
 				}
 			}
 			else


### PR DESCRIPTION
# What does this implement/fix?

Skip empty elements in config arrays both when reading and writing. This fixes https://github.com/pi-hole/web/issues/2754 and possibly related issues we haven't seen yet.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.