### PR TITLE
Move dhcp.domain -> dns.domain

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -206,6 +206,8 @@ components:
                   type: boolean
                 expandHosts:
                   type: boolean
+                domain:
+                  type: string
                 bogusPriv:
                   type: boolean
                 dnssec:
@@ -583,6 +585,7 @@ components:
               - "192.168.2.123 mymusicbox"
             domainNeeded: true
             expandHosts: true
+            domain: "lan"
             bogusPriv: true
             dnssec: true
             interface: "eth0"

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -303,6 +303,8 @@ components:
                   type: string
                 domain:
                   type: string
+                  description: |
+                    *Note:* This setting is deprecated and will be removed in a future release. Use dns.domain instead.
                 leaseTime:
                   type: string
                 ipv6:

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -477,6 +477,13 @@ void initConfig(struct config *conf)
 	conf->dns.expandHosts.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
 	conf->dns.expandHosts.d.b = false;
 
+	conf->dns.domain.k = "dns.domain";
+	conf->dns.domain.h = "The DNS domain used by your Pi-hole to expand hosts and for DHCP.\n\n Only if DHCP is enabled below: For DHCP, this has two effects; firstly it causes the DHCP server to return the domain to any hosts which request it, and secondly it sets the domain which it is legal for DHCP-configured hosts to claim. The intention is to constrain hostnames so that an untrusted host on the LAN cannot advertise its name via DHCP as e.g. \"google.com\" and capture traffic not meant for it. If no domain suffix is specified, then any DHCP hostname with a domain part (ie with a period) will be disallowed and logged. If a domain is specified, then hostnames with a domain part are allowed, provided the domain part matches the suffix. In addition, when a suffix is set then hostnames without a domain part have the suffix added as an optional domain part. For instance, we can set domain=mylab.com and have a machine whose DHCP hostname is \"laptop\". The IP address for that machine is available both as \"laptop\" and \"laptop.mylab.com\".\n\n You can disable setting a domain by setting this option to an empty string.";
+	conf->dns.domain.a = cJSON_CreateStringReference("<any valid domain>");
+	conf->dns.domain.t = CONF_STRING;
+	conf->dns.domain.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
+	conf->dns.domain.d.s = (char*)"lan";
+
 	conf->dns.bogusPriv.k = "dns.bogusPriv";
 	conf->dns.bogusPriv.h = "Should all reverse lookups for private IP ranges (i.e., 192.168.x.y, etc) which are not found in /etc/hosts or the DHCP leases file be answered with \"no such domain\" rather than being forwarded upstream?";
 	conf->dns.bogusPriv.t = CONF_BOOL;
@@ -706,7 +713,7 @@ void initConfig(struct config *conf)
 	conf->dhcp.router.d.s = (char*)"";
 
 	conf->dhcp.domain.k = "dhcp.domain";
-	conf->dhcp.domain.h = "The DNS domain used by your Pi-hole";
+	conf->dhcp.domain.h = "The DNS domain used by your Pi-hole (*** DEPRECATED ***)\n This setting is deprecated and will be removed in a future version. Please use dns.domain instead. Setting it to any non-default value will overwrite the value of dns.domain if it is still set to its default value.";
 	conf->dhcp.domain.a = cJSON_CreateStringReference("<any valid domain>");
 	conf->dhcp.domain.t = CONF_STRING;
 	conf->dhcp.domain.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -125,6 +125,7 @@ struct config {
 		struct conf_item hosts;
 		struct conf_item domainNeeded;
 		struct conf_item expandHosts;
+		struct conf_item domain;
 		struct conf_item bogusPriv;
 		struct conf_item dnssec;
 		struct conf_item interface;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -402,16 +402,18 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# Never forward A or AAAA queries for plain names, without\n",pihole_conf);
 		fputs("# dots or domain parts, to upstream nameservers. If the name\n", pihole_conf);
 		fputs("# is not known from /etc/hosts or DHCP a NXDOMAIN is returned\n", pihole_conf);
-			fprintf(pihole_conf, "local=/%s/\n",
-				conf->dhcp.domain.v.s);
-		fputs("\n", pihole_conf);
+		if(strlen(conf->dns.domain.v.s))
+			fprintf(pihole_conf, "local=/%s/\n\n", conf->dns.domain.v.s);
+		else
+			fputs("\n", pihole_conf);
 	}
 
-	if(strlen(conf->dhcp.domain.v.s) > 0 && strcasecmp("none", conf->dhcp.domain.v.s) != 0)
+	// Add domain to DNS server. It will also be used for DHCP if the DHCP
+	// server is enabled below
+	if(strlen(conf->dns.domain.v.s) > 0)
 	{
-		fputs("# DNS domain for the DHCP server\n", pihole_conf);
-		fprintf(pihole_conf, "domain=%s\n", conf->dhcp.domain.v.s);
-		fputs("\n", pihole_conf);
+		fputs("# DNS domain for both the DNS and DHCP server\n", pihole_conf);
+		fprintf(pihole_conf, "domain=%s\n\n", conf->dns.domain.v.s);
 	}
 
 	if(conf->dhcp.active.v.b)

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -20,6 +20,25 @@
 // watch_config()
 #include "config/inotify.h"
 
