### PR TITLE
Allow adlist duplicates

### DIFF
--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -5,6 +5,7 @@ components:
       summary: Modify list
       parameters:
         - $ref: 'lists.yaml#/components/parameters/list'
+        - $ref: 'lists.yaml#/components/parameters/listtype'
       get:
         summary: Get lists
         tags:
@@ -449,3 +450,14 @@ components:
       required: true
       description: Address of the list
       example: https://hosts-file.net/ad_servers.txt
+    listtype:
+      in: query
+      name: type
+      schema:
+        type: string
+        enum:
+          - "allow"
+          - "block"
+      required: false
+      description: Type of list, optional
+      example: block

--- a/src/enums.h
+++ b/src/enums.h
@@ -189,7 +189,9 @@ enum gravity_list_type {
 	GRAVITY_ADLISTS,
 	GRAVITY_CLIENTS,
 	GRAVITY_GRAVITY,
-	GRAVITY_ANTIGRAVITY
+	GRAVITY_ANTIGRAVITY,
+	GRAVITY_ADLISTS_BLOCK,
+	GRAVITY_ADLISTS_ALLOW
 } __attribute__ ((packed));
 
 enum gravity_tables {

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1420,6 +1420,28 @@
   [[ ${lines[0]} == "145" ]]
 }
 
+@test "Check /api/lists?type=block returning only blocking lists" {
+  run bash -c 'curl -s 127.0.0.1/api/lists?type=block | jq ".lists[].type"'
+  printf "%s\n" "${lines[@]}"
+  # Check no allow entries are present
+  [[ ${lines[@]} != *"allow"* ]]
+}
+
+@test "Check /api/lists?type=allow returning only allowing lists" {
+  run bash -c 'curl -s 127.0.0.1/api/lists?type=allow | jq ".lists[].type"'
+  printf "%s\n" "${lines[@]}"
+  # Check no block entries are present
+  [[ ${lines[@]} != *"block"* ]]
+}
+
+@test "Check /api/lists without type parameter returning all lists" {
+  run bash -c 'curl -s 127.0.0.1/api/lists | jq ".lists[].type"'
+  printf "%s\n" "${lines[@]}"
+  # Check both block and allow entries are present
+  [[ ${lines[@]} == *"allow"* ]]
+  [[ ${lines[@]} == *"block"* ]]
+}
+
 @test "API authorization (without password): No login required" {
   run bash -c 'curl -s 127.0.0.1/api/auth'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
# What does this implement/fix?

Allow narrowing down the (ad)list type using the (optional) query parameter `?type={allow,block}`.

Accompanying change related to https://github.com/pi-hole/pi-hole/pull/5572. See reasoning therein.

This is a feature request submitted on Discourse (see link below).

> [!NOTE]
> This pull requests requires all three Pi-hole components to be checked out
> ```
> pihole checkout core tweak/allow_adlist_dups
> pihole checkout web tweak/allow_adlist_dups
> pihole checkout ftl tweak/allow_adlist_dups
> ```
> for testing

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.