### PR TITLE
Add environmental variables support

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -283,26 +283,8 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 				break;
 			}
 
-			// Get password hash as allocated string (an empty string is hashed to an empty string)
-			char *pwhash = strlen(elem->valuestring) > 0 ? create_password(elem->valuestring) : strdup("");
-
-			// Verify that the password hash is valid
-			if(verify_password(elem->valuestring, pwhash, false) != PASSWORD_CORRECT)
-			{
-				free(pwhash);
+			if(!set_and_check_password(conf_item, elem->valuestring))
 				return "Failed to create password hash (verification failed), password remains unchanged";
-			}
-
-			// Get pointer to pwhash instead
-			conf_item--;
-
-			// Free previously allocated memory (if applicable)
-			if(conf_item->t == CONF_STRING_ALLOCATED)
-				free(conf_item->v.s);
-
-			// Set item
-			conf_item->v.s = pwhash;
-			log_debug(DEBUG_CONFIG, "Set %s to \"%s\"", conf_item->k, conf_item->v.s);
 
 			break;
 		}

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -570,3 +570,30 @@ int run_performance_test(void)
 
 	return EXIT_SUCCESS;
 }
+
+bool set_and_check_password(struct conf_item *conf_item, const char *password)
+{
+	// Get password hash as allocated string (an empty string is hashed to an empty string)
+	char *pwhash = strlen(password) > 0 ? create_password(password) : strdup("");
+
+	// Verify that the password hash is valid
+	if(verify_password(password, pwhash, false) != PASSWORD_CORRECT)
+	{
+		free(pwhash);
+		log_warn("Failed to create password hash (verification failed), password remains unchanged");
+		return false;
+	}
+
+	// Get pointer to pwhash instead
+	conf_item--;
+
+	// Free previously allocated memory (if applicable)
+	if(conf_item->t == CONF_STRING_ALLOCATED)
+		free(conf_item->v.s);
+
+	// Set item
+	conf_item->v.s = pwhash;
+	log_debug(DEBUG_CONFIG, "Set %s to \"%s\"", conf_item->k, conf_item->v.s);
+
+	return true;
+}

--- a/src/config/password.h
+++ b/src/config/password.h
@@ -18,6 +18,7 @@ void sha256_raw_to_hex(uint8_t *data, char *buffer);
 char *create_password(const char *password) __attribute__((malloc));
 char verify_password(const char *password, const char *pwhash, const bool rate_limiting);
 int run_performance_test(void);
+bool set_and_check_password(struct conf_item *conf_item, const char *password);
 
 enum password_result {
 	PASSWORD_INCORRECT = 0,

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -18,6 +18,8 @@
 #include <sys/file.h>
 // rotate_files()
 #include "files.h"
+//set_and_check_password()
+#include "config/password.h"
 
 // Open the TOML file for reading or writing
 FILE * __attribute((malloc)) __attribute((nonnull(1))) openFTLtoml(const char *mode)
@@ -714,6 +716,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		case CONF_PASSWORD:
 		{
 			// This is ignored, it is only a pseudo-element with no real content
+			break;
 		}
 	}
 }
