### PR TITLE
Do not overwrite errors on ROLLBACK

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1840,15 +1840,11 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 		*message = sqlite3_errmsg(gravity_db);
 		log_err("gravityDB_delFromTable(%d) - SQL error prepare(\"%s\"): %s",
 		        listtype, querystr, *message);
+
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-		if(rc != SQLITE_OK)
-		{
-			*message = sqlite3_errmsg(gravity_db);
-			log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-			        listtype, querystr, *message);
-		}
+		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+
 		return false;
 	}
 
@@ -1860,15 +1856,11 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 		        listtype, querystr, *message);
 		sqlite3_reset(stmt);
 		sqlite3_finalize(stmt);
+
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-		if(rc != SQLITE_OK)
-		{
-			*message = sqlite3_errmsg(gravity_db);
-			log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-			        listtype, querystr, *message);
-		}
+		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+
 		return false;
 	}
 
@@ -1888,15 +1880,11 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 		*message = sqlite3_errmsg(gravity_db);
 		log_err("gravityDB_delFromTable(%d) - SQL error prepare(\"%s\"): %s",
 		        listtype, querystr, *message);
+
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-		if(rc != SQLITE_OK)
-		{
-			*message = sqlite3_errmsg(gravity_db);
-			log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-			        listtype, querystr, *message);
-		}
+		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+
 		return false;
 	}
 
@@ -1914,15 +1902,11 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 			        type->valueint, rc, *message);
 			sqlite3_reset(stmt);
 			sqlite3_finalize(stmt);
+
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-			if(rc != SQLITE_OK)
-			{
-				*message = sqlite3_errmsg(gravity_db);
-				log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-				        type->valueint, querystr, *message);
-			}
+			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+
 			return false;
 		}
 
@@ -1936,15 +1920,11 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 			        listtype, rc, *message);
 			sqlite3_reset(stmt);
 			sqlite3_finalize(stmt);
+
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-			if(rc != SQLITE_OK)
-			{
-				*message = sqlite3_errmsg(gravity_db);
-				log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-				        listtype, querystr, *message);
-			}
+			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+
 			return false;
 		}
 
@@ -1956,15 +1936,11 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 			        listtype, querystr, *message);
 			sqlite3_reset(stmt);
 			sqlite3_finalize(stmt);
+
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-			if(rc != SQLITE_OK)
-			{
-				*message = sqlite3_errmsg(gravity_db);
-				log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-				        listtype, querystr, *message);
-			}
+			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+
 			return false;
 		}
 
@@ -2024,13 +2000,7 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-			if(rc != SQLITE_OK)
-			{
-				*message = sqlite3_errmsg(gravity_db);
-				log_err("gravityDB_delFromTable(%d): SQL error exec: %s",
-				        listtype, *message);
-			}
+			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
 
 			break;
 		}
@@ -2048,13 +2018,7 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-		if(rc != SQLITE_OK)
-		{
-			*message = sqlite3_errmsg(gravity_db);
-			log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-			        listtype, querystr, *message);
-		}
+		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
 	}
 
 	// Commit transaction
@@ -2069,13 +2033,7 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
-		if(rc != SQLITE_OK)
-		{
-			*message = sqlite3_errmsg(gravity_db);
-			log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
-			        listtype, querystr, *message);
-		}
+		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
 	}
 
 	return okay;


### PR DESCRIPTION
# What does this implement/fix?

Do not check errors on `ROLLBACK TRANSACTION` when `gravityDB_delFromTable()` fails. We remove this to avoid overwriting the initial cause of the error. See linked Discourse thread for context.

Additional context from [the SQLite3 documentation](https://www.sqlite.org/lang_transaction.html):

> [!TIP]
> 3. Response To Errors Within A Transaction
>
> If certain kinds of errors occur within a transaction, the transaction may or may not be rolled back automatically. The errors that can cause an automatic rollback include:
>
> *   [SQLITE_FULL](https://www.sqlite.org/rescode.html#full): database or disk full
> *   [SQLITE_IOERR](https://www.sqlite.org/rescode.html#ioerr): disk I/O error
> *   [SQLITE_BUSY](https://www.sqlite.org/rescode.html#busy): database in use by another process
> *   [SQLITE_NOMEM](https://www.sqlite.org/rescode.html#nomem): out of memory 
> 
> For all of these errors, SQLite attempts to undo just the one statement it was working on and leave changes from prior statements within the same transaction intact and continue with the transaction. However, depending on the statement being evaluated and the point at which the error occurs, it might be necessary for SQLite to rollback and cancel the entire transaction. An application can tell which course of action SQLite took by using the [sqlite3_get_autocommit()](https://www.sqlite.org/c3ref/get_autocommit.html) C-language interface.
> 
> **It is recommended that applications respond to the errors listed above by explicitly issuing a ROLLBACK command.** If the transaction has already been rolled back automatically by the error response, then the ROLLBACK command will fail with an error, but no harm is caused by this.
>
> Future versions of SQLite may extend the list of errors which might cause automatic transaction rollback. Future versions of SQLite might change the error response. In particular, we may choose to simplify the interface in future versions of SQLite by causing the errors above to force an unconditional rollback.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.