### PR TITLE
Root zone substitution

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -773,11 +773,16 @@ void DB_read_queries(void)
 		}
 		const enum query_status status = status_int;
 
-		const char * domainname = (const char *)sqlite3_column_text(stmt, 4);
+		const char *domainname = (const char *)sqlite3_column_text(stmt, 4);
 		if(domainname == NULL)
 		{
 			logg("DB warn: DOMAIN should never be NULL, %lli", (long long)queryTimeStamp);
 			continue;
+		}
+		if(!domainname[0])
+		{
+			// Substitute "." for the root zone (stored as empty domain in earlier FTL versions)
+			domainname = ".";
 		}
 
 		const char * clientIP = (const char *)sqlite3_column_text(stmt, 5);


### PR DESCRIPTION
# What does this implement/fix?

Substitute `.` for the root zone on history import. This is necessary because earlier FTL versions store root zone queries with an empty domain string.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.