### PR TITLE
Always return full overTime data

### DIFF
--- a/src/api/history.c
+++ b/src/api/history.c
@@ -39,35 +39,22 @@ int api_history(struct ftl_conn *api)
 		JSON_ADD_ITEM_TO_ARRAY(history, item);
 	}
 
+	// Unlock already here to avoid keeping the lock during JSON generation
+	// This is safe because we don't access any shared memory after this
+	// point. All numbers in the JSON are copied
+	unlock_shm();
+
 	// Minimum structure is
 	// {"history":[]}
 	cJSON *json = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(json, "history", history);
-	JSON_SEND_OBJECT_UNLOCK(json);
+	JSON_SEND_OBJECT(json);
 }
 
 int api_history_clients(struct ftl_conn *api)
 {
-	int sendit = false;
-	unsigned int from = 0, until = OVERTIME_SLOTS;
-	const time_t now = time(NULL);
-
-	lock_shm();
-
-	// Find minimum ID to send
-	for(unsigned int slot = 0; slot < OVERTIME_SLOTS; slot++)
-	{
-		if((overTime[slot].total > 0 || overTime[slot].blocked > 0) &&
-		   overTime[slot].timestamp >= overTime[0].timestamp)
-		{
-			sendit = true;
-			from = slot;
-			break;
-		}
-	}
-
 	// Exit before processing any data if requested via config setting
-	if(config.misc.privacylevel.v.privacy_level >= PRIVACY_HIDE_DOMAINS_CLIENTS || !sendit)
+	if(config.misc.privacylevel.v.privacy_level >= PRIVACY_HIDE_DOMAINS_CLIENTS)
 	{
 		// Minimum structure is
 		// {"history":[], "clients":[]}
@@ -79,17 +66,7 @@ int api_history_clients(struct ftl_conn *api)
 		JSON_SEND_OBJECT_UNLOCK(json);
 	}
 
-	// End with last non-empty overTime slot or the last slot that is not
-	// older than the maximum history to be sent
-	for(unsigned int slot = 0; slot < OVERTIME_SLOTS; slot++)
-	{
-		if(overTime[slot].timestamp >= now ||
-		   overTime[slot].timestamp - now > (time_t)config.webserver.api.maxHistory.v.ui)
-		{
-			until = slot;
-			break;
-		}
-	}
+	lock_shm();
 
 	// Get clients which the user doesn't want to see
 	// if skipclient[i] == true then this client should be hidden from
@@ -116,7 +93,7 @@ int api_history_clients(struct ftl_conn *api)
 		}
 	}
 
-	// Also skip alias-clients
+	// Also skip clients included in others (in alias-clients)
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		// Get client pointer
@@ -127,9 +104,9 @@ int api_history_clients(struct ftl_conn *api)
 			skipclient[clientID] = true;
 	}
 
-	cJSON *history = JSON_NEW_ARRAY();
 	// Main return loop
-	for(unsigned int slot = from; slot < until; slot++)
+	cJSON *history = JSON_NEW_ARRAY();
+	for(unsigned int slot = 0; slot < OVERTIME_SLOTS; slot++)
 	{
 		cJSON *item = JSON_NEW_OBJECT();
 		JSON_ADD_NUMBER_TO_OBJECT(item, "timestamp", overTime[slot].timestamp);
@@ -158,8 +135,8 @@ int api_history_clients(struct ftl_conn *api)
 	cJSON *json = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(json, "history", history);
 
-	cJSON *clients = JSON_NEW_ARRAY();
 	// Loop over clients to generate output to be sent to the client
+	cJSON *clients = JSON_NEW_ARRAY();
 	for(int clientID = 0; clientID < counters->clients; clientID++)
 	{
 		if(skipclient[clientID])
@@ -178,10 +155,16 @@ int api_history_clients(struct ftl_conn *api)
 		JSON_REF_STR_IN_OBJECT(item, "ip", client_ip);
 		JSON_ADD_ITEM_TO_ARRAY(clients, item);
 	}
-	JSON_ADD_ITEM_TO_OBJECT(json, "clients", clients);
+
+	// Unlock already here to avoid keeping the lock during JSON generation
+	// This is safe because we don't access any shared memory after this
+	// point and all strings in the JSON are references to idempotent shared
+	// memory and can, thus, be accessed at any time without locking
+	unlock_shm();
 
 	// Free memory
 	free(skipclient);
 
-	JSON_SEND_OBJECT_UNLOCK(json);
+	JSON_ADD_ITEM_TO_OBJECT(json, "clients", clients);
+	JSON_SEND_OBJECT(json);
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1292,6 +1292,18 @@
   [[ ${lines[0]} == '"xn--bc-uia.com"' ]]
 }
 
+@test "API history: Returns full 24 hours even if only a few queries are made" {
+  run bash -c 'curl -s 127.0.0.1/api/history | jq ".history | length"'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "145" ]]
+}
+
+@test "API history/clients: Returns full 24 hours even if only a few queries are made" {
+  run bash -c 'curl -s 127.0.0.1/api/history/clients | jq ".history | length"'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "145" ]]
+}
+
 @test "API authorization (without password): No login required" {
   run bash -c 'curl -s 127.0.0.1/api/auth'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
# What does this implement/fix?

Do not reduce the number of sent timeslots based on the real activity but instead always send everything (even if there are many zeros). This brings https://github.com/pi-hole/FTL/pull/1345 to FTL v6.0. See also the reasoning over there.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.