### PR TITLE
Do not rewrite config files if unchanged

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -804,6 +804,17 @@ bool read_legacy_custom_hosts_config(void)
 
 bool write_custom_list(void)
 {
+	// Ensure that the directory exists
+	if(!directory_exists(DNSMASQ_HOSTSDIR))
+	{
+		log_debug(DEBUG_CONFIG, "Creating directory "DNSMASQ_HOSTSDIR);
+		if(mkdir(DNSMASQ_HOSTSDIR, 0755) != 0)
+		{
+			log_err("Cannot create directory "DNSMASQ_HOSTSDIR": %s", strerror(errno));
+			return false;
+		}
+	}
+
 	log_debug(DEBUG_CONFIG, "Opening "DNSMASQ_CUSTOM_LIST_LEGACY".tmp for writing");
 	FILE *custom_list = fopen(DNSMASQ_CUSTOM_LIST_LEGACY".tmp", "w");
 	// Return early if opening failed

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -586,16 +586,16 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		// Rotate old config files
 		rotate_files(DNSMASQ_PH_CONFIG, NULL);
 
-		log_debug(DEBUG_CONFIG, "Installing "DNSMASQ_TEMP_CONF" to "DNSMASQ_PH_CONFIG);
 		if(rename(DNSMASQ_TEMP_CONF, DNSMASQ_PH_CONFIG) != 0)
 		{
 			log_err("Cannot install dnsmasq config file: %s", strerror(errno));
 			return false;
 		}
+		log_debug(DEBUG_CONFIG, "Config file written to "DNSMASQ_PH_CONFIG);
 	}
 	else
 	{
-		log_debug(DEBUG_CONFIG, "dnsmasq config file unchanged");
+		log_debug(DEBUG_CONFIG, "dnsmasq.conf unchanged");
 		// Remove temporary config file
 		if(remove(DNSMASQ_TEMP_CONF) != 0)
 		{
@@ -858,12 +858,12 @@ bool write_custom_list(void)
 		// Rotate old hosts files
 		rotate_files(DNSMASQ_CUSTOM_LIST, NULL);
 
-		log_debug(DEBUG_CONFIG, "Installing "DNSMASQ_CUSTOM_LIST".tmp to "DNSMASQ_CUSTOM_LIST);
 		if(rename(DNSMASQ_CUSTOM_LIST".tmp", DNSMASQ_CUSTOM_LIST) != 0)
 		{
 			log_err("Cannot install custom.list: %s", strerror(errno));
 			return false;
 		}
+		log_debug(DEBUG_CONFIG, "HOSTS file written to "DNSMASQ_CUSTOM_LIST);
 	}
 	else
 	{

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -22,16 +22,10 @@
 #include "config/password.h"
 
 // Open the TOML file for reading or writing
-FILE * __attribute((malloc)) __attribute((nonnull(1))) openFTLtoml(const char *mode)
+FILE * __attribute((malloc)) __attribute((nonnull(1,2))) openFTLtoml(const char *path, const char *mode)
 {
-	FILE *fp;
-	// Rotate config file, no rotation is done when the file is opened for
-	// reading (mode == "r")
-	if(mode[0] != 'r')
-		rotate_files(GLOBALTOMLPATH, NULL);
-
-	// No readable local file found, try global file
-	fp = fopen(GLOBALTOMLPATH, mode);
+	// Try to open file in requested mode
+	FILE *fp = fopen(path, mode);
 
 	// Return early if opening failed
 	if(!fp)

--- a/src/config/toml_helper.h
+++ b/src/config/toml_helper.h
@@ -17,7 +17,7 @@
 #include "tomlc99/toml.h"
 
 void indentTOML(FILE *fp, const unsigned int indent);
-FILE *openFTLtoml(const char *mode) __attribute((malloc)) __attribute((nonnull(1)));
+FILE *openFTLtoml(const char *path, const char *mode) __attribute((malloc)) __attribute((nonnull(1,2)));
 void closeFTLtoml(FILE *fp);
 void print_comment(FILE *fp, const char *str, const char *intro, const unsigned int width, const unsigned int indent);
 void print_toml_allowed_values(cJSON *allowed_values, FILE *fp, const unsigned int width, const unsigned int indent);

--- a/src/config/toml_reader.c
+++ b/src/config/toml_reader.c
@@ -138,7 +138,7 @@ static toml_table_t *parseTOML(void)
 {
 	// Try to open default config file. Use fallback if not found
 	FILE *fp;
-	if((fp = openFTLtoml("r")) == NULL)
+	if((fp = openFTLtoml(GLOBALTOMLPATH, "r")) == NULL)
 	{
 		log_warn("No config file available (%s), using defaults",
 		         strerror(errno));

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -148,10 +148,8 @@ bool writeFTLtoml(const bool verbose)
 			return false;
 		}
 
-		// Log that we have written the config file if either in verbose or
-		// debug mode
-		if(verbose || config.debug.config.v.b)
-			log_info("Config file unchanged");
+		// Log that the config file has not changed if in debug mode
+		log_debug(DEBUG_CONFIG, "Config file unchanged");
 	}
 
 	return true;

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -149,7 +149,7 @@ bool writeFTLtoml(const bool verbose)
 		}
 
 		// Log that the config file has not changed if in debug mode
-		log_debug(DEBUG_CONFIG, "Config file unchanged");
+		log_debug(DEBUG_CONFIG, "pihole.toml unchanged");
 	}
 
 	return true;

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -19,26 +19,18 @@
 #include "datastructure.h"
 // watch_config()
 #include "config/inotify.h"
+// files_different()
+#include "files.h"
 
 bool writeFTLtoml(const bool verbose)
 {
-	// Stop watching for changes in the config file
-	watch_config(false);
-
-	// Try to open global config file
+	// Try to open a temporary config file for writing
 	FILE *fp;
-	if((fp = openFTLtoml("w")) == NULL)
+	if((fp = openFTLtoml(GLOBALTOMLPATH".tmp", "w")) == NULL)
 	{
 		log_warn("Cannot write to FTL config file (%s), content not updated", strerror(errno));
-		// Restart watching for changes in the config file
-		watch_config(true);
 		return false;
 	}
-
-	// Log that we are (re-)writing the config file if either in verbose or
-	// debug mode
-	if(verbose || config.debug.config.v.b)
-		log_info("Writing config file");
 
 	// Write header
 	fputs("# This file is managed by pihole-FTL\n#\n", fp);
@@ -119,8 +111,48 @@ bool writeFTLtoml(const bool verbose)
 	// Close file and release exclusive lock
 	closeFTLtoml(fp);
 
-	// Restart watching for changes in the config file
-	watch_config(true);
+	// Move temporary file to the final location if it is different
+	// We skip the first 8 lines as they contain the header and will always
+	// be different
+	if(files_different(GLOBALTOMLPATH".tmp", GLOBALTOMLPATH, 8))
+	{
+		// Stop watching for changes in the config file
+		watch_config(false);
+
+		// Rotate config file
+		rotate_files(GLOBALTOMLPATH, NULL);
+
+		// Move file
+		if(rename(GLOBALTOMLPATH".tmp", GLOBALTOMLPATH) != 0)
+		{
+			log_warn("Cannot move temporary config file to final location (%s), content not updated", strerror(errno));
+			// Restart watching for changes in the config file
+			watch_config(true);
+			return false;
+		}
+
+		// Restart watching for changes in the config file
+		watch_config(true);
+
+		// Log that we have written the config file if either in verbose or
+		// debug mode
+		if(verbose || config.debug.config.v.b)
+			log_info("Config file written to %s", GLOBALTOMLPATH);
+	}
+	else
+	{
+		// Remove temporary file
+		if(unlink(GLOBALTOMLPATH".tmp") != 0)
+		{
+			log_warn("Cannot remove temporary config file (%s), content not updated", strerror(errno));
+			return false;
+		}
+
+		// Log that we have written the config file if either in verbose or
+		// debug mode
+		if(verbose || config.debug.config.v.b)
+			log_info("Config file unchanged");
+	}
 
 	return true;
 }

--- a/src/files.c
+++ b/src/files.c
@@ -625,3 +625,66 @@ char * __attribute__((malloc)) get_hwmon_target(const char *path)
 
 	return target;
 }
