### PR TITLE
Add pihole-FTL sqlite3 -ni ...

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -536,6 +536,21 @@ void parse_args(int argc, char* argv[])
 					argv2[5 + j] = argv[i + 2 + j];
 				exit(sqlite3_shell_main(argc2, argv2));
 			}
+			// Special non-interative mode
+			else if(i+1 < argc && strcmp(argv[i+1], "-ni") == 0)
+			{
+				int argc2 = argc - i + 4 - 2;
+				char **argv2 = calloc(argc2, sizeof(char*));
+				argv2[0] = argv[0]; // Application name
+				argv2[1] = (char*)"-batch";
+				argv2[2] = (char*)"-init";
+				argv2[3] = (char*)"/dev/null";
+				// i = "sqlite3"
+				// i+1 = "-h"
+				for(int j = 0; j < argc - i - 2; j++)
+					argv2[4 + j] = argv[i + 2 + j];
+				exit(sqlite3_shell_main(argc2, argv2));
+			}
 			else
 				exit(sqlite3_shell_main(argc - i, &argv[i]));
 		}
@@ -879,19 +894,30 @@ void parse_args(int argc, char* argv[])
 			printf("      the script.\n\n");
 
 			printf("%sEmbedded SQLite3 shell:%s\n", yellow, normal);
-			printf("\t%ssql %s[-h]%s, %ssqlite3 %s[-h]%s        FTL's SQLite3 shell\n", green, purple, normal, green, purple, normal);
-			printf("\t%s-h%s starts a special %shuman-readable mode%s\n\n", purple, normal, bold, normal);
+			printf("\t%ssql%s, %ssqlite3%s                      FTL's SQLite3 shell\n", green, normal, green, normal);
 
-			printf("    Usage: %spihole-FTL sqlite3 %s[-h] %s[OPTIONS] [FILENAME] [SQL]%s\n\n", green, purple, cyan, normal);
+			printf("    Usage: %spihole-FTL sqlite3 %s[OPTIONS] [FILENAME] [SQL]%s\n\n", green, cyan, normal);
 			printf("    Options:\n\n");
 			printf("    - %s[OPTIONS]%s is an optional set of options. All available\n", cyan, normal);
-			printf("      options can be found in %spihole-FTL sqlite3 --help%s\n", green, normal);
+			printf("      options can be found in %spihole-FTL sqlite3 --help%s.\n", green, normal);
+			printf("      The first option can be either %s-h%s or %s-ni%s, see below.\n", purple, normal, purple, normal);
 			printf("    - %s[FILENAME]%s is the optional name of an SQLite database.\n", cyan, normal);
 			printf("      A new database is created if the file does not previously\n");
 			printf("      exist. If this argument is omitted, SQLite3 will use a\n");
 			printf("      transient in-memory database instead.\n");
 			printf("    - %s[SQL]%s is an optional SQL statement to be executed. If\n", cyan, normal);
 			printf("      omitted, an interactive shell is started instead.\n\n");
+			printf("    There are two special %spihole-FTL sqlite3%s mode switches:\n", green, normal);
+			printf("    %s-h%s  %shuman-readable%s mode:\n", purple, normal, bold, normal);
+			printf("        In this mode, the output of the shell is formatted in\n");
+			printf("        a human-readable way. This is especially useful for\n");
+			printf("        debugging purposes. %s-h%s is a shortcut for\n", purple, normal);
+			printf("        %spihole-FTL sqlite3 %s-column -header -nullvalue '(null)'%s\n\n", green, purple, normal);
+			printf("    %s-ni%s %snon-interative%s mode\n", purple, normal, bold, normal);
+			printf("        In this mode, batch mode is enforced and any possibly\n");
+			printf("        existing .sqliterc file is ignored. %s-ni%s is a shortcut\n", purple, normal);
+			printf("        for %spihole-FTL sqlite3 %s-batch -init /dev/null%s\n\n", green, purple, normal);
+			printf("    Usage: %spihole-FTL sqlite3 %s-ni %s[OPTIONS] [FILENAME] [SQL]%s\n\n", green, purple, cyan, normal);
 
 			printf("%sEmbedded dnsmasq options:%s\n", yellow, normal);
 			printf("\t%sdnsmasq-test%s        Test syntax of dnsmasq's config\n", green, normal);

--- a/src/args.c
+++ b/src/args.c
@@ -546,7 +546,7 @@ void parse_args(int argc, char* argv[])
 				argv2[2] = (char*)"-init";
 				argv2[3] = (char*)"/dev/null";
 				// i = "sqlite3"
-				// i+1 = "-h"
+				// i+1 = "-ni"
 				for(int j = 0; j < argc - i - 2; j++)
 					argv2[4 + j] = argv[i + 2 + j];
 				exit(sqlite3_shell_main(argc2, argv2));

--- a/test/sqliterc
+++ b/test/sqliterc
@@ -1,0 +1,3 @@
+.mode column
+.headers on
+.tables

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1169,6 +1169,18 @@
   [[ ${lines[0]} == "Pi-hole FTL"* ]]
 }
 
+@test "Embedded SQLite3 shell ignores .sqliterc \"-ni\"" {
+  # Install .sqliterc file at current home directory
+  cp test/sqliterc ~/.sqliterc
+  run bash -c "./pihole-FTL sqlite3 /etc/pihole/gravity.db \"SELECT value FROM info WHERE property = 'abp_domains';\""
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} != "1" ]]
+  run bash -c "./pihole-FTL sqlite3 -ni /etc/pihole/gravity.db \"SELECT value FROM info WHERE property = 'abp_domains';\""
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "1" ]]
+  rm ~/.sqliterc
+}
+
 @test "Embedded LUA engine is called for .lua file" {
   echo 'print("Hello from LUA")' > abc.lua
   run bash -c './pihole-FTL abc.lua'


### PR DESCRIPTION
# What does this implement/fix?

Add special non-interactive mode for the embedded sqlite3 engine accessible via "`-ni`". This is meant to be used by Pi-hole's shell scripts to make the calls to `sqlite3` independent from possibly system-wide applied config files which may prevent Pi-hole from working as expected. See the linked Discourse thread for reference.

The change is documented in `pihole-FTL --help`:

![Screenshot from 2023-12-09 20-17-18](https://github.com/pi-hole/FTL/assets/16748619/63378dc9-b882-475b-902f-cb40180f407d)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** Documentation change is included in this PR (cfm. `pihole-FTL --help`)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.