### PR TITLE
Improve DHCP handling

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -128,12 +128,22 @@ static cJSON *addJSONvalue(const enum conf_type conf_type, union conf_value *val
 			return cJSON_CreateStringReference(get_temp_unit_str(val->temp_unit));
 		case CONF_STRUCT_IN_ADDR:
 		{
+			// Special case 0.0.0.0 -> return empty string
+			if(val->in_addr.s_addr == INADDR_ANY)
+				return cJSON_CreateStringReference("");
+
+			// else: normal address
 			char addr4[INET_ADDRSTRLEN] = { 0 };
 			inet_ntop(AF_INET, &val->in_addr, addr4, INET_ADDRSTRLEN);
 			return cJSON_CreateString(addr4); // Performs a copy
 		}
 		case CONF_STRUCT_IN6_ADDR:
 		{
+			// Special case :: -> return empty string
+			if(memcmp(&val->in6_addr, &in6addr_any, sizeof(in6addr_any)) == 0)
+				return cJSON_CreateStringReference("");
+
+			// else: normal address
 			char addr6[INET6_ADDRSTRLEN] = { 0 };
 			inet_ntop(AF_INET6, &val->in6_addr, addr6, INET6_ADDRSTRLEN);
 			return cJSON_CreateString(addr6); // Performs a copy
@@ -400,11 +410,19 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 			struct in_addr addr4 = { 0 };
 			if(!cJSON_IsString(elem))
 				return "not of type string";
-			if(!inet_pton(AF_INET, elem->valuestring, &addr4))
+			if(strlen(elem->valuestring) == 0)
+			{
+				// Special case: empty string -> 0.0.0.0
+				conf_item->v.in_addr.s_addr = INADDR_ANY;
+			}
+			else if(inet_pton(AF_INET, elem->valuestring, &addr4))
+			{
+				// Set item
+				memcpy(&conf_item->v.in_addr, &addr4, sizeof(addr4));
+			}
+			else
 				return "not a valid IPv4 address";
-			// Set item
-			memcpy(&conf_item->v.in_addr, &addr4, sizeof(addr4));
-			log_debug(DEBUG_CONFIG, "%s = %s", conf_item->k, elem->valuestring);
+			log_debug(DEBUG_CONFIG, "%s = \"%s\"", conf_item->k, elem->valuestring);
 			break;
 		}
 		case CONF_STRUCT_IN6_ADDR:
@@ -412,11 +430,16 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 			struct in6_addr addr6 = { 0 };
 			if(!cJSON_IsString(elem))
 				return "not of type string";
-			if(!inet_pton(AF_INET6, elem->valuestring, &addr6))
+			if(strlen(elem->valuestring) == 0)
+			{
+				// Special case: empty string -> ::
+				memcpy(&conf_item->v.in6_addr, &in6addr_any, sizeof(in6addr_any));
+			}
+			else if(!inet_pton(AF_INET6, elem->valuestring, &addr6))
 				return "not a valid IPv6 address";
 			// Set item
 			memcpy(&conf_item->v.in6_addr, &addr6, sizeof(addr6));
-			log_debug(DEBUG_CONFIG, "%s = %s", conf_item->k, elem->valuestring);
+			log_debug(DEBUG_CONFIG, "%s = \"%s\"", conf_item->k, elem->valuestring);
 			break;
 		}
 		case CONF_JSON_STRING_ARRAY:

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -693,8 +693,23 @@ static int api_config_patch(struct ftl_conn *api)
 		const char *response = getJSONvalue(new_item, elem, &newconf);
 		if(response != NULL)
 		{
-			log_err("/api/config: %s invalid: %s", new_item->k, response);
-			continue;
+			char *hint = calloc(strlen(new_item->k) + strlen(response) + 3, sizeof(char));
+			if(hint == NULL)
+			{
+				free_config(&newconf);
+				return send_json_error(api, 500,
+				                       "internal_error",
+				                       "Failed to allocate memory for hint",
+				                       NULL);
+			}
+			strcpy(hint, new_item->k);
+			strcat(hint, ": ");
+			strcat(hint, response);
+			free_config(&newconf);
+			return send_json_error_free(api, 400,
+			                            "bad_request",
+			                            "Config item is invalid",
+			                            hint, true);
 		}
 
 		// Get pointer to memory location of this conf_item (global)

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -299,6 +299,8 @@ components:
                   type: string
                 router:
                   type: string
