### PR TITLE
Make number of maximum concurrent API sessions adjustable

### DIFF
--- a/src/api/2fa.c
+++ b/src/api/2fa.c
@@ -198,7 +198,7 @@ static bool encode_uint8_t_array_to_base32(const uint8_t *in, const size_t in_le
 }
 
 static uint32_t last_code = 0;
-bool verifyTOTP(const uint32_t incode)
+enum totp_status verifyTOTP(const uint32_t incode)
 {
 	// Decode base32 secret
 	uint8_t decoded_secret[RFC6238_SECRET_LEN];
@@ -228,15 +228,15 @@ bool verifyTOTP(const uint32_t incode)
 			{
 				log_warn("2FA code has already been used (%i, %u), please wait %lu seconds",
 				         i, gencode, (unsigned long)(RFC6238_X - (now % RFC6238_X)));
-				return false;
+				return TOTP_REUSED;
 			}
 			log_info("2FA code verified successfully at %i", i);
 			last_code = gencode;
-			return true;
+			return TOTP_CORRECT;
 		}
 	}
 
-	return false;
+	return TOTP_INVALID;
 }
 
 // Print TOTP code to stdout (for CLI use)

--- a/src/api/2fa.c
+++ b/src/api/2fa.c
@@ -230,7 +230,8 @@ enum totp_status verifyTOTP(const uint32_t incode)
 				         i, gencode, (unsigned long)(RFC6238_X - (now % RFC6238_X)));
 				return TOTP_REUSED;
 			}
-			log_info("2FA code verified successfully at %i", i);
+			const char *which = i == -1 ? "previous" : i == 0 ? "current" : "next";
+			log_debug(DEBUG_API, "2FA code from %s time step is valid", which);
 			last_code = gencode;
 			return TOTP_CORRECT;
 		}

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -92,7 +92,12 @@ int api_auth_session_delete(struct ftl_conn *api);
 bool is_local_api_user(const char *remote_addr) __attribute__((pure));
 
 // 2FA methods
