### PR TITLE
Add missing bits to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ version~
 
 # CMake files generated during compilation
 /cmake/
+/cmake_ci/
 /cmake-build-debug/
 /cmake-build-release/
 
@@ -17,6 +18,15 @@ version~
 .vscode/
 /.vscode/
 /build/
+
+# __pycache__ files (API tests)
+__pycache__/
+
+# When patch fails to apply a patch segment to the original file, it saves the
+# temporary original file copy out durably as *.orig, dumps the rejected segment
+# to *.rej, and continues trying to apply patch segments.
+*.orig
+*.rej
 
 # MAC->Vendor database files
 tools/manuf.data


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a few more files I found on my local installation to the `.gitignore` file

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.