### PR TITLE
PUT and DELETE on forced config items are errors

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -843,6 +843,20 @@ static int api_config_put_delete(struct ftl_conn *api)
 		if(min_level != level + 1)
 			continue;
 
+		// Error when this config item is read-only due to an
+		// environment variable forcing its value
+		if(new_item->f & FLAG_ENV_VAR)
+		{
+			char *key = strdup(new_item->k);
+			free_config(&newconf);
+			if(requested_path != NULL)
+				free_config_path(requested_path);
+			return send_json_error_free(api, 400,
+			                            "bad_request",
+			                            "Config items set via environment variables cannot be changed via the API",
+			                            key, true);
+		}
+
 		// Check if this entry does already exist in the array
 		int idx = 0;
 		for(; idx < cJSON_GetArraySize(new_item->v.json); idx++)


### PR DESCRIPTION
# What does this implement/fix?

`PUT` and `DELETE` on config items which are forced by env variable should be rejected with `400 Bad Request` + explanation

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.