-bool verifyTOTP(const uint32_t code);
+enum totp_status {
+	TOTP_INVALID,
+	TOTP_CORRECT,
+	TOTP_REUSED,
+} __attribute__ ((packed));
+enum totp_status verifyTOTP(const uint32_t code);
 int generateTOTP(struct ftl_conn *api);
 int printTOTP(void);
 int generateAppPw(struct ftl_conn *api);

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -593,16 +593,22 @@ int api_auth(struct ftl_conn *api)
 		}
 		if(user_id == API_AUTH_UNAUTHORIZED)
 		{
-			log_warn("No free API seats available, not authenticating client");
+			log_warn("No free API seats available (webserver.api.max_sessions = %u), not authenticating client",
+			         config.webserver.api.max_sessions.v.u16);
+
+			return send_json_error(api, 429,
+			                       "too_many_requests",
+			                       "Too many requests",
+			                       "no free API seats available");
 		}
 	}
 	else if(result == PASSWORD_RATE_LIMITED)
 	{
 		// Rate limited
 		return send_json_error(api, 429,
-					"too_many_requests",
-					"Too many requests",
-					"login rate limiting");
+		                       "too_many_requests",
+		                       "Too many requests",
+		                       "login rate limiting");
 	}
 	else
 	{

--- a/src/api/auth.h
+++ b/src/api/auth.h
@@ -11,9 +11,6 @@
 #ifndef AUTH_H
 #define AUTH_H
 
-// How many authenticated API clients are allowed simultaneously? [.]
-#define API_MAX_CLIENTS 16
-
 // crypto library
 #include <nettle/sha2.h>
 #include <nettle/base64.h>

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -96,6 +96,11 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/too_many_requests'
                     - $ref: 'common.yaml#/components/schemas/took'
+                examples:
+                  rate_limit:
+                    $ref: 'auth.yaml#/components/examples/errors/rate_limit'
+                  no_seats:
+                    $ref: 'auth.yaml#/components/examples/errors/no_seats'
       delete:
         summary: Delete session
         tags:
@@ -507,6 +512,20 @@ components:
             key: "bad_request"
             message: "Session ID not in use"
             hint: null
+      rate_limit:
+        summary: Rate limit exceeded
+        value:
+          error:
+            key: "too_many_requests"
+            message: "Too many requests"
+            hint: "login rate limiting"
+      no_seats:
+        summary: No free API seats available
+        value:
+          error:
+            key: "too_many_requests"
+            message: "Too many requests"
+            hint: "no free API seats available"
   parameters:
     id:
       in: path

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -80,6 +80,8 @@ components:
                     $ref: 'auth.yaml#/components/examples/errors/no_password'
                   password_inval:
                     $ref: 'auth.yaml#/components/examples/errors/password_inval'
+                  totp_missing:
+                    $ref: 'auth.yaml#/components/examples/errors/totp_missing'
           '401':
             description: Unauthorized
             content:
@@ -88,6 +90,11 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
+                examples:
+                  totp_invalid:
+                    $ref: 'auth.yaml#/components/examples/errors/totp_invalid'
+                  totp_reused:
+                    $ref: 'auth.yaml#/components/examples/errors/totp_reused'
           '429':
             description: Too Many Requests
             content:
@@ -491,6 +498,13 @@ components:
             key: "bad_request"
             message: "Field password has to be of type 'string'"
             hint: null
+      totp_missing:
+        summary: Bad request (2FA token missing)
+        value:
+          error:
+            key: "bad_request"
+            message: "No 2FA token found in JSON payload"
+            hint: null
       missing_session_id:
         summary: Bad request (missing session ID)
         value:
@@ -512,20 +526,34 @@ components:
             key: "bad_request"
             message: "Session ID not in use"
             hint: null
+      totp_invalid:
+        summary: 2FA token invalid
+        value:
+          error:
+            key: "unauthorized"
+            message: "Invalid 2FA token"
+            hint: null
+      totp_reused:
+        summary: 2FA token reused
+        value:
+          error:
+            key: "unauthorized"
+            message: "Reused 2FA token"
+            hint: "wait for new token"
       rate_limit:
         summary: Rate limit exceeded
         value:
           error:
-            key: "too_many_requests"
-            message: "Too many requests"
-            hint: "login rate limiting"
+            key: "rate_limiting"
+            message: "Rate-limiting login attempts"
+            hint: null
       no_seats:
         summary: No free API seats available
         value:
           error:
-            key: "too_many_requests"
-            message: "Too many requests"
-            hint: "no free API seats available"
+            key: "api_seats_exceeded"
+            message: "API seats exceeded"
+            hint: "increase webserver.api.max_sessions"
   parameters:
     id:
       in: path

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -386,6 +386,8 @@ components:
                       type: boolean
                     searchAPIauth:
                       type: boolean
+                    max_sessions:
+                      type: integer
                     prettyJSON:
                       type: boolean
                     password:
@@ -666,6 +668,7 @@ components:
             api:
               localAPIauth: false
               searchAPIauth: false
+              max_sessions: 16
               prettyJSON: false
               password: "********"
               pwhash: ''

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -903,6 +903,12 @@ void initConfig(struct config *conf)
 	conf->webserver.api.localAPIauth.t = CONF_BOOL;
 	conf->webserver.api.localAPIauth.d.b = true;
 
+	conf->webserver.api.max_sessions.k = "webserver.api.max_sessions";
+	conf->webserver.api.max_sessions.h = "Number of concurrent sessions allowed for the API. If the number of sessions exceeds this value, no new sessions will be allowed until the number of sessions drops due to session expiration or logout. Note that the number of concurrent sessions is irrelevant if authentication is disabled as no sessions are used in this case.";
+	conf->webserver.api.max_sessions.t = CONF_UINT16;
+	conf->webserver.api.max_sessions.d.u16 = 16;
+	conf->webserver.api.max_sessions.f = FLAG_ADVANCED_SETTING | FLAG_RESTART_FTL;
+
 	conf->webserver.api.prettyJSON.k = "webserver.api.prettyJSON";
 	conf->webserver.api.prettyJSON.h = "Should FTL prettify the API output (add extra spaces, newlines and indentation)?";
 	conf->webserver.api.prettyJSON.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -226,6 +226,7 @@ struct config {
 		struct {
 			struct conf_item localAPIauth;
 			struct conf_item searchAPIauth;
+			struct conf_item max_sessions;
 			struct conf_item prettyJSON;
 			struct conf_item pwhash;
 			struct conf_item password; // This is a pseudo-item

--- a/src/database/session-table.c
+++ b/src/database/session-table.c
@@ -89,7 +89,7 @@ bool backup_db_sessions(struct session *sessions)
 	}
 
 	unsigned int api_sessions = 0;
-	for(unsigned int i = 0; i < API_MAX_CLIENTS; i++)
+	for(unsigned int i = 0; i < config.webserver.api.max_sessions.v.u16; i++)
 	{
 		// Get session
 		struct session *sess = &sessions[i];
@@ -237,7 +237,7 @@ bool restore_db_sessions(struct session *sessions)
 
 	// Iterate over all still valid sessions
 	unsigned int i = 0;
-	while(sqlite3_step(stmt) == SQLITE_ROW && i++ < API_MAX_CLIENTS)
+	while(sqlite3_step(stmt) == SQLITE_ROW && i++ < config.webserver.api.max_sessions.v.u16)
 	{
 		// Allocate memory for new session
 		struct session *sess = &sessions[i];

--- a/src/database/session-table.c
+++ b/src/database/session-table.c
@@ -64,7 +64,7 @@ bool add_session_app_column(sqlite3 *db)
 }
 
 // Store all session in database
-bool backup_db_sessions(struct session *sessions)
+bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 {
 	if(!config.webserver.session.restore.v.b)
 	{
@@ -89,7 +89,7 @@ bool backup_db_sessions(struct session *sessions)
 	}
 
 	unsigned int api_sessions = 0;
-	for(unsigned int i = 0; i < config.webserver.api.max_sessions.v.u16; i++)
+	for(unsigned int i = 0; i < max_sessions; i++)
 	{
 		// Get session
 		struct session *sess = &sessions[i];
@@ -198,8 +198,8 @@ bool backup_db_sessions(struct session *sessions)
 		return false;
 	}
 
-	log_info("Stored %u API session%s in the database",
-	         api_sessions, api_sessions == 1 ? "" : "s");
+	log_info("Stored %u/%u API session%s in the database",
+	         api_sessions, max_sessions, max_sessions == 1 ? "" : "s");
 
 	// Close database connection
 	dbclose(&db);
@@ -208,7 +208,7 @@ bool backup_db_sessions(struct session *sessions)
 }
 
 // Restore all sessions found in the database
-bool restore_db_sessions(struct session *sessions)
+bool restore_db_sessions(struct session *sessions, const uint16_t max_sessions)
 {
 	if(!config.webserver.session.restore.v.b)
 	{
@@ -237,7 +237,7 @@ bool restore_db_sessions(struct session *sessions)
 
 	// Iterate over all still valid sessions
 	unsigned int i = 0;
-	while(sqlite3_step(stmt) == SQLITE_ROW && i++ < config.webserver.api.max_sessions.v.u16)
+	while(sqlite3_step(stmt) == SQLITE_ROW && i < max_sessions)
 	{
 		// Allocate memory for new session
 		struct session *sess = &sessions[i];
@@ -292,10 +292,12 @@ bool restore_db_sessions(struct session *sessions)
 
 		// Mark session as used
 		sess->used = true;
+
+		i++;
 	}
 
-	log_info("Restored %u API session%s from the database",
-	         i, i == 1 ? "" : "s");
+	log_info("Restored %u/%u API session%s from the database",
+	         i, max_sessions, max_sessions == 1 ? "" : "s");
 
 	// Finalize statement
 	if(sqlite3_finalize(stmt) != SQLITE_OK)

--- a/src/database/session-table.h
+++ b/src/database/session-table.h
@@ -16,7 +16,7 @@
 
 bool create_session_table(sqlite3 *db);
 bool add_session_app_column(sqlite3 *db);
-bool backup_db_sessions(struct session *sessions);
-bool restore_db_sessions(struct session *sessions);
+bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions);
+bool restore_db_sessions(struct session *sessions, const uint16_t max_sessions);
 
 #endif // SESSION_TABLE_PRIVATE_H

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -152,8 +152,8 @@ class ResponseVerifyer():
 
 			# Check for properties in FTL that are not in the API specs
 			for property in FTLflat.keys():
-				if property not in YAMLflat.keys() and len([p.startswith(property + ".") for p in YAMLflat.keys()]) == 0:
-					self.errors.append("Property '" + property + "' missing in the API specs (have " + ",".join(YAMLflat.keys()) + ")")
+				if property not in YAMLflat.keys():
+					self.errors.append("Property '" + property + "' missing in the API specs")
 
 		elif expected_mimetype == "application/zip":
 			file_like_object = io.BytesIO(FTLresponse)
@@ -296,6 +296,9 @@ class ResponseVerifyer():
 				for j in FTLprop[i]:
 					if not self.verify_property(YAMLprop['items']['properties'], YAMLexamples, FTLprop[i], props + [i, str(j)]):
 						all_okay = False
+
+			# Add this property to the YAML response
+			self.YAMLresponse[flat_path] = []
 		else:
 			# Check this property
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -604,6 +604,12 @@
     # sense of the option means only 127.0.0.1 and [::1]
     searchAPIauth = false
 
+    # Number of concurrent sessions allowed for the API. If the number of sessions exceeds
+    # this value, no new sessions will be allowed until the number of sessions drops due
+    # to session expiration or logout. Note that the number of concurrent sessions is
+    # irrelevant if authentication is disabled as no sessions are used in this case.
+    max_sessions = 16
+
     # Should FTL prettify the API output (add extra spaces, newlines and indentation)?
     prettyJSON = false
 


### PR DESCRIPTION
# What does this implement/fix?

Make number of maximum concurrent API sessions adjustable via `webserver.api.max_sessions` defaulting to 16 (as before this change). This PR also fixes a small glitch in the API verifier that lost the ability to detect properties returned by FTL but not documented. This bug was introduced when adding the ability to check arrays as we implemented a workaround that had adverse effects. Arrays are not handled as first-class YAML citizens and can hence be checked as well.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.