### PR TITLE
NULL after free()

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -138,7 +138,7 @@
 // caused by insufficient memory or by code bugs (not properly dealing
 // with NULL pointers) much easier.
 #undef strdup // strdup() is a macro in itself, it needs special handling
-#define free(ptr) FTLfree(ptr, __FILE__,  __FUNCTION__,  __LINE__)
+#define free(ptr) FTLfree((void**)&ptr, __FILE__,  __FUNCTION__,  __LINE__)
 #define strdup(str_in) FTLstrdup(str_in, __FILE__,  __FUNCTION__,  __LINE__)
 #define calloc(numer_of_elements, element_size) FTLcalloc(numer_of_elements, element_size, __FILE__,  __FUNCTION__,  __LINE__)
 #define realloc(ptr, new_size) FTLrealloc(ptr, new_size, __FILE__,  __FUNCTION__,  __LINE__)

--- a/src/syscalls/free.c
+++ b/src/syscalls/free.c
@@ -13,7 +13,7 @@
 #include "../log.h"
 
 #undef free
-void FTLfree(void *ptr, const char *file, const char *func, const int line)
+void FTLfree(void **ptr, const char *file, const char *func, const int line)
 {
 	// The free() function frees the memory space pointed  to  by  ptr,  which
 	// must  have  been  returned by a previous call to malloc(), calloc(), or
@@ -21,9 +21,18 @@ void FTLfree(void *ptr, const char *file, const char *func, const int line)
 	// undefined behavior occurs.  If ptr is NULL, no operation is performed.
 	if(ptr == NULL)
 	{
+		log_warn("Trying to free NULL memory location in %s() (%s:%i)", func, file, line);
+		return;
+	}
+	if(*ptr == NULL)
+	{
 		log_warn("Trying to free NULL pointer in %s() (%s:%i)", func, file, line);
 		return;
 	}
 
-	free(ptr);
+	// Actually free the memory
+	free(*ptr);
+
+	// Set the pointer to NULL
+	*ptr = NULL;
 }

--- a/src/syscalls/syscalls.h
+++ b/src/syscalls/syscalls.h
@@ -14,7 +14,7 @@
 char *FTLstrdup(const char *src, const char *file, const char *func, const int line) __attribute__((malloc));
 void *FTLcalloc(size_t n, size_t size, const char *file, const char *func, const int line) __attribute__((malloc)) __attribute__((alloc_size(1,2)));
 void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *func, const int line) __attribute__((alloc_size(2)));
-void FTLfree(void *ptr, const char*file, const char *func, const int line);
+void FTLfree(void **ptr, const char*file, const char *func, const int line);
 int FTLfallocate(const int fd, const off_t offset, const off_t len, const char *file, const char *func, const int line);
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR extends `free()` to always set `free`'d pointers to `NULL`. This will effectively avoid future `double free`-related exceptions and prevent crashes like the recently fixed one (#1742).

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.