@@ -950,7 +953,11 @@ bool readEnvValue(struct conf_item *conf_item, struct config *newconf)
 		}
 		case CONF_PASSWORD:
 		{
-			// This is ignored, it is only a pseudo-element with no real content
+			if(!set_and_check_password(conf_item, envvar))
+			{
+				log_warn("ENV %s is invalid", envkey);
+				break;
+			}
 		}
 	}
 

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -751,9 +751,9 @@ bool readEnvValue(struct conf_item *conf_item, struct config *newconf)
 	{
 		case CONF_BOOL:
 		{
-			if(strcasecmp(envkey, "true") == 0 || strcasecmp(envkey, "yes") == 0)
+			if(strcasecmp(envvar, "true") == 0 || strcasecmp(envvar, "yes") == 0)
 				conf_item->v.b = true;
-			else if(strcasecmp(envkey, "false") == 0 || strcasecmp(envkey, "no") == 0)
+			else if(strcasecmp(envvar, "false") == 0 || strcasecmp(envvar, "no") == 0)
 				conf_item->v.b = false;
 			else
 				log_warn("ENV %s is not of type bool", envkey);
@@ -761,9 +761,9 @@ bool readEnvValue(struct conf_item *conf_item, struct config *newconf)
 		}
 		case CONF_ALL_DEBUG_BOOL:
 		{
-			if(strcasecmp(envkey, "true") == 0 || strcasecmp(envkey, "yes") == 0)
+			if(strcasecmp(envvar, "true") == 0 || strcasecmp(envvar, "yes") == 0)
 				set_all_debug(newconf, true);
-			else if(strcasecmp(envkey, "false") == 0 || strcasecmp(envkey, "no") == 0)
+			else if(strcasecmp(envvar, "false") == 0 || strcasecmp(envvar, "no") == 0)
 				set_all_debug(newconf, false);
 			else
 				log_warn("ENV %s is not of type bool", envkey);

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -444,7 +444,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok)
 				conf_item->v.b = val.u.b;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type bool", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid bool", conf_item->k);
 			break;
 		}
 		case CONF_ALL_DEBUG_BOOL:
@@ -453,7 +453,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok)
 				set_all_debug(newconf, val.u.b);
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type bool", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid bool", conf_item->k);
 			break;
 		}
 		case CONF_INT:
@@ -462,7 +462,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok)
 				conf_item->v.i = val.u.i;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type integer", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid integer", conf_item->k);
 			break;
 		}
 		case CONF_UINT:
@@ -471,7 +471,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok && val.u.i >= 0)
 				conf_item->v.ui = val.u.i;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type unsigned integer", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid unsigned integer", conf_item->k);
 			break;
 		}
 		case CONF_UINT16:
@@ -480,7 +480,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok && val.u.i >= 0 && val.u.i <= UINT16_MAX)
 				conf_item->v.ui = val.u.i;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type unsigned integer (16 bit)", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid unsigned integer (16 bit)", conf_item->k);
 			break;
 		}
 		case CONF_LONG:
@@ -489,7 +489,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok)
 				conf_item->v.l = val.u.i;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type long", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid long integer", conf_item->k);
 			break;
 		}
 		case CONF_ULONG:
@@ -498,7 +498,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok && val.u.i >= 0)
 				conf_item->v.ul = val.u.i;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type unsigned long", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid unsigned long integer", conf_item->k);
 			break;
 		}
 		case CONF_DOUBLE:
@@ -507,7 +507,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok)
 				conf_item->v.d = val.u.d;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type double", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid double", conf_item->k);
 			break;
 		}
 		case CONF_STRING:
@@ -522,7 +522,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 				conf_item->t = CONF_STRING_ALLOCATED;
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_PTR_TYPE:
@@ -538,7 +538,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_BUSY_TYPE:
@@ -554,7 +554,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_BLOCKING_MODE:
@@ -570,7 +570,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a validstring", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_REFRESH_HOSTNAMES:
@@ -586,7 +586,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_LISTENING_MODE:
@@ -602,7 +602,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_WEB_THEME:
@@ -618,7 +618,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_TEMP_UNIT:
@@ -634,7 +634,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not of type string", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
 			break;
 		}
 		case CONF_ENUM_PRIVACY_LEVEL:
@@ -643,7 +643,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			if(val.ok && val.u.i >= PRIVACY_SHOW_ALL && val.u.i <= PRIVACY_MAXIMUM)
 				conf_item->v.i = val.u.i;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is invalid (not of type integer or outside allowed bounds)", conf_item->k);
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is invalid (not an integer or outside allowed bounds)", conf_item->k);
 			break;
 		}
 		case CONF_STRUCT_IN_ADDR:
@@ -654,8 +654,12 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			{
 				if(inet_pton(AF_INET, val.u.s, &addr4))
 					memcpy(&conf_item->v.in_addr, &addr4, sizeof(addr4));
+				else
+					log_warn("Config %s is invalid (not of type IPv4 address)", conf_item->k);
 				free(val.u.s);
 			}
