### PR TITLE
Ensure %used is 0.0 if no swap is used

### DIFF
--- a/src/api/info.c
+++ b/src/api/info.c
@@ -194,7 +194,7 @@ static int get_system_obj(struct ftl_conn *api, cJSON *system)
 	// "cached", which was fine ten years ago, but is pretty much guaranteed
 	// to be wrong today."
 	JSON_ADD_NUMBER_TO_OBJECT(ram, "available", mem.avail);
-	JSON_ADD_NUMBER_TO_OBJECT(ram, "%used", 100.0*mem.used/mem.total);
+	JSON_ADD_NUMBER_TO_OBJECT(ram, "%used", mem.total > 0 ? 100.0*mem.used/mem.total : 0);
 	JSON_ADD_ITEM_TO_OBJECT(memory, "ram", ram);
 
 	cJSON *swap = JSON_NEW_OBJECT();
@@ -206,7 +206,7 @@ static int get_system_obj(struct ftl_conn *api, cJSON *system)
 	// Used swap space
 	const float used_swap = (info.totalswap - info.freeswap) * info.mem_unit / 1024;
 	JSON_ADD_NUMBER_TO_OBJECT(swap, "used", used_swap);
-	JSON_ADD_NUMBER_TO_OBJECT(swap, "%used", 100.0*used_swap/total_swap);
+	JSON_ADD_NUMBER_TO_OBJECT(swap, "%used", total_swap > 0 ? 100.0*used_swap/total_swap : 0);
 	JSON_ADD_ITEM_TO_OBJECT(memory, "swap", swap);
 	JSON_ADD_ITEM_TO_OBJECT(system, "memory", memory);
 


### PR DESCRIPTION
# What does this implement/fix?

When test compiling FTL on a machine without swap, we've seen the following result in the tests:
```
GET /api/info/system (BODY auth):
  - FTL's reply (<class 'NoneType'>) does not match defined type (number) in system.memory.swap.%used
```

This is caused by a division-by-zero error which lead to a `null` being returned in the JSON. There are two obvious fixes:

1. Change the API specs to accept returning a `null` here, or
2. Ensure that in case of no swap, `0` is returned instead (0% swap used).

The latter seems superior as it needs less logic on the client side to handle this.

Even when we will never see a system with no RAM, the logic is applied here as well - just as a precaution because division-by-zero is never a good thing.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
3. I have commented my proposed changes within the code.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.