### PR TITLE
Validate domains before adding them to the database via /api/list

### DIFF
--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -223,6 +223,7 @@ components:
             items:
               allOf:
                 - $ref: 'domains.yaml#/components/schemas/domain'
+                - $ref: 'domains.yaml#/components/schemas/unicode'
                 - $ref: 'domains.yaml#/components/schemas/type'
                 - $ref: 'domains.yaml#/components/schemas/kind'
                 - $ref: 'domains.yaml#/components/schemas/comment'
@@ -249,6 +250,13 @@ components:
           description: Domain
           type: string
           example: testdomain.com
+    unicode:
+      type: object
+      properties:
+        unicode:
+          description: Unicode domain (may be different from `domain` if punycode-encoding is used)
+          type: string
+          example: "äbc.com"
     domain_array:
       type: object
       properties:
@@ -368,6 +376,7 @@ components:
       value:
         domains:
           - domain: "allowed.com"
+            unicode: "allowed.com"
             type: allow
             kind: exact
             comment: null
@@ -377,7 +386,8 @@ components:
             id: 299
             date_added: 1611239095
             date_modified: 1612163756
-          - domain: "allowed2.comm"
+          - domain: "xn--4ca.com"
+            unicode: "ä.com"
             type: allow
             kind: regex
             comment: "Some text"

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -17,6 +17,8 @@
 #include "shmem.h"
 // getNameFromIP()
 #include "database/network-table.h"
+// valid_domain()
+#include "tools/gravity-parseList.h"
 
 static int api_list_read(struct ftl_conn *api,
                          const int code,
@@ -399,6 +401,19 @@ static int api_list_write(struct ftl_conn *api,
 							"bad_request",
 							"Spaces, newlines and tabs are not allowed in domains and URLs",
 							it->valuestring);
+			}
+
+			// Validate domains
+			if((listtype == GRAVITY_DOMAINLIST_ALLOW_EXACT ||
+			    listtype == GRAVITY_DOMAINLIST_DENY_EXACT) &&
+			   !valid_domain(it->valuestring, strlen(it->valuestring), false))
+			{
+				if(allocated_json)
+					cJSON_free(row.items);
+				return send_json_error(api, 400, // 400 Bad Request
+				                       "bad_request",
+				                       "Invalid domain",
+				                       it->valuestring);
 			}
 		}
 	}

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -74,10 +74,18 @@ static int api_list_read(struct ftl_conn *api,
 		}
 		else // domainlists
 		{
+			char *unicode = NULL;
+			const Idna_rc rc = idna_to_unicode_lzlz(table.domain, &unicode, 0);
 			JSON_COPY_STR_TO_OBJECT(row, "domain", table.domain);
+			if(rc == IDNA_SUCCESS)
+				JSON_COPY_STR_TO_OBJECT(row, "unicode", unicode);
+			else
+				JSON_COPY_STR_TO_OBJECT(row, "unicode", table.domain);
 			JSON_REF_STR_IN_OBJECT(row, "type", table.type);
 			JSON_REF_STR_IN_OBJECT(row, "kind", table.kind);
 			JSON_COPY_STR_TO_OBJECT(row, "comment", table.comment);
+			if(unicode != NULL)
+				free(unicode);
 		}
 
 		// Groups don't have the groups property

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -398,9 +398,9 @@ static int api_list_write(struct ftl_conn *api,
 				if(allocated_json)
 					cJSON_free(row.items);
 				return send_json_error(api, 400, // 400 Bad Request
-							"bad_request",
-							"Spaces, newlines and tabs are not allowed in domains and URLs",
-							it->valuestring);
+				                       "bad_request",
+				                       "Spaces, newlines and tabs are not allowed in domains and URLs",
+				                       it->valuestring);
 			}
 
 			// Validate domains

--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -40,7 +40,7 @@ static const char *false_positives[] = {
 #define MAX_INVALID_DOMAINS 5
 
 // Validate domain name
-inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool abp)
+inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool fqdn_only)
 {
 	// Domain must not be NULL or empty, and they should not be longer than
 	// 255 characters
@@ -87,7 +87,7 @@ inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t 
 	// e.g., "example.com" but not "localhost" for exact domain
 	// We do not enforce this for ABP domains
 	// (see https://github.com/pi-hole/pi-hole/pull/5240)
-	if(last_dot == -1 && !abp)
+	if(last_dot == -1 && fqdn_only)
 		return false;
 
 	// TLD must not start or end with a hyphen
@@ -123,7 +123,7 @@ static inline bool __attribute__((pure)) valid_abp_domain(const char *line, cons
 			return false;
 
 		// Domain must be valid
-		return valid_domain(line+4, len-5, true);
+		return valid_domain(line+4, len-5, false);
 	}
 	else
 	{
@@ -140,7 +140,7 @@ static inline bool __attribute__((pure)) valid_abp_domain(const char *line, cons
 			return false;
 
 		// Domain must be valid
-		return valid_domain(line+2, len-3, true);
+		return valid_domain(line+2, len-3, false);
 	}
 }
 
@@ -281,7 +281,7 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 
 		// Validate line
 		if(line[0] != (antigravity ? '@' : '|') &&           // <- Not an ABP-style match
-		   valid_domain(line, read, false))
+		   valid_domain(line, read, true))
 		{
 			// Exact match found
 			if(checkOnly)

--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -40,7 +40,7 @@ static const char *false_positives[] = {
 #define MAX_INVALID_DOMAINS 5
 
 // Validate domain name
-static inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool abp)
+inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool abp)
 {
 	// Domain must not be NULL or empty, and they should not be longer than
 	// 255 characters

--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -85,7 +85,7 @@ inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t 
 
 	// There must be at least two labels (i.e. one dot)
 	// e.g., "example.com" but not "localhost" for exact domain
-	// We do not enforce this for ABP domains
+	// We do not enforce this for ABP domains and domainlist input
 	// (see https://github.com/pi-hole/pi-hole/pull/5240)
 	if(last_dot == -1 && fqdn_only)
 		return false;

--- a/src/tools/gravity-parseList.h
+++ b/src/tools/gravity-parseList.h
@@ -11,3 +11,4 @@
 #include "FTL.h"
 
 int gravity_parseList(const char *infile, const char *outfile, const char *adlistID, const bool checkOnly, const bool antigravity);
+bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool abp);

--- a/src/tools/gravity-parseList.h
+++ b/src/tools/gravity-parseList.h
@@ -11,4 +11,4 @@
 #include "FTL.h"
 
 int gravity_parseList(const char *infile, const char *outfile, const char *adlistID, const bool checkOnly, const bool antigravity);
-bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool abp);
+bool __attribute__((pure)) valid_domain(const char *domain, const size_t len, const bool fqdn_only);


### PR DESCRIPTION
# What does this implement/fix?

See title. Fixes #1760 

Current `development-v6` will allow you to add any string as domain, this PR validates domains before adding them.

![Screenshot from 2023-11-18 12-48-03](https://github.com/pi-hole/web/assets/16748619/404b0786-1b41-447c-8460-78631fab7b57)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.