+
+// Returns true if the files have different contents
+// from specifies from which line number the files should be compared
+bool files_different(const char *pathA, const char* pathB, unsigned int from)
+{
+	// Check if both files exist
+	if(!file_exists(pathA) || !file_exists(pathB))
+		return true;
+
+	// Check if both files are identical
+	if(strcmp(pathA, pathB) == 0)
+		return false;
+
+	// Open both files
+	FILE *fpA = fopen(pathA, "r");
+	if(fpA == NULL)
+	{
+		log_warn("files_different(): Failed to open \"%s\" for reading: %s", pathA, strerror(errno));
+		return true;
+	}
+	FILE *fpB = fopen(pathB, "r");
+	if(fpB == NULL)
+	{
+		log_warn("files_different(): Failed to open \"%s\" for reading: %s", pathB, strerror(errno));
+		fclose(fpA);
+		return true;
+	}
+
+	// Compare both files line by line
+	char *lineA = NULL;
+	size_t lenA = 0;
+	ssize_t readA;
+	char *lineB = NULL;
+	size_t lenB = 0;
+	ssize_t readB;
+	bool different = false;
+	while((readA = getline(&lineA, &lenA, fpA)) != -1 &&
+	      (readB = getline(&lineB, &lenB, fpB)) != -1)
+	{
+		// Skip lines until we reach the requested line number
+		if(from > 0)
+		{
+			from--;
+			continue;
+		}
+		// Compare lines
+		if(strcmp(lineA, lineB) != 0)
+		{
+			different = true;
+			break;
+		}
+	}
+
+	// Free memory
+	free(lineA);
+	free(lineB);
+
+	// Close files
+	fclose(fpA);
+	fclose(fpB);
+
+	return different;
+}

