### PR TITLE
Improve query table parsing warnings

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -850,17 +850,18 @@ void DB_read_queries(void)
 	// Loop through returned database rows
 	while((rc = sqlite3_step(stmt)) == SQLITE_ROW)
 	{
+		const sqlite3_int64 dbID = sqlite3_column_int64(stmt, 0);
 		const double queryTimeStamp = sqlite3_column_double(stmt, 1);
 		// 1483228800 = 01/01/2017 @ 12:00am (UTC)
 		if(queryTimeStamp < 1483228800)
 		{
-			sqlite3_int64 dbID = sqlite3_column_int64(stmt, 0);
-			log_warn("Database: TIMESTAMP of query should be larger than 01/01/2017 but is %f (DB ID %lli)", queryTimeStamp, dbID);
+			log_warn("Database: TIMESTAMP of query should be larger than 01/01/2017 but is %f (DB ID %lli)",
+			         queryTimeStamp, dbID);
 			continue;
 		}
 		if(queryTimeStamp > now)
 		{
-			log_debug(DEBUG_DATABASE, "Skipping query logged in the future (%lli)", (long long)queryTimeStamp);
+			log_debug(DEBUG_DATABASE, "Skipping query logged in the future (%f > %f)", queryTimeStamp, now);
 			continue;
 		}
 
@@ -885,14 +886,16 @@ void DB_read_queries(void)
 		const char *domainname = (const char *)sqlite3_column_text(stmt, 4);
 		if(domainname == NULL)
 		{
-			log_warn("Database: DOMAIN should never be NULL, %lli", (long long)queryTimeStamp);
+			log_warn("Database: DOMAIN should never be NULL, ID = %lld, timestamp = %f",
+			         dbID, queryTimeStamp);
 			continue;
 		}
 
 		const char *clientIP = (const char *)sqlite3_column_text(stmt, 5);
 		if(clientIP == NULL)
 		{
-			log_warn("Database: CLIENT should never be NULL, %lli", (long long)queryTimeStamp);
+			log_warn("Database: CLIENT should never be NULL, ID = %lld, timestamp = %f",
+			         dbID, queryTimeStamp);
 			continue;
 		}
 
@@ -906,8 +909,8 @@ void DB_read_queries(void)
 		const int reply_int = sqlite3_column_int(stmt, 8);
 		if(reply_int < REPLY_UNKNOWN || reply_int >= QUERY_REPLY_MAX)
 		{
-			log_warn("Database: REPLY should be within [%i,%i] but is %i",
-			         REPLY_UNKNOWN, QUERY_REPLY_MAX-1, reply_int);
+			log_warn("Database: REPLY should be within [%i,%i] but is %i, ID = %lld, timestamp = %f",
+			         REPLY_UNKNOWN, QUERY_REPLY_MAX-1, reply_int, dbID, queryTimeStamp);
 			continue;
 		}
 		const enum reply_type reply = reply_int;
@@ -915,8 +918,8 @@ void DB_read_queries(void)
 		const int dnssec_int = sqlite3_column_int(stmt, 10);
 		if(dnssec_int < DNSSEC_UNKNOWN || dnssec_int >= DNSSEC_MAX)
 		{
-			log_warn("Database: REPLY should be within [%i,%i] but is %i",
-			         DNSSEC_UNKNOWN, DNSSEC_MAX-1, dnssec_int);
+			log_warn("Database: REPLY should be within [%i,%i] but is %i, ID = %lld, timestamp = %f",
+			         DNSSEC_UNKNOWN, DNSSEC_MAX-1, dnssec_int, dbID, queryTimeStamp);
 			continue;
 		}
 		const enum dnssec_status dnssec = dnssec_int;
@@ -950,7 +953,8 @@ void DB_read_queries(void)
 			reply_time_avail = true;
 			if(reply_time < 0.0)
 			{
-				log_warn("REPLY_TIME value %f is invalid, %lli", reply_time, (long long)queryTimeStamp);
+				log_warn("REPLY_TIME value %f is invalid, ID = %lld, timestamp = %f",
+				         reply_time, dbID, queryTimeStamp);
 				continue;
 			}
 		}
@@ -975,7 +979,8 @@ void DB_read_queries(void)
 			else
 			{
 				// Invalid query type
-				log_warn("Query type %d is invalid.", type);
+				log_warn("Query type %d is invalid, ID = %lld, timestamp = %f",
+				         type, dbID, queryTimeStamp);
 				continue;
 			}
 		}
@@ -1111,7 +1116,8 @@ void DB_read_queries(void)
 
 			case QUERY_STATUS_MAX:
 			default:
-				log_warn("Found unknown status %i in long term database!", status);
+				log_warn("Found unknown status %i in long term database, ID = %lld, timestamp = %f",
+				         status, dbID, queryTimeStamp);
 				break;
 		}
 


### PR DESCRIPTION
# What does this implement/fix?

Improve warning messages printed during query table parsing (history import). This branch was long forgotten about the change it adds is still worth having.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.