### PR TITLE
Simplify artifacts download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
         if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
         uses: actions/upload-artifact@v4.0.0
         with:
-          name: api-docs
+          name: pihole-api-docs
           path: 'api-docs.tar.gz'
 
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,18 +149,14 @@ jobs:
         uses: actions/download-artifact@v4.1.0
         id: download
         with:
-          path: download/
+          path: ftl_builds/
+          pattern: pihole-*
+          merge-multiple: true
       -
         name: Display structure of downloaded files
         run: ls -R
         working-directory: ${{steps.download.outputs.download-path}}
       
-      - 
-        name: Copy all artifacts from sub-directories to ftl_builds/
-        run: |
-          mkdir ftl_builds/
-          cp ${{steps.download.outputs.download-path}}/**/* ftl_builds/
-
       -
         name: Install SSH Key
         uses: benoitchantre/setup-ssh-authentication-action@1.0.1


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

https://github.com/actions/download-artifact v4.10. added the ability to download multiple artifacts by "pattern" and merge them into a single output directory. This simplifies the artifact download step.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