--- a/src/files.h
+++ b/src/files.h
@@ -30,6 +30,7 @@ unsigned int get_path_usage(const char *path, char buffer[64]);
 struct mntent *get_filesystem_details(const char *path);
 bool directory_exists(const char *path);
 void rotate_files(const char *path, char **first_file);
+bool files_different(const char *pathA, const char* pathB, unsigned int from);
 
 int parse_line(char *line, char **key, char **value);
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -20,7 +20,7 @@ while pidof -s pihole-FTL > /dev/null; do
 done
 
 # Clean up possible old files from earlier test runs
-rm -f /etc/pihole/gravity.db /etc/pihole/pihole-FTL.db /var/log/pihole/pihole.log /var/log/pihole/FTL.log /dev/shm/FTL-*
+rm -rf /etc/pihole /var/log/pihole /dev/shm/FTL-*
 
 # Create necessary directories and files
 mkdir -p /home/pihole /etc/pihole /run/pihole /var/log/pihole

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1445,3 +1445,24 @@
   [[ $status == 0 ]]
   run bash -c "rm ${filename}"
 }
+
+@test "Expected number of config file rotations" {
+  run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "3" ]]
+  run bash -c 'grep -c "DEBUG_CONFIG: pihole.toml unchanged" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "3" ]]
+  run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "1" ]]
+  run bash -c 'grep -c "DEBUG_CONFIG: dnsmasq.conf unchanged" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "2" ]]
+  run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/custom.list" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "1" ]]
+  run bash -c 'grep -c "DEBUG_CONFIG: custom.list unchanged" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "3" ]]
+}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1542,7 +1542,7 @@
   run bash -c 'grep -c "DEBUG_CONFIG: dnsmasq.conf unchanged" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "2" ]]
-  run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/custom.list" /var/log/pihole/FTL.log'
+  run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/hosts/custom.list" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: custom.list unchanged" /var/log/pihole/FTL.log'


### PR DESCRIPTION
# What does this implement/fix?

Do not rewrite config files if they are unchanged. This PR implements this for
- `/etc/pihole/pihole.toml`
- `/etc/pihole/dnsmasq.conf`
- `/etc/pihole/custom.list`

The goal is to effectively preserve a larger number of config file backups as needless rotations (without any changes) are prevented.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.