### PR TITLE
Warn if the system has no resolver configured.

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -235,6 +235,13 @@ char *resolveHostname(const char *addr)
 	struct in_addr FTLaddr = { htonl(INADDR_LOOPBACK) };
 	in_port_t FTLport = htons(config.dns.port.v.u16);
 
+	// Warn if no system resolvers are configured
+	if(_res.nscount == 0 && _res._u._ext.nscount6 == 0)
+	{
+		log_warn("No system resolvers found, trying to use FTL at %s#%hu as resolver",
+		         inet_ntoa(FTLaddr), FTLport);
+	}
+
 	// Temporarily set FTL as system resolver
 
 	// Backup configured name servers and invalidate them (IPv4)


### PR DESCRIPTION
# What does this implement/fix?

Warn if the system has no resolver configured. The system may not be ready to resolve host names, not even when we insert FTL's IP address manually.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.