### PR TITLE
Add SAN field into self-generated certificates

### DIFF
--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -179,13 +179,26 @@ bool generate_certificate(const char* certfile, bool rsa, const char *domain)
 	// subjectAltName must always be used and that the use of the CN field
 	// should be limited to support legacy implementations.
 	//
-	mbedtls_x509_san_list san_dns = { 0 };
-	san_dns.node.type = MBEDTLS_X509_SAN_DNS_NAME;
-	san_dns.node.san.unstructured_name.p = (unsigned char *) domain;
-	san_dns.node.san.unstructured_name.len = strlen(domain);
-	san_dns.next = NULL; // No more SANs (linked list)
+	mbedtls_x509_san_list san_dns_pihole = { 0 };
+	san_dns_pihole.node.type = MBEDTLS_X509_SAN_DNS_NAME;
+	san_dns_pihole.node.san.unstructured_name.p = (unsigned char *) "pi.hole";
+	san_dns_pihole.node.san.unstructured_name.len = 7; // strlen("pi.hole")
+	san_dns_pihole.next = NULL; // No further element
 
-	ret = mbedtls_x509write_crt_set_subject_alternative_name(&crt, &san_dns);
+	// Furthermore, add "pi.hole" when a custom domain is used to make the
+	// certificate more universal
+	mbedtls_x509_san_list san_dns_domain = { 0 };
+	if(strcasecmp(domain, "pi.hole") != 0)
+	{
+		san_dns_domain.node.type = MBEDTLS_X509_SAN_DNS_NAME;
+		san_dns_domain.node.san.unstructured_name.p = (unsigned char *) domain;
+		san_dns_domain.node.san.unstructured_name.len = strlen(domain);
+		san_dns_domain.next = NULL; // No more SANs (linked list)
+
+		san_dns_pihole.next = &san_dns_domain; // Link this domain
+	}
+
+	ret = mbedtls_x509write_crt_set_subject_alternative_name(&crt, &san_dns_pihole);
 	if (ret != 0)
 		printf("mbedtls_x509write_crt_set_subject_alternative_name returned %d\n", ret);
 

--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -185,7 +185,7 @@ bool generate_certificate(const char* certfile, bool rsa, const char *domain)
 	san_dns_pihole.node.san.unstructured_name.len = 7; // strlen("pi.hole")
 	san_dns_pihole.next = NULL; // No further element
 
-	// Furthermore, add "pi.hole" when a custom domain is used to make the
+	// Furthermore, add the domain when a custom domain is used to make the
 	// certificate more universal
 	mbedtls_x509_san_list san_dns_domain = { 0 };
 	if(strcasecmp(domain, "pi.hole") != 0)


### PR DESCRIPTION
# What does this implement/fix?

Add SAN field into self-generated X.509 TLS certificates. It is mandatory since RFCs 2818 (page 5)

>    If a subjectAltName extension of type dNSName is present, that **MUST**
   be used as the identity. Otherwise, the (most specific) Common Name
   field in the Subject field of the certificate **MUST** be used. Although
   the use of the Common Name is existing practice, it is deprecated and
   Certification Authorities are encouraged to use the dNSName instead.

as well as RFC 3280 (4.2.1.7, 1. paragraph)

>    The subject alternative names extension allows additional identities
   to be bound to the subject of the certificate.  Defined options
   include an Internet electronic mail address, a DNS name, an IP
   address, and a uniform resource identifier (URI).  Other options
   exist, including completely local definitions.  Multiple name forms,
   and multiple instances of each name form, MAY be included.  Whenever
   such identities are to be bound into a certificate, the subject
   alternative name (or issuer alternative name) extension **MUST** be used;
   however, a DNS name MAY be represented in the subject field using the
   domainComponent attribute as described in section 4.1.2.4.


Proper functionality be verified using, e.g.
```
pihole-FTL --gen-x509 /tmp/test.pem
```
and then
```
openssl x509 -in /tmp/test.pem -text -noout
```
looking for these lines:
```
            X509v3 Subject Alternative Name: 
                DNS:pi.hole
```

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.