+			else
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is invalid (not a valid string of type IPv4 address)", conf_item->k);
 			break;
 		}
 		case CONF_STRUCT_IN6_ADDR:
@@ -666,8 +670,12 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			{
 				if(inet_pton(AF_INET6, val.u.s, &addr6))
 					memcpy(&conf_item->v.in6_addr, &addr6, sizeof(addr6));
+				else
+					log_warn("Config %s is invalid (not of type IPv6 address)", conf_item->k);
 				free(val.u.s);
 			}
+			else
+				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is invalid (not a valid string of type IPv6 address)", conf_item->k);
 			break;
 		}
 		case CONF_JSON_STRING_ARRAY:
@@ -686,7 +694,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 					const toml_datum_t d = toml_string_at(array, i);
 					if(!d.ok)
 					{
-						log_debug(DEBUG_CONFIG, "%s is an invalid array (found at index %u)", conf_item->k, i);
+						log_warn("Config %s is an invalid array (found at index %u)", conf_item->k, i);
 						break;
 					}
 					// Only import non-empty entries
@@ -708,4 +716,245 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 			// This is ignored, it is only a pseudo-element with no real content
 		}
 	}
+}
+
+#define FTLCONF_PREFIX "FTLCONF_"
+bool readEnvValue(struct conf_item *conf_item, struct config *newconf)
+{
+	// Allocate memory for config key + prefix (sizeof includes the trailing '\0')
+	const size_t envkey_size = strlen(conf_item->k) + sizeof(FTLCONF_PREFIX);
+	char *envkey = calloc(envkey_size, sizeof(char));
+
+	// Build env key to look for
+	strcpy(envkey, FTLCONF_PREFIX);
+	strcat(envkey, conf_item->k);
+
+	// Replace all "." by "_" as this is the convention used in v5.x and earlier
+	for(unsigned int i = 0; i < envkey_size - 1; i++)
+		if(envkey[i] == '.')
+			envkey[i] = '_';
+
+	// First check if a environmental variable with the given key exists
+	const char *envvar = getenv(envkey);
+
+	// Return early if this environment variable does not exist
+	if(envvar == NULL)
+	{
+		log_debug(DEBUG_CONFIG, "ENV %s is not set", envkey);
+		free(envkey);
+		return false;
+	}
+
+	log_debug(DEBUG_CONFIG, "ENV %s = \"%s\"", envkey, envvar);
+
+	switch(conf_item->t)
+	{
+		case CONF_BOOL:
+		{
+			if(strcasecmp(envkey, "true") == 0 || strcasecmp(envkey, "yes") == 0)
+				conf_item->v.b = true;
+			else if(strcasecmp(envkey, "false") == 0 || strcasecmp(envkey, "no") == 0)
+				conf_item->v.b = false;
+			else
+				log_warn("ENV %s is not of type bool", envkey);
+			break;
+		}
+		case CONF_ALL_DEBUG_BOOL:
+		{
+			if(strcasecmp(envkey, "true") == 0 || strcasecmp(envkey, "yes") == 0)
+				set_all_debug(newconf, true);
+			else if(strcasecmp(envkey, "false") == 0 || strcasecmp(envkey, "no") == 0)
+				set_all_debug(newconf, false);
+			else
+				log_warn("ENV %s is not of type bool", envkey);
+			break;
+		}
+		case CONF_INT:
+		{
+			int val = 0;
+			if(sscanf(envvar, "%i", &val) == 1)
+				conf_item->v.i = val;
+			else
+				log_warn("ENV %s is not of type integer", envkey);
+			break;
+		}
+		case CONF_UINT:
+		{
+			unsigned int val = 0;
+			if(sscanf(envvar, "%u", &val) == 1)
+				conf_item->v.ui = val;
+			else
+				log_warn("ENV %s is not of type unsigned integer", envkey);
+			break;
+		}
+		case CONF_UINT16:
+		{
+			unsigned int val = 0;
+			if(sscanf(envvar, "%u", &val) == 1 && val <= UINT16_MAX)
+				conf_item->v.ui = val;
+			else
+				log_warn("ENV %s is not of type unsigned integer (16 bit)", envkey);
+			break;
+		}
+		case CONF_LONG:
+		{
+			long val = 0;
+			if(sscanf(envvar, "%li", &val) == 1)
+				conf_item->v.l = val;
+			else
+				log_warn("ENV %s is not of type long", envkey);
+			break;
+		}
+		case CONF_ULONG:
+		{
+			unsigned long val = 0;
+			if(sscanf(envvar, "%lu", &val) == 1)
+				conf_item->v.ul = val;
+			else
+				log_warn("ENV %s is not of type unsigned long", envkey);
+			break;
+		}
+		case CONF_DOUBLE:
+		{
+			double val = 0;
+			if(sscanf(envvar, "%lf", &val) == 1)
+				conf_item->v.d = val;
+			else
+				log_warn("ENV %s is not of type double", envkey);
+			break;
+		}
+		case CONF_STRING:
+		case CONF_STRING_ALLOCATED:
+		{
+			if(conf_item->t == CONF_STRING_ALLOCATED)
+				free(conf_item->v.s);
+			conf_item->v.s = strdup(envvar);
+			conf_item->t = CONF_STRING_ALLOCATED;
+			break;
+		}
+		case CONF_ENUM_PTR_TYPE:
+		{
+			const int ptr_type = get_ptr_type_val(envvar);
+			if(ptr_type != -1)
+				conf_item->v.ptr_type = ptr_type;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_BUSY_TYPE:
+		{
+			const int busy_reply = get_busy_reply_val(envvar);
+			if(busy_reply != -1)
+				conf_item->v.busy_reply = busy_reply;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_BLOCKING_MODE:
+		{
+			const int blocking_mode = get_blocking_mode_val(envvar);
+			if(blocking_mode != -1)
+				conf_item->v.blocking_mode = blocking_mode;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_REFRESH_HOSTNAMES:
+		{
+			const int refresh_hostnames = get_refresh_hostnames_val(envvar);
+			if(refresh_hostnames != -1)
+				conf_item->v.refresh_hostnames = refresh_hostnames;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_LISTENING_MODE:
+		{
+			const int listeningMode = get_listeningMode_val(envvar);
+			if(listeningMode != -1)
+				conf_item->v.listeningMode = listeningMode;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_WEB_THEME:
+		{
+			const int web_theme = get_web_theme_val(envvar);
+			if(web_theme != -1)
+				conf_item->v.web_theme = web_theme;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_TEMP_UNIT:
+		{
+			const int temp_unit = get_temp_unit_val(envvar);
+			if(temp_unit != -1)
+				conf_item->v.temp_unit = temp_unit;
+			else
+				log_warn("ENV %s is invalid, allowed options are: %s", envkey, conf_item->h);
+			break;
+		}
+		case CONF_ENUM_PRIVACY_LEVEL:
+		{
+			int val = 0;
+			if(sscanf(envvar, "%i", &val) == 1 && val >= PRIVACY_SHOW_ALL && val <= PRIVACY_MAXIMUM)
+				conf_item->v.i = val;
+			else
+				log_warn("ENV %s is invalid (not of type integer or outside allowed bounds)", envkey);
+			break;
+		}
+		case CONF_STRUCT_IN_ADDR:
+		{
+			struct in_addr addr4 = { 0 };
+			if(inet_pton(AF_INET, envvar, &addr4))
+				memcpy(&conf_item->v.in_addr, &addr4, sizeof(addr4));
+			else
+				log_warn("ENV %s is invalid (not of type IPv4 address)", envkey);
+			break;
+		}
+		case CONF_STRUCT_IN6_ADDR:
+		{
+			struct in6_addr addr6 = { 0 };
+			if(inet_pton(AF_INET6, envvar, &addr6))
+				memcpy(&conf_item->v.in6_addr, &addr6, sizeof(addr6));
+			else
+				log_warn("ENV %s is invalid (not of type IPv6 address)", envkey);
+			break;
+		}
+		case CONF_JSON_STRING_ARRAY:
+		{
+			// Make a copy of envvar as strtok modified the input string
+			char *envvar_copy = strdup(envvar);
+			// Free previously allocated JSON array
+			cJSON_Delete(conf_item->v.json);
+			conf_item->v.json = cJSON_CreateArray();
+			// Parse envvar array and generate a JSON array
+			const char delim[] =",";
+			const char *elem = strtok(envvar_copy, delim);
+			while(elem != NULL)
+			{
+				// Only import non-empty entries
+				if(strlen(elem) > 0)
+				{
+					// Add string to our JSON array
+					cJSON *item = cJSON_CreateString(elem);
+					cJSON_AddItemToArray(conf_item->v.json, item);
+				}
+
+				// Search for the next element
+				elem = strtok(NULL, delim);
+			}
+			free(envvar_copy);
+			break;
+		}
+		case CONF_PASSWORD:
+		{
+			// This is ignored, it is only a pseudo-element with no real content
+		}
+	}
+
+	// Free allocated env var name
+	free(envkey);
+	return true;
 }

--- a/src/config/toml_helper.h
+++ b/src/config/toml_helper.h
@@ -23,5 +23,6 @@ void print_comment(FILE *fp, const char *str, const char *intro, const unsigned 
 void print_toml_allowed_values(cJSON *allowed_values, FILE *fp, const unsigned int width, const unsigned int indent);
 void writeTOMLvalue(FILE * fp, const int indent, const enum conf_type t, union conf_value *v);
 void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *toml, struct config *newconf);
+bool readEnvValue(struct conf_item *conf_item, struct config *newconf);
 
 #endif //CONFIG_WRITER_H

--- a/test/run.sh
+++ b/test/run.sh
@@ -69,6 +69,7 @@ OLDUMASK=$(umask)
 umask 0022
 
 # Start FTL
+export FTLCONF_misc_nice="-11"
 if ! su pihole -s /bin/sh -c /home/pihole/pihole-FTL; then
   echo "pihole-FTL failed to start"
   exit 1

--- a/test/run.sh
+++ b/test/run.sh
@@ -68,8 +68,10 @@ bash test/pdns/setup.sh
 OLDUMASK=$(umask)
 umask 0022
 
-# Start FTL
+# Set exemplary config value by environment variable
 export FTLCONF_misc_nice="-11"
+
+# Start FTL
 if ! su pihole -s /bin/sh -c /home/pihole/pihole-FTL; then
   echo "pihole-FTL failed to start"
   exit 1

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1185,7 +1185,7 @@
   [[ ${lines[0]} == "0" ]]
 }
 
-@test "No config errors in pihole.toml" {
+@test "No missing config items in pihole.toml" {
   run bash -c 'grep "DEBUG_CONFIG: " /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   run bash -c 'grep "DEBUG_CONFIG: " /var/log/pihole/FTL.log | grep -c "DOES NOT EXIST"'
@@ -1249,6 +1249,13 @@
   run bash -c "dig A x.y.z.abp.antigravity.ftl +short @127.0.0.1"
   printf "A: %s\n" "${lines[@]}"
   [[ "${lines[0]}" == "192.168.1.7" ]]
+}
+
+@test "Environmental variable is favored over config file" {
+  # The config file has -10 but we set FTLCONF_misc_nice="-11"
+  run bash -c 'grep -c "nice = -11" /etc/pihole/pihole.toml'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "1" ]]
 }
 
 @test "API domain search: Non-existing domain returns expected JSON" {


### PR DESCRIPTION
# What does this implement/fix?

Make FTL read and parse `FTLCONF_*` environmental variables. If they exist, they take precedence over config file values. The config file is updated from environmental variables so any changes can be followed therein.

We furthermore add a special environmental variable `FTLCONF_ENV_ONLY`. When set to `true`, *only* environmental variables are used to configure FTL and the config file is ignored. All variables not defined by appropriate env vars are initialized with their defaults (check `/etc/pihole/pihole.toml` for the defaults).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.