### PR TITLE
Update embedded SQLite3 engine to version 3.44.2

### DIFF
--- a/src/database/shell.c
+++ b/src/database/shell.c
@@ -896,8 +896,8 @@ static PerStreamTags * getDesignatedEmitStream(FILE *pf, unsigned chix,
 ** chix equals 1 or 2, or for an arbitrary stream when chix == 0.
 ** In either case, ppst references a caller-owned PerStreamTags
 ** struct which may be filled in if none of the known writable
-** streams is being held by consoleInfo. The ppf parameter is an
-** output when chix!=0 and an input when chix==0.
+** streams is being held by consoleInfo. The ppf parameter is a
+** byref output when chix!=0 and a byref input when chix==0.
  */
 static PerStreamTags *
 getEmitStreamInfo(unsigned chix, PerStreamTags *ppst,
@@ -910,7 +910,7 @@ getEmitStreamInfo(unsigned chix, PerStreamTags *ppst,
       ppstTry = &consoleInfo.pstSetup[chix];
       pfEmit = ppst->pf;
     }else pfEmit = ppstTry->pf;
-    if( !isValidStreamInfo(ppst) ){
+    if( !isValidStreamInfo(ppstTry) ){
       pfEmit = (chix > 1)? stderr : stdout;
       ppstTry = ppst;
       streamOfConsole(pfEmit, ppstTry);

--- a/src/database/sqlite3.h
+++ b/src/database/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.44.1"
-#define SQLITE_VERSION_NUMBER 3044001
-#define SQLITE_SOURCE_ID      "2023-11-22 14:18:12 d295f48e8f367b066b881780c98bdf980a1d550397d5ba0b0e49842c95b3e8b4"
+#define SQLITE_VERSION        "3.44.2"
+#define SQLITE_VERSION_NUMBER 3044002
+#define SQLITE_SOURCE_ID      "2023-11-24 11:41:44 ebead0e7230cd33bcec9f95d2183069565b9e709bf745c9b5db65cc0cbf92c0f"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# What does this implement/fix?

### CHANGELOG

1. Fix a mistake in the [CLI](https://sqlite.org/cli.html) that was introduced by the fix (item 15 above) in 3.44.1. 
2. Fix a problem in FTS5 that was discovered during internal fuzz testing only minutes after the 3.44.1 release was tagged. 
3. Fix incomplete assert() statements that the fuzzer discovered the day after the previous release. 
4. Fix a couple of harmless compiler warnings that appeared in debug builds with GCC 16. 

Note: we are not affected by no. 1 as it only affects native Windows binaries ([commit](https://www.sqlite.org/src/info/ce542fee6f0150bb))

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.