### PR TITLE
Fix DELETE API endpoints return codes

### DIFF
--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -648,6 +648,11 @@ int api_auth(struct ftl_conn *api)
 		                       "Rate-limiting login attempts",
 		                       NULL);
 	}
+	else if(result == NO_PASSWORD_SET)
+	{
+		// No password set
+		log_debug(DEBUG_API, "API: Trying to auth with password but none set: '%s'", password);
+	}
 	else
 	{
 		log_debug(DEBUG_API, "API: Password incorrect: '%s'", password);

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -294,7 +294,7 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 			}
 
 			if(!set_and_check_password(conf_item, elem->valuestring))
-				return "Failed to create password hash (verification failed), password remains unchanged";
+				return "password hash verification failed";
 
 			break;
 		}

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -904,7 +904,7 @@ static int api_config_put_delete(struct ftl_conn *api)
 			                            key, true);
 		}
 
-		// Check if this entry does already exist in the array
+		// Check if this entry exists in the array
 		int idx = 0;
 		for(; idx < cJSON_GetArraySize(new_item->v.json); idx++)
 		{
@@ -938,13 +938,12 @@ static int api_config_put_delete(struct ftl_conn *api)
 			if(found)
 			{
 				// Remove item from array
+				found = true;
 				cJSON_DeleteItemFromArray(new_item->v.json, idx);
 			}
 			else
 			{
 				// Item not found
-				message = "Item not found";
-				hint = "Can only delete existing items";
 				break;
 			}
 		}
@@ -964,13 +963,16 @@ static int api_config_put_delete(struct ftl_conn *api)
 	// Release allocated memory
 	free_config_path(requested_path);
 
-	// Error 404 if not found
-	if(!found || message != NULL)
+	// Error 404 if config element not found
+	if(!found)
 	{
-		// For any other error, a more specific message will have been added
-		// above
-		if(!message)
-			message = "No item specified";
+		cJSON *json = JSON_NEW_OBJECT();
+		JSON_SEND_OBJECT_CODE(json, 404);
+	}
+
+	// Error 400 if unique item already present
+	if(message != NULL)
+	{
 		return send_json_error(api, 400,
 		                       "bad_request",
 		                       message,

--- a/src/api/dhcp.c
+++ b/src/api/dhcp.c
@@ -85,16 +85,18 @@ int api_dhcp_leases_DELETE(struct ftl_conn *api)
 		// Send empty reply with code 204 No Content
 		return send_json_error(api,
 		                       400,
-				       "bad_request",
+		                       "bad_request",
 		                       "The provided IPv4 address is invalid",
-				       api->item);
+		                       api->item);
 	}
 
 	// Delete lease
 	log_debug(DEBUG_API, "Deleting DHCP lease for address %s", api->item);
-	FTL_unlink_DHCP_lease(api->item);
+	const bool found = FTL_unlink_DHCP_lease(api->item);
 
-	// Send empty reply with code 204 No Content
+	// Send empty reply with codes:
+	// - 204 No Content (if a lease was deleted)
+	// - 404 Not Found (if no lease was found)
 	cJSON *json = JSON_NEW_OBJECT();
-	JSON_SEND_OBJECT_CODE(json, 204);
+	JSON_SEND_OBJECT_CODE(json, found ? 204 : 404);
 }

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -118,21 +118,23 @@ components:
           - Authentication
         operationId: "delete_groups"
         description: |
-          A logout attempt without a valid session will result in a `401 Unauthorized` error.
+          This endpoint can be used to delete the current session. It will
+          invalidate the session token and the CSRF token. The session can be
+          extended before its expiration by performing any authenticated action.
+          By default, the session lasts for 5 minutes. It can be invalidated by
+          either logging out or deleting the session. Additionally, the session
+          becomes invalid when the password is altered or a new application
+          password is created.
 
-          A session that was not created due to a login cannot be deleted (e.g., empty API password).
+          You can also delete a session by its ID using the `DELETE /auth/session/{id}` endpoint.
+
+          Note that you cannot delete the current session if you have not
+          authenticated (e.g., no password has been set on your Pi-hole).
         responses:
