### PR TITLE
Make WAL mode for pihole-FTL.db optional

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -351,6 +351,8 @@ components:
                   type: integer
                 DBinterval:
                   type: integer
+                useWAL:
+                  type: boolean
                 network:
                   type: object
                   properties:
@@ -671,6 +673,7 @@ components:
             DBexport: true
             maxDBdays: 365
             DBinterval: 60
+            useWAL: true
             network:
               parseARPcache: true
               expire: 365

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -816,7 +816,7 @@ void initConfig(struct config *conf)
 	// Note: We would not necessarily need to restart FTL when this setting
 	// is changed, but we do it anyway as this ensures the database is
 	// properly re-initialized and the new journal mode is used. As this is
-	// a setting that will be changed very rarely, this semms the better
+	// a setting that will be changed very rarely, this seems the better
 	// compromise than adding special code that can transform the database
 	// while being active.
 	// The in-memory database is not affected by this setting as it uses a

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -810,6 +810,23 @@ void initConfig(struct config *conf)
 	conf->database.DBinterval.t = CONF_UINT;
 	conf->database.DBinterval.d.ui = 60;
 
+	conf->database.useWAL.k = "database.useWAL";
+	conf->database.useWAL.h = "Should FTL enable Write-Ahead Log (WAL) mode for the on-disk query database (configured via files.database)?\n It is recommended to leave this setting enabled for performance reasons. About the only reason to disable WAL mode is if you are experiencing specific issues with it, e.g., when using a database that is accessed from multiple hosts via a network share. When this setting is disabled, FTL will use SQLite3's default journal mode (rollback journal in DELETE mode).";
+	conf->database.useWAL.t = CONF_BOOL;
+	// Note: We would not necessarily need to restart FTL when this setting
+	// is changed, but we do it anyway as this ensures the database is
+	// properly re-initialized and the new journal mode is used. As this is
+	// a setting that will be changed very rarely, this semms the better
+	// compromise than adding special code that can transform the database
+	// while being active.
+	// The in-memory database is not affected by this setting as it uses a
+	// MEMORY journal mode anyway (there is nothing to be restored after power
+	// loss). The gravity database is also not affected as it is only written
+	// to on an individual basis (explicit API calls) and not continuously
+	// (like the query database).
+	conf->database.useWAL.f = FLAG_ADVANCED_SETTING | FLAG_RESTART_FTL;
+	conf->database.useWAL.d.b = true;
+
 	// sub-struct database.network
 	conf->database.network.parseARPcache.k = "database.network.parseARPcache";
 	conf->database.network.parseARPcache.h = "Should FTL analyze the local ARP cache? When disabled, client identification and the network table will stop working reliably.";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -207,6 +207,7 @@ struct config {
 		struct conf_item DBexport;
 		struct conf_item maxDBdays;
 		struct conf_item DBinterval;
+		struct conf_item useWAL;
 		struct {
 			struct conf_item parseARPcache;
 			struct conf_item expire;

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -123,7 +123,7 @@ bool init_memory_database(void)
 		// - WAL provides more concurrency as readers do not block writers and a
 		//   writer does not block readers. Reading and writing can proceed
 		//   concurrently.
-		// - Disk I/O operations tends to be more sequential using WAL.
+		// - Disk I/O operations tend to be more sequential using WAL.
 		rc = sqlite3_exec(_memdb, "PRAGMA disk.journal_mode=WAL", NULL, NULL, NULL);
 		if( rc != SQLITE_OK )
 		{

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -490,6 +490,15 @@
   # How often do we store queries in FTL's database [seconds]?
   DBinterval = 60
 
+  # Should FTL enable Write-Ahead Log (WAL) mode for the on-disk query database
+  # (configured via files.database)?
+  # It is recommended to leave this setting enabled for performance reasons. About the
+  # only reason to disable WAL mode is if you are experiencing specific issues with it,
+  # e.g., when using a database that is accessed from multiple hosts via a network
+  # share. When this setting is disabled, FTL will use SQLite3's default journal mode
+  # (rollback journal in DELETE mode).
+  useWAL = true
+
   [database.network]
     # Should FTL analyze the local ARP cache? When disabled, client identification and the
     # network table will stop working reliably.


### PR DESCRIPTION
# What does this implement/fix?

Add new config option `database.useWAL` defaulting to true making the use of the WAL journal optional for the on-disk query database. Reasons why this might be useful are given in the description of the new config option:

> **Should FTL enable Write-Ahead Log (WAL) mode for the on-disk query database (configured via files.database)?**
> It is recommended to leave this setting enabled for performance reasons. About the only reason to disable WAL mode is if you are experiencing specific issues with it, e.g., when using a database that is accessed from multiple hosts via a network share. When this setting is disabled, FTL will use SQLite3's default journal mode (rollback journal in DELETE mode).

This PR was initially triggered by [this Discourse thread](https://discourse.pi-hole.net/t/no-query-log-update-anymore-and-no-top-clients-all-and-blocked/67929), however, by now I think that WAL wasn't the issue here but specific user configuration I had not noticed before in the debug log.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.