### PR TITLE
Prevent unconditional free on error reporting

### DIFF
--- a/src/api/list.c
+++ b/src/api/list.c
@@ -393,7 +393,8 @@ static int api_list_write(struct ftl_conn *api,
 			   strchr(it->valuestring, '\t') != NULL ||
 			   strchr(it->valuestring, '\n') != NULL)
 			{
-				cJSON_free(row.items);
+				if(allocated_json)
+					cJSON_free(row.items);
 				return send_json_error(api, 400, // 400 Bad Request
 							"bad_request",
 							"Spaces, newlines and tabs are not allowed in domains and URLs",
@@ -406,11 +407,12 @@ static int api_list_write(struct ftl_conn *api,
 	if(!okay)
 	{
 		// Send error reply
-		cJSON_free(row.items);
-		return send_json_error(api, 400, // 400 Bad Request
-		                       "regex_error",
-		                       "Regex validation failed",
-		                       regex_msg);
+		if(allocated_json)
+			cJSON_free(row.items);
+		return send_json_error_free(api, 400, // 400 Bad Request
+		                            "regex_error",
+		                            "Regex validation failed",
+		                            regex_msg, true);
 	}
 
 	// Try to add item(s) to table

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -85,7 +85,7 @@ int send_json_error_free(struct ftl_conn *api, const int code,
                          const char *key, const char* message,
                          char *hint, bool free_hint)
 {
-	if(hint)
+	if(hint != NULL)
 		log_warn("API: %s (%s)", message, hint);
 	else
 		log_warn("API: %s", message);
@@ -94,7 +94,7 @@ int send_json_error_free(struct ftl_conn *api, const int code,
 	JSON_REF_STR_IN_OBJECT(error, "key", key);
 	JSON_REF_STR_IN_OBJECT(error, "message", message);
 	JSON_COPY_STR_TO_OBJECT(error, "hint", hint);
-	if(free_hint)
+	if(free_hint && hint != NULL)
 		free(hint);
 
 	cJSON *json = JSON_NEW_OBJECT();


### PR DESCRIPTION
# What does this implement/fix?

Don't call `cJSON_free()` unconditionally on errors in `api_list_write()`. This PR fixes the crash reported in https://github.com/pi-hole/web/issues/2834 and can easily be reproduced by adding an invalid regex like
```
google{1
```

The expected error response is:

![Screenshot from 2023-11-15 12-04-50](https://github.com/pi-hole/FTL/assets/16748619/233ed4c6-4386-496f-9f94-246872ec569a)


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.