### PR TITLE
DNSSEC validation should not be enabled by default in v6

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -497,7 +497,7 @@ void initConfig(struct config *conf)
 	conf->dns.dnssec.h = "Validate DNS replies using DNSSEC?";
 	conf->dns.dnssec.t = CONF_BOOL;
 	conf->dns.dnssec.f = FLAG_RESTART_FTL;
-	conf->dns.dnssec.d.b = true;
+	conf->dns.dnssec.d.b = false;
 
 	conf->dns.interface.k = "dns.interface";
 	conf->dns.interface.h = "Interface to use for DNS (see also dnsmasq.listening.mode) and DHCP (if enabled)";


### PR DESCRIPTION
# What does this implement/fix?

DNSSEC validation should not be enabled by default - it wasn't in v5, either. The reason for this is that it may be causing issues on devices with broken/missing RTCs where NTP time synchronization relies on DNS resolution

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.