### PR TITLE
Include number of active clients in summary

### DIFF
--- a/src/api/docs/content/specs/stats.yaml
+++ b/src/api/docs/content/specs/stats.yaml
@@ -469,6 +469,10 @@ components:
         clients:
           type: object
           properties:
+            active:
+              type: integer
+              description: Number of active clients (seen in the last 24 hours)
+              example: 10
             total:
               type: integer
               description: Total number of clients seen by FTL

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -106,7 +106,21 @@ int api_stats_summary(struct ftl_conn *api)
 		JSON_ADD_NUMBER_TO_OBJECT(replies, get_query_reply_str(reply), counters->reply[reply]);
 	JSON_ADD_ITEM_TO_OBJECT(queries, "replies", replies);
 
+	// Count clients that have been active within the most recent 24 hours
+	unsigned int activeclients = 0;
+	for(int clientID=0; clientID < counters->clients; clientID++)
+	{
+		// Get client pointer
+		const clientsData* client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
+
+		if(client->count > 0)
+			activeclients++;
+	}
+
 	cJSON *clients = JSON_NEW_OBJECT();
+	JSON_ADD_NUMBER_TO_OBJECT(clients, "active", activeclients);
 	JSON_ADD_NUMBER_TO_OBJECT(clients, "total", counters->clients);
 
 	cJSON *gravity = JSON_NEW_OBJECT();


### PR DESCRIPTION
# What does this implement/fix?

Include number of active clients in the response of `GET /api/stats/summary`

Needed for https://github.com/pi-hole/web/pull/2769

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.