### PR TITLE
Only log how many sessions have been restored

### DIFF
--- a/src/database/session-table.c
+++ b/src/database/session-table.c
@@ -296,8 +296,8 @@ bool restore_db_sessions(struct session *sessions, const uint16_t max_sessions)
 		i++;
 	}
 
-	log_info("Restored %u/%u API session%s from the database",
-	         i, max_sessions, max_sessions == 1 ? "" : "s");
+	log_info("Restored %u API session%s from the database",
+	         i, i == 1 ? "" : "s");
 
 	// Finalize statement
 	if(sqlite3_finalize(stmt) != SQLITE_OK)


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Change the logging of the session restoration.
Currently, FTL prints how many sessions have been restored and the total number of possible sessions storable

```
2023-11-21 12:32:23.975 [11360M] INFO: Restored 1/16 API sessions from the database

```

However, this is confusing: `16` is not the number of sessions stored in the database, but the maximum of possible sessions. This can be confusing, as it is not clear if this is an error - as in: "Why did it not restore the other 15 sessions".

This PR changes only the logging to

```
2023-11-21 12:32:23.975 [11360M] INFO: Restored 1 API session from the database

```


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
