### PR TITLE
Fix revServer importing from former setupVars.conf

### DIFF
--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -175,14 +175,14 @@ static void get_revServer_from_setupVars(void)
 	// Free memory, harmless to call if read_setupVarsconf() didn't return a result
 	clearSetupVarsArray();
 
-	if(active && cidr != NULL && target != NULL && domain != NULL)
+	if(cidr != NULL && target != NULL && domain != NULL)
 	{
 		// Build comma-separated string of all values
-		char *old = calloc(strlen(active_str) + strlen(cidr) + strlen(target) + strlen(domain) + 4, sizeof(char));
+		char *old = calloc(5 + strlen(cidr) + strlen(target) + strlen(domain) + 4, sizeof(char));
 		if(old)
 		{
 			// Add to new config
-			sprintf(old, "%s,%s,%s,%s", active_str, cidr, target, domain);
+			sprintf(old, "%s,%s,%s,%s", active ? "true" : "false", cidr, target, domain);
 			cJSON_AddItemToArray(config.dns.revServers.v.json, cJSON_CreateString(old));
 			free(old);
 		}

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -175,14 +175,17 @@ static void get_revServer_from_setupVars(void)
 	// Free memory, harmless to call if read_setupVarsconf() didn't return a result
 	clearSetupVarsArray();
 
-	if(cidr != NULL && target != NULL && domain != NULL)
+	// Only add the entry if all values are present and active
+	if(active && cidr != NULL && target != NULL && domain != NULL)
 	{
 		// Build comma-separated string of all values
-		char *old = calloc(5 + strlen(cidr) + strlen(target) + strlen(domain) + 4, sizeof(char));
+		// 8 = 3 commas, "true", and null terminator
+		char *old = calloc(strlen(cidr) + strlen(target) + strlen(domain) + 8, sizeof(char));
 		if(old)
 		{
 			// Add to new config
-			sprintf(old, "%s,%s,%s,%s", active ? "true" : "false", cidr, target, domain);
+			// active is always true as we only add active entries
+			sprintf(old, "true,%s,%s,%s", cidr, target, domain);
 			cJSON_AddItemToArray(config.dns.revServers.v.json, cJSON_CreateString(old));
 			free(old);
 		}


### PR DESCRIPTION
# What does this implement/fix?

Use correct variable when migrating possible `revServer` settings from `setupVars.conf` to the new multiple-servers-aware JSON string formulation

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/docker-pi-hole/issues/1550

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.