### PR TITLE
Remove deprecated dhcp.domain setting

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -311,10 +311,6 @@ components:
                 netmask:
                   type: string
                   x-format: ipv4
-                domain:
-                  type: string
-                  description: |
-                    *Note:* This setting is deprecated and will be removed in a future release. Use dns.domain instead.
                 leaseTime:
                   type: string
                 ipv6:
@@ -645,7 +641,6 @@ components:
             start: "192.168.0.10"
             end: "192.168.0.250"
             router: "192.168.0.1"
-            domain: "lan"
             netmask: "0.0.0.0"
             leaseTime: "24h"
             ipv6: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -681,8 +681,8 @@ void initConfig(struct config *conf)
 	conf->dns.revServer.target.f = FLAG_RESTART_FTL;
 
 	conf->dns.revServer.domain.k = "dns.revServer.domain";
-	conf->dns.revServer.domain.h = "Domain used for the reverse server feature";
-	conf->dns.revServer.domain.a = cJSON_CreateStringReference("<valid domain>, typically set to the same value as dhcp.domain");
+	conf->dns.revServer.domain.h = "Domain used for the reverse server feature (e.g., \"fritz.box\")";
+	conf->dns.revServer.domain.a = cJSON_CreateStringReference("<valid domain>");
 	conf->dns.revServer.domain.t = CONF_STRING;
 	conf->dns.revServer.domain.d.s = (char*)"";
 	conf->dns.revServer.domain.f = FLAG_RESTART_FTL;
@@ -714,13 +714,6 @@ void initConfig(struct config *conf)
 	conf->dhcp.router.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.router.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.router.d.in_addr, 0, sizeof(struct in_addr));
-
-	conf->dhcp.domain.k = "dhcp.domain";
-	conf->dhcp.domain.h = "The DNS domain used by your Pi-hole (*** DEPRECATED ***)\n This setting is deprecated and will be removed in a future version. Please use dns.domain instead. Setting it to any non-default value will overwrite the value of dns.domain if it is still set to its default value.";
-	conf->dhcp.domain.a = cJSON_CreateStringReference("<any valid domain>");
-	conf->dhcp.domain.t = CONF_STRING;
-	conf->dhcp.domain.f = FLAG_RESTART_FTL | FLAG_ADVANCED_SETTING;
-	conf->dhcp.domain.d.s = (char*)"lan";
 
 	conf->dhcp.netmask.k = "dhcp.netmask";
 	conf->dhcp.netmask.h = "The netmask used by your Pi-hole. For directly connected networks (i.e., networks on which the machine running Pi-hole has an interface) the netmask is optional and may be set to an empty string (\"\"): it will then be determined from the interface configuration itself. For networks which receive DHCP service via a relay agent, we cannot determine the netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses based on the class (A, B or C) of the network address.";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -183,7 +183,6 @@ struct config {
 		struct conf_item start;
 		struct conf_item end;
 		struct conf_item router;
-		struct conf_item domain;
 		struct conf_item netmask;
 		struct conf_item leaseTime;
 		struct conf_item ipv6;

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -25,25 +25,6 @@
 // defined in config/config.c
 extern uint8_t last_checksum[SHA256_DIGEST_SIZE];
 
-static void migrate_config(void)
-{
-	// Migrating dhcp.domain -> dns.domain
-	if(strcmp(config.dns.domain.v.s, config.dns.domain.d.s) == 0)
-	{
-		// If the domain is the same as the default, check if the dhcp domain
-		// is different from the default. If so, migrate it
-		if(strcmp(config.dhcp.domain.v.s, config.dhcp.domain.d.s) != 0)
-		{
-			// Migrate dhcp.domain -> dns.domain
-			log_info("Migrating dhcp.domain = \"%s\" -> dns.domain", config.dhcp.domain.v.s);
-			if(config.dns.domain.t == CONF_STRING_ALLOCATED)
-				free(config.dns.domain.v.s);
-			config.dns.domain.v.s = strdup(config.dhcp.domain.v.s);
-			config.dns.domain.t = CONF_STRING_ALLOCATED;
-		}
-	}
-}
-
 bool writeFTLtoml(const bool verbose)
 {
 	// Try to open a temporary config file for writing
@@ -67,9 +48,6 @@ bool writeFTLtoml(const bool verbose)
 	fputs("# Last updated on ", fp);
 	fputs(timestring, fp);
 	fputs("\n\n", fp);
-
-	// Perform possible config migration
-	migrate_config();
 
 	// Iterate over configuration and store it into the file
 	char *last_path = (char*)"";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -370,7 +370,7 @@
     # Domain used for the reverse server feature
     #
     # Possible values are:
-    #     <valid domain>, typically set to the same value as dhcp.domain
+    #     <valid domain> (e.g., "fritz.box")
     domain = ""
 
 [dhcp]
@@ -395,15 +395,6 @@
   # Possible values are:
   #     <ip-addr>, e.g., "192.168.0.1"
   router = ""
-
-  # The DNS domain used by your Pi-hole (*** DEPRECATED ***)
-  # This setting is deprecated and will be removed in a future version. Please use
-  # dns.domain instead. Setting it to any non-default value will overwrite the value of
-  # dns.domain if it is still set to its default value.
-  #
-  # Possible values are:
-  #     <any valid domain>
-  domain = "lan"
 
   # The netmask used by your Pi-hole. For directly connected networks (i.e., networks on
   # which the machine running Pi-hole has an interface) the netmask is optional and may


### PR DESCRIPTION
# What does this implement/fix?

https://github.com/pi-hole/FTL/pull/1739 has been merged > two weeks ago. This PR fixes https://github.com/pi-hole/FTL/issues/1753

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.