### PR TITLE
Retry failed FTL builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,22 +87,23 @@ jobs:
         run: ls -l
       -
         name: Build and test FTL in ftl-build container (QEMU)
-        uses: docker/build-push-action@v5.0.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
-          platforms: ${{ matrix.platform }}
-          # Always load latest container image
-          pull: true
-          # Do not push anything
-          push: false
-          context: .
-          target: result
-          file: .github/Dockerfile
-          outputs: |
-            type=tar,dest=build.tar
-          build-args: |
-            "CI_ARCH=${{ matrix.platform }}"
-            "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
-            "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
+          attempt_limit: 3
+          action: docker/build-push-action@v5.0.0
+          with: |
+            platforms: ${{ matrix.platform }}
+            pull: true
+            push: false
+            context: .
+            target: result
+            file: .github/Dockerfile
+            outputs: |
+              type=tar,dest=build.tar
+            build-args: |
+              "CI_ARCH=${{ matrix.platform }}"
+              "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
+              "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
       -
         name: List files in current directory
         run: ls -l


### PR DESCRIPTION
# What does this implement/fix?

We see sporadic but intermittent failures for FTL jobs in emulated environments (most often, `armv6` or `riscv64` fail). The PR adds a retry action that - well - retries failed jobs up to three times until they are are finally marked as failed.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.