### PR TITLE
API: Clients without queries should not be included

### DIFF
--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -293,7 +293,6 @@ int api_stats_top_domains(struct ftl_conn *api)
 int api_stats_top_clients(struct ftl_conn *api)
 {
 	int count = 10;
-	bool includezeroclients = false;
 	int *temparray = calloc(2*counters->clients, sizeof(int*));
 	if(temparray == NULL)
 	{
@@ -325,9 +324,6 @@ int api_stats_top_clients(struct ftl_conn *api)
 		// Does the user request a non-default number of replies?
 		// Note: We do not accept zero query requests here
 		get_int_var(api->request->query_string, "count", &count);
-
-		// Show also clients which have not been active recently?
-		get_bool_var(api->request->query_string, "withzero", &includezeroclients);
 	}
 
 	// Lock shared memory
@@ -388,10 +384,9 @@ int api_stats_top_clients(struct ftl_conn *api)
 		const char *client_ip = getstr(client->ippos);
 		const char *client_name = getstr(client->namepos);
 
-		// Return this client if either
-		// - "withzero" option is set, and/or
-		// - the client made at least one query within the most recent 24 hours
-		if(includezeroclients || client_count > 0)
+		// Return this client if the client made at least one query
+		// within the most recent 24 hours
+		if(client_count > 0)
 		{
 			cJSON *client_item = JSON_NEW_OBJECT();
 			JSON_REF_STR_IN_OBJECT(client_item, "name", client_name);

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -366,18 +366,18 @@ int api_stats_top_clients(struct ftl_conn *api)
 			continue;
 
 		// Skip this client if there is a filter on it
-		bool skip_domain = false;
+		bool skip_client = false;
 		for(unsigned int j = 0; j < excludeClients; j++)
 		{
 			cJSON *item = cJSON_GetArrayItem(config.webserver.api.excludeClients.v.json, j);
 			if(strcmp(getstr(client->ippos), item->valuestring) == 0 ||
 			   strcmp(getstr(client->namepos), item->valuestring) == 0)
 			{
-				skip_domain = true;
+				skip_client = true;
 				break;
 			}
 		}
-		if(skip_domain)
+		if(skip_client)
 			continue;
 
 		// Hidden client, probably due to privacy level. Skip this in the top lists
@@ -391,7 +391,7 @@ int api_stats_top_clients(struct ftl_conn *api)
 		// Return this client if either
 		// - "withzero" option is set, and/or
 		// - the client made at least one query within the most recent 24 hours
-		if(includezeroclients || count > 0)
+		if(includezeroclients || client_count > 0)
 		{
 			cJSON *client_item = JSON_NEW_OBJECT();
 			JSON_REF_STR_IN_OBJECT(client_item, "name", client_name);

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -163,7 +163,7 @@ int api_stats_top_domains(struct ftl_conn *api)
 	// /api/stats/top_domains?blocked=true
 	if(api->request->query_string != NULL)
 	{
-		// Should blocked clients be shown?
+		// Should blocked domains be shown?
 		get_bool_var(api->request->query_string, "blocked", &blocked);
 
 		// Does the user request a non-default number of replies?
@@ -229,7 +229,7 @@ int api_stats_top_domains(struct ftl_conn *api)
 		// Skip this domain if there is a filter on it (but only if not in audit mode)
 		if(!audit)
 		{
-			// Check if this client should be skipped
+			// Check if this domain should be skipped
 			bool skip_domain = false;
 			for(unsigned int j = 0; j < excludeDomains; j++)
 			{


### PR DESCRIPTION
# What does this implement/fix?

Clients with zero queries should not be returned

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.