### PR TITLE
Inotify: Watch for config file MOVED_TO

### DIFF
--- a/src/config/inotify.c
+++ b/src/config/inotify.c
@@ -106,18 +106,38 @@ bool check_inotify_event(void)
 		// Check if this is the event we are looking for
 		if(event->mask & IN_CLOSE_WRITE)
 		{
+			// File opened for writing was closed
 			log_debug(DEBUG_INOTIFY, "File written: "WATCHDIR"/%s", event->name);
 			if(strcmp(event->name, "pihole.toml") == 0)
 				config_changed = true;
 		}
 		else if(event->mask & IN_CREATE)
+		{
+			// File was created
 			log_debug(DEBUG_INOTIFY, "File created: "WATCHDIR"/%s", event->name);
-		else if(event->mask & IN_MOVE)
-			log_debug(DEBUG_INOTIFY, "File moved: "WATCHDIR"/%s", event->name);
+		}
+		else if(event->mask & IN_MOVED_FROM)
+		{
+			// File was moved (source)
+			log_debug(DEBUG_INOTIFY, "File moved from: "WATCHDIR"/%s", event->name);
+		}
+		else if(event->mask & IN_MOVED_TO)
+		{
+			// File was moved (target)
+			log_debug(DEBUG_INOTIFY, "File moved to: "WATCHDIR"/%s", event->name);
+			if(strcmp(event->name, "pihole.toml") == 0)
+				config_changed = true;
+		}
 		else if(event->mask & IN_DELETE)
+		{
+			// File was deleted
 			log_debug(DEBUG_INOTIFY, "File deleted: "WATCHDIR"/%s", event->name);
+		}
 		else if(event->mask & IN_IGNORED)
+		{
+			// Watch descriptor was removed
 			log_warn("Inotify watch descriptor for "WATCHDIR" was removed (directory deleted or unmounted?)");
+		}
 		else
 			log_debug(DEBUG_INOTIFY, "Unknown event (%X) on watched file: "WATCHDIR"/%s", event->mask, event->name);
 	}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1575,7 +1575,7 @@
   [[ ${lines[0]} == "3" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: pihole.toml unchanged" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "3" ]]
+  [[ ${lines[0]} == "4" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]
@@ -1587,5 +1587,5 @@
   [[ ${lines[0]} == "1" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: custom.list unchanged" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "3" ]]
+  [[ ${lines[0]} == "4" ]]
 }


### PR DESCRIPTION
# What does this implement/fix?

This is a regression of https://github.com/pi-hole/FTL/pull/1746. Before, we wrote directly to `pihole.toml` triggering a `CLOSE_WRITE` event in `inotify`. Now we, instead, first write to `pihole.toml.tmp`, compare it with `pihole.toml` and either *replace* `pihole.toml` (`MOVE` event) or simply discard `pihole.toml.tmp` not touching `pihole.toml` at all.

The `inotify` watching was configured to *only* monitor writing events but not the replacement due to `move`. I also refined the debug printing to instead log more explicitly:
```
2023-11-22 20:58:50.826 File moved from: /etc/pihole/pihole.toml.tmp
2023-11-22 20:58:50.826 File moved to: /etc/pihole/pihole.toml
```

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.