### PR TITLE
Ensure database upgrades use transactions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "FTL x86_64 Build Env",
-  "image": "ghcr.io/pi-hole/ftl-build:ftl-build-buildx-alpine",
+  "image": "ghcr.io/pi-hole/ftl-build:v2.3-alpine",
   "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
   "extensions": [
     "jetmartin.bats",

--- a/src/database/aliasclients.c
+++ b/src/database/aliasclients.c
@@ -22,6 +22,9 @@
 
 bool create_aliasclients_table(sqlite3 *db)
 {
+	// Start transaction
+	SQL_bool(db, "BEGIN TRANSACTION");
+
 	// Create aliasclient table in the database
 	SQL_bool(db, "CREATE TABLE aliasclient (id INTEGER PRIMARY KEY NOT NULL, " \
 	                                       "name TEXT NOT NULL, " \
@@ -36,6 +39,9 @@ bool create_aliasclients_table(sqlite3 *db)
 		log_err("create_aliasclients_table(): Failed to update database version!");
 		return false;
 	}
+
+	// End transaction
+	SQL_bool(db, "COMMIT");
 
 	return true;
 }

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -166,6 +166,9 @@ int dbquery(sqlite3* db, const char *format, ...)
 
 static bool create_counter_table(sqlite3* db)
 {
+	// Start transaction
+	SQL_bool(db, "BEGIN TRANSACTION");
+
 	// Create FTL table in the database (holds properties like database version, etc.)
 	SQL_bool(db, "CREATE TABLE counters ( id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL );");
 
@@ -196,6 +199,8 @@ static bool create_counter_table(sqlite3* db)
 		log_err("create_counter_table(): Failed to update database version!");
 		return false;
 	}
+	// End transaction
+	SQL_bool(db, "COMMIT");
 
 	return true;
 }

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -572,8 +572,12 @@ double db_get_FTL_property_double(sqlite3 *db, const enum ftl_table_props ID)
 
 bool db_set_FTL_property(sqlite3 *db, const enum ftl_table_props ID, const int value)
 {
-	// return dbquery(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %ld );", ID, value) == SQLITE_OK;
-	SQL_bool(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES ( %u, %d );", ID, value);
+	// Use UPSERT (https://sqlite.org/lang_upsert.html)
+	// UPSERT is a clause added to INSERT that causes the INSERT to behave
+	// as an UPDATE or a no-op if the INSERT would violate a uniqueness
+	// constraint. UPSERT is not standard SQL. UPSERT in SQLite follows the
+	// syntax established by PostgreSQL, with generalizations. 
+	SQL_bool(db, "INSERT INTO ftl (id, value) VALUES ( %u, %d ) ON CONFLICT (id) DO UPDATE SET value=%d;", ID, value, value);
 	return true;
 }
 

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -498,6 +498,21 @@ void db_init(void)
 		dbversion = db_get_int(db, DB_VERSION);
 	}
 
+	// Update to version 14 if lower
+	if(dbversion < 14)
+	{
+		// Update to version 14: Add additional column for the ftl table
+		log_info("Updating long-term database to version 14");
+		if(!add_ftl_table_description(db))
+		{
+			log_info("FTL table description cannot be added, database not available");
+			dbclose(&db);
+			return;
+		}
+		// Get updated version
+		dbversion = db_get_int(db, DB_VERSION);
+	}
+
 	lock_shm();
 	import_aliasclients(db);
 	unlock_shm();

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -172,6 +172,9 @@ static unsigned char message_blob_types[MAX_MESSAGE][5] =
 // Create message table in the database
 bool create_message_table(sqlite3 *db)
 {
+	// Start transaction
+	SQL_bool(db, "BEGIN TRANSACTION");
+
 	// The blob fields can hold arbitrary data. Their type is specified through the type.
 	SQL_bool(db, "CREATE TABLE message ( id INTEGER PRIMARY KEY AUTOINCREMENT, "
 	                                    "timestamp INTEGER NOT NULL, "
@@ -189,6 +192,9 @@ bool create_message_table(sqlite3 *db)
 		log_err("create_message_table(): Failed to update database version!");
 		return false;
 	}
+
+	// End transaction
+	SQL_bool(db, "COMMIT");
 
 	return true;
 }

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -34,6 +34,9 @@ bool create_network_table(sqlite3 *db)
 	if(FTLDBerror())
 		return false;
 
+	// Start transaction
+	SQL_bool(db, "BEGIN TRANSACTION");
+
 	// Create network table in the database
 	SQL_bool(db, "CREATE TABLE network ( id INTEGER PRIMARY KEY NOT NULL, " \
 	                                    "ip TEXT NOT NULL, " \
@@ -51,6 +54,9 @@ bool create_network_table(sqlite3 *db)
 		log_warn("create_network_table(): Failed to update database version!");
 		return false;
 	}
+
+	// End transaction
+	SQL_bool(db, "COMMIT");
 
 	return true;
 }
@@ -1609,6 +1615,9 @@ bool unify_hwaddr(sqlite3 *db)
 	                        "HAVING MAX(lastQuery) "
 	                        "AND cnt > 1;";
 
+	// Start transaction
+	SQL_bool(db, "BEGIN TRANSACTION");
+
 	// Perform SQL query
 	sqlite3_stmt *stmt = NULL;
 	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
