### PR TITLE
Use regex_id instead of regex.id for query log sorting

### DIFF
--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -215,7 +215,7 @@ static void querystr_finish(char *querystr, const char *sort_col, const char *so
 			sort_col_sql = "q.reply_time";
 		else if(strcasecmp(sort_col, "dnssec") == 0)
 			sort_col_sql = "q.dnssec";
-		else if(strcasecmp(sort_col, "regex.id") == 0)
+		else if(strcasecmp(sort_col, "regex_id") == 0)
 			sort_col_sql = "regex_id";
 
 		// ... and the sort direction


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Server side sorting of the query log was added by https://github.com/pi-hole/FTL/pull/1660.
Not all options are used right now. However, event the unused should match what we have on `web`. `regex.id` was not used in `ftl` not `web`. Changing it to `regex_id` which is wildly used.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
