### PR TITLE
Escape invalid domains possibly containing control characters

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -388,14 +388,14 @@ void parse_args(int argc, char* argv[])
 		const bool antigravity = strcmp(argv[1], "antigravity") == 0;
 
 		// pihole-FTL gravity parseList <infile> <outfile> <adlistID>
-		if(argc == 6 && strcmp(argv[2], "parseList") == 0)
+		if(argc == 6 && strcasecmp(argv[2], "parseList") == 0)
 		{
 			// Parse the given list and write the result to the given file
 			exit(gravity_parseList(argv[3], argv[4], argv[5], false, antigravity));
 		}
 
 		// pihole-FTL gravity checkList <infile>
-		if(argc == 4 && strcmp(argv[2], "checkList") == 0)
+		if(argc == 4 && strcasecmp(argv[2], "checkList") == 0)
 		{
 			// Parse the given list and write the result to the given file
 			exit(gravity_parseList(argv[3], "", "-1", true, antigravity));

--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -152,6 +152,17 @@ static inline bool is_false_positive(const char *line)
 	return false;
 }
 
+// Print domain (escape non-printable characters)
+static void print_escaped(const char *str, const ssize_t len)
+{
+	for(ssize_t j = 0; j < len; j++)
+		if(isgraph(str[j]))
+			putchar(str[j]);
+		else
+			// Escape non-printable characters
+			printf("\\x%02x", (unsigned char)str[j]);
+}
+
 int gravity_parseList(const char *infile, const char *outfile, const char *adlistIDstr,
                       const bool checkOnly, const bool antigravity)
 {
@@ -353,7 +364,9 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 				{
 					// Increment counter
 					invalid_domains++;
-					printf("%s  %s Invalid domain on line %zu: %s\n", over, cross, lineno, line);
+					printf("%s  %s Invalid domain on line %zu: ", over, cross, lineno);
+					print_escaped(line, read);
+					puts("");
 					continue;
 				}
 				// Add the domain to invalid_domains_list only
@@ -525,13 +538,7 @@ end_of_parseList:
 		{
 			// Print indentation
 			printf("        - ");
-			// Print domain (escape non-printable characters)
-			for(ssize_t j = 0; j < invalid_domains_list_lengths[i]; j++)
-				if(isgraph(invalid_domains_list[i][j]))
-					putchar(invalid_domains_list[i][j]);
-				else
-					// Escape non-printable characters
-					printf("\\x%02x", (unsigned char)invalid_domains_list[i][j]);
+			print_escaped(invalid_domains_list[i], invalid_domains_list_lengths[i]);
 			// Print newline
 			puts("");
 		}


### PR DESCRIPTION
# What does this implement/fix?

See title. This PR fixes https://github.com/pi-hole/FTL/issues/1783 by escaping non-printable characters possibly found in user-supplied files. We had to switch from using `strcmp` to `memcmp` as, otherwise, `\0` character contained in the strings would not make their way into the invalid domains display.

Using the [hosts3.csv](https://github.com/pi-hole/web/files/13464821/hosts3.csv) list provided by @Willem60 in https://github.com/pi-hole/FTL/issues/1783 and increasing the shown number of invalid domains from 5 to 10 now shows:
```
  [i] Target: https://github.com/pi-hole/web/files/13464821/hosts3.csv
  [✓] Status: No changes detected
  [✓] Parsed 1136005 exact domains and 0 ABP-style domains (blocking, ignored 156 non-domain entries)
      Sample of non-domain entries:
        - www..am
        - cdn..am
        - cas..criteo.com
        - stats2..fdnames.com
        - stat..v-56.com
        - \x00d\x00i\x00r\x00e\x00k\x00t\x00p\x00a\x00k\x00e\x00t\x00.\x00c\x00o\x00m
        - \x00d\x00o\x00n\x00z\x00i\x00d\x00i\x00r\x00e\x00c\x00t\x00.\x00c\x00o\x00m
        - \x00d\x00o\x00w\x00s\x00l\x00a\x00k\x00e\x00m\x00i\x00c\x00r\x00o\x00.\x00c\x00o\x00m
        - \x00d\x00r\x00a\x00g\x00o\x00m\x00a\x00n\x00.\x00c\x00o\x00m
        - \x00d\x00r\x00i\x00s\x00n\x00e\x00r\x00-\x00t\x00r\x00o\x00c\x00k\x00e\x00n\x00b\x00a\x00u\x00.\x00d\x00e
```
---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.