@@ -1661,6 +1670,9 @@ bool unify_hwaddr(sqlite3 *db)
 	// Update database version to 4
 	if(!db_set_FTL_property(db, DB_VERSION, 4))
 		return false;
+
+	// End transaction
+	SQL_bool(db, "COMMIT");
 
 	return true;
 }

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -758,6 +758,32 @@ bool add_query_storage_column_regex_id(sqlite3 *db)
 	return true;
 }
 
+bool add_ftl_table_description(sqlite3 *db)
+{
+	// Start transaction of database update
+	SQL_bool(db, "BEGIN TRANSACTION");
+
+	// Add additional column to the ftl table
+	SQL_bool(db, "ALTER TABLE ftl ADD COLUMN description TEXT");
+
+	// Update ftl table
+	SQL_bool(db, "UPDATE ftl SET description = 'Database version' WHERE id = %d", DB_VERSION);
+	SQL_bool(db, "UPDATE ftl SET description = 'Unix timestamp of the latest stored query' WHERE id = %d", DB_LASTTIMESTAMP);
+	SQL_bool(db, "UPDATE ftl SET description = 'Unix timestamp of the database creation' WHERE id = %d", DB_FIRSTCOUNTERTIMESTAMP);
+
+	// Update database version to 14
+	if(!db_set_FTL_property(db, DB_VERSION, 14))
+	{
+		log_err("add_query_storage_column_regex_id(): Failed to update database version!");
+		return false;
+	}
+
+	// Finish transaction
+	SQL_bool(db, "COMMIT");
+
+	return true;
+}
+
 bool optimize_queries_table(sqlite3 *db)
 {
 	// Start transaction of database update

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -673,11 +673,21 @@ bool delete_old_queries_from_db(const bool use_memdb, const double mintime)
 
 bool add_additional_info_column(sqlite3 *db)
 {
+	// Start transaction
+	SQL_bool(db, "BEGIN TRANSACTION");
+
 	// Add column additinal_info to queries table
 	SQL_bool(db, "ALTER TABLE queries ADD COLUMN additional_info TEXT;");
 
 	// Update the database version to 7
-	SQL_bool(db, "INSERT OR REPLACE INTO ftl (id, value) VALUES (%d, 7);", DB_VERSION);
+	if(!db_set_FTL_property(db, DB_VERSION, 7))
+	{
+		log_err("add_additional_info_column(): Failed to update database version!");
+		return false;
+	}
+
+	// End transaction
+	SQL_bool(db, "COMMIT");
 
 	return true;
 }

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -127,5 +127,6 @@ bool optimize_queries_table(sqlite3 *db);
 bool create_addinfo_table(sqlite3 *db);
 bool add_query_storage_columns(sqlite3 *db);
 bool add_query_storage_column_regex_id(sqlite3 *db);
+bool add_ftl_table_description(sqlite3 *db);
 
 #endif //QUERY_TABLE_PRIVATE_H

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -448,12 +448,12 @@
   printf "%s\n" "${lines[@]}"
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"query_storage\" (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain INTEGER NOT NULL, client INTEGER NOT NULL, forward INTEGER, additional_info INTEGER, reply_type INTEGER, reply_time REAL, dnssec INTEGER, regex_id INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE INDEX idx_queries_timestamps ON \"query_storage\" (timestamp);"* ]]
-  [[ "${lines[@]}" == *"CREATE TABLE ftl (id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL);"* ]]
+  [[ "${lines[@]}" == *"CREATE TABLE ftl (id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL, description TEXT);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE counters (id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network\" (id INTEGER PRIMARY KEY NOT NULL, hwaddr TEXT UNIQUE NOT NULL, interface TEXT NOT NULL, firstSeen INTEGER NOT NULL, lastQuery INTEGER NOT NULL, numQueries INTEGER NOT NULL, macVendor TEXT, aliasclient_id INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network_addresses\" (network_id INTEGER NOT NULL, ip TEXT UNIQUE NOT NULL, lastSeen INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), name TEXT, nameUpdated INTEGER, FOREIGN KEY(network_id) REFERENCES network(id));"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE aliasclient (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, comment TEXT);"* ]]
-  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,13);"* ]] # Expecting FTL database version 13
+  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,14,'Database version');"* ]] # Expecting FTL database version 14
   # vvv This has been added in version 10 vvv
   [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info, reply_type, reply_time, dnssec, regex_id FROM query_storage q;"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE domain_by_id (id INTEGER PRIMARY KEY, domain TEXT NOT NULL);"* ]]


### PR DESCRIPTION
# What does this implement/fix?

This PR improves `pihole-FTL.db` handling in two ways:

1. Ensure all database upgrade steps are wrapped into transactions. When the database upgrade is interrupted (FTL is killed, or crashed or power loss, ...), then the rollback journal file is left on disk. The next time another application attempts to open the database file, it notices the presence of the abandoned rollback journal (we call it a "hot journal" in this circumstance) and uses the information in the journal to restore the database to its state prior to the start of the incomplete transaction. This fixes sporadic issues with only partially initialized databases mostly seen on devices with unstable power supply.
   So far, it is unclear how the initial database migration happens but it is likely due to the reasons mentioned above. We have reports of this seen every now and then (also with v5.x releases) but never really tracked it down before.

2. Add a new `descriptions` column to the `ftl` database table to make working with the database more human-friendly. This updates the database to version 14

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.