### PR TITLE
Never recycle alias-clients

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -86,6 +86,11 @@ static void recycle(void)
 		if(client == NULL)
 			continue;
 
+		// Never recycle aliasclients (they are not counted above but
+		// are only indirectly referenced by other clients)
+		if(client->flags.aliasclient)
+			continue;
+
 		log_debug(DEBUG_GC, "Recycling client %s (ID %d, lastQuery at %.3f)",
 		          getstr(client->ippos), clientID, client->lastQuery);
 


### PR DESCRIPTION
# What does this implement/fix?

Never recycle aliasclients. As they are not directly referenced by queries (but only indirectly by other clients), it is not easy to decide if they can be removed. However, since aliasclients are always manually administered through the database, their number should anyway be limited and it is fine to have them life forever.

This is a edge-case regression of https://github.com/pi-hole/FTL/pull/1694

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.