### PR TITLE
Fix API GET /api/auth documentation

### DIFF
--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -20,12 +20,23 @@ components:
                     - $ref: 'auth.yaml#/components/schemas/session'
                     - $ref: 'common.yaml#/components/schemas/took'
                 examples:
-                  login_okay:
-                    $ref: 'auth.yaml#/components/examples/login_okay'
+                  auth_okay:
+                    $ref: 'auth.yaml#/components/examples/auth_okay'
                   no_login_required:
                     $ref: 'auth.yaml#/components/examples/no_login_required'
+          '401':
+            description: Unauthorized
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'auth.yaml#/components/schemas/session'
+                    - $ref: 'common.yaml#/components/schemas/took'
+                examples:
                   login_required:
                     $ref: 'auth.yaml#/components/examples/login_required'
+                  login_required_2fa:
+                    $ref: 'auth.yaml#/components/examples/login_required_2fa'
       post:
         summary: Submit password for login
         tags:
@@ -358,14 +369,23 @@ components:
               nullable: true
 
   examples:
-    login_okay:
-      summary: Login successful
+    auth_okay:
+      summary: Authentication valid
       value:
         session:
           valid: true
           totp: false
           sid: null
           csrf: null
+          validity: 300
+    login_okay:
+      summary: Login successful
+      value:
+        session:
+          valid: true
+          totp: false
+          sid: "vFA+EP4MQ5JJvJg+3Q2Jnw="
+          csrf: "Ux87YTIiMOf/GKCefVIOMw="
           validity: 300
     no_login_required:
       summary: No login required for this client
@@ -377,11 +397,20 @@ components:
           csrf: null
           validity: -1
     login_required:
-      summary: Login required
+      summary: Login required, 2FA disabled
       value:
         session:
           valid: false
           totp: false
+          sid: null
+          csrf: null
+          validity: -1
+    login_required_2fa:
+      summary: Login required, 2FA enabled
+      value:
+        session:
+          valid: false
+          totp: true
           sid: null
           csrf: null
           validity: -1


### PR DESCRIPTION
# What does this implement/fix?

`GET /api/auth` returns `401 Unauthorized` when login is required and the user has no valid session.
This is currently missing in the API docs. Thanks @yubiuser for spotting this. We furthermore tweak the auth-related examples.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.