### PR TITLE
/api/search/{domain}: Add IDN compatibility

### DIFF
--- a/.github/.codespellignore
+++ b/.github/.codespellignore
@@ -5,3 +5,4 @@ nd
 doubleclick
 requestor
 requestors
+punycode

--- a/patch/civetweb.sh
+++ b/patch/civetweb.sh
@@ -9,5 +9,6 @@ patch -p1 < patch/civetweb/0001-Add-mbedTLS-debug-logging-hook.patch
 patch -p1 < patch/civetweb/0001-Register-CSRF-token-in-conn-request_info.patch
 patch -p1 < patch/civetweb/0001-Do-not-try-to-guess-server-hostname-in-Civetweb-when.patch
 patch -p1 < patch/civetweb/0001-Log-debug-messages-to-webserver.log-when-debug.webse.patch
+patch -p1 < patch/civetweb/0001-Allow-extended-ASCII-characters-in-URIs.patch
 
 echo "ALL PATCHES APPLIED OKAY"

--- a/patch/civetweb/0001-Allow-extended-ASCII-characters-in-URIs.patch
+++ b/patch/civetweb/0001-Allow-extended-ASCII-characters-in-URIs.patch
@@ -1,0 +1,35 @@
+From ebb27741b10ed2eac51ac356708800ae96cdd17a Mon Sep 17 00:00:00 2001
+From: DL6ER <dl6er@dl6er.de>
+Date: Tue, 31 Oct 2023 08:35:31 +0100
+Subject: [PATCH] Allow extended ASCII characters in URIs
+
+Signed-off-by: DL6ER <dl6er@dl6er.de>
+---
+ src/webserver/civetweb/civetweb.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/webserver/civetweb/civetweb.c b/src/webserver/civetweb/civetweb.c
+index 9b0c6308..5320c4d4 100644
+--- a/src/webserver/civetweb/civetweb.c
++++ b/src/webserver/civetweb/civetweb.c
+@@ -10734,7 +10734,7 @@ skip_to_end_of_word_and_terminate(char **ppw, int eol)
+ {
+ 	/* Forward until a space is found - use isgraph here */
+ 	/* See http://www.cplusplus.com/reference/cctype/ */
+-	while (isgraph((unsigned char)**ppw)) {
++	while ((unsigned char)**ppw > 127 || isgraph((unsigned char)**ppw)) {
+ 		(*ppw)++;
+ 	}
+ 
+@@ -18473,7 +18473,7 @@ get_uri_type(const char *uri)
+ 	 * and % encoded symbols.
+ 	 */
+ 	for (i = 0; uri[i] != 0; i++) {
+-		if (uri[i] < 33) {
++		if ((unsigned char)uri[i] < 33) {
+ 			/* control characters and spaces are invalid */
+ 			return 0;
+ 		}
+-- 
+2.34.1
+

--- a/src/api/docs/content/specs/search.yaml
+++ b/src/api/docs/content/specs/search.yaml
@@ -14,10 +14,12 @@ components:
           - $ref: 'search.yaml#/components/parameters/N'
           - $ref: 'search.yaml#/components/parameters/debug'
         description: |
-          Search for domains in Pi-hole's list. The optional parameters `N` and `partial` limit the maximum number of returned records and whether partial matches should be returned, respectively.
+          Search for domains in Pi-hole's list. The specified domain is automatically converted to lowercase.
+          The optional parameters `N` and `partial` limit the maximum number of returned records and whether partial matches should be returned, respectively.
           There is a hard upper limit of `N` defined in FTL (currently set to 10,000) to ensure that the response is not too large.
           ABP matches are not returned when partial matching is requested.
           Depending on the value of the config option webserver.api.searchAPIauth, local clients may not need to authenticate for this endpoint.
+          International domains names (IDNs) are internally converted to punycode before matching.
         responses:
           '200':
             description: OK

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -10734,7 +10734,7 @@ skip_to_end_of_word_and_terminate(char **ppw, int eol)
 {
 	/* Forward until a space is found - use isgraph here */
 	/* See http://www.cplusplus.com/reference/cctype/ */
-	while (isgraph((unsigned char)**ppw)) {
+	while ((unsigned char)**ppw > 127 || isgraph((unsigned char)**ppw)) {
 		(*ppw)++;
 	}
 
@@ -18473,7 +18473,7 @@ get_uri_type(const char *uri)
 	 * and % encoded symbols.
 	 */
 	for (i = 0; uri[i] != 0; i++) {
-		if (uri[i] < 33) {
+		if ((unsigned char)uri[i] < 33) {
 			/* control characters and spaces are invalid */
 			return 0;
 		}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1286,6 +1286,12 @@
   [[ ${lines[0]} == '{"search":{"domains":[],"gravity":[{"domain":"antigravity.ftl","type":"block","address":"https://pi-hole.net/block.txt","comment":"Fake block-list","enabled":true,"id":1,"date_added":1559928803,"date_modified":1559928803,"type":"block","date_updated":1559928803,"number":2000,"invalid_domains":2,"abp_entries":0,"status":1,"groups":[0,2]},{"domain":"antigravity.ftl","type":"allow","address":"https://pi-hole.net/allow.txt","comment":"Fake allow-list","enabled":true,"id":2,"date_added":1559928803,"date_modified":1559928803,"type":"allow","date_updated":1559928803,"number":2000,"invalid_domains":2,"abp_entries":0,"status":1,"groups":[0]},{"domain":"@@||antigravity.ftl^","type":"allow","address":"https://pi-hole.net/allow.txt","comment":"Fake allow-list","enabled":true,"id":2,"date_added":1559928803,"date_modified":1559928803,"type":"allow","date_updated":1559928803,"number":2000,"invalid_domains":2,"abp_entries":0,"status":1,"groups":[0]}],"results":{"domains":{"exact":0,"regex":0},"gravity":{"allow":2,"block":1},"total":3},"parameters":{"N":20,"partial":false,"domain":"antigravity.ftl","debug":false}},"took":'*'}' ]]
 }
 
+@test "API domain search: Internationalized/partially capital domain returns expected lowercase punycode domain" {
+  run bash -c 'curl -s 127.0.0.1/api/search/äBC.com?debug=true | jq .search.debug.punycode'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == '"xn--bc-uia.com"' ]]
+}
+
 @test "API authorization (without password): No login required" {
   run bash -c 'curl -s 127.0.0.1/api/auth'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
# What does this implement/fix?

Lowercase domains passed to `GET /api/search/{domain}` and convert them to punycode (if applicable), e.g., `GET /api/search/äBC.cOm` (mind the Umlaut `ä`) will now actually trigger a search for `xn--bc-uia.com`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.