### PR TITLE
Create dynamic validity period when generating X.509 certificate

### DIFF
--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -148,7 +148,8 @@ bool generate_certificate(const char* certfile, bool rsa, const char *domain)
 	// Create validity period
 	// Use YYYYMMDDHHMMSS as required by RFC 5280
 	const time_t now = time(NULL);
-	struct tm *tm = localtime(&now);
+	struct tm tms = { 0 };
+	struct tm *tm = localtime_r(&now, &tms);
 	char not_before[16] = { 0 };
 	char not_after[16] = { 0 };
 	strftime(not_before, sizeof(not_before), "%Y%m%d%H%M%S", tm);

--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -145,6 +145,16 @@ bool generate_certificate(const char* certfile, bool rsa, const char *domain)
 		serial[i] = '0' + (serial[i] % 10);
 	serial[sizeof(serial) - 1] = '\0';
 
+	// Create validity period
+	// Use YYYYMMDDHHMMSS as required by RFC 5280
+	const time_t now = time(NULL);
+	struct tm *tm = localtime(&now);
+	char not_before[16] = { 0 };
+	char not_after[16] = { 0 };
+	strftime(not_before, sizeof(not_before), "%Y%m%d%H%M%S", tm);
+	tm->tm_year += 30; // 30 years from now
+	strftime(not_after, sizeof(not_after), "%Y%m%d%H%M%S", tm);
+
 	// Generate certificate
 	printf("Generating new certificate with serial number %s...\n", serial);
 	mbedtls_x509write_crt_set_version(&crt, MBEDTLS_X509_CRT_VERSION_3);
@@ -154,7 +164,7 @@ bool generate_certificate(const char* certfile, bool rsa, const char *domain)
 	mbedtls_x509write_crt_set_subject_key(&crt, &key);
 	mbedtls_x509write_crt_set_issuer_key(&crt, &key);
 	mbedtls_x509write_crt_set_issuer_name(&crt, "CN=pi.hole");
-	mbedtls_x509write_crt_set_validity(&crt, "20010101000000", "20301231235959");
+	mbedtls_x509write_crt_set_validity(&crt, not_before, not_after);
 	mbedtls_x509write_crt_set_basic_constraints(&crt, 0, -1);
 	mbedtls_x509write_crt_set_subject_key_identifier(&crt);
 	mbedtls_x509write_crt_set_authority_key_identifier(&crt);


### PR DESCRIPTION
# What does this implement/fix?

See title, this is the result of https://github.com/pi-hole/FTL/pull/1744#pullrequestreview-1725644799

```
$pihole-FTL --gen-x509 /tmp/test.pem && pihole-FTL --read-x509 /tmp/test.pem

[...]
  issued  on        : 2023-11-10 22:17:27
  expires on        : 2053-11-10 22:17:27
[...]
```

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.