-          '200':
-            description: OK (session not deletable)
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: 'auth.yaml#/components/schemas/session'
-                    - $ref: 'common.yaml#/components/schemas/took'
-                examples:
-                  no_login_required:
-                    $ref: 'auth.yaml#/components/examples/no_login_required'
+          '204':
+            description: No Content (deleted)
+          '404':
+            description: Not Found (no session active)
           '401':
             description: Unauthorized
             content:
@@ -141,17 +143,6 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
-          '410':
-            description: Gone
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: 'auth.yaml#/components/schemas/session'
-                    - $ref: 'common.yaml#/components/schemas/took'
-                examples:
-                  login_failed:
-                    $ref: 'auth.yaml#/components/examples/login_failed'
     session_list:
       get:
         summary: List of all current sessions
@@ -213,6 +204,8 @@ components:
         responses:
           '204':
             description: No Content (deleted)
+          '404':
+            description: Not Found (session not found)
           '400':
             description: Bad Request
             content:

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -133,8 +133,16 @@ components:
         responses:
           '204':
             description: No Content (deleted)
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Not Found (no session active)
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '401':
             description: Unauthorized
             content:
@@ -204,8 +212,16 @@ components:
         responses:
           '204':
             description: No Content (deleted)
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Not Found (session not found)
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad Request
             content:

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -133,10 +133,6 @@ components:
         responses:
           '204':
             description: No Content (deleted)
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Not Found (no session active)
             content:
@@ -212,10 +208,6 @@ components:
         responses:
           '204':
             description: No Content (deleted)
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Not Found (session not found)
             content:

--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -95,6 +95,8 @@ components:
         responses:
           '204':
             description: Item deleted
+          '404':
+            description: Item not found
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -95,8 +95,16 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:
@@ -235,6 +243,16 @@ components:
         responses:
           '204':
             description: Items deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
+          '404':
+            description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -95,10 +95,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:
@@ -243,10 +239,6 @@ components:
         responses:
           '204':
             description: Items deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -144,6 +144,10 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -144,10 +144,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -121,7 +121,7 @@ components:
                 examples:
                   invalid_path_depth:
                     $ref: 'config.yaml#/components/examples/errors/bad_request/invalid_path_depth'
-                  item_not_found:
+                  item_already_present:
                     $ref: 'config.yaml#/components/examples/errors/bad_request/item_already_present'
           '401':
             description: Unauthorized
@@ -144,6 +144,12 @@ components:
         responses:
           '204':
             description: Item deleted
+          '404':
+            description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:
@@ -155,8 +161,8 @@ components:
                 examples:
                   invalid_path_depth:
                     $ref: 'config.yaml#/components/examples/errors/bad_request/invalid_path_depth'
-                  item_not_found:
-                    $ref: 'config.yaml#/components/examples/errors/bad_request/item_not_found'
+                  item_already_present:
+                    $ref: 'config.yaml#/components/examples/errors/bad_request/item_already_present'
           '401':
             description: Unauthorized
             content:
@@ -795,13 +801,6 @@ components:
               key: "bad_request"
               message: "Invalid path depth"
               hint: "Use, e.g., DELETE /config/dnsmasq/upstreams/127.0.0.1 to remove \"127.0.0.1\" from config.dns.upstreams"
-        item_not_found:
-          summary: Item to be deleted does not exist
-          value:
-            error:
-              key: "bad_request"
-              message: "Item not found"
-              hint: "Can only delete existing items"
         item_already_present:
           summary: Item to be added exists already
           value:

--- a/src/api/docs/content/specs/dhcp.yaml
+++ b/src/api/docs/content/specs/dhcp.yaml
@@ -40,10 +40,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/dhcp.yaml
+++ b/src/api/docs/content/specs/dhcp.yaml
@@ -40,6 +40,10 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/dhcp.yaml
+++ b/src/api/docs/content/specs/dhcp.yaml
@@ -40,6 +40,12 @@ components:
         responses:
           '204':
             description: Item deleted
