### PR TITLE
Use webserver.domain as "account" in the TOTP QR code

### DIFF
--- a/src/api/2fa.c
+++ b/src/api/2fa.c
@@ -282,7 +282,7 @@ int generateTOTP(struct ftl_conn *api)
 	// Create JSON object
 	cJSON *tjson = cJSON_CreateObject();
 	JSON_REF_STR_IN_OBJECT(tjson, "type", "totp");
-	JSON_REF_STR_IN_OBJECT(tjson, "account", "pi.hole");
+	JSON_REF_STR_IN_OBJECT(tjson, "account", config.webserver.domain.v.s);
 	JSON_REF_STR_IN_OBJECT(tjson, "issuer", "Pi-hole%20API");
 	JSON_REF_STR_IN_OBJECT(tjson, "algorithm", "SHA1");
 	JSON_ADD_NUMBER_TO_OBJECT(tjson, "digits", RFC6238_DIGITS);


### PR DESCRIPTION
# What does this implement/fix?

A very simple change, fixes #1729 

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.