+                netmask:
+                  type: string
                 domain:
                   type: string
                 leaseTime:
@@ -627,6 +629,7 @@ components:
             end: "192.168.0.250"
             router: "192.168.0.1"
             domain: "lan"
+            netmask: "0.0.0.0"
             leaseTime: "24h"
             ipv6: true
             rapidCommit: true

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -268,8 +268,10 @@ components:
                           type: boolean
                         IPv4:
                           type: string
+                          x-format: ipv4
                         IPv6:
                           type: string
+                          x-format: ipv6
                     blocking:
                       type: object
                       properties:
@@ -279,8 +281,10 @@ components:
                           type: boolean
                         IPv4:
                           type: string
+                          x-format: ipv4
                         IPv6:
                           type: string
+                          x-format: ipv6
                 rateLimit:
                   type: object
                   properties:
@@ -295,12 +299,16 @@ components:
                   type: boolean
                 start:
                   type: string
+                  x-format: ipv4
                 end:
                   type: string
+                  x-format: ipv4
                 router:
                   type: string
+                  x-format: ipv4
                 netmask:
                   type: string
+                  x-format: ipv4
                 domain:
                   type: string
                 leaseTime:

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -295,7 +295,12 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 		case CONF_STRUCT_IN_ADDR:
 		{
 			struct in_addr addr4 = { 0 };
-			if(inet_pton(AF_INET, value, &addr4))
+			if(strlen(value) == 0)
+			{
+				// Special case: empty string -> 0.0.0.0
+				conf_item->v.in_addr.s_addr = INADDR_ANY;
+			}
+			else if(inet_pton(AF_INET, value, &addr4))
 				memcpy(&conf_item->v.in_addr, &addr4, sizeof(addr4));
 			else
 			{
@@ -307,7 +312,12 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 		case CONF_STRUCT_IN6_ADDR:
 		{
 			struct in6_addr addr6 = { 0 };
-			if(inet_pton(AF_INET6, value, &addr6))
+			if(strlen(value) == 0)
+			{
+				// Special case: empty string -> ::
+				memcpy(&conf_item->v.in6_addr, &in6addr_any, sizeof(in6addr_any));
+			}
+			else if(inet_pton(AF_INET6, value, &addr6))
 				memcpy(&conf_item->v.in6_addr, &addr6, sizeof(addr6));
 			else
 			{

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -686,21 +686,21 @@ void initConfig(struct config *conf)
 
 	conf->dhcp.start.k = "dhcp.start";
 	conf->dhcp.start.h = "Start address of the DHCP address pool";
-	conf->dhcp.start.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.10\"");
+	conf->dhcp.start.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\"), e.g., \"192.168.0.10\"");
 	conf->dhcp.start.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.start.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.start.d.in_addr, 0, sizeof(struct in_addr));
 
 	conf->dhcp.end.k = "dhcp.end";
 	conf->dhcp.end.h = "End address of the DHCP address pool";
-	conf->dhcp.end.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.250\"");
+	conf->dhcp.end.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\"), e.g., \"192.168.0.250\"");
 	conf->dhcp.end.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.end.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.end.d.in_addr, 0, sizeof(struct in_addr));
 
 	conf->dhcp.router.k = "dhcp.router";
 	conf->dhcp.router.h = "Address of the gateway to be used (typically the address of your router in a home installation)";
-	conf->dhcp.router.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.1\"");
+	conf->dhcp.router.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\"), e.g., \"192.168.0.1\"");
 	conf->dhcp.router.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.router.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.router.d.in_addr, 0, sizeof(struct in_addr));