+static void migrate_config(void)
+{
+	// Migrating dhcp.domain -> dns.domain
+	if(strcmp(config.dns.domain.v.s, config.dns.domain.d.s) == 0)
+	{
+		// If the domain is the same as the default, check if the dhcp domain
+		// is different from the default. If so, migrate it
+		if(strcmp(config.dhcp.domain.v.s, config.dhcp.domain.d.s) != 0)
+		{
+			// Migrate dhcp.domain -> dns.domain
+			log_info("Migrating dhcp.domain = \"%s\" -> dns.domain", config.dhcp.domain.v.s);
+			if(config.dns.domain.t == CONF_STRING_ALLOCATED)
+				free(config.dns.domain.v.s);
+			config.dns.domain.v.s = strdup(config.dhcp.domain.v.s);
+			config.dns.domain.t = CONF_STRING_ALLOCATED;
+		}
+	}
+}
+
 bool writeFTLtoml(const bool verbose)
 {
 	// Stop watching for changes in the config file
@@ -51,6 +70,9 @@ bool writeFTLtoml(const bool verbose)
 	fputs("\n# by FTL ", fp);
 	fputs(get_FTL_version(), fp);
 	fputs("\n\n", fp);
+
+	// Perform possible config migration
+	migrate_config();
 
 	// Iterate over configuration and store it into the file
 	char *last_path = (char*)"";

--- a/src/setupVars.c
+++ b/src/setupVars.c
@@ -339,7 +339,7 @@ void importsetupVarsConf(void)
 	get_conf_upstream_servers_from_setupVars(&config.dns.upstreams);
 
 	// Try to get Pi-hole domain
-	get_conf_string_from_setupVars("PIHOLE_DOMAIN", &config.dhcp.domain);
+	get_conf_string_from_setupVars("PIHOLE_DOMAIN", &config.dns.domain);
 
 	// Try to get bool properties (the first two are intentionally set from the same key)
 	get_conf_bool_from_setupVars("DNS_FQDN_REQUIRED", &config.dns.domainNeeded);

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -110,6 +110,27 @@
   # same way as for DHCP-derived names
   expandHosts = false
 
+  # The DNS domain used by your Pi-hole to expand hosts and for DHCP.
+  #
+  # Only if DHCP is enabled below: For DHCP, this has two effects; firstly it causes the
+  # DHCP server to return the domain to any hosts which request it, and secondly it sets
+  # the domain which it is legal for DHCP-configured hosts to claim. The intention is to
+  # constrain hostnames so that an untrusted host on the LAN cannot advertise its name
+  # via DHCP as e.g. "google.com" and capture traffic not meant for it. If no domain
+  # suffix is specified, then any DHCP hostname with a domain part (ie with a period)
+  # will be disallowed and logged. If a domain is specified, then hostnames with a
+  # domain part are allowed, provided the domain part matches the suffix. In addition,
+  # when a suffix is set then hostnames without a domain part have the suffix added as
+  # an optional domain part. For instance, we can set domain=mylab.com and have a
+  # machine whose DHCP hostname is "laptop". The IP address for that machine is
+  # available both as "laptop" and "laptop.mylab.com".
+  #
+  # You can disable setting a domain by setting this option to an empty string.
+  #
+  # Possible values are:
+  #     <any valid domain>
+  domain = "lan"
+
   # Should all reverse lookups for private IP ranges (i.e., 192.168.x.y, etc) which are
   # not found in /etc/hosts or the DHCP leases file be answered with "no such domain"
   # rather than being forwarded upstream?
@@ -370,7 +391,10 @@
   #     <ip-addr>, e.g., "192.168.0.1"
   router = ""
 
-  # The DNS domain used by your Pi-hole
+  # The DNS domain used by your Pi-hole (*** DEPRECATED ***)
+  # This setting is deprecated and will be removed in a future version. Please use
+  # dns.domain instead. Setting it to any non-default value will overwrite the value of
+  # dns.domain if it is still set to its default value.
   #
   # Possible values are:
   #     <any valid domain>


### PR DESCRIPTION
# What does this implement/fix?

See title. This is to avoid confusion. Even when it is primarily being used when DHCP is enabled, it can also be used by DNS server features like `dns.expandHosts`. It was probably not the idea to move the setting into `[dhcp]` which is why I move it to `[dns]` now.

~~Note that there is no migration strategy here as it would required adding quite a bit of code to FTL (unknown config options are automatically cleaned from the file) and additional PRs in the future to remove this extra code. Seems fine to me during the beta phase and something that should definitely be done before the release.~~

If `dhcp.domain` was set, it will be migrated to `dns.domain`. This code can be removed in some future iteration of the beta (or even after release, if we forget).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.