### PR TITLE
Fix setting empty password

### DIFF
--- a/src/config/password.c
+++ b/src/config/password.c
@@ -309,13 +309,13 @@ char * __attribute__((malloc)) create_password(const char *password)
 
 char verify_password(const char *password, const char* pwhash, const bool rate_limiting)
 {
-	// No password supplied
-	if(password == NULL || password[0] == '\0')
-		return PASSWORD_INCORRECT;
-
 	// No password set
 	if(pwhash == NULL || pwhash[0] == '\0')
 		return PASSWORD_CORRECT;
+
+	// No password supplied
+	if(password == NULL || password[0] == '\0')
+		return PASSWORD_INCORRECT;
 
 	// Check if there has already been one login attempt within this second
 	static time_t last_password_attempt = 0;


### PR DESCRIPTION
# What does this implement/fix?

Fix small logic bug preventing setting an empty (= no) password via API/CLI/file. So far, it was only possible by directly interacting with `.pwhash`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.