### PR TITLE
Limit number of clients returned by /api/history/clients

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -24,6 +24,7 @@
 int api_handler(struct mg_connection *conn, void *ignored);
 
 // Statistic methods
+int __attribute__((pure)) cmpdesc(const void *a, const void *b);
 int api_stats_summary(struct ftl_conn *api);
 int api_stats_query_types(struct ftl_conn *api);
 int api_stats_upstreams(struct ftl_conn *api);

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -426,6 +426,8 @@ components:
                         type: string
                     maxHistory:
                       type: integer
+                    maxClients:
+                      type: integer
                     allow_destructive:
                       type: boolean
                     temp:
@@ -700,6 +702,7 @@ components:
               excludeClients: [ '1.2.3.4', 'localhost', 'fe80::345' ]
               excludeDomains: [ 'google.de', 'pi-hole.net' ]
               maxHistory: 86400
+              maxClients: 10
               allow_destructive: true
               temp:
                 limit: 60.0

--- a/src/api/docs/content/specs/history.yaml
+++ b/src/api/docs/content/specs/history.yaml
@@ -150,35 +150,6 @@ components:
     client_history:
       type: object
       properties:
-        history:
-          type: array
-          description: Data array
-          items:
-            type: object
-            properties:
-              timestamp:
-                type: number
-                description: Timestamp
-              data:
-                type: array
-                description: Data corresponding to the individual clients
-                items:
-                  type: integer
-          example:
-            - timestamp: 1511819900.539157
-              data:
-                - 12
-                - 65
-                - 67
-                - 9
-                - 5
-            - timestamp: 1511820500.583821
-              data:
-                - 1
-                - 35
-                - 63
-                - 20
-                - 9
         clients:
           type: array
           description: Data array
@@ -211,6 +182,35 @@ components:
             - name: "other clients"
               ip: "0.0.0.0"
               total: 14
+        history:
+          type: array
+          description: Data array
+          items:
+            type: object
+            properties:
+              timestamp:
+                type: number
+                description: Timestamp
+              data:
+                type: array
+                description: Data corresponding to the individual clients
+                items:
+                  type: integer
+          example:
+            - timestamp: 1511819900.539157
+              data:
+                - 12
+                - 65
+                - 67
+                - 9
+                - 5
+            - timestamp: 1511820500.583821
+              data:
+                - 1
+                - 35
+                - 63
+                - 20
+                - 9
   parameters:
     clients:
       N:

--- a/src/api/docs/content/specs/history.yaml
+++ b/src/api/docs/content/specs/history.yaml
@@ -62,7 +62,13 @@ components:
           - Metrics
         operationId: "get_client_metrics"
         description: |
-          Request data needed to generate the \"Client activity over last 24 hours\" graph
+          Request data needed to generate the \"Client activity over last 24 hours\" graph.
+          This endpoint returns the top N clients, sorted by total number of queries within 24 hours. If N is set to 0, all clients will be returned.
+          The client name is only available if the client's IP address can be resolved to a hostname.
+
+          The last client returned is a special client that contains the total number of queries that were not sent by any of the other shown clients , i.e. queries that were sent by clients that are not in the top N. This client is always present, even if it has 0 queries and can be identified by the special name "other clients" (mind the space in the hostname) and the IP address "0.0.0.0".
+
+          Note that, due to privacy settings, the returned data may also be empty.
         parameters:
           - $ref: 'history.yaml#/components/parameters/clients/N'
         responses:
@@ -164,11 +170,15 @@ components:
                 - 12
                 - 65
                 - 67
+                - 9
+                - 5
             - timestamp: 1511820500.583821
               data:
                 - 1
                 - 35
                 - 63
+                - 20
+                - 9
         clients:
           type: array
           description: Data array
@@ -195,6 +205,12 @@ components:
             - name: null
               ip: "192.168.1.1"
               total: 254
+            - name: "pi.hole"
+              ip: "::"
+              total: 29
+            - name: "other clients"
+              ip: "0.0.0.0"
+              total: 14
   parameters:
     clients:
       N:

--- a/src/api/docs/content/specs/history.yaml
+++ b/src/api/docs/content/specs/history.yaml
@@ -63,6 +63,8 @@ components:
         operationId: "get_client_metrics"
         description: |
           Request data needed to generate the \"Client activity over last 24 hours\" graph
+        parameters:
+          - $ref: 'history.yaml#/components/parameters/clients/N'
         responses:
           '200':
             description: OK
@@ -180,10 +182,26 @@ components:
               ip:
                 type: string
                 description: Client IP address
+              total:
+                type: integer
+                description: Total number of queries
           example:
             - name: localhost
               ip: "127.0.0.1"
+              total: 13428
             - name: ip6-localnet
               ip: "::1"
+              total: 2100
             - name: null
               ip: "192.168.1.1"
+              total: 254
+  parameters:
+    clients:
+      N:
+        in: query
+        description: Maximum number of clients to return
+        name: N
+        schema:
+          type: integer
+        required: false
+        example: 20

--- a/src/api/docs/content/specs/history.yaml
+++ b/src/api/docs/content/specs/history.yaml
@@ -199,7 +199,7 @@ components:
     clients:
       N:
         in: query
-        description: Maximum number of clients to return
+        description: Maximum number of clients to return, setting this to 0 will return all clients
         name: N
         schema:
           type: integer

--- a/src/api/history.c
+++ b/src/api/history.c
@@ -73,6 +73,12 @@ int api_history_clients(struct ftl_conn *api)
 	{
 		// Does the user request a non-default number of clients
 		get_uint_var(api->request->query_string, "N", &Nc);
+
+		// Limit the number of clients to return to the number of
+		// clients to avoid possible overflows for very large N
+		// Also allow N=0 to return all clients
+		if((int)Nc > counters->clients || Nc == 0)
+			Nc = counters->clients;
 	}
 
 	// Lock shared memory

--- a/src/api/history.c
+++ b/src/api/history.c
@@ -51,7 +51,6 @@ int api_history(struct ftl_conn *api)
 	JSON_SEND_OBJECT(json);
 }
 
-#define DEFAULT_MAX_CLIENTS 10
 int api_history_clients(struct ftl_conn *api)
 {
 	// Exit before processing any data if requested via config setting
@@ -68,7 +67,7 @@ int api_history_clients(struct ftl_conn *api)
 	}
 
 	// Get number of clients to return´
-	unsigned int Nc = min(counters->clients, DEFAULT_MAX_CLIENTS);
+	unsigned int Nc = min(counters->clients, config.webserver.api.maxClients.v.u16);
 	if(api->request->query_string != NULL)
 	{
 		// Does the user request a non-default number of clients

--- a/src/api/history.c
+++ b/src/api/history.c
@@ -51,7 +51,7 @@ int api_history(struct ftl_conn *api)
 	JSON_SEND_OBJECT(json);
 }
 
-#define DEFAULT_MAX_CLIENTS 20
+#define DEFAULT_MAX_CLIENTS 10
 int api_history_clients(struct ftl_conn *api)
 {
 	// Exit before processing any data if requested via config setting

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -42,7 +42,7 @@ static int __attribute__((pure)) cmpasc(const void *a, const void *b)
 } */
 
 // qsort subroutine, sort DESC
-static int __attribute__((pure)) cmpdesc(const void *a, const void *b)
+int __attribute__((pure)) cmpdesc(const void *a, const void *b)
 {
 	const int *elem1 = (int*)a;
 	const int *elem2 = (int*)b;
@@ -139,7 +139,7 @@ int api_stats_top_domains(struct ftl_conn *api)
 {
 	int count = 10;
 	const int domains = counters->domains;
-	int *temparray = calloc(2*domains, sizeof(int*));
+	int *temparray = calloc(2*domains, sizeof(int));
 	if(temparray == NULL)
 	{
 		log_err("Memory allocation failed in %s()", __FUNCTION__);
@@ -282,7 +282,7 @@ int api_stats_top_clients(struct ftl_conn *api)
 {
 	int count = 10;
 	const int clients = counters->clients;
-	int *temparray = calloc(2*clients, sizeof(int*));
+	int *temparray = calloc(2*clients, sizeof(int));
 	if(temparray == NULL)
 	{
 		log_err("Memory allocation failed in api_stats_top_clients()");

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -972,6 +972,11 @@ void initConfig(struct config *conf)
 	conf->webserver.api.maxHistory.t = CONF_UINT;
 	conf->webserver.api.maxHistory.d.ui = MAXLOGAGE*3600;
 
+	conf->webserver.api.maxClients.k = "webserver.api.maxClients";
+	conf->webserver.api.maxClients.h = "Up to how many clients should be returned in the activity graph endpoint (/api/history/clients)?\n This setting can be overwritten at run-time using the parameter N";
+	conf->webserver.api.maxClients.t = CONF_UINT16;
+	conf->webserver.api.maxClients.d.u16 = 10;
+
 	conf->webserver.api.allow_destructive.k = "webserver.api.allow_destructive";
 	conf->webserver.api.allow_destructive.h = "Allow destructive API calls (e.g. deleting all queries, powering off the system, ...)";
 	conf->webserver.api.allow_destructive.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -245,6 +245,7 @@ struct config {
 			struct conf_item excludeClients;
 			struct conf_item excludeDomains;
 			struct conf_item maxHistory;
+			struct conf_item maxClients;
 			struct conf_item allow_destructive;
 			struct {
 				struct conf_item limit;

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -314,7 +314,7 @@ int _findClientID(const char *clientIP, const bool count, const bool aliasclient
 	// Set all MAC address bytes to zero
 	client->hwlen = -1;
 	memset(client->hwaddr, 0, sizeof(client->hwaddr));
-	// This may be a alias-client, the ID is set elsewhere
+	// This may be an alias-client, the ID is set elsewhere
 	client->flags.aliasclient = aliasclient;
 	client->aliasclient_id = -1;
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -693,6 +693,11 @@
     # 86400)
     maxHistory = 86400
 
+    # Up to how many clients should be returned in the activity graph endpoint
+    # (/api/history/clients)?
+    # This setting can be overwritten at run-time using the parameter N
+    maxClients = 10
+
     # Allow destructive API calls (e.g. deleting all queries, powering off the system, ...)
     allow_destructive = true
 


### PR DESCRIPTION
# What does this implement/fix?

Limit number of clients returned by the `/api/history/clients` endpoint to 20 (default value).
This can be overwritten at compile-time and at run-time using the query parameter `?N=...`

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.