### PR TITLE
Fix spurious "resource limit exceeded" messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,6 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.90)
+set(DNSMASQ_VERSION pi-hole-v2.90+1)
 
 add_subdirectory(src)

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -981,10 +981,10 @@ static void dnssec_validate(struct frec *forward, struct dns_header *header,
 	status = dnssec_validate_reply(now, header, plen, daemon->namebuff, daemon->keyname, &forward->class, 
 				       !option_bool(OPT_DNSSEC_IGN_NS) && (forward->sentto->flags & SERV_DO_DNSSEC),
 				       NULL, NULL, NULL, &orig->validate_counter);
-    }
 
-  if (STAT_ISEQUAL(status, STAT_ABANDONED))
-    log_resource = 1;
+      if (STAT_ISEQUAL(status, STAT_ABANDONED))
+	log_resource = 1;
+    }
   
   /* Can't validate, as we're missing key data. Put this
      answer aside, whilst we get that. */     


### PR DESCRIPTION
# What does this implement/fix?

This PR imports https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commitdiff;h=1ed783b8d7343c42910a61f12a8fc6237eb80417:

> Replies from upstream with a REFUSED rcode can result in log messages stating that a resource limit has been exceeded, which is not the case.

and updates the version of the embedded `dnsmasq` server.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/pihole-unbound-dnsmasq-validation-failed-resource-limit-exeeded/68388

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.