+          '404':
+            description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -128,6 +128,8 @@ components:
         responses:
           '204':
             description: Item deleted
+          '404':
+            description: Item not found
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -128,10 +128,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:
@@ -261,10 +257,6 @@ components:
         responses:
           '204':
             description: Items deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -128,8 +128,16 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:
@@ -253,6 +261,16 @@ components:
         responses:
           '204':
             description: Items deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
+          '404':
+            description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -94,6 +94,8 @@ components:
         responses:
           '204':
             description: Item deleted
+          '404':
+            description: Item not found
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -97,10 +97,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:
@@ -208,10 +204,6 @@ components:
         responses:
           '204':
             description: Items deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -63,6 +63,9 @@ components:
                     - $ref: 'groups.yaml#/components/schemas/groups/get' # identical to GET
                     - $ref: 'groups.yaml#/components/schemas/lists_processed'
                     - $ref: 'common.yaml#/components/schemas/took'
+            headers:
+              Location:
+                $ref: 'common.yaml#/components/headers/Location'
           '400':
             description: Bad request
             content:
@@ -94,8 +97,16 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:
@@ -195,18 +206,18 @@ components:
                   - "item": "test1"
                   - "item": "test2"
         responses:
-          '201':
-            description: Created item
+          '204':
+            description: Items deleted
             content:
               application/json:
                 schema:
-                  allOf:
-                    - $ref: 'groups.yaml#/components/schemas/groups/get' # identical to GET
-                    - $ref: 'groups.yaml#/components/schemas/lists_processed'
-                    - $ref: 'common.yaml#/components/schemas/took'
-            headers:
-              Location:
-                $ref: 'common.yaml#/components/headers/Location'
+                  $ref: 'common.yaml#/components/schemas/took'
+          '404':
+            description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -222,10 +222,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Not found
             content:

--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -222,6 +222,10 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -218,10 +218,16 @@ components:
         parameters:
           - $ref: 'info.yaml#/components/parameters/message_id'
         description: |
-          *Note:* There will be no content on success. You may specify multiple IDs to delete multiple messages at once (comma-separated in the path like `1,2,3`)
+          You may specify multiple IDs to delete multiple messages at once (comma-separated in the path like `1,2,3`)
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
+          '404':
+            description: Not found
             content:
               application/json:
                 schema:
@@ -239,6 +245,14 @@ components:
                     $ref: 'info.yaml#/components/examples/errors/messages/uri_error'
                   bad_request:
                     $ref: 'info.yaml#/components/examples/errors/messages/bad_request'
+          '401':
+            description: Unauthorized
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'common.yaml#/components/errors/unauthorized'
+                    - $ref: 'common.yaml#/components/schemas/took'
     messages_count:
       get:
         summary: Get count of Pi-hole diagnosis messages

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -93,6 +93,8 @@ components:
         responses:
           '204':
             description: Item deleted
+          '404':
+            description: Item not found
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -93,10 +93,6 @@ components:
         responses:
           '204':
             description: Item deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:
@@ -201,10 +197,6 @@ components:
         responses:
           '204':
             description: Items deleted
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
             content:

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -93,8 +93,16 @@ components:
         responses:
           '204':
             description: Item deleted
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:
@@ -191,18 +199,18 @@ components:
               schema:
                 $ref: 'lists.yaml#/components/schemas/lists/post'
         responses:
-          '201':
-            description: Created item
+          '204':
+            description: Items deleted
             content:
               application/json:
                 schema:
-                  allOf:
-                    - $ref: 'lists.yaml#/components/schemas/lists/get'
-                    - $ref: 'lists.yaml#/components/schemas/lists_processed'
-                    - $ref: 'common.yaml#/components/schemas/took'
-            headers:
-              Location:
-                $ref: 'common.yaml#/components/headers/Location'
+                  $ref: 'common.yaml#/components/schemas/took'
+          '404':
+            description: Item not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '400':
             description: Bad request
             content:

