### PR TITLE
If someone terminates FTL, try to obtain who is the murderer and log it

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -94,7 +94,7 @@ int main_dnsmasq (int argc, char **argv)
   sigaction(SIGUSR1, &sigact, NULL);
   sigaction(SIGUSR2, &sigact, NULL);
   sigaction(SIGHUP, &sigact, NULL);
-  sigaction(SIGTERM, &sigact, NULL);
+  sigaction(SIGUSR6, &sigact, NULL); // Pi-hole modification
   sigaction(SIGALRM, &sigact, NULL);
   sigaction(SIGCHLD, &sigact, NULL);
   sigaction(SIGINT, &sigact, NULL);
@@ -1330,7 +1330,7 @@ static void sig_handler(int sig)
 	event = EVENT_CHILD;
       else if (sig == SIGALRM)
 	event = EVENT_ALARM;
-      else if (sig == SIGTERM)
+      else if (sig == SIGUSR6) // Pi-hole modified
 	event = EVENT_TERM;
       else if (sig == SIGUSR1)
 	event = EVENT_DUMP;

--- a/src/signals.h
+++ b/src/signals.h
@@ -12,6 +12,8 @@
 
 #include "enums.h"
 
+#define SIGUSR6 (SIGRTMIN + 6)
+
 // defined in dnsmasq/dnsmasq.h
 extern volatile char FTL_terminate;
 


### PR DESCRIPTION
# What does this implement/fix?

See title. When FTL is restarted using, e.g., `sudo system pihole-FTL restart` the new log looks like:
```
2023-12-23 16:00:47.926 [2260911M] INFO: Asked to terminate by "/lib/systemd/systemd --system --deserialize 56" (PID 1, user root UID 0)
```

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.