### PR TITLE
Changing dns.hosts does not need a restart

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -462,7 +462,7 @@ void initConfig(struct config *conf)
 	conf->dns.hosts.h = "Array of custom DNS records\n Example: hosts = [ \"127.0.0.1 mylocal\", \"192.168.0.1 therouter\" ]";
 	conf->dns.hosts.a = cJSON_CreateStringReference("Array of custom DNS records each one in HOSTS form: \"IP HOSTNAME\"");
 	conf->dns.hosts.t = CONF_JSON_STRING_ARRAY;
-	conf->dns.hosts.f = FLAG_ADVANCED_SETTING | FLAG_RESTART_FTL;
+	conf->dns.hosts.f = FLAG_ADVANCED_SETTING;
 	conf->dns.hosts.d.json = cJSON_CreateArray();
 
 	conf->dns.domainNeeded.k = "dns.domainNeeded";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -88,7 +88,7 @@ enum conf_type {
 #define FLAG_PSEUDO_ITEM           (1 << 2)
 #define FLAG_INVALIDATE_SESSIONS   (1 << 3)
 #define FLAG_WRITE_ONLY            (1 << 4)
-#define FLAG_ENV_VAR     (1 << 5)
+#define FLAG_ENV_VAR               (1 << 5)
 
 struct conf_item {
 	const char *k;        // item Key


### PR DESCRIPTION
# What does this implement/fix?

Changing `dns.hosts` does not need a full FTL restart but only a cache flush and re-read of `custom.list`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.