### PR TITLE
/api/client: Include hostnames of clients specified by MAC

### DIFF
--- a/src/api/list.c
+++ b/src/api/list.c
@@ -58,9 +58,11 @@ static int api_list_read(struct ftl_conn *api,
 			char *name = NULL;
 			if(table.client != NULL)
 			{
-				// Try to obtain hostname if this is a valid IP address
+				// Try to obtain hostname
 				if(isValidIPv4(table.client) || isValidIPv6(table.client))
 					name = getNameFromIP(NULL, table.client);
+				else if(isMAC(table.client))
+					name = getNameFromMAC(table.client);
 			}
 
 			JSON_COPY_STR_TO_OBJECT(row, "client", table.client);

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -2151,7 +2151,7 @@ char *__attribute__((malloc)) getNameFromMAC(const char *client)
 	if(FTLDBerror())
 		return NULL;
 
-	log_info("Looking up host name for %s", client);
+	log_debug(DEBUG_DATABASE,"Looking up host name for %s", client);
 
 	// Open pihole-FTL.db database file
 	sqlite3 *db = NULL;
@@ -2161,7 +2161,6 @@ char *__attribute__((malloc)) getNameFromMAC(const char *client)
 		return NULL;
 	}
 
-	// Nothing found for the same device
 	// Check for a host name associated with the given client as MAC address
 	// COLLATE NOCASE: Case-insensitive comparison
 	const char *querystr = "SELECT name FROM network_addresses "

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -18,12 +18,14 @@ bool create_network_addresses_with_names_table(sqlite3 *db);
 void parse_neighbor_cache(sqlite3 *db);
 void updateMACVendorRecords(sqlite3 *db);
 bool unify_hwaddr(sqlite3 *db);
-char* __attribute__((malloc)) getMACfromIP(sqlite3 *db, const char* ipaddr);
+char *getMACfromIP(sqlite3 *db, const char* ipaddr) __attribute__((malloc));
 int getAliasclientIDfromIP(sqlite3 *db, const char *ipaddr);
-char* __attribute__((malloc)) getNameFromIP(sqlite3 *db, const char* ipaddr);
-char* __attribute__((malloc)) getIfaceFromIP(sqlite3 *db, const char* ipaddr);
+char *getNameFromIP(sqlite3 *db, const char* ipaddr) __attribute__((malloc));
+char *getNameFromMAC(const char *client) __attribute__((malloc));
+char *getIfaceFromIP(sqlite3 *db, const char* ipaddr) __attribute__((malloc));
 void resolveNetworkTableNames(void);
 bool flush_network_table(void);
+bool isMAC(const char *input) __attribute__ ((pure));
 
 typedef struct {
 	unsigned int id;

--- a/src/database/sqlite3-ext.c
+++ b/src/database/sqlite3-ext.c
@@ -29,32 +29,6 @@
 // isMAC()
 #include "network-table.h"
 
-// Counting number of occurrences of a specific char in a string
-static size_t __attribute__ ((pure)) count_char(const char *haystack, const char needle)
-{
-	size_t count = 0u;
-	while(*haystack)
-		if (*haystack++ == needle)
-			++count;
-	return count;
-}
-
-// Identify MAC addresses using a set of suitable criteria
-static bool __attribute__ ((pure)) isMAC(const char *input)
-{
-	if(input != NULL &&                // Valid input
-	   strlen(input) == 17u &&         // MAC addresses are always 17 chars long (6 bytes + 5 colons)
-	   count_char(input, ':') == 5u && // MAC addresses always have 5 colons
-	   strstr(input, "::") == NULL)    // No double-colons (IPv6 address abbreviation)
-	   {
-		// This is a MAC address of the form AA:BB:CC:DD:EE:FF
-		return true;
-	   }
-
-	// Not a MAC address
-	return false;
-}
-
 static void subnet_match_impl(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
 	// Exactly two arguments should be submitted to this routine


### PR DESCRIPTION
# What does this implement/fix?

Add ability to get most recent client hostname from network table if specified by MAC address

Fixes https://github.com/pi-hole/FTL/issues/1768

### `development-v6`
![Screenshot from 2023-11-21 14-13-01](https://github.com/pi-hole/FTL/assets/16748619/b46edb0e-0c32-4f36-b4e3-07b7859c7962)


### this PR
![Screenshot from 2023-11-21 14-12-46](https://github.com/pi-hole/FTL/assets/16748619/9acaa2bc-55b4-447c-b828-12d6b25a4083)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.