@@ -713,8 +713,8 @@ void initConfig(struct config *conf)
 	conf->dhcp.domain.d.s = (char*)"lan";
 
 	conf->dhcp.netmask.k = "dhcp.netmask";
-	conf->dhcp.netmask.h = "The netmask used by your Pi-hole. For directly connected networks (i.e., networks on which the machine running Pi-hole has an interface) the netmask is optional and may be set to \"0.0.0.0\": it will then be determined from the interface configuration itself. For networks which receive DHCP service via a relay agent, we cannot determine the netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses based on the class (A, B or C) of the network address.";
-	conf->dhcp.netmask.a = cJSON_CreateStringReference("<any valid netmask>, e.g., \"255.255.255.0\" or \"0.0.0.0\" for auto-discovery");
+	conf->dhcp.netmask.h = "The netmask used by your Pi-hole. For directly connected networks (i.e., networks on which the machine running Pi-hole has an interface) the netmask is optional and may be set to an empty string (\"\"): it will then be determined from the interface configuration itself. For networks which receive DHCP service via a relay agent, we cannot determine the netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses based on the class (A, B or C) of the network address.";
+	conf->dhcp.netmask.a = cJSON_CreateStringReference("<any valid netmask> (e.g., \"255.255.255.0\") or empty string (\"\") for auto-discovery");
 	conf->dhcp.netmask.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.netmask.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
 	memset(&conf->dhcp.netmask.d.in_addr, 0, sizeof(struct in_addr));

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -687,23 +687,23 @@ void initConfig(struct config *conf)
 	conf->dhcp.start.k = "dhcp.start";
 	conf->dhcp.start.h = "Start address of the DHCP address pool";
 	conf->dhcp.start.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.10\"");
-	conf->dhcp.start.t = CONF_STRING;
+	conf->dhcp.start.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.start.f = FLAG_RESTART_FTL;
-	conf->dhcp.start.d.s = (char*)"";
+	memset(&conf->dhcp.start.d.in_addr, 0, sizeof(struct in_addr));
 
 	conf->dhcp.end.k = "dhcp.end";
 	conf->dhcp.end.h = "End address of the DHCP address pool";
 	conf->dhcp.end.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.250\"");
-	conf->dhcp.end.t = CONF_STRING;
+	conf->dhcp.end.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.end.f = FLAG_RESTART_FTL;
-	conf->dhcp.end.d.s = (char*)"";
+	memset(&conf->dhcp.end.d.in_addr, 0, sizeof(struct in_addr));
 
 	conf->dhcp.router.k = "dhcp.router";
 	conf->dhcp.router.h = "Address of the gateway to be used (typically the address of your router in a home installation)";
 	conf->dhcp.router.a = cJSON_CreateStringReference("<ip-addr>, e.g., \"192.168.0.1\"");
-	conf->dhcp.router.t = CONF_STRING;
+	conf->dhcp.router.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.router.f = FLAG_RESTART_FTL;
-	conf->dhcp.router.d.s = (char*)"";
+	memset(&conf->dhcp.router.d.in_addr, 0, sizeof(struct in_addr));
 
 	conf->dhcp.domain.k = "dhcp.domain";
 	conf->dhcp.domain.h = "The DNS domain used by your Pi-hole";
@@ -711,6 +711,13 @@ void initConfig(struct config *conf)
 	conf->dhcp.domain.t = CONF_STRING;
 	conf->dhcp.domain.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
 	conf->dhcp.domain.d.s = (char*)"lan";
