### PR TITLE
Fix a few API config issues

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -337,10 +337,7 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 				return "not of type string";
 			const int blocking_mode = get_blocking_mode_val(elem->valuestring);
 			if(blocking_mode == -1)
-			{
-				log_warn("Blocking mode \"%s\" is invalid", elem->valuestring);
 				return "invalid option";
-			}
 			// Set item
 			conf_item->v.blocking_mode = blocking_mode;
 			log_debug(DEBUG_CONFIG, "Set %s to %d", conf_item->k, conf_item->v.blocking_mode);
@@ -401,13 +398,18 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 		case CONF_ENUM_PRIVACY_LEVEL:
 		{
 			// Check type
-			if(!cJSON_IsNumber(elem))
+			int value;
+			if(cJSON_IsNumber(elem))
+				value = elem->valueint;
+			else if(cJSON_IsString(elem) && sscanf(elem->valuestring, "%i", &value) == 1)
+				; // value imported into variable
+			else
 				return "not of type integer";
 			// Check allowed interval
-			if(elem->valuedouble < PRIVACY_SHOW_ALL || elem->valuedouble > PRIVACY_MAXIMUM)
+			if(value < PRIVACY_SHOW_ALL || value > PRIVACY_MAXIMUM)
 				return "not within valid range";
 			// Set item
-			conf_item->v.i = elem->valueint;
+			conf_item->v.i = value;
 			log_debug(DEBUG_CONFIG, "Set %s to %d", conf_item->k, conf_item->v.i);
 			break;
 		}

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -27,8 +27,6 @@
 // hash_password()
 #include "config/password.h"
 
