### PR TITLE
API tests: Implement deep-recursion of arrays

### DIFF
--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -317,6 +317,9 @@ components:
                   mixed:
                     type: boolean
                     description: Indicator if TLS (end-to-end encryption) is used only partially for this session
+              app:
+                type: boolean
+                description: Indicator if this session was initiated using an application password
               login_at:
                 type: integer
                 description: Timestamp of login (seconds since epoch)
@@ -339,7 +342,7 @@ components:
               tls:
                 login: true
                 mixed: false
-              strict_tls: false
+              app: false
               login_at: 1580000000
               last_active: 1580000000
               valid_until: 1580000300

--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -246,8 +246,9 @@ components:
                 example: "127.0.0.1,::1"
               names:
                 type: string
-                description: Comma-separated list of hostnames
-                example: "localhost"
+                nullable: true
+                description: Comma-separated list of hostnames (if available)
+                example: "localhost,ip6-localhost"
     client:
       type: object
       properties:
@@ -284,6 +285,7 @@ components:
           description: hostname (only available when {client} is an IP address)
           type: string
           readOnly: true
+          nullable: true
           example: localhost
     groups:
       type: object

--- a/src/api/docs/content/specs/endpoints.yaml
+++ b/src/api/docs/content/specs/endpoints.yaml
@@ -37,25 +37,118 @@ components:
             get:
               type: array
               items:
-                type: string
-              example: ["/api/dns/blocking", "/api/dns/cache", "/api/dns/port", "/api/domains", "/api/groups", "/api/lists"]
+                type: object
+                properties:
+                  uri:
+                    type: string
+                    description: URI
+                  parameters:
+                    type: string
+                    description: Parameters
+              example:
+                - uri: "/api/dns/blocking"
+                  parameters: ''
+                - uri: "/api/dns/cache"
+                  parameters: ''
+                - uri: "/api/dns/port"
+                  parameters: ''
+                - uri: "/api/domains"
+                  parameters: ''
+                - uri: "/api/groups"
+                  parameters: ''
+                - uri: "/api/lists"
+                  parameters: ''
             post:
               type: array
               items:
-                type: string
-              example: ["/api/dns/blocking", "/api/dns/cache", "/api/dns/port", "/api/domains", "/api/groups", "/api/lists"]
+                type: object
+                properties:
+                  uri:
+                    type: string
+                    description: URI
+                  parameters:
+                    type: string
+                    description: Parameters
+              example:
+                - uri: "/api/dns/blocking"
+                  parameters: ''
+                - uri: "/api/dns/cache"
+                  parameters: ''
+                - uri: "/api/dns/port"
+                  parameters: ''
+                - uri: "/api/domains"
+                  parameters: ''
+                - uri: "/api/groups"
+                  parameters: ''
+                - uri: "/api/lists"
+                  parameters: ''
             put:
               type: array
               items:
-                type: string
-              example: ["/api/dns/blocking", "/api/dns/cache", "/api/dns/port", "/api/domains", "/api/groups", "/api/lists"]
+                type: object
+                properties:
+                  uri:
+                    type: string
+                    description: URI
+                  parameters:
+                    type: string
+                    description: Parameters
+              example:
+                - uri: "/api/dns/blocking"
+                  parameters: ''
+                - uri: "/api/dns/cache"
+                  parameters: ''
+                - uri: "/api/dns/port"
+                  parameters: ''
+                - uri: "/api/domains"
+                  parameters: ''
+                - uri: "/api/groups"
+                  parameters: ''
+                - uri: "/api/lists"
+                  parameters: ''
             patch:
               type: array
               items:
-                type: string
-              example: ["/api/dns/blocking", "/api/dns/cache", "/api/dns/port", "/api/domains", "/api/groups", "/api/lists"]
+                properties:
+                  uri:
+                    type: string
+                    description: URI
+                  parameters:
+                    type: string
+                    description: Parameters
+              example:
+                - uri: "/api/dns/blocking"
+                  parameters: ''
+                - uri: "/api/dns/cache"
+                  parameters: ''
+                - uri: "/api/dns/port"
+                  parameters: ''
+                - uri: "/api/domains"
+                  parameters: ''
+                - uri: "/api/groups"
+                  parameters: ''
+                - uri: "/api/lists"
+                  parameters: ''
             delete:
               type: array
               items:
-                type: string
-              example: ["/api/dns/blocking", "/api/dns/cache", "/api/dns/port", "/api/domains", "/api/groups", "/api/lists"]
+                properties:
+                  uri:
+                    type: string
+                    description: URI
+                  parameters:
+                    type: string
+                    description: Parameters
+              example:
+                - uri: "/api/dns/blocking"
+                  parameters: ''
+                - uri: "/api/dns/cache"
+                  parameters: ''
+                - uri: "/api/dns/port"
+                  parameters: ''
+                - uri: "/api/domains"
+                  parameters: ''
+                - uri: "/api/groups"
+                  parameters: ''
+                - uri: "/api/lists"
+                  parameters: ''

--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -505,7 +505,7 @@ components:
                           type: number
                           nullable: true
                           description: Critical sensor value (if available, `null` otherwise)
-                        path:
+                        sensor:
                           type: string
                           description: Short path of temperature sensor
               example:

--- a/src/api/docs/content/specs/network.yaml
+++ b/src/api/docs/content/specs/network.yaml
@@ -126,6 +126,9 @@ components:
                 type: string
                 nullable: true
                 description: Interface name
+              default:
+                type: boolean
+                description: If the interface is the default gateway
               carrier:
                 type: boolean
                 description: If the interface is connected
@@ -248,6 +251,7 @@ components:
                     name:
                       type: string
                       description: Associated hostname (can be null)
+                      nullable: true
                       example: ubuntu-server
                     lastSeen:
                       type: integer

--- a/src/api/docs/content/specs/network.yaml
+++ b/src/api/docs/content/specs/network.yaml
@@ -237,7 +237,8 @@ components:
                 example: 585462
               macVendor:
                 type: string
-                description: Vendor name associated with the device's MAC address
+                nullable: true
+                description: Vendor name associated with the device's MAC address (if available)
                 example: "Digital Data Communications Asia Co.,Ltd"
               ips:
                 type: array


### PR DESCRIPTION
# What does this implement/fix?

This PR originated from https://github.com/pi-hole/FTL/pull/1705#issuecomment-1784234456 but sent me way down the rabbit hole. At first, I only added `.session.X.app` as this was missing in the API specs. This raised the question why our fully-automated API checks didn't unveil this before.

The reason is simple: When we find an object in the API specs, we recurse. Otherwise, we simply check this property. So when we found an array, we checked whether the API specs defined this as array, too, and when this is the case, we say that's correct. However, the *content* of the array - may it be a plain array of `strings` or maybe an array of complex objects, possibly containing further arrays (yes, we have such things...) - was not checked.

This has now been added in this PR and we immediately found a few bits and pieces that were not correct and fixed them as well.

Examples of what we found (I will add only a few):
```
  GET /api/auth/sessions (BODY auth):
  - Property 'sessions.0.app' missing in the API specs
  - Property 'sessions.1.app' missing in the API specs
  - Property 'sessions.2.app' missing in the API specs
  - Property 'sessions.3.app' missing in the API specs
  - Property 'sessions.4.app' missing in the API specs
  - Property 'sessions.5.app' missing in the API specs
  - Property 'sessions.6.app' missing in the API specs
  - Property 'sessions.7.app' missing in the API specs
```
fixed by adding `.session.X.app` to the API specs

```
  GET /api/info/sensors (HEADER auth):
  - Property 'sensors.list.0.temps.0.sensor' missing in the API specs
  - Property 'sensors.list.0.temps.1.sensor' missing in the API specs
  - Property 'sensors.list.0.temps.2.sensor' missing in the API specs
  - Property 'sensors.list.0.temps.3.sensor' missing in the API specs
  - Property 'sensors.list.0.temps.4.sensor' missing in the API specs
  - Property 'sensors.list.0.temps.5.sensor' missing in the API specs
  - Property 'sensors.list.0.temps.6.sensor' missing in the API specs
  - Property 'sensors.list.1.temps.0.sensor' missing in the API specs
  - Property 'sensors.list.2.temps.0.sensor' missing in the API specs
  - Property 'sensors.list.3.temps.0.sensor' missing in the API specs
```
fixed by renaming `sensors.list.X.temps.Y.path -> sensors.list.X.temps.Y.sensor`

```
  GET /api/network/devices (HEADER auth):
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.1.ips.1.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.2.ips.1.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.2.ips.2.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.4.ips.1.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.4.ips.2.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.6.ips.1.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.6.ips.2.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.7.ips.1.name
  - FTL's reply (<class 'NoneType'>) does not match defined type (string) in devices.7.ips.2.name
```
fixed by adding `nullable: true` for `devices.X.ips.Y.name`

... and many more ...

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.