### PR TITLE
Only use IPv6 in the webserver when available

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -396,3 +396,51 @@ ssize_t getrandom_fallback(void *buf, size_t buflen, unsigned int flags)
 
 	return buflen;
 }
+
+bool ipv6_enabled(void)
+{
+	// First we check a few virtual system files to see if IPv6 is disabled
+	const char *files[] = {
+		"/sys/module/ipv6/parameters/disable", // GRUB - ipv6.disable=1
+		"/proc/sys/net/ipv6/conf/all/disable_ipv6", // sysctl.conf - net.ipv6.conf.all.disable_ipv6=1
+		"/proc/sys/net/ipv6/conf/default/disable_ipv6", // sysctl.conf - net.ipv6.conf.all.disable_ipv6=1
+		NULL
+	};
+
+	// Loop over the files
+	for(int i = 0; files[i] != NULL; i++)
+	{
+		// Open file for reading
+		FILE *f = fopen(files[i], "r");
+		if(f == NULL)
+			continue;
+
+		// Read first character
+		const int c = fgetc(f);
+		fclose(f);
+		// If the first character is a 1, then IPv6 is disabled
+		if(c == '1')
+			return false;
+	}
+
+	// If the file does not exist or if it does not contain a 1, then we check
+	// if /proc/net/if_inet6 has any IPv6-capable interfaces
+	// Since Linux 2.6.25 (April 2008), files in /proc/net are a symlink to
+	// /proc/self/net and provide information about the network devices and
+	// interfaces for the network namespace of which the process is a member
+	FILE *f = fopen("/proc/net/if_inet6", "r");
+
+	if(f != NULL)
+	{
+		// If the file exists, we check if it is empty
+		const int c = fgetc(f);
+		fclose(f);
+		// If the file is empty, then there are no IPv6-capable interfaces
+		if(c == EOF)
+			return false;
+	}
+
+	// else: IPv6 is not obviously disabled and there is at least one
+	// IPv6-capable interface
+	return true;
+}

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -23,6 +23,7 @@ void cleanup(const int ret);
 void set_nice(void);
 void calc_cpu_usage(void);
 float get_cpu_percentage(void) __attribute__((pure));
+bool ipv6_enabled(void);
 
 #include <sys/syscall.h>
 #include <unistd.h>


### PR DESCRIPTION
# What does this implement/fix?

Check that IPv6 support is not disabled either via the boot command line or at runtime (via `/etc/sysctl.conf`) before trying to launch the webserver for the first time. This will only set the ports once on the very first start of Pi-hole v6.0 and can be freely edited in `/etc/pihole/pihole.toml` (`webserver.ports`) to whatever the user deems appropriate.

Hint: This will typically disable binding to IPv6 in `docker` containers as they most often have `net.ipv6.conf.all.disable_ipv6 = 1`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.