--- a/src/api/docs/content/specs/network.yaml
+++ b/src/api/docs/content/specs/network.yaml
@@ -93,6 +93,10 @@ components:
         responses:
           '204':
             description: No Content (deleted)
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
           '401':
             description: Unauthorized
             content:

--- a/src/api/docs/content/specs/network.yaml
+++ b/src/api/docs/content/specs/network.yaml
@@ -97,6 +97,20 @@ components:
               application/json:
                 schema:
                   $ref: 'common.yaml#/components/schemas/took'
+          '404':
+            description: Not found
+            content:
+              application/json:
+                schema:
+                  $ref: 'common.yaml#/components/schemas/took'
+          '400':
+            description: Bad request
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'common.yaml#/components/errors/bad_request'
+                    - $ref: 'common.yaml#/components/schemas/took'
           '401':
             description: Unauthorized
             content:

--- a/src/api/docs/content/specs/network.yaml
+++ b/src/api/docs/content/specs/network.yaml
@@ -93,10 +93,6 @@ components:
         responses:
           '204':
             description: No Content (deleted)
-            content:
-              application/json:
-                schema:
-                  $ref: 'common.yaml#/components/schemas/took'
           '404':
             description: Not found
             content:

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -940,15 +940,18 @@ static int api_info_messages_DELETE(struct ftl_conn *api)
 	}
 
 	// Delete message with this ID from the database
-	delete_message(ids);
+	int deleted = 0;
+	delete_message(ids, &deleted);
 
 	// Free memory
 	free(id);
 	cJSON_free(ids);
 
-	// Send empty reply with code 204 No Content
+	// Send empty reply with codes:
+	// - 204 No Content (if any items were deleted)
+	// - 404 Not Found (if no items were deleted)
 	cJSON *json = JSON_NEW_OBJECT();
-	JSON_SEND_OBJECT_CODE(json, 204);
+	JSON_SEND_OBJECT_CODE(json, deleted > 0u ? 204 : 404);
 }
 
 int api_info_messages(struct ftl_conn *api)

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -951,7 +951,7 @@ static int api_info_messages_DELETE(struct ftl_conn *api)
 	// - 204 No Content (if any items were deleted)
 	// - 404 Not Found (if no items were deleted)
 	cJSON *json = JSON_NEW_OBJECT();
-	JSON_SEND_OBJECT_CODE(json, deleted > 0u ? 204 : 404);
+	JSON_SEND_OBJECT_CODE(json, deleted > 0 ? 204 : 404);
 }
 
 int api_info_messages(struct ftl_conn *api)

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -705,7 +705,8 @@ static int api_list_remove(struct ftl_conn *api,
 	}
 
 	// From here on, we can assume the JSON payload is valid
