### PR TITLE
 Implement selective Teleporter restoring

### DIFF
--- a/src/api/docs/content/specs/teleporter.yaml
+++ b/src/api/docs/content/specs/teleporter.yaml
@@ -42,6 +42,50 @@ components:
                   file:
                     type: string
                     format: binary
+                  import:
+                    type: object
+                    nullable: true
+                    properties:
+                      config:
+                        type: boolean
+                        description: "Import Pi-hole configuration"
+                        example: true
+                      dhcp_leases:
+                        type: boolean
+                        description: "Import Pi-hole DHCP leases"
+                        example: true
+                      gravity:
+                        type: object
+                        properties:
+                          group:
+                            type: boolean
+                            description: "Import Pi-hole's groups table"
+                            example: true
+                          adlist:
+                            type: boolean
+                            description: "Import Pi-hole's adlist table"
+                            example: true
+                          adlist_by_group:
+                            type: boolean
+                            description: "Import Pi-hole's table relating adlist entries to groups"
+                            example: true
+                          domainlist:
+                            type: boolean
+                            description: "Import Pi-hole's domainlist table"
+                            example: true
+                          domainlist_by_group:
+                            type: boolean
+                            description: "Import Pi-hole's table relating domainlist entries to groups"
+                            example: true
+                          client:
+                            type: boolean
+                            description: "Import Pi-hole's client table"
+                            example: true
+                          client_by_group:
+                            type: boolean
+                            description: "Import Pi-hole's table relating client entries to groups"
+                            example: true
+                    description: "A JSON object of files to import. If omitted, all files will be imported."
         responses:
           '200':
             description: OK

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -673,19 +673,22 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 	cJSON *gravity = data->import != NULL ? cJSON_GetObjectItemCaseSensitive(data->import, "gravity") : NULL;
 	for(size_t i = 0; i < sizeof(teleporter_v5_files) / sizeof(struct teleporter_files); i++)
 	{
-		// - if import is NULL we import all files/tables
-		// - if import is non-NULL, but gravity is NULL we skip
-		//   the import of gravity tables
-		// - if import is non-NULL, and gravity is non-NULL, we
-		//   import the file/table if it is in the object, a
-		//   boolean and true
-		if(data->import != NULL || gravity == NULL || !JSON_KEY_TRUE(gravity, teleporter_v5_files[i].table_name))
+		// - if import is non-NULL we may skip some tables
+		if(data->import != NULL)
 		{
-			log_info("Skipping import of \"%s\" as it was not requested for import (JSON: %s, gravity: %s)",
-			         teleporter_v5_files[i].filename,
-			         data->import != NULL ? "yes" : "no",
-			         gravity != NULL ? "yes" : "no");
-			continue;
+			// - if import is non-NULL, but gravity is NULL we skip
+			//   the import of gravity tables altogether
+			// - if import is non-NULL, and gravity is non-NULL, we
+			//   import the file/table if it is in the object, a
+			//   boolean and true
+			if(gravity == NULL || !JSON_KEY_TRUE(gravity, teleporter_v5_files[i].table_name))
+			{
+				log_info("Skipping import of \"%s\" as it was not requested for import (JSON: %s, gravity: %s)",
+				         teleporter_v5_files[i].filename,
+				         data->import != NULL ? "yes" : "no",
+				         gravity != NULL ? "yes" : "no");
+				continue;
+			}
 		}
 
 		// Import the JSON file

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -346,7 +346,7 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 			cJSON *elem = cJSON_ParseWithOpts(value, &json_error, 0);
 			if(elem == NULL)
 			{
-				log_err("Config setting %s is invalid: not valid JSON, error at: %s", conf_item->k, json_error);
+				log_err("Config setting %s is invalid: not valid JSON, error at: %.20s", conf_item->k, json_error);
 				return false;
 			}
 			if(!cJSON_IsArray(elem))

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -620,7 +620,7 @@ int parse_groupIDs(struct ftl_conn *api, tablerow *table, cJSON *row)
 		// Error parsing group_ids, substitute empty array
 		// Note: This should never happen as the database's aggregate
 		//       function should always return a valid JSON array
-		log_err("Error parsing group_ids, error at: %s", json_error);
+		log_err("Error parsing group_ids, error at: %.20s", json_error);
 		JSON_ADD_ITEM_TO_OBJECT(row, "groups", JSON_NEW_ARRAY());
 	}
 	else

--- a/src/webserver/json_macros.h
+++ b/src/webserver/json_macros.h
@@ -254,3 +254,9 @@
 #define JSON_INCREMENT_NUMBER(number_obj, inc)({ \
 	cJSON_SetNumberHelper(number_obj, number_obj->valuedouble + inc); \
 })
+
+// Returns true if the key exists and is true, otherwise false
+#define JSON_KEY_TRUE(obj, key)({ \
+	cJSON *elem = cJSON_GetObjectItemCaseSensitive(obj, key); \
+	elem != NULL ? cJSON_IsTrue(elem) : false; \
+})

--- a/src/zip/teleporter.h
+++ b/src/zip/teleporter.h
@@ -15,7 +15,7 @@
 
 const char *generate_teleporter_zip(mz_zip_archive *zip, char filename[128], void **ptr, size_t *size);
 bool free_teleporter_zip(mz_zip_archive *zip);
-const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char *hint, cJSON *json_files);
+const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char *hint, cJSON *import, cJSON *json_files);
 
 bool write_teleporter_zip_to_disk(void);
 bool read_teleporter_zip_from_disk(const char *filename);


### PR DESCRIPTION
# What does this implement/fix?

Add optional JSON object `.import` to `POST /api/teleporter` that allows the user to pick what is to be restored.
Fixes #1802

![Screenshot](https://github.com/pi-hole/FTL/assets/16748619/a76f3e50-4abe-4d9f-9662-e0c8c1927335)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.