### PR TITLE
Use hostsdir for custom.list to avoid cache flushing on changes

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -778,11 +778,7 @@ static int api_config_patch(struct ftl_conn *api)
 
 		// Rewrite HOSTS file if required
 		if(rewrite_hosts)
-		{
 			write_custom_list();
-			// Reload HOSTS file
-			kill(main_pid(), SIGHUP);
-		}
 	}
 	else
 	{
@@ -976,11 +972,7 @@ static int api_config_put_delete(struct ftl_conn *api)
 
 	// Rewrite HOSTS file if required
 	if(rewrite_hosts)
-	{
 		write_custom_list();
-		// Reload HOSTS file
-		kill(main_pid(), SIGHUP);
-	}
 
 	// Send empty reply with matching HTTP status code
 	// 201 - Created or 204 - No content

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -441,10 +441,8 @@ int set_config_from_CLI(const char *key, const char *value)
 		}
 		else if(conf_item == &config.dns.hosts)
 		{
-			// We need to rewrite the custom.list file but do not need to
-			// restart dnsmasq. If dnsmasq is going to be restarted anyway,
-			// this is not necessary as the file will be rewritten during
-			// the restart
+			// We need to rewrite the custom.list file but do not
+			// need to restart dnsmasq
 			write_custom_list();
 		}
 

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -580,9 +580,6 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		return false;
 	}
 
-	// Rotate old config files
-	rotate_files(DNSMASQ_PH_CONFIG, NULL);
-
 	log_debug(DEBUG_CONFIG, "Installing "DNSMASQ_TEMP_CONF" to "DNSMASQ_PH_CONFIG);
 	if(rename(DNSMASQ_TEMP_CONF, DNSMASQ_PH_CONFIG) != 0)
 	{

--- a/src/config/dnsmasq_config.h
+++ b/src/config/dnsmasq_config.h
@@ -26,7 +26,9 @@ bool write_custom_list(void);
 #define DNSMASQ_TEMP_CONF "/etc/pihole/dnsmasq.conf.temp"
 #define DNSMASQ_STATIC_LEASES "/etc/pihole/04-pihole-static-dhcp.conf"
 #define DNSMASQ_CNAMES "/etc/pihole/05-pihole-custom-cname.conf"
-#define DNSMASQ_CUSTOM_LIST "/etc/pihole/custom.list"
+#define DNSMASQ_HOSTSDIR "/etc/pihole/hosts"
+#define DNSMASQ_CUSTOM_LIST DNSMASQ_HOSTSDIR"/custom.list"
+#define DNSMASQ_CUSTOM_LIST_LEGACY "/etc/pihole/custom.list"
 #define DHCPLEASESFILE "/etc/pihole/dhcp.leases"
 
 #endif //DNSMASQ_CONFIG_H


### PR DESCRIPTION
# What does this implement/fix?

Use `hostsdir` for `custom.list` to avoid cache flushing on changes. When adding a domain into the empty list, the expected output in `pihole.log` is:
```
Nov 13 09:56:00 dnsmasq[1761111]: inotify: /etc/pihole/hosts/custom.list new or modified
Nov 13 09:56:00 dnsmasq[1761111]: read /etc/pihole/hosts/custom.list - 2 names
```
when removing it again:
```
Nov 13 09:56:34 dnsmasq[1761111]: inotify: /etc/pihole/hosts/custom.list new or modified
Nov 13 09:56:34 dnsmasq[1761111]: inotify: flushed 2 names read from /etc/pihole/hosts/custom.list
Nov 13 09:56:34 dnsmasq[1761111]: read /etc/pihole/hosts/custom.list - 0 names
```
The DNS cache stays intact across these events.

It is expected to see two instead of one domain being added above if `dns.expandHosts` is `true` as each HOSTS entry actually adds two domains: `test` and `test.lan` (assuming you added `test` and `lan` is your `dhcp/dns.domain`).

On a fresh migration, FTL reads `custom.list` and copies it into `pihole.toml`. Then the file is renamed to `custom.list.bck`. From this point on, FTL abandons this file and will now use `/etc/pihole/hosts/custom.list`. The old `/etc/pihole/custom.list` can be removed manually. I don't think we need a cleaning strategy here as only beta users will have this file as a remnant. Users freshly upgrading will not see this file there once this PR got merged.

One other note: I removed rotation of `custom.list` as it can fully be reconstructed from `pihole.toml` - we should think about only rotating `pihole.toml` (and `dhcp.leases` on Teleporter import) in the future as the same holds true for `dnsmasq.conf`

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.