### PR TITLE
Initialize mbedtls with default instead of SuiteB presets

### DIFF
--- a/src/webserver/civetweb/mod_mbedtls.inl
+++ b/src/webserver/civetweb/mod_mbedtls.inl
@@ -135,7 +135,7 @@ mbed_sslctx_init(SSL_CTX *ctx, const char *crt)
 	rc = mbedtls_ssl_config_defaults(conf,
 	                                 MBEDTLS_SSL_IS_SERVER,
 	                                 MBEDTLS_SSL_TRANSPORT_STREAM,
-	                                 MBEDTLS_SSL_PRESET_SUITEB);
+	                                 MBEDTLS_SSL_PRESET_DEFAULT);
 	if (rc != 0) {
 		DEBUG_TRACE("TLS set defaults failed (%i)", rc);
 		return -1;


### PR DESCRIPTION
# What does this implement/fix?

We are seeing that the strict commitment of FTL to the [NSA Suite B Cryptography](https://en.wikipedia.org/wiki/NSA_Suite_B_Cryptography) recommendations for improved TLS security are in fact too strict to cover all use cases.

Under Suite B, FTL accepts exactly two possible cipersuites (OpenSSL notation as used by Firefox, etc., too):
- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`

Using the "default" ciphersuite, however, allows not only those two but in total 165 ciphersuites:

- `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_PSK_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`
- `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`
- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`
- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
- `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384`
- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
- `TLS_ECDHE_ECDSA_WITH_AES_256_CCM`
- `TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8`
- `TLS_ECDHE_ECDSA_WITH_AES_128_CCM`
- `TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8`
- `TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
- `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`
- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
- `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384`
- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256`
- `TLS_DHE_RSA_WITH_AES_128_CBC_SHA256`
- `TLS_DHE_RSA_WITH_AES_256_CBC_SHA256`
- `TLS_DHE_RSA_WITH_AES_128_CBC_SHA`
- `TLS_DHE_RSA_WITH_AES_256_CBC_SHA`
- `TLS_DHE_RSA_WITH_AES_256_CCM`
- `TLS_DHE_RSA_WITH_AES_256_CCM_8`
- `TLS_DHE_RSA_WITH_AES_128_CCM`
- `TLS_DHE_RSA_WITH_AES_128_CCM_8`
- `TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256`
- `TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA`
- `TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA`
- `TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_RSA_WITH_AES_128_GCM_SHA256`
- `TLS_RSA_WITH_AES_128_CBC_SHA256`
- `TLS_RSA_WITH_AES_256_CBC_SHA256`
- `TLS_RSA_WITH_AES_128_CBC_SHA`
- `TLS_RSA_WITH_AES_256_CBC_SHA`
- `TLS_RSA_WITH_AES_256_CCM`
- `TLS_RSA_WITH_AES_256_CCM_8`
- `TLS_RSA_WITH_AES_128_CCM`
- `TLS_RSA_WITH_AES_128_CCM_8`
- `TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256`
- `TLS_RSA_WITH_CAMELLIA_128_CBC_SHA`
- `TLS_RSA_WITH_CAMELLIA_256_CBC_SHA`
- `TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_ECDH_RSA_WITH_AES_128_CBC_SHA`
- `TLS_ECDH_RSA_WITH_AES_256_CBC_SHA`
- `TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256`
- `TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256`
- `TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384`
- `TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA`
- `TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA`
- `TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256`
- `TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256`
- `TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384`
- `TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384`
- `TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_PSK_WITH_AES_128_GCM_SHA256`
- `TLS_PSK_WITH_AES_256_GCM_SHA384`
- `TLS_PSK_WITH_AES_128_CBC_SHA256`
- `TLS_PSK_WITH_AES_256_CBC_SHA384`
- `TLS_PSK_WITH_AES_128_CBC_SHA`
- `TLS_PSK_WITH_AES_256_CBC_SHA`
- `TLS_PSK_WITH_AES_256_CCM`
- `TLS_PSK_WITH_AES_256_CCM_8`
- `TLS_PSK_WITH_AES_128_CCM`
- `TLS_PSK_WITH_AES_128_CCM_8`
- `TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_DHE_PSK_WITH_AES_128_GCM_SHA256`
- `TLS_DHE_PSK_WITH_AES_256_GCM_SHA384`
- `TLS_DHE_PSK_WITH_AES_128_CBC_SHA256`
- `TLS_DHE_PSK_WITH_AES_256_CBC_SHA384`
- `TLS_DHE_PSK_WITH_AES_128_CBC_SHA`
- `TLS_DHE_PSK_WITH_AES_256_CBC_SHA`
- `TLS_DHE_PSK_WITH_AES_256_CCM`
- `TLS_DHE_PSK_WITH_AES_256_CCM_8`
- `TLS_DHE_PSK_WITH_AES_128_CCM`
- `TLS_DHE_PSK_WITH_AES_128_CCM_8`
- `TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256`
- `TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384`
- `TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA`
- `TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA`
- `TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_RSA_PSK_WITH_AES_128_GCM_SHA256`
- `TLS_RSA_PSK_WITH_AES_256_GCM_SHA384`
- `TLS_RSA_PSK_WITH_AES_128_CBC_SHA256`
- `TLS_RSA_PSK_WITH_AES_256_CBC_SHA384`
- `TLS_RSA_PSK_WITH_AES_128_CBC_SHA`
- `TLS_RSA_PSK_WITH_AES_256_CBC_SHA`
- `TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256`
- `TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384`
- `TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256`
- `TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384`
- `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
- `TLS_RSA_WITH_ARIA_256_GCM_SHA384`
- `TLS_RSA_WITH_ARIA_256_CBC_SHA384`
- `TLS_RSA_WITH_ARIA_128_GCM_SHA256`
- `TLS_RSA_WITH_ARIA_128_CBC_SHA256`
- `TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384`
- `TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384`
- `TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256`
- `TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256`
- `TLS_PSK_WITH_ARIA_256_GCM_SHA384`
- `TLS_PSK_WITH_ARIA_256_CBC_SHA384`
- `TLS_PSK_WITH_ARIA_128_GCM_SHA256`
- `TLS_PSK_WITH_ARIA_128_CBC_SHA256`
- `TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384`
- `TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384`
- `TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256`
- `TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256`
- `TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384`
- `TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384`
- `TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256`
- `TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256`
- `TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384`
- `TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256`
- `TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384`
- `TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384`
- `TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256`
- `TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256`
- `TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384`
- `TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384`
- `TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256`
- `TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256`
- `TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384`
- `TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384`
- `TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256`
- `TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256`
- `TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384`
- `TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384`
- `TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.