-	if(gravityDB_delFromTable(listtype, array, &sql_msg))
+	unsigned int deleted = 0u;
+	if(gravityDB_delFromTable(listtype, array, &deleted, &sql_msg))
 	{
 		// Inform the resolver that it needs to reload gravity
 		set_event(RELOAD_GRAVITY);
@@ -714,9 +715,11 @@ static int api_list_remove(struct ftl_conn *api,
 		if(allocated_json)
 			cJSON_free(array);
 
-		// Send empty reply with code 204 No Content
+		// Send empty reply with codes:
+		// - 204 No Content (if any items were deleted)
+		// - 404 Not Found (if no items were deleted)
 		cJSON *json = JSON_NEW_OBJECT();
-		JSON_SEND_OBJECT_CODE(json, 204);
+		JSON_SEND_OBJECT_CODE(json, deleted > 0u ? 204 : 404);
 	}
 	else
 	{

--- a/src/api/network.c
+++ b/src/api/network.c
@@ -440,7 +440,8 @@ static int api_network_devices_DELETE(struct ftl_conn *api)
 
 	// Delete row from network table by ID
 	const char *sql_msg = NULL;
-	if(!networkTable_deleteDevice(db, device_id, &sql_msg))
+	int deleted = 0;
+	if(!networkTable_deleteDevice(db, device_id, &deleted, &sql_msg))
 	{
 		// Add SQL message (may be NULL = not available)
 		return send_json_error(api, 500,
@@ -452,9 +453,11 @@ static int api_network_devices_DELETE(struct ftl_conn *api)
 	// Close database
 	dbclose(&db);
 
-	// Send empty reply with code 204 No Content
+	// Send empty reply with codes:
+	// - 204 No Content (if any items were deleted)
+	// - 404 Not Found (if no items were deleted)
 	cJSON *json = JSON_NEW_OBJECT();
-	JSON_SEND_OBJECT_CODE(json, 204);
+	JSON_SEND_OBJECT_CODE(json, deleted > 0 ? 204 : 404);
 }
 
 int api_network_devices(struct ftl_conn *api)

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -160,8 +160,9 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 			// Get password hash as allocated string (an empty string is hashed to an empty string)
 			char *pwhash = strlen(value) > 0 ? create_password(value) : strdup("");
 
-			// Verify that the password hash is valid
-			if(verify_password(value, pwhash, false) != PASSWORD_CORRECT)
+			// Verify that the password hash is either valid or empty
+			const enum password_result status = verify_password(value, pwhash, false);
+			if(status != PASSWORD_CORRECT && status != NO_PASSWORD_SET)
 			{
 				log_err("Failed to create password hash (verification failed), password remains unchanged");
 				free(pwhash);

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -328,6 +328,7 @@ enum password_result verify_login(const char *password)
 		log_debug(DEBUG_API, "App password correct");
 		return APPPASSWORD_CORRECT;
 	}
+
 	// Return result
 	return pw;
 }
@@ -336,7 +337,7 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 {
 	// No password set
 	if(pwhash == NULL || pwhash[0] == '\0')
-		return PASSWORD_CORRECT;
+		return NO_PASSWORD_SET;
 
 	// No password supplied
 	if(password == NULL || password[0] == '\0')

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -607,8 +607,9 @@ bool set_and_check_password(struct conf_item *conf_item, const char *password)
 	// Get password hash as allocated string (an empty string is hashed to an empty string)
 	char *pwhash = strlen(password) > 0 ? create_password(password) : strdup("");
 
-	// Verify that the password hash is valid
-	if(verify_password(password, pwhash, false) != PASSWORD_CORRECT)
+	// Verify that the password hash is valid or that no password is set
+	const enum password_result status = verify_password(password, pwhash, false);
+	if(status != PASSWORD_CORRECT && status != NO_PASSWORD_SET)
 	{
 		free(pwhash);
 		log_warn("Failed to create password hash (verification failed), password remains unchanged");

--- a/src/config/password.h
+++ b/src/config/password.h
@@ -26,6 +26,7 @@ enum password_result {
 	PASSWORD_INCORRECT = 0,
 	PASSWORD_CORRECT = 1,
 	APPPASSWORD_CORRECT = 2,
+	NO_PASSWORD_SET = 3,
 	PASSWORD_RATE_LIMITED = -1
 } __attribute__((packed));
 

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1792,8 +1792,9 @@ bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
 	return okay;
 }
 
-bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, const char **message)
+bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
 {
+	// Return early if database is not available
 	if(gravity_db == NULL)
 	{
 		*message = "Database not available";
@@ -2004,6 +2005,9 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 
 			break;
 		}
+
+		// Add number of deleted rows
+		*deleted += sqlite3_changes(gravity_db);
 	}
 
 	// Drop temporary table

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -69,7 +69,7 @@ bool gravityDB_readTableGetRow(const enum gravity_list_type listtype, tablerow *
 void gravityDB_readTableFinalize(void);
 bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
                           const char **message, const enum http_method method);
-bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, const char **message);
+bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message);
 bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
                            const tablerow *row, const char **message);
 

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -378,7 +378,7 @@ end_of_add_message: // Close database connection
 	return rowid;
 }
 
