### PR TITLE
Include property startup_time in GET /api/config responses

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -28,6 +28,8 @@
 #include "config/password.h"
 // main_pid()
 #include "signals.h"
+// get_startup_time()
+#include "daemon.h"
 
 static struct {
 	const char *name;
@@ -628,6 +630,7 @@ static int api_config_get(struct ftl_conn *api)
 
 	// Build and return JSON response
 	JSON_ADD_ITEM_TO_OBJECT(json, "config", config_j);
+	JSON_ADD_NUMBER_TO_OBJECT(json, "startup_time", get_startup_time());
 	JSON_SEND_OBJECT(json);
 }
 

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -170,6 +170,10 @@ components:
     config:
       type: object
       properties:
+        startup_time:
+          type: number
+          description: |
+            Seconds it took to start FTL
         config:
           type: object
           properties:
@@ -575,6 +579,7 @@ components:
     config:
       summary: The entire configuration
       value:
+        startup_time: 0.2551
         config:
           dns:
             upstreams: [ "127.0.0.1#5353", "8.8.8.8" ]

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -40,6 +40,8 @@ pthread_t threads[THREADS_MAX] = { 0 };
 bool resolver_ready = false;
 bool dnsmasq_failed = false;
 
+static void fix_startup_time(const double correction);
+
 void go_daemon(void)
 {
 	// Create child process
@@ -221,6 +223,7 @@ void delay_startup(void)
 		cleanup(EXIT_FAILURE);
 		exit(EXIT_FAILURE);
 	}
+	fix_startup_time(config.misc.delay_startup.v.ui);
 	log_info("Done sleeping, continuing startup of resolver...");
 }
 
@@ -443,4 +446,23 @@ bool ipv6_enabled(void)
 	// else: IPv6 is not obviously disabled and there is at least one
 	// IPv6-capable interface
 	return true;
+}
+
+static double startup_time = 0.0;
+// Get the time it took to start FTL
+double __attribute__((pure)) get_startup_time(void)
+{
+	return startup_time;
+}
+// Fix the startup time by subtracting the given correction
+static void fix_startup_time(const double correction)
+{
+	startup_time -= correction;
+}
+// Store the startup time
+void store_startup_time(void)
+{
+	// We add the measured time to the variable to account for possibly
+	// applied corrections above
+	startup_time += 1e-3*timer_elapsed_msec(EXIT_TIMER);
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -24,6 +24,8 @@ void set_nice(void);
 void calc_cpu_usage(void);
 float get_cpu_percentage(void) __attribute__((pure));
 bool ipv6_enabled(void);
+double get_startup_time(void) __attribute__((pure));
+void store_startup_time(void);
 
 #include <sys/syscall.h>
 #include <unistd.h>

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2917,6 +2917,9 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 
 	// Initialize Pi-hole PTR pointer
 	init_pihole_PTR();
+
+	// Memorize startup-time
+	store_startup_time();
 }
 
 static char *get_ptrname(struct in_addr *addr)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1325,7 +1325,7 @@
   # Set app password hash
   run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config/webserver/api/app_pwhash -d  "{\"config\":{\"webserver\":{\"api\":{\"app_pwhash\":${0}}}}}"' "${pwhash}"
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "{\"config\":{\"webserver\":{\"api\":{\"app_pwhash\":${pwhash}}}},\"took\":"*"}" ]]
+  [[ ${lines[0]} == "{\"config\":{\"webserver\":{\"api\":{\"app_pwhash\":${pwhash}}}},\"startup_time\":"*",\"took\":"*"}" ]]
 
   # Login using app password is successful
   run bash -c 'curl -s -X POST 127.0.0.1/api/auth -d "{\"password\":${0}}" | jq .session.valid' "${password}"
@@ -1337,7 +1337,7 @@
   # Password: ABC
   run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config/webserver/api/password -d "{\"config\":{\"webserver\":{\"api\":{\"password\":\"ABC\"}}}}"'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "{\"config\":{\"webserver\":{\"api\":{\"password\":\"********\"}}},\"took\":"*"}" ]]
+  [[ ${lines[0]} == "{\"config\":{\"webserver\":{\"api\":{\"password\":\"********\"}}},\"startup_time\":"*",\"took\":"*"}" ]]
 }
 
 @test "API authorization (with password): Incorrect password is rejected if password auth is enabled" {


### PR DESCRIPTION
# What does this implement/fix?

See title. This PR accompanies https://github.com/pi-hole/web/pull/2829 and provides the time approximately needed to restart `pihole-FTL`.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.