### PR TITLE
Make inclusion of /etc/dnsmasq.d/*.conf files configurable

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -450,6 +450,8 @@ components:
                   type: integer
                 addr2line:
                   type: boolean
+                etc_dnsmasq_d:
+                  type: boolean
                 privacylevel:
                   type: integer
                 dnsmasq_lines:
@@ -694,6 +696,7 @@ components:
             delay_startup: 10
             addr2line: true
             privacylevel: 0
+            etc_dnsmasq_d: false
             dnsmasq_lines: [ ]
             check:
               load: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1074,6 +1074,12 @@ void initConfig(struct config *conf)
 	conf->misc.addr2line.f = FLAG_ADVANCED_SETTING;
 	conf->misc.addr2line.d.b = true;
 
+	conf->misc.etc_dnsmasq_d.k = "misc.etc_dnsmasq_d";
+	conf->misc.etc_dnsmasq_d.h = "Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?";
+	conf->misc.etc_dnsmasq_d.t = CONF_BOOL;
+	conf->misc.etc_dnsmasq_d.f = FLAG_ADVANCED_SETTING;
+	conf->misc.etc_dnsmasq_d.d.b = false;
+
 	conf->misc.dnsmasq_lines.k = "misc.dnsmasq_lines";
 	conf->misc.dnsmasq_lines.h = "Additional lines to inject into the generated dnsmasq configuration.\n Warning: This is an advanced setting and should only be used with care. Incorrectly formatted or duplicated lines as well as lines conflicting with the automatic configuration of Pi-hole can break the embedded dnsmasq and will stop DNS resolution from working.\n Use this option with extra care.";
 	conf->misc.dnsmasq_lines.a = cJSON_CreateStringReference("array of valid dnsmasq config line options");

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1077,7 +1077,7 @@ void initConfig(struct config *conf)
 	conf->misc.etc_dnsmasq_d.k = "misc.etc_dnsmasq_d";
 	conf->misc.etc_dnsmasq_d.h = "Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?";
 	conf->misc.etc_dnsmasq_d.t = CONF_BOOL;
-	conf->misc.etc_dnsmasq_d.f = FLAG_ADVANCED_SETTING;
+	conf->misc.etc_dnsmasq_d.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
 	conf->misc.etc_dnsmasq_d.d.b = false;
 
 	conf->misc.dnsmasq_lines.k = "misc.dnsmasq_lines";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -261,6 +261,7 @@ struct config {
 		struct conf_item delay_startup;
 		struct conf_item nice;
 		struct conf_item addr2line;
+		struct conf_item etc_dnsmasq_d;
 		struct conf_item dnsmasq_lines;
 		struct {
 			struct conf_item load;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -207,11 +207,12 @@ static void write_config_header(FILE *fp, const char *description)
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "ANY CHANGES MADE TO THIS FILE WILL BE LOST WHEN THE CONFIGURATION CHANGES");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "IF YOU WISH TO CHANGE ANY OF THESE VALUES, CHANGE THEM IN");
-	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "etc/pihole/pihole.toml");
+	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "/etc/pihole/pihole.toml");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "and restart pihole-FTL");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "ANY OTHER CHANGES SHOULD BE MADE IN A SEPARATE CONFIG FILE");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "WITHIN /etc/dnsmasq.d/yourname.conf");
+	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "(make sure misc.etc_dnsmasq_d is set to true in /etc/pihole/pihole.toml)");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "");
 	CONFIG_CENTER(fp, HEADER_WIDTH, "Last updated: %s", timestring);
 	CONFIG_CENTER(fp, HEADER_WIDTH, "by FTL version %s", get_FTL_version());
@@ -508,11 +509,11 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 	fputs("server=/bind/\n", pihole_conf);
 	fputs("server=/onion/\n", pihole_conf);
 
-	if(directory_exists("/etc/dnsmasq.d"))
+	if(directory_exists("/etc/dnsmasq.d") && conf->misc.etc_dnsmasq_d.v.b)
 	{
-		// Load possible additional user scripts from /etc/dnsmasq.d if
-		// the directory exists (it may not, e.g., in a container)
-		fputs("# Load possible additional user scripts\n", pihole_conf);
+		// Load additional user scripts from /etc/dnsmasq.d if the
+		// directory exists (it may not, e.g., in a container)
+		fputs("# Load additional user scripts\n", pihole_conf);
 		fputs("conf-dir=/etc/dnsmasq.d\n", pihole_conf);
 		fputs("\n", pihole_conf);
 	}

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -775,6 +775,9 @@
   # malfunctioning addr2line can prevent from generating any backtrace at all.
   addr2line = true
 
+  # Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?
+  etc_dnsmasq_d = true ### CHANGED, default = false
+
   # Additional lines to inject into the generated dnsmasq configuration. Warning: This is
   # an advanced setting and should only be used with care. Incorrectly formatted or
   # duplicated lines as well as lines conflicting with the automatic configuration of


### PR DESCRIPTION
# What does this implement/fix?

Add a new config option `misc.etc_dnsmasq_d` to allow setting whether files in `/etc/dnsmasq.d` are loaded as additional config files for Pi-hole.

This resolves two long standing issues

1. with Pi-hole not being compatible with software that installs custom files with conflicting lines in this directory (e.g.,` lxd`, [example reference](https://discourse.pi-hole.net/t/dns-service-is-not-running-ubuntu-19-10/30157/5?u=dl6er)) as well as
2. improving the coexistence of Pi-hole with an already running `dnsmasq` on the host as - by default - we won't share any config files in the future (no reference needed)

This change also goes hand-in-hand with [a recently discovered issue](https://discourse.pi-hole.net/t/ftl-failed-to-start-due-to-duplicate-cname-at-line-1-of-etc-dnsmasq-d-05-pihole-custom-cname-conf/66087) where the origin of a spurious file inside `/etc/dnsmasq.d/` could not be determined. We have reports of at least a few dozen testers which had no issues with the CNAME migration FTL applies when moving from pre-v6.0 to v6.0 for the first time.

Overall, it took me a day to realize that this is probably really the better default as it finally makes Pi-hole be able run - for the first time - independent from a possibly intentionally installed `dnsmasq` that may be listening only on some interfaces or on another port and, hence, is in no other conflict with Pi-hole on this machine.

It is important to make it crystal clear in the blog post describing the release that this setting should be switched to on for those that have custom files in there. In case they only want to add one or two custom options, they can already do so from the web interface in v6.0 and doesn't even have to create a file, improving user experience:

![Screenshot from 2023-11-05 10-31-28](https://github.com/pi-hole/FTL/assets/16748619/4fca3c9e-3717-4f2c-826f-ae17d6f72487)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
4. I have commented my proposed changes within the code.
5. I am willing to help maintain this change if there are issues with it later.
6. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
7. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.