### PR TITLE
Amend description of expiration field in GET /dhcp/leases

### DIFF
--- a/src/api/docs/content/specs/dhcp.yaml
+++ b/src/api/docs/content/specs/dhcp.yaml
@@ -76,7 +76,7 @@ components:
             properties:
               expires:
                 type: integer
-                description: Expiration time
+                description: Expiration time (0 = infinite lease, never expires)
                 example: 1675671991
               name:
                 type: string


### PR DESCRIPTION
# What does this implement/fix?

Amend description of expiration field in `GET /dhcp/leases`: 0 means "infinite". No functional changes.

Accompanies but also independent of https://github.com/pi-hole/web/pull/2941

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.