+
+	conf->dhcp.netmask.k = "dhcp.netmask";
+	conf->dhcp.netmask.h = "The netmask used by your Pi-hole. For directly connected networks (i.e., networks on which the machine running Pi-hole has an interface) the netmask is optional and may be set to \"0.0.0.0\": it will then be determined from the interface configuration itself. For networks which receive DHCP service via a relay agent, we cannot determine the netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses based on the class (A, B or C) of the network address.";
+	conf->dhcp.netmask.a = cJSON_CreateStringReference("<any valid netmask>, e.g., \"255.255.255.0\" or \"0.0.0.0\" for auto-discovery");
+	conf->dhcp.netmask.t = CONF_STRUCT_IN_ADDR;
+	conf->dhcp.netmask.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
+	memset(&conf->dhcp.netmask.d.in_addr, 0, sizeof(struct in_addr));
 
 	conf->dhcp.leaseTime.k = "dhcp.leaseTime";
 	conf->dhcp.leaseTime.h = "If the lease time is given, then leases will be given for that length of time. If not given, the default lease time is one hour for IPv4 and one day for IPv6.";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -88,7 +88,7 @@ enum conf_type {
 #define FLAG_PSEUDO_ITEM           (1 << 2)
 #define FLAG_INVALIDATE_SESSIONS   (1 << 3)
 #define FLAG_WRITE_ONLY            (1 << 4)
-#define FLAG_ENV_VAR     (1 << 5)
+#define FLAG_ENV_VAR               (1 << 5)
 
 struct conf_item {
 	const char *k;        // item Key
@@ -178,6 +178,7 @@ struct config {
 		struct conf_item end;
 		struct conf_item router;
 		struct conf_item domain;
+		struct conf_item netmask;
 		struct conf_item leaseTime;
 		struct conf_item ipv6;
 		struct conf_item rapidCommit;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -419,9 +419,12 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# DHCP server setting\n", pihole_conf);
 		fputs("dhcp-authoritative\n", pihole_conf);
 		fputs("dhcp-leasefile="DHCPLEASESFILE"\n", pihole_conf);
-		char start[INET_ADDRSTRLEN] = { 0 }, end[INET_ADDRSTRLEN] = { 0 };
+		char start[INET_ADDRSTRLEN] = { 0 },
+		     end[INET_ADDRSTRLEN] = { 0 },
+		     router[INET_ADDRSTRLEN] = { 0 };
 		inet_ntop(AF_INET, &conf->dhcp.start.v.in_addr, start, INET_ADDRSTRLEN);
 		inet_ntop(AF_INET, &conf->dhcp.end.v.in_addr, end, INET_ADDRSTRLEN);
+		inet_ntop(AF_INET, &conf->dhcp.router.v.in_addr, router, INET_ADDRSTRLEN);
 		fprintf(pihole_conf, "dhcp-range=%s,%s", start, end);
 		// Net mask is optional, only add if it is not 0.0.0.0
 		const struct in_addr inaddr_empty = {0};
@@ -429,13 +432,12 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		{
 			char netmask[INET_ADDRSTRLEN] = { 0 };
 			inet_ntop(AF_INET, &conf->dhcp.netmask.v.in_addr, netmask, INET_ADDRSTRLEN);
-			fprintf(pihole_conf, ",%s", conf->dhcp.netmask.v.s);
+			fprintf(pihole_conf, ",%s", netmask);
 		}
 		// Lease time is optional, only add it if it is set
 		if(strlen(conf->dhcp.leaseTime.v.s) > 0)
 			fprintf(pihole_conf, ",%s", conf->dhcp.leaseTime.v.s);
-		fprintf(pihole_conf, "\ndhcp-option=option:router,%s\n",
-		        conf->dhcp.router.v.s);
+		fprintf(pihole_conf, "\ndhcp-option=option:router,%s\n", router);
 
 		if(conf->dhcp.rapidCommit.v.b)
 			fputs("dhcp-rapid-commit\n", pihole_conf);

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -419,11 +419,13 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# DHCP server setting\n", pihole_conf);
 		fputs("dhcp-authoritative\n", pihole_conf);
 		fputs("dhcp-leasefile="DHCPLEASESFILE"\n", pihole_conf);
-		fprintf(pihole_conf, "dhcp-range=%s,%s,%s\n",
+		fprintf(pihole_conf, "dhcp-range=%s,%s",
 		        conf->dhcp.start.v.s,
-				conf->dhcp.end.v.s,
-				conf->dhcp.leaseTime.v.s);
-		fprintf(pihole_conf, "dhcp-option=option:router,%s\n",
+		        conf->dhcp.end.v.s);
+		// Lease time is optional, only add it if it is set
+		if(strlen(conf->dhcp.leaseTime.v.s) > 0)
+			fprintf(pihole_conf, ",%s", conf->dhcp.leaseTime.v.s);
+		fprintf(pihole_conf, "\ndhcp-option=option:router,%s\n",
 		        conf->dhcp.router.v.s);
 
 		if(conf->dhcp.rapidCommit.v.b)

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -419,9 +419,18 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# DHCP server setting\n", pihole_conf);
 		fputs("dhcp-authoritative\n", pihole_conf);
 		fputs("dhcp-leasefile="DHCPLEASESFILE"\n", pihole_conf);
-		fprintf(pihole_conf, "dhcp-range=%s,%s",
-		        conf->dhcp.start.v.s,
-		        conf->dhcp.end.v.s);
+		char start[INET_ADDRSTRLEN] = { 0 }, end[INET_ADDRSTRLEN] = { 0 };
+		inet_ntop(AF_INET, &conf->dhcp.start.v.in_addr, start, INET_ADDRSTRLEN);
+		inet_ntop(AF_INET, &conf->dhcp.end.v.in_addr, end, INET_ADDRSTRLEN);
+		fprintf(pihole_conf, "dhcp-range=%s,%s", start, end);
+		// Net mask is optional, only add if it is not 0.0.0.0
+		const struct in_addr inaddr_empty = {0};
+		if(memcmp(&conf->dhcp.netmask.v.in_addr, &inaddr_empty, sizeof(inaddr_empty)) != 0)
+		{
+			char netmask[INET_ADDRSTRLEN] = { 0 };
+			inet_ntop(AF_INET, &conf->dhcp.netmask.v.in_addr, netmask, INET_ADDRSTRLEN);
+			fprintf(pihole_conf, ",%s", conf->dhcp.netmask.v.s);
+		}
 		// Lease time is optional, only add it if it is set
 		if(strlen(conf->dhcp.leaseTime.v.s) > 0)
 			fprintf(pihole_conf, ",%s", conf->dhcp.leaseTime.v.s);

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -223,24 +223,21 @@ class ResponseVerifyer():
 
 	# Check if a string is a valid IPv4 address
 	def valid_ipv4(self, addr: str) -> bool:
-		octets = addr.split(".") # type: list[str]
-		if len(octets) != 4:
-			return False
-		for octet in octets:
-			if not octet.isdigit():
-				return False
-			if int(octet) < 0 or int(octet) > 255:
-				return False
-		return True
-
+		try:
+			if type(ipaddress.ip_address(addr)) is ipaddress.IPv4Address:
+				return True
+		except ValueError:
+			pass
+		return False
 
 	# Check if a string is a valid IPv6 address
 	def valid_ipv6(self, addr: str) -> bool:
-		# Split the address into parts
-		parts = addr.split(":") # type: list[str]
-		# Check if the address is a valid IPv6 address
-		if len(parts) != 8:
-			return False
+		try:
+			if type(ipaddress.ip_address(addr)) is ipaddress.IPv6Address:
+				return True
+		except ValueError:
+			pass
+		return False
 
 
 	# Verify a single property's type

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -223,6 +223,9 @@ class ResponseVerifyer():
 
 	# Check if a string is a valid IPv4 address
 	def valid_ipv4(self, addr: str) -> bool:
+		# Empty string is valid (0.0.0.0)
+		if len(addr) == 0:
+			return True
 		try:
 			if type(ipaddress.ip_address(addr)) is ipaddress.IPv4Address:
 				return True
@@ -232,6 +235,9 @@ class ResponseVerifyer():
 
 	# Check if a string is a valid IPv6 address
 	def valid_ipv6(self, addr: str) -> bool:
+		# Empty string is valid (::)
+		if len(addr) == 0:
+			return True
 		try:
 			if type(ipaddress.ip_address(addr)) is ipaddress.IPv6Address:
 				return True
@@ -253,10 +259,10 @@ class ResponseVerifyer():
 			return False
 		if yaml_format is not None:
 			# Check if the format is correct
-			if yaml_format == "ipv4" and not type(ipaddress.ip_address(prop)) is ipaddress.IPv4Address:
+			if yaml_format == "ipv4" and not self.valid_ipv4(prop):
 				self.errors.append("Property \"" + str(prop) + "\" is not a valid IPv4 address")
 				return False
-			elif yaml_format == "ipv6" and not type(ipaddress.ip_address(prop)) is ipaddress.IPv6Address:
+			elif yaml_format == "ipv6" and not self.valid_ipv6(prop):
 				self.errors.append("Property \"" + str(prop) + "\" is not a valid IPv6 address")
 				return False
 		return prop_type in self.YAML_TYPES[yaml_type]

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -376,6 +376,17 @@
   #     <any valid domain>
   domain = "lan"
 
+  # The netmask used by your Pi-hole. For directly connected networks (i.e., networks on
+  # which the machine running Pi-hole has an interface) the netmask is optional and may
+  # be set to "0.0.0.0": it will then be determined from the interface configuration
+  # itself. For networks which receive DHCP service via a relay agent, we cannot
+  # determine the netmask itself, so it should explicitly be specified, otherwise
+  # Pi-hole guesses based on the class (A, B or C) of the network address.
+  #
+  # Possible values are:
+  #     <any valid netmask>, e.g., "255.255.255.0" or "0.0.0.0" for auto-discovery
+  netmask = "0.0.0.0"
+
   # If the lease time is given, then leases will be given for that length of time. If not
   # given, the default lease time is one hour for IPv4 and one day for IPv6.
   #


### PR DESCRIPTION
# What does this implement/fix?

1. Only add `dhcp.leaseTime` if it is a non-empty string. By default it is non-empty, however we have seen users making it empty.  If empty, the default lease time is one hour for IPv4 and one day for IPv6 (`dnsmasq` defaults, see their man page).
2. Add new option `dhcp.netmask` defaulting to `0.0.0.0` (auto-discovery as before this PR) but freely settable to, e.g. `255.255.0.0` to make a `/16` DHCP network
3. Add API string verification for IPv4 and IPv6 addresses. As `ipv4` and `ipv6` are not standardized `format` properties, we add them as a `x-format` instead. However, since `swagger-api` [supports them](https://github.com/swagger-api/swagger-ui/pull/5033) there is some hope this will end up in a future revision of the OpenAPI standard. Even if not, having the verification using a non-default property seems still useful
4. Reject invalid config items (error 400) instead of merely logging a warning to the log, e.g.,
    ![image](https://github.com/pi-hole/FTL/assets/16748619/b6c9e089-9d21-4fad-bdaf-c14187a43f26)
    where I tried to set
    ![image](https://github.com/pi-hole/FTL/assets/16748619/05219cad-0d36-46e3-868d-444d3cac4651)
    This still adds a warning to `FTL.log`:
    ```
    2023-11-04 12:41:12.792 [2357991/T2358010] WARNING: API: Config item is invalid (dhcp.end: not a valid IPv4 address)
    ```

The first two items address [a bug reported on Discourse](https://discourse.pi-hole.net/t/api-error-when-enabling-dhcp-server/66079?u=dl6er) where a user tried to specify a DHCP range from `192.168.0.300` to `192.168.0.500` with an empty `leaseTime` config option. The fourth item goes into this direction was well as it will allow us to show the error in a more human-digestible form to the user (upcoming web PR).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.