### PR TITLE
Declare pihole.toml as UTF-8 document

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -33,6 +33,11 @@
 // This static string represents an unchanged password
 #define PASSWORD_VALUE "********"
 
+// Remove the following line to disable the use of UTF-8 in the config file
+// As consequence, the config file will be written in ASCII and all non-ASCII
+// characters will be replaced by their UTF-8 escape sequences (UCS-2)
+#define TOML_UTF8
+
 union conf_value {
 	bool b;                                     // boolean value
 	int i;                                      // integer value

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -41,15 +41,17 @@ bool writeFTLtoml(const bool verbose)
 		log_info("Writing config file");
 
 	// Write header
-	fputs("# This file is managed by pihole-FTL\n#\n", fp);
-	fputs("# Do not edit the file while FTL is\n", fp);
-	fputs("# running or your changes may be overwritten\n#\n", fp);
+	fprintf(fp, "# Pi-hole configuration file (%s)\n", get_FTL_version());
+#ifdef TOML_UTF8
+	fputs("# Encoding: UTF-8\n", fp);
+#else
+	fputs("# Encoding: ASCII + UCS\n", fp);
+#endif
+	fputs("# This file is managed by pihole-FTL\n", fp);
 	char timestring[TIMESTR_SIZE] = "";
 	get_timestr(timestring, time(NULL), false, false);
 	fputs("# Last updated on ", fp);
 	fputs(timestring, fp);
-	fputs("\n# by FTL ", fp);
-	fputs(get_FTL_version(), fp);
 	fputs("\n\n", fp);
 
 	// Iterate over configuration and store it into the file

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -35,6 +35,8 @@
 #include "webserver/webserver.h"
 // free_api()
 #include "api/api.h"
+// setlocale()
+#include <locale.h>
 
 pthread_t threads[THREADS_MAX] = { 0 };
 bool resolver_ready = false;
@@ -443,4 +445,17 @@ bool ipv6_enabled(void)
 	// else: IPv6 is not obviously disabled and there is at least one
 	// IPv6-capable interface
 	return true;
+}
+
+void init_locale(void)
+{
+	// Set locale to system default, needed for libidn to work properly
+	// Without this, libidn will not be able to convert UTF-8 to ASCII
+	// (error message "Character encoding conversion error")
+	setlocale(LC_ALL, "");
+
+	// Set locale for numeric values to C to ensure that we always use
+	// the dot as decimal separator (even if the system locale uses a
+	// comma, e.g., in German)
+	setlocale(LC_NUMERIC, "C");
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -24,6 +24,7 @@ void set_nice(void);
 void calc_cpu_usage(void);
 float get_cpu_percentage(void) __attribute__((pure));
 bool ipv6_enabled(void);
+void init_locale(void);
 
 #include <sys/syscall.h>
 #include <unistd.h>

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -81,10 +81,7 @@ int main_dnsmasq (int argc, char **argv)
 #endif
 
 #if defined(HAVE_IDN) || defined(HAVE_LIBIDN2) || defined(LOCALEDIR)
-  setlocale(LC_ALL, "");
-  /*** Pi-hole modification ***/
-  setlocale(LC_NUMERIC, "C");
-  /****************************/
+  /*** Pi-hole modification: Locale is already initialized in main.c ***/
 #endif
 #ifdef LOCALEDIR
   bindtextdomain("dnsmasq", LOCALEDIR); 

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,9 @@ jmp_buf exit_jmp;
 
 int main (int argc, char *argv[])
 {
+	// Initialize locale (needed for libidn)
+	init_locale();
+
 	// Get user pihole-FTL is running as
 	// We store this in a global variable
 	// such that the log routine can access

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -159,7 +159,7 @@ class ResponseVerifyer():
 						if expected_file not in zipfile_obj.namelist():
 							self.errors.append("File " + expected_file + " is missing in received archive.")
 					pihole_toml = zipfile_obj.read("etc/pihole/pihole.toml")
-					if not pihole_toml.startswith(b"# This file is managed by pihole-FTL"):
+					if not pihole_toml.startswith(b"# Pi-hole configuration file (v"):
 						self.errors.append("Received ZIP file's pihole.toml starts with wrong header")
 				except Exception as err:
 					self.errors.append("Error during ZIP analysis: " + str(err))

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -100,7 +100,10 @@
   #
   # Possible values are:
   #     Array of custom DNS records each one in HOSTS form: "IP HOSTNAME"
-  hosts = []
+  hosts = [
+    "1.1.1.1 abc-custom.com def-custom.de",
+    "2.2.2.2 äste.com steä.com"
+  ] ### CHANGED, default = []
 
   # If set, A and AAAA queries for plain names, without dots or domain parts, are never
   # forwarded to upstream nameservers

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -178,7 +178,9 @@
   # Possible values are:
   #     Array of static leases each on in one of the following forms:
   #     "<cname>,<target>[,<TTL>]"
-  cnameRecords = []
+  cnameRecords = [
+    "brücke.com,äste.com,2",
+  ]
 
   # Port used by the DNS server
   port = 53

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1273,6 +1273,15 @@
   [[ "${lines[0]}" == "2.2.2.2" ]]
 }
 
+@test "Local CNAME records: International domains are converted to IDNA form" {
+  # brücke.com ---> xn--brcke-lva.com
+  run bash -c "dig A xn--brcke-lva.com +short @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  # xn--ste-pla.com ---> äste.com
+  [[ "${lines[0]}" == "xn--ste-pla.com." ]]
+  [[ "${lines[1]}" == "2.2.2.2" ]]
+}
+
 @test "Environmental variable is favored over config file" {
   # The config file has -10 but we set FTLCONF_misc_nice="-11"
   run bash -c 'grep -B1 "nice = -11" /etc/pihole/pihole.toml'

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1253,6 +1253,26 @@
   [[ "${lines[0]}" == "192.168.1.7" ]]
 }
 
+@test "Custom DNS records: Multiple domains per line are accepted" {
+  run bash -c "dig A abc-custom.com +short @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "1.1.1.1" ]]
+  run bash -c "dig A def-custom.de +short @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "1.1.1.1" ]]
+}
+
+@test "Custom DNS records: International domains are converted to IDNA form" {
+  # äste.com ---> xn--ste-pla.com
+  run bash -c "dig A xn--ste-pla.com +short @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "2.2.2.2" ]]
+  # steä.com -> xn--ste-sla.com
+  run bash -c "dig A xn--ste-sla.com +short @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "2.2.2.2" ]]
+}
+
 @test "Environmental variable is favored over config file" {
   # The config file has -10 but we set FTLCONF_misc_nice="-11"
   run bash -c 'grep -B1 "nice = -11" /etc/pihole/pihole.toml'
@@ -1410,7 +1430,7 @@
   [[ "${lines[0]}" == "PI.HOLE" ]]
   run bash -c './pihole-FTL --config dns.hosts'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "[]" ]]
+  [[ "${lines[0]}" == "[ 1.1.1.1 abc-custom.com def-custom.de, 2.2.2.2 äste.com steä.com ]" ]]
   run bash -c './pihole-FTL --config webserver.port'
   printf "%s\n" "${lines[@]}"
   [[ "${lines[0]}" == "80,[::]:80,443s" ]]


### PR DESCRIPTION
# What does this implement/fix?

Declare `pihole.toml` as UTF-8 document. we add a compile-time switch to use ASCII with UTF-8 escaping instead in case this is a necessity for anyone. We are in the third millennium A.C. but we also know people are still using Windows XP on the web...

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.