### PR TITLE
Include PID in /api/logs

### DIFF
--- a/src/api/docs/content/specs/logs.yaml
+++ b/src/api/docs/content/specs/logs.yaml
@@ -132,6 +132,10 @@ components:
               type: integer
               description: Next ID to query if checking for new log lines
               example: 229
+            pid:
+              type: integer
+              description: Process ID of FTL. When this changes, FTL was restarted and nextID should be reset to 0.
+              example: 2258
             file:
               type: string
               description: Path to respective log file on disk

--- a/src/api/logs.c
+++ b/src/api/logs.c
@@ -15,6 +15,8 @@
 // struct fifologData
 #include "log.h"
 #include "config/config.h"
+// main_pid()
+#include "signals.h"
 
 // fifologData is allocated in shared memory for cross-fork compatibility
 int api_logs(struct ftl_conn *api)
@@ -70,6 +72,7 @@ int api_logs(struct ftl_conn *api)
 	}
 	JSON_ADD_ITEM_TO_OBJECT(json, "log", log);
 	JSON_ADD_NUMBER_TO_OBJECT(json, "nextID", fifo_log->logs[api->opts.which].next_id);
+	JSON_ADD_NUMBER_TO_OBJECT(json, "pid", main_pid());
 
 	// Add file name
 	const char *logfile = NULL;


### PR DESCRIPTION
# What does this implement/fix?

Include PID of the currently running FTL instance in the logs response. This allows clients to easily detect when FTL is restarted to reset their `nextID` to zero.

This is PR is part of a bug fix fixing that no new log lines are shown after FTL restarts as `nextID` was not reset.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.