### PR TITLE
Fix free() being used in the wrong page

### DIFF
--- a/src/api/search.c
+++ b/src/api/search.c
@@ -244,9 +244,11 @@ int api_search(struct ftl_conn *api)
 		char *allow_list = cJSON_PrintUnformatted(allow_ids);
 		ret = search_table(api,punycode, GRAVITY_DOMAINLIST_ALLOW_REGEX, allow_list, limit, &Nregex, false, domains);
 		free(allow_list);
-		free(punycode);
 		if(ret != 200)
+		{
+			free(punycode);
 			return ret;
+		}
 	}
 
 	if(cJSON_GetArraySize(deny_ids) > 0)
@@ -254,9 +256,11 @@ int api_search(struct ftl_conn *api)
 		char *deny_list = cJSON_PrintUnformatted(deny_ids);
 		ret = search_table(api, punycode, GRAVITY_DOMAINLIST_DENY_REGEX, deny_list, limit, &Nregex, false, domains);
 		free(deny_list);
-		free(punycode);
 		if(ret != 200)
+		{
+			free(punycode);
 			return ret;
+		}
 	}
 
 	cJSON *search = JSON_NEW_OBJECT();


### PR DESCRIPTION
# What does this implement/fix?

Fix `free()` being used in the wrong place. It should only be called here when we have to exit early. Otherwise, it is called at the end of the function because we may want to use it later on:

![Screenshot from 2023-11-08 11-14-50](https://github.com/pi-hole/FTL/assets/16748619/0f6f35ef-474c-4ac3-a6ec-d680e64f3189)


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.