### PR TITLE
Update ftl-build container to v2.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "FTL x86_64 Build Env",
-  "image": "ghcr.io/pi-hole/ftl-build:v2.4.1",
+  "image": "ghcr.io/pi-hole/ftl-build:v2.5",
   "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
   "extensions": [
     "jetmartin.bats",

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pi-hole/ftl-build:v2.4.1 AS builder
+FROM ghcr.io/pi-hole/ftl-build:v2.5 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
# What does this implement/fix?

Use latest `ftl-build` container to pick up both the most recent `Alpine` version as well as the updated `libreadline`

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.