### PR TITLE
Add Basic Auth authentication

### DIFF
--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -9,7 +9,7 @@ components:
         operationId: "get_auth"
         security: []
         description: |
-          The API may chose to reply with a valid session if no authentication is needed for this server.
+          The API may chose to reply with a valid session if no authentication is needed for this server. It is possible to initiate a session using HTTP Basic Auth (username: `pi-hole`).
         responses:
           '200':
             description: OK

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -77,7 +77,7 @@ static char * __attribute__((malloc)) double_sha256_password(const char *passwor
 	return strdup(response);
 }
 
-static char * __attribute__((malloc)) base64_encode(const uint8_t *data, const size_t length)
+char * __attribute__((malloc)) base64_encode(const uint8_t *data, const size_t length)
 {
 	// Base64 encoding requires 4 bytes for every 3 bytes of input, plus
 	// additional bytes for padding. The output buffer must be large enough
@@ -94,7 +94,7 @@ static char * __attribute__((malloc)) base64_encode(const uint8_t *data, const s
 	return encoded;
 }
 
-static uint8_t * __attribute__((malloc)) base64_decode(const char *data, size_t *length)
+uint8_t * __attribute__((malloc)) base64_decode(const char *data, size_t *length)
 {
 	// Base64 decoding requires 3 bytes for every 4 bytes of input, plus
 	// additional bytes for padding. The output buffer must be large enough

--- a/src/config/password.h
+++ b/src/config/password.h
@@ -15,6 +15,8 @@
 #include <unistd.h>
 
 void sha256_raw_to_hex(uint8_t *data, char *buffer);
+char * __attribute__((malloc)) base64_encode(const uint8_t *data, const size_t length);
+uint8_t * __attribute__((malloc)) base64_decode(const char *data, size_t *length);
 char *create_password(const char *password) __attribute__((malloc));
 enum password_result verify_login(const char *password);
 enum password_result verify_password(const char *password, const char *pwhash, const bool rate_limiting);
@@ -30,6 +32,6 @@ enum password_result {
 } __attribute__((packed));
 
 // The maximum number of password attempts per second
-#define MAX_PASSWORD_ATTEMPTS_PER_SECOND 3
+#define MAX_PASSWORD_ATTEMPTS_PER_SECOND 6
 
 #endif //PASSWORD_H

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1337,6 +1337,18 @@
   [[ ${lines[0]} == "true" ]]
 }
 
+@test "API authorization (HTTP Basic Auth): Incorrect password is rejected if password auth is enabled" {
+  run bash -c 'curl -s -u pi-hole:XXX 127.0.0.1/api/auth | jq .session.valid'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == 'false' ]]
+}
+
+@test "API authorization (HTTP Basic Auth): Correct password is accepted" {
+  run bash -c 'curl -s -u pi-hole:ABC 127.0.0.1/api/auth | jq .session.valid'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == 'true' ]]
+}
+
 @test "Test TLS/SSL server using self-signed certificate" {
   # -s: silent
   # -I: HEAD request


### PR DESCRIPTION
# What does this implement/fix?

Add ability to create a session using [HTTP Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) ([RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617)).

Example:
``` bash
$ curl -s 127.0.0.1/api/auth | jq .session.valid
false

$ curl -s -u pi-hole:ABC 127.0.0.1/api/auth | jq .session.valid
true
```

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.