-#define WRITE_ONLY_TEXT "<write-only property>"
-
 static struct {
 	const char *name;
 	const char *title;
@@ -339,7 +337,10 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 				return "not of type string";
 			const int blocking_mode = get_blocking_mode_val(elem->valuestring);
 			if(blocking_mode == -1)
+			{
+				log_warn("Blocking mode \"%s\" is invalid", elem->valuestring);
 				return "invalid option";
+			}
 			// Set item
 			conf_item->v.blocking_mode = blocking_mode;
 			log_debug(DEBUG_CONFIG, "Set %s to %d", conf_item->k, conf_item->v.blocking_mode);
@@ -537,7 +538,7 @@ static int api_config_get(struct ftl_conn *api)
 
 			// Special case: write-only values
 			if(conf_item->f & FLAG_WRITE_ONLY)
-				JSON_REF_STR_IN_OBJECT(leaf, "value", WRITE_ONLY_TEXT);
+				JSON_REF_STR_IN_OBJECT(leaf, "value", PASSWORD_VALUE);
 			else
 			{
 				// Add current value
@@ -576,7 +577,7 @@ static int api_config_get(struct ftl_conn *api)
 		{
 			// Special case: write-only values
 			if(conf_item->f & FLAG_WRITE_ONLY)
-				JSON_REF_STR_IN_OBJECT(parent, conf_item->p[level - 1], WRITE_ONLY_TEXT);
+				JSON_REF_STR_IN_OBJECT(parent, conf_item->p[level - 1], PASSWORD_VALUE);
 			else
 			{
 				// Create the config item leaf object
@@ -696,7 +697,7 @@ static int api_config_patch(struct ftl_conn *api)
 
 		// Check if this is a write-only config item with the placeholder value
 		if(new_item->f & FLAG_WRITE_ONLY && cJSON_IsString(elem) &&
-		   strcmp(elem->valuestring, WRITE_ONLY_TEXT) == 0)
+		   strcmp(elem->valuestring, PASSWORD_VALUE) == 0)
 		{
 			log_debug(DEBUG_CONFIG, "%s is write-only with place-holder, skipping", new_item->k);
 			continue;
@@ -714,8 +715,8 @@ static int api_config_patch(struct ftl_conn *api)
 		struct conf_item *conf_item = get_conf_item(&config, i);
 
 		// Skip processing if value didn't change compared to current value
-		if(compare_config_item(conf_item->t, &new_item->v, &conf_item->v) &&
-		   conf_item->t != CONF_PASSWORD)
+		if((conf_item->t != CONF_PASSWORD && compare_config_item(conf_item->t, &new_item->v, &conf_item->v)) ||
+		   (conf_item->t == CONF_PASSWORD && strcmp(elem->valuestring, PASSWORD_VALUE) == 0))
 		{
 			log_debug(DEBUG_CONFIG, "Config item %s: Unchanged", conf_item->k);
 			continue;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -423,10 +423,10 @@ void initConfig(struct config *conf)
 	{
 		struct enum_options piholePTR[] =
 		{
-			{ "NONE", "Pi-hole will not respond automatically on PTR requests to local interface addresses. Ensure pi.hole and/or hostname records exist elsewhere." },
-			{ "HOSTNAME", "Pi-hole will not respond automatically on PTR requests to local interface addresses. Ensure pi.hole and/or hostname records exist elsewhere." },
-			{ "HOSTNAMEFQDN", "Serve the machine's global hostname as fully qualified domain by adding the local suffix. If no local suffix has been defined, FTL appends the local domain .no_fqdn_available. In this case you should either add domain=whatever.com to a custom config file inside /etc/dnsmasq.d/ (to set whatever.com as local domain) or use domain=# which will try to derive the local domain from /etc/resolv.conf (or whatever is set with resolv-file, when multiple search directives exist, the first one is used)." },
-			{ "PI.HOLE", "Respond with \"pi.hole\"." }
+			{ get_ptr_type_str(PTR_NONE), "Pi-hole will not respond automatically on PTR requests to local interface addresses. Ensure pi.hole and/or hostname records exist elsewhere." },
+			{ get_ptr_type_str(PTR_HOSTNAME), "Pi-hole will not respond automatically on PTR requests to local interface addresses. Ensure pi.hole and/or hostname records exist elsewhere." },
+			{ get_ptr_type_str(PTR_HOSTNAMEFQDN), "Serve the machine's global hostname as fully qualified domain by adding the local suffix. If no local suffix has been defined, FTL appends the local domain .no_fqdn_available. In this case you should either add domain=whatever.com to a custom config file inside /etc/dnsmasq.d/ (to set whatever.com as local domain) or use domain=# which will try to derive the local domain from /etc/resolv.conf (or whatever is set with resolv-file, when multiple search directives exist, the first one is used)." },
+			{ get_ptr_type_str(PTR_PIHOLE), "Respond with \"pi.hole\"." }
 		};
 		CONFIG_ADD_ENUM_OPTIONS(conf->dns.piholePTR.a, piholePTR);
 	}
@@ -439,10 +439,10 @@ void initConfig(struct config *conf)
 	{
 		struct enum_options replyWhenBusy[] =
 		{
-			{ "BLOCK", "Block all queries when the database is busy." },
-			{ "ALLOW", "Allow all queries when the database is busy." },
-			{ "REFUSE", "Refuse all queries which arrive while the database is busy." },
-			{ "DROP", "Just drop the queries, i.e., never reply to them at all. Despite \"REFUSE\" sounding similar to \"DROP\", it turned out that many clients will just immediately retry, causing up to several thousands of queries per second. This does not happen in \"DROP\" mode." }
+			{ get_busy_reply_str(BUSY_BLOCK), "Block all queries when the database is busy." },
+			{ get_busy_reply_str(BUSY_ALLOW), "Allow all queries when the database is busy." },
+			{ get_busy_reply_str(BUSY_REFUSE), "Refuse all queries which arrive while the database is busy." },
+			{ get_busy_reply_str(BUSY_DROP), "Just drop the queries, i.e., never reply to them at all. Despite \"REFUSE\" sounding similar to \"DROP\", it turned out that many clients will just immediately retry, causing up to several thousands of queries per second. This does not happen in \"DROP\" mode." }
 		};
 		CONFIG_ADD_ENUM_OPTIONS(conf->dns.replyWhenBusy.a, replyWhenBusy);
 	}
@@ -506,11 +506,11 @@ void initConfig(struct config *conf)
 	{
 		struct enum_options listeningMode[] =
 		{
-			{ "LOCAL", "Allow only local requests. This setting accepts DNS queries only from hosts whose address is on a local subnet, i.e., a subnet for which an interface exists on the server. It is intended to be set as a default on installation, to allow unconfigured installations to be useful but also safe from being used for DNS amplification attacks if (accidentally) running public." },
-			{ "SINGLE", "Permit all origins, accept only on the specified interface. Respond only to queries arriving on the specified interface. The loopback (lo) interface is automatically added to the list of interfaces to use when this option is used. Make sure your Pi-hole is properly firewalled!" },
-			{ "BIND", "By default, FTL binds the wildcard address. If this is not what you want, you can use this option as it forces FTL to really bind only the interfaces it is listening on. Note that this may result in issues when the interface may go down (cable unplugged, etc.). About the only time when this is useful is when running another nameserver on the same port on the same machine. This may also happen if you run a virtualization API such as libvirt. When this option is used, IP alias interface labels (e.g. enp2s0:0) are checked rather than interface names." },
-			{ "ALL", "Permit all origins, accept on all interfaces. Make sure your Pi-hole is properly firewalled! This truly allows any traffic to be replied to and is a dangerous thing to do as your Pi-hole could become an open resolver. You should always ask yourself if the first option doesn't work for you as well." },
-			{ "NONE", "Do not add any configuration concerning the listening mode to the dnsmasq configuration file. This is useful if you want to manually configure the listening mode in auxiliary configuration files. This option is really meant for advanced users only, support for this option may be limited." }
+			{ get_listeningMode_str(LISTEN_LOCAL), "Allow only local requests. This setting accepts DNS queries only from hosts whose address is on a local subnet, i.e., a subnet for which an interface exists on the server. It is intended to be set as a default on installation, to allow unconfigured installations to be useful but also safe from being used for DNS amplification attacks if (accidentally) running public." },
+			{ get_listeningMode_str(LISTEN_SINGLE), "Permit all origins, accept only on the specified interface. Respond only to queries arriving on the specified interface. The loopback (lo) interface is automatically added to the list of interfaces to use when this option is used. Make sure your Pi-hole is properly firewalled!" },
+			{ get_listeningMode_str(LISTEN_BIND), "By default, FTL binds the wildcard address. If this is not what you want, you can use this option as it forces FTL to really bind only the interfaces it is listening on. Note that this may result in issues when the interface may go down (cable unplugged, etc.). About the only time when this is useful is when running another nameserver on the same port on the same machine. This may also happen if you run a virtualization API such as libvirt. When this option is used, IP alias interface labels (e.g. enp2s0:0) are checked rather than interface names." },
+			{ get_listeningMode_str(LISTEN_ALL), "Permit all origins, accept on all interfaces. Make sure your Pi-hole is properly firewalled! This truly allows any traffic to be replied to and is a dangerous thing to do as your Pi-hole could become an open resolver. You should always ask yourself if the first option doesn't work for you as well." },
+			{ get_listeningMode_str(LISTEN_NONE), "Do not add any configuration concerning the listening mode to the dnsmasq configuration file. This is useful if you want to manually configure the listening mode in auxiliary configuration files. This option is really meant for advanced users only, support for this option may be limited." }
 		};
 		CONFIG_ADD_ENUM_OPTIONS(conf->dns.listeningMode.a, listeningMode);
 	}
@@ -561,11 +561,11 @@ void initConfig(struct config *conf)
 	{
 		struct enum_options blockingmode[] =
 		{
-			{ "NULL", "In NULL mode, which is both the default and recommended mode for Pi-hole FTLDNS, blocked queries will be answered with the \"unspecified address\" (0.0.0.0 or ::). The \"unspecified address\" is a reserved IP address specified by RFC 3513 - Internet Protocol Version 6 (IPv6) Addressing Architecture, section 2.5.2." },
-			{ "IP-NODATA-AAAA", "In IP-NODATA-AAAA mode, blocked queries will be answered with the local IPv4 addresses of your Pi-hole. Blocked AAAA queries will be answered with NODATA-IPV6 and clients will only try to reach your Pi-hole over its static IPv4 address." },
-			{ "IP", "In IP mode, blocked queries will be answered with the local IP addresses of your Pi-hole." },
-			{ "NXDOMAIN", "In NXDOMAIN mode, blocked queries will be answered with an empty response (i.e., there won't be an answer section) and status NXDOMAIN. A NXDOMAIN response should indicate that there is no such domain to the client making the query." },
-			{ "NODATA", "In NODATA mode, blocked queries will be answered with an empty response (no answer section) and status NODATA. A NODATA response indicates that the domain exists, but there is no record for the requested query type." }
+			{ get_blocking_mode_str(MODE_NULL), "In NULL mode, which is both the default and recommended mode for Pi-hole FTLDNS, blocked queries will be answered with the \"unspecified address\" (0.0.0.0 or ::). The \"unspecified address\" is a reserved IP address specified by RFC 3513 - Internet Protocol Version 6 (IPv6) Addressing Architecture, section 2.5.2." },
+			{ get_blocking_mode_str(MODE_IP_NODATA_AAAA), "In IP-NODATA-AAAA mode, blocked queries will be answered with the local IPv4 addresses of your Pi-hole. Blocked AAAA queries will be answered with NODATA-IPV6 and clients will only try to reach your Pi-hole over its static IPv4 address." },
+			{ get_blocking_mode_str(MODE_IP), "In IP mode, blocked queries will be answered with the local IP addresses of your Pi-hole." },
+			{ get_blocking_mode_str(MODE_NX), "In NXDOMAIN mode, blocked queries will be answered with an empty response (i.e., there won't be an answer section) and status NXDOMAIN. A NXDOMAIN response should indicate that there is no such domain to the client making the query." },
+			{ get_blocking_mode_str(MODE_NODATA), "In NODATA mode, blocked queries will be answered with an empty response (no answer section) and status NODATA. A NODATA response indicates that the domain exists, but there is no record for the requested query type." }
 		};
 		CONFIG_ADD_ENUM_OPTIONS(conf->dns.blocking.mode.a, blockingmode);
 	}
@@ -765,10 +765,10 @@ void initConfig(struct config *conf)
 	{
 		struct enum_options refreshNames[] =
 		{
-			{ "IPV4_ONLY", "Do hourly PTR lookups only for IPv4 addresses. This is the new default since Pi-hole FTL v5.3.2. It should resolve issues with more and more very short-lived PE IPv6 addresses coming up in a lot of networks." },
-			{ "ALL", "Do hourly PTR lookups for all addresses. This was the default until FTL v5.3(.1). It has been replaced as it can create a lot of PTR queries for those with many IPv6 addresses in their networks." },
-			{ "UNKNOWN", "Only resolve unknown hostnames. Already existing hostnames are never refreshed, i.e., there will be no PTR queries made for clients where hostnames are known. This also means that known hostnames will not be updated once known." },
-			{ "NONE", "Don't do any hourly PTR lookups. This means we look host names up exactly once (when we first see a client) and never again. You may miss future changes of host names." }
+			{ get_refresh_hostnames_str(REFRESH_IPV4_ONLY), "Do hourly PTR lookups only for IPv4 addresses. This is the new default since Pi-hole FTL v5.3.2. It should resolve issues with more and more very short-lived PE IPv6 addresses coming up in a lot of networks." },
+			{ get_refresh_hostnames_str(REFRESH_ALL), "Do hourly PTR lookups for all addresses. This was the default until FTL v5.3(.1). It has been replaced as it can create a lot of PTR queries for those with many IPv6 addresses in their networks." },
+			{ get_refresh_hostnames_str(REFRESH_UNKNOWN), "Only resolve unknown hostnames. Already existing hostnames are never refreshed, i.e., there will be no PTR queries made for clients where hostnames are known. This also means that known hostnames will not be updated once known." },
+			{ get_refresh_hostnames_str(REFRESH_NONE), "Don't do any hourly PTR lookups. This means we look host names up exactly once (when we first see a client) and never again. You may miss future changes of host names." }
 		};
 		CONFIG_ADD_ENUM_OPTIONS(conf->resolver.refreshNames.a, refreshNames);
 	}


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes three connected issues with the API endpoint `/api/config`:

- Fix detection of unchanged password. This fixes a forced invalidation of all currently active API session on every config change because every saving was misinterpreted as a password change.
- Ensure we are using the same constants everywhere for our enums (this fixes the issue reported on [Discourse](https://discourse.pi-hole.net/t/dns-blocking-mode-does-not-apply/65674))
- Tweak `misc.privacylevel` to also accept numbers formatted as strings. This can happen when using a dropdown select as done, e.g., on the web interface in `System-> Settings -> All Settings`.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.