### PR TITLE
Remove config option database.DBexport

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -345,8 +345,6 @@ components:
               properties:
                 DBimport:
                   type: boolean
-                DBexport:
-                  type: boolean
                 maxDBdays:
                   type: integer
                 DBinterval:
@@ -668,7 +666,6 @@ components:
             refreshNames: IPV4_ONLY
           database:
             DBimport: true
-            DBexport: true
             maxDBdays: 365
             DBinterval: 60
             network:

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -795,15 +795,10 @@ void initConfig(struct config *conf)
 	conf->database.DBimport.t = CONF_BOOL;
 	conf->database.DBimport.d.b = true;
 
-	conf->database.DBexport.k = "database.DBexport";
-	conf->database.DBexport.h =  "Should FTL store queries in the long-term database?";
-	conf->database.DBexport.t = CONF_BOOL;
-	conf->database.DBexport.d.b = true;
-
 	conf->database.maxDBdays.k = "database.maxDBdays";
-	conf->database.maxDBdays.h = "How long should queries be stored in the database [days]?";
-	conf->database.maxDBdays.t = CONF_INT;
-	conf->database.maxDBdays.d.i = (365/4);
+	conf->database.maxDBdays.h = "How long should queries be stored in the database [days]?\n Setting this to 0 disables exporting queries to the database.";
+	conf->database.maxDBdays.t = CONF_UINT;
+	conf->database.maxDBdays.d.ui = (365u/4);
 
 	conf->database.DBinterval.k = "database.DBinterval";
 	conf->database.DBinterval.h = "How often do we store queries in FTL's database [seconds]?";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -204,7 +204,6 @@ struct config {
 
 	struct {
 		struct conf_item DBimport;
-		struct conf_item DBexport;
 		struct conf_item maxDBdays;
 		struct conf_item DBinterval;
 		struct {

--- a/src/config/legacy_reader.c
+++ b/src/config/legacy_reader.c
@@ -132,9 +132,9 @@ const char *readFTLlegacy(struct config *conf)
 		if(value > maxdbdays_max)
 			value = maxdbdays_max;
 
-		// Only use valid values
-		if(value == -1 || value >= 0)
-			conf->database.maxDBdays.v.i = value;
+		// Import value if it is >= than 0, convert negative values
+		// to 0 to disable the database
+		conf->database.maxDBdays.v.ui = value >= 0 ? value : 0;
 	}
 
 	// RESOLVE_IPV6
@@ -177,7 +177,7 @@ const char *readFTLlegacy(struct config *conf)
 		// Use standard path if path was set to zero but override
 		// MAXDBDAYS=0 to ensure no queries are stored in the database
 		conf->files.database.v.s = conf->files.database.d.s;
-		conf->database.maxDBdays.v.i = 0;
+		conf->database.maxDBdays.v.ui = 0;
 	}
 
 	// MAXLOGAGE

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -558,13 +558,9 @@ void db_init(void)
 	dbclose(&db);
 
 	// Log if users asked us to not use the long-term database for queries
-	// We will still use it to store warnings in it
-	config.database.DBexport.v.b = true;
-	if(config.database.maxDBdays.v.i == 0)
-	{
+	// We will still use it to store warnings (Pi-hole diagnosis system)
+	if(config.database.maxDBdays.v.ui == 0)
 		log_info("Not using the database for storing queries");
-		config.database.DBexport.v.b = false;
-	}
 
 	log_info("Database successfully initialized");
 }

--- a/src/main.c
+++ b/src/main.c
@@ -148,7 +148,7 @@ int main (int argc, char *argv[])
 	sleepms(250);
 
 	// Save new queries to database (if database is used)
-	if(config.database.DBexport.v.b)
+	if(config.database.maxDBdays.v.ui > 0)
 	{
 		export_queries_to_disk(true);
 		log_info("Finished final database update");

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -485,6 +485,7 @@
   DBexport = true
 
   # How long should queries be stored in the database [days]?
+  # Setting this to 0 disables exporting queries to the database.
   maxDBdays = 365
 
   # How often do we store queries in FTL's database [seconds]?


### PR DESCRIPTION
# What does this implement/fix?

Remove config option `database.DBexport`. Its implementation was broken by design as its value was always overwritten by the condition (`database.maxDBdays > 0`). Replace it with exactly this condition and document the behavior in the config file.

---

**Related issue or feature (if applicable):** Fixes #1853 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.