-bool delete_message(cJSON *ids)
+bool delete_message(cJSON *ids, int *deleted)
 {
 	// Return early if database is known to be broken
 	if(FTLDBerror())
@@ -413,6 +413,10 @@ bool delete_message(cJSON *ids)
 			log_err("SQL error (%i): %s", sqlite3_errcode(db), sqlite3_errmsg(db));
 			return false;
 		}
+
+		// Add to deleted count
+		*deleted += sqlite3_changes(db);
+
 		sqlite3_reset(res);
 		sqlite3_clear_bindings(res);
 	}

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -16,7 +16,7 @@
 int count_messages(const bool filter_dnsmasq_warnings);
 bool format_messages(cJSON *array);
 bool create_message_table(sqlite3 *db);
-bool delete_message(cJSON *ids);
+bool delete_message(cJSON *ids, int *deleted);
 bool flush_message_table(void);
 void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex);
 void logg_subnet_warning(const char *ip, const int matching_count, const char *matching_ids,

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -2425,7 +2425,7 @@ void networkTable_readIPsFinalize(sqlite3_stmt *read_stmt)
 	sqlite3_finalize(read_stmt);
 }
 
-bool networkTable_deleteDevice(sqlite3 *db, const int id, const char **message)
+bool networkTable_deleteDevice(sqlite3 *db, const int id, int *deleted, const char **message)
 {
 	// First step: Delete all associated IPs of this device
 	// Prepare SQLite statement
@@ -2462,6 +2462,9 @@ bool networkTable_deleteDevice(sqlite3 *db, const int id, const char **message)
 		return false;
 	}
 
+	// Check if we deleted any rows
+	*deleted += sqlite3_changes(db);
+
 	// Finalize statement
 	sqlite3_finalize(stmt);
 
@@ -2497,6 +2500,9 @@ bool networkTable_deleteDevice(sqlite3 *db, const int id, const char **message)
 		sqlite3_finalize(stmt);
 		return false;
 	}
+
+	// Check if we deleted any rows
+	*deleted += sqlite3_changes(db);
 
 	// Finalize statement
 	sqlite3_finalize(stmt);

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -52,6 +52,6 @@ bool networkTable_readIPs(sqlite3 *db, sqlite3_stmt **read_stmt, const int id, c
 bool networkTable_readIPsGetRecord(sqlite3_stmt *read_stmt, network_addresses_record *network_addresses, const char **message);
 void networkTable_readIPsFinalize(sqlite3_stmt *read_stmt);
 
-bool networkTable_deleteDevice(sqlite3 *db, const int id, const char **message);
+bool networkTable_deleteDevice(sqlite3 *db, const int id, int *deleted, const char **message);
 
 #endif //NETWORKTABLE_H

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3263,6 +3263,7 @@ bool FTL_unlink_DHCP_lease(const char *ipaddr)
 #endif
 	else
 	{
+		// Invalid IP address or no lease found
 		return false;
 	}
 

--- a/src/webserver/json_macros.h
+++ b/src/webserver/json_macros.h
@@ -200,7 +200,10 @@
 })
 
 #define JSON_SEND_OBJECT_CODE(object, code)({ \
-	cJSON_AddNumberToObject(object, "took", double_time() - api->now);\
+	if((code) != 204) \
+	{ \
+		cJSON_AddNumberToObject(object, "took", double_time() - api->now); \
+	} \
 	char *json_string = json_formatter(object); \
 	if(json_string == NULL) \
 	{ \


### PR DESCRIPTION
# What does this implement/fix?

The `DELETE` endpoints should return 204 when something was deleted and 404 is nothing was found at this resource. This PR follows a discussion in #1833 

See here the result of triggering to identical `DELETE` for a blocked domain. The first one got deleted fine (204), the second one errored because the requested resource wasn't there (we delete it before):

![Screenshot from 2023-12-21 21-09-31](https://github.com/pi-hole/FTL/assets/16748619/3f47e1b9-c87b-49bb-b324-a133125afb4c)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.