### PR TITLE
Fix one-of definition in clients, domains, groups, and lists POST

### DIFF
--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -262,7 +262,7 @@ components:
             description: Array of clients
             items:
               allOf:
-                - $ref: 'clients.yaml#/components/schemas/client'
+                - $ref: 'clients.yaml#/components/schemas/client_object'
                 - $ref: 'clients.yaml#/components/schemas/comment'
                 - $ref: 'clients.yaml#/components/schemas/groups'
                 - $ref: 'clients.yaml#/components/schemas/readonly'
@@ -305,25 +305,27 @@ components:
                 description: Comma-separated list of hostnames (if available)
                 example: "localhost,ip6-localhost"
     client:
-      type: object
-      properties:
-        client:
-          description: client IP / MAC / hostname / interface
-          type: string
-          example: 127.0.0.1
+      description: client IP / MAC / hostname / interface
+      type: string
+      example: 127.0.0.1
     client_array:
+      description: array of client IPs / MACs / hostnames / interfaces
+      type: array
+      items:
+        type: string
+      example: ["127.0.0.1", "192.168.2.12"]
+    client_maybe_array:
       type: object
       properties:
         client:
-          description: array of client IPs / MACs / hostnames / interfaces
-          type: array
-          items:
-            type: string
-          example: ["127.0.0.1", "192.168.2.12"]
-    client_maybe_array:
-      oneOf:
-        - $ref: 'clients.yaml#/components/schemas/client'
-        - $ref: 'clients.yaml#/components/schemas/client_array'
+          oneOf:
+            - $ref: 'clients.yaml#/components/schemas/client'
+            - $ref: 'clients.yaml#/components/schemas/client_array'
+    client_object:
+      type: object
+      properties:
+        client:
+          $ref: 'clients.yaml#/components/schemas/client'
     comment:
       type: object
       properties:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -280,7 +280,7 @@ components:
             description: Array of domains
             items:
               allOf:
-                - $ref: 'domains.yaml#/components/schemas/domain'
+                - $ref: 'domains.yaml#/components/schemas/domain_object'
                 - $ref: 'domains.yaml#/components/schemas/unicode'
                 - $ref: 'domains.yaml#/components/schemas/type'
                 - $ref: 'domains.yaml#/components/schemas/kind'
@@ -302,12 +302,9 @@ components:
           - $ref: 'domains.yaml#/components/schemas/groups'
           - $ref: 'domains.yaml#/components/schemas/enabled'
     domain:
-      type: object
-      properties:
-        domain:
-          description: Domain
-          type: string
-          example: testdomain.com
+      description: Domain
+      type: string
+      example: testdomain.com
     unicode:
       type: object
       properties:
@@ -316,18 +313,23 @@ components:
           type: string
           example: "äbc.com"
     domain_array:
+      description: array of domains
+      type: array
+      items:
+        type: string
+      example: ["testdomain.com", "otherdomain.de"]
+    domain_maybe_array:
       type: object
       properties:
         domain:
-          description: array of domains
-          type: array
-          items:
-            type: string
-          example: ["testdomain.com", "otherdomain.de"]
-    domain_maybe_array:
-      oneOf:
-        - $ref: 'domains.yaml#/components/schemas/domain'
-        - $ref: 'domains.yaml#/components/schemas/domain_array'
+          oneOf:
+            - $ref: 'domains.yaml#/components/schemas/domain'
+            - $ref: 'domains.yaml#/components/schemas/domain_array'
+    domain_object:
+      type: object
+      properties:
+        domain:
+          $ref: 'domains.yaml#/components/schemas/domain'
     type:
       type: object
       properties:

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -235,13 +235,14 @@ components:
             type: array
             items:
               allOf:
-                - $ref: 'groups.yaml#/components/schemas/name'
+                - $ref: 'groups.yaml#/components/schemas/name_object'
                 - $ref: 'groups.yaml#/components/schemas/comment'
                 - $ref: 'groups.yaml#/components/schemas/enabled'
                 - $ref: 'groups.yaml#/components/schemas/readonly'
       put:
         allOf:
-          - $ref: 'groups.yaml#/components/schemas/name'
+          # Can rename group
+          - $ref: 'groups.yaml#/components/schemas/name_object'
           - $ref: 'groups.yaml#/components/schemas/comment'
           - $ref: 'groups.yaml#/components/schemas/enabled'
       post:
@@ -250,25 +251,27 @@ components:
           - $ref: 'groups.yaml#/components/schemas/comment'
           - $ref: 'groups.yaml#/components/schemas/enabled'
     name:
-      type: object
-      properties:
-        name:
-          description: Group name
-          type: string
-          example: test_group
+      description: Group name
+      type: string
+      example: test_group
     name_array:
+      description: array of group names
+      type: array
+      items:
+        type: string
+      example: ["test1", "test2", "test3"]
+    name_maybe_array:
       type: object
       properties:
         name:
-          description: array of group names
-          type: array
-          items:
-            type: string
-          example: ["test1", "test2", "test3"]
-    name_maybe_array:
-      oneOf:
-        - $ref: 'groups.yaml#/components/schemas/name'
-        - $ref: 'groups.yaml#/components/schemas/name_array'
+          oneOf:
+            - $ref: 'groups.yaml#/components/schemas/name'
+            - $ref: 'groups.yaml#/components/schemas/name_array'
+    name_object:
+      type: object
+      properties:
+        name:
+          $ref: 'groups.yaml#/components/schemas/name'
     comment:
       type: object
       properties:

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -230,7 +230,7 @@ components:
             description: Array of lists
             items:
               allOf:
-                - $ref: 'lists.yaml#/components/schemas/list'
+                - $ref: 'lists.yaml#/components/schemas/address_object'
                 - $ref: 'lists.yaml#/components/schemas/type'
                 - $ref: 'lists.yaml#/components/schemas/comment'
                 - $ref: 'lists.yaml#/components/schemas/groups'
@@ -244,31 +244,33 @@ components:
           - $ref: 'lists.yaml#/components/schemas/enabled'
       post:
         allOf:
-          - $ref: 'lists.yaml#/components/schemas/list_maybe_array'
+          - $ref: 'lists.yaml#/components/schemas/address_maybe_array'
           - $ref: 'lists.yaml#/components/schemas/type'
           - $ref: 'lists.yaml#/components/schemas/comment'
           - $ref: 'lists.yaml#/components/schemas/groups'
           - $ref: 'lists.yaml#/components/schemas/enabled'
-    list:
+    address:
+      description: Address of the list
+      type: string
+      example: https://hosts-file.net/ad_servers.txt
+    address_array:
+      description: array of list addresses
+      type: array
+      items:
+        type: string
+      example: ["https://hosts-file.net/ad_servers.txt"]
+    address_maybe_array:
       type: object
       properties:
         address:
-          description: Address of the list
-          type: string
-          example: https://hosts-file.net/ad_servers.txt
-    list_array:
+          oneOf:
+            - $ref: 'lists.yaml#/components/schemas/address'
+            - $ref: 'lists.yaml#/components/schemas/address_array'
+    address_object:
       type: object
       properties:
-        list:
-          description: array of list addresses
-          type: array
-          items:
-            type: string
-          example: ["https://hosts-file.net/ad_servers.txt"]
-    list_maybe_array:
-      oneOf:
-        - $ref: 'lists.yaml#/components/schemas/list'
-        - $ref: 'lists.yaml#/components/schemas/list_array'
+        address:
+          $ref: 'lists.yaml#/components/schemas/address'
     type:
       type: object
       properties:


### PR DESCRIPTION
# What does this implement/fix?

Fix one-of definition in `clients`, `domains`, `groups`, and `lists` `POST` request payloads.

Exemplary previous/after screenshot:

![BEFORE](https://github.com/pi-hole/FTL/assets/16748619/f39a2ce8-b6e4-4605-acf8-57c10ab31dd3)
![AFTER](https://github.com/pi-hole/FTL/assets/16748619/375ee05c-e684-45b0-bb7f-27d66fe43111)



Fixes #1834

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.