### PR TITLE
Accelerate CI builds substantially

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -1,0 +1,93 @@
+name: Build and test
+description: Builds and tests FTL on all supported platforms
+
+inputs:
+  platform:
+    required: true
+    description: The platform to build for
+  git_branch:
+    required: true
+    description: The branch to build from
+  git_tag:
+    required: true
+    description: The tag to build from (if any)
+  bin_name:
+    required: true
+    description: The name of the binary to build
+  artifact_name:
+    required: true
+    description: The name of the artifact to upload
+  event_name:
+    required: true
+    description: The name of the event that triggered the workflow run
+
+# Both the definition of environment variables and checking out the code
+# needs to be done outside of the composite action as
+# - environment variables cannot be defined using inputs
+# - the checkout action needs to be the first step in the workflow, otherwise we
+#   cannot use the composite action as the corresponding "action.yml" isn't
+#   there yet
+runs:
+  using: "composite"
+  steps:
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3.1.0
+    -
+      name: Print directory contents
+      shell: bash
+      run: ls -l
+    -
+      name: Build and test FTL in ftl-build container (QEMU)
+      uses: Wandalen/wretry.action@v1.4.5
+      with:
+        attempt_limit: 3
+        action: docker/build-push-action@v5.0.0
+        with: |
+          platforms: ${{ inputs.platform }}
+          pull: true
+          push: false
+          context: .
+          target: result
+          file: .github/Dockerfile
+          outputs: |
+            type=tar,dest=build.tar
+          build-args: |
+            "CI_ARCH=${{ inputs.platform }}"
+            "GIT_BRANCH=${{ inputs.git_branch }}"
+            "GIT_TAG=${{ inputs.git_tag }}"
+    -
+      name: List files in current directory
+      shell: bash
+      run: ls -l
+    -
+      name: Extract FTL binary from container
+      shell: bash
+      run: |
+        tar -xf build.tar pihole-FTL
+    -
+      name: "Generate checksum file"
+      shell: bash
+      run: |
+        mv pihole-FTL "${{ inputs.bin_name }}"
+        sha1sum pihole-FTL-* > ${{ inputs.bin_name }}.sha1
+    -
+      name: Store binary artifacts for later deployoment
+      if: inputs.event_name != 'pull_request'
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: '${{ inputs.bin_name }}*'
+    -
+      name: Extract documentation files from container
+      if: inputs.event_name != 'pull_request' && inputs.platform == 'linux/amd64'
+      shell: bash
+      run: |
+        tar -xf build.tar api-docs.tar.gz
+    -
+      name: Upload documentation artifacts for deployoment
+      if: inputs.event_name != 'pull_request' && inputs.platform == 'linux/amd64'
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: pihole-api-docs
+        path: 'api-docs.tar.gz'

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -20,6 +20,26 @@ inputs:
   event_name:
     required: true
     description: The name of the event that triggered the workflow run
+  actor:
+    required: true
+    description: The name of the user or app that initiated the workflow run
+  target_dir:
+    required: true
+    description: The directory to deploy the artifacts to
+  # Secrets cannot be accessed in the action.yml file so we need to pass them as
+  # inputs to the action.
+  SSH_KEY:
+    required: true
+    description: The SSH private key to use for authentication
+  KNOWN_HOSTS:
+    required: true
+    description: The SSH known hosts file
+  SSH_USER:
+    required: true
+    description: The SSH user to use for authentication
+  SSH_HOST:
+    required: true
+    description: The SSH host to connect to
 
 # Both the definition of environment variables and checking out the code
 # needs to be done outside of the composite action as
@@ -91,3 +111,16 @@ runs:
       with:
         name: pihole-api-docs
         path: 'api-docs.tar.gz'
+    -
+      name: Deploy
+      if: inputs.event_name != 'pull_request'
+      uses: ./.github/actions/deploy
+      with:
+        pattern: ${{ inputs.bin_name }}-binary
+        target_dir: ${{ inputs.target_dir }}
+        event_name: ${{ inputs.event_name }}
+        actor: ${{ inputs.actor }}
+        SSH_KEY: ${{ inputs.SSH_KEY }}
+        KNOWN_HOSTS: ${{ inputs.KNOWN_HOSTS }}
+        SSH_USER: ${{ inputs.SSH_USER }}
+        SSH_HOST: ${{ inputs.SSH_HOST }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,0 +1,83 @@
+name: Deploy
+description: Deploy the FTL binary and documentation
+
+inputs:
+  pattern:
+    required: true
+    description: The pattern to match the artifacts to download
+  target_dir:
+    required: true
+    description: The directory to deploy the artifacts to
+  event_name:
+    required: true
+    description: The name of the event that triggered the workflow run
+  actor:
+    required: true
+    description: The name of the user or app that initiated the workflow run
+  # Secrets cannot be accessed in the action.yml file so we need to pass them as
+  # inputs to the action.
+  SSH_KEY:
+    required: true
+    description: The SSH private key to use for authentication
+  KNOWN_HOSTS:
+    required: true
+    description: The SSH known hosts file
+  SSH_USER:
+    required: true
+    description: The SSH user to use for authentication
+  SSH_HOST:
+    required: true
+    description: The SSH host to connect to
+
+runs:
+  using: "composite"
+  steps:
+    -
+      name: Get Binaries and documentation built in previous jobs
+      uses: actions/download-artifact@v4.1.4
+      id: download
+      with:
+        path: ftl_builds/
+        pattern: ${{ inputs.pattern }}
+        merge-multiple: true
+    -
+      name: Display structure of downloaded files
+      shell: bash
+      run: ls -R
+      working-directory: ${{steps.download.outputs.download-path}}
+    -
+      name: Install SSH Key
+      uses: benoitchantre/setup-ssh-authentication-action@1.0.1
+      with:
+        private-key: ${{ inputs.SSH_KEY }}
+        known-hosts: ${{ inputs.KNOWN_HOSTS }}
+    -
+      name: Untar documentation files
+      working-directory: ftl_builds/
+      shell: bash
+      run: |
+        mkdir docs/
+        tar xzvf api-docs.tar.gz -C docs/
+    -
+      name: Display structure of files ready for upload
+      working-directory: ftl_builds/
+      shell: bash
+      run: ls -R
+    -
+      name: Transfer Builds to Pi-hole server for pihole checkout
+      if: inputs.actor != 'dependabot[bot]'
+      env:
+        USER: ${{ inputs.SSH_USER }}
+        HOST: ${{ inputs.SSH_HOST }}
+        TARGET_DIR: ${{ inputs.target_dir }}
+        SOURCE_DIR: ftl_builds/
+      shell: bash
+      run: |
+        bash ./deploy.sh
+    -
+      name: Attach binaries to release
+      if: inputs.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ftl_builds/*

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -33,13 +33,20 @@ runs:
   using: "composite"
   steps:
     -
-      name: Get binaries (and possibly documentation) built in previous jobs
+      name: Get binaries built in previous jobs
       uses: actions/download-artifact@v4.1.4
       id: download
       with:
         path: ftl_builds/
         pattern: ${{ inputs.pattern }}
         merge-multiple: true
+    -
+      name: Get documentation files built in previous jobs
+      if: inputs.pattern == 'pihole-FTL-amd64-binary'
+      uses: actions/download-artifact@v4.1.4
+      with:
+        path: ftl_builds/
+        name: pihole-api-docs
     -
       name: Display structure of downloaded files
       shell: bash
@@ -50,7 +57,12 @@ runs:
       uses: benoitchantre/setup-ssh-authentication-action@1.0.1
       with:
         private-key: ${{ inputs.SSH_KEY }}
+        private-key-name: id_rsa
         known-hosts: ${{ inputs.KNOWN_HOSTS }}
+    -
+      name: Set private key permissions
+      shell: bash
+      run: chmod 600 ~/.ssh/id_rsa
     -
       name: Untar documentation files
       if: inputs.pattern == 'pihole-FTL-amd64-binary'

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -14,9 +14,6 @@ inputs:
   actor:
     required: true
     description: The name of the user or app that initiated the workflow run
-  upload_docs:
-    required: true
-    description: Whether to upload the documentation to the server
   # Secrets cannot be accessed in the action.yml file so we need to pass them as
   # inputs to the action.
   SSH_KEY:
@@ -56,7 +53,7 @@ runs:
         known-hosts: ${{ inputs.KNOWN_HOSTS }}
     -
       name: Untar documentation files
-      if: inputs.upload_docs == 'true'
+      if: inputs.pattern == 'pihole-FTL-amd64-binary'
       working-directory: ftl_builds/
       shell: bash
       run: |

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -14,6 +14,9 @@ inputs:
   actor:
     required: true
     description: The name of the user or app that initiated the workflow run
+  upload_docs:
+    required: true
+    description: Whether to upload the documentation to the server
   # Secrets cannot be accessed in the action.yml file so we need to pass them as
   # inputs to the action.
   SSH_KEY:
@@ -33,7 +36,7 @@ runs:
   using: "composite"
   steps:
     -
-      name: Get Binaries and documentation built in previous jobs
+      name: Get binaries (and possibly documentation) built in previous jobs
       uses: actions/download-artifact@v4.1.4
       id: download
       with:
@@ -53,6 +56,7 @@ runs:
         known-hosts: ${{ inputs.KNOWN_HOSTS }}
     -
       name: Untar documentation files
+      if: inputs.upload_docs == 'true'
       working-directory: ftl_builds/
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,7 @@ jobs:
           target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           event_name: ${{ github.event_name }}
           actor: ${{ github.actor }}
+          upload_docs: true
           SSH_KEY: ${{ secrets.SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
           SSH_USER: ${{ secrets.SSH_USER }}
@@ -171,6 +172,7 @@ jobs:
           target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           event_name: ${{ github.event_name }}
           actor: ${{ github.actor }}
+          upload_docs: false
           SSH_KEY: ${{ secrets.SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
         shell: bash
 
-  build-gha-x86:
+  gha-x86:
     runs-on: ubuntu-latest
     needs: smoke-tests
     strategy:
@@ -70,22 +70,15 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Build and test FTL
+        name: Build and test and deploy FTL
         uses: ./.github/actions/build-and-test
         with:
           platform: ${{ matrix.platform }}
           bin_name: ${{ matrix.bin_name }}
           artifact_name: ${{ matrix.bin_name }}-binary
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-          event_name: ${{ github.event_name }}
-      -
-        name: Deploy
-        if: github.event_name != 'pull_request'
-        uses: ./.github/actions/deploy
-        with:
-          pattern: ${{ matrix.bin_name }}-binary
-          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           event_name: ${{ github.event_name }}
           actor: ${{ github.actor }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
@@ -93,7 +86,7 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
 
-  build-gha-riscv64:
+  gha-riscv64:
     runs-on: ubuntu-latest
     needs: smoke-tests
     env:
@@ -105,22 +98,15 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Build and test FTL
+        name: Build and test and deploy FTL
         uses: ./.github/actions/build-and-test
         with:
           platform: linux/riscv64
           bin_name: pihole-FTL-riscv64
           artifact_name: pihole-FTL-riscv64-binary
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-          event_name: ${{ github.event_name }}
-      -
-        name: Deploy
-        if: github.event_name != 'pull_request'
-        uses: ./.github/actions/deploy
-        with:
-          pattern: ${{ matrix.bin_name }}-binary
-          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           event_name: ${{ github.event_name }}
           actor: ${{ github.actor }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
@@ -128,7 +114,7 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
 
-  build-self-hosted:
+  self-hosted:
     runs-on: self-hosted
     needs: smoke-tests
     strategy:
@@ -150,22 +136,15 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Build and test FTL
+        name: Build and test and deploy FTL
         uses: ./.github/actions/build-and-test
         with:
           platform: ${{ matrix.platform }}
           bin_name: ${{ matrix.bin_name }}
           artifact_name: ${{ matrix.bin_name }}-binary
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-          event_name: ${{ github.event_name }}
-      -
-        name: Deploy
-        if: github.event_name != 'pull_request'
-        uses: ./.github/actions/deploy
-        with:
-          pattern: ${{ matrix.bin_name }}-binary
-          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           event_name: ${{ github.event_name }}
           actor: ${{ github.actor }}
           SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
         shell: bash
 
-  gha-x86:
+  gha:
     runs-on: ubuntu-latest
     needs: smoke-tests
     strategy:
@@ -61,6 +61,8 @@ jobs:
             bin_name: pihole-FTL-amd64
           - platform: linux/386
             bin_name: pihole-FTL-386
+          - platform: linux/riscv64
+            bin_name: pihole-FTL-riscv64
     env:
       CI_ARCH: ${{ matrix.platform }}
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
@@ -76,34 +78,6 @@ jobs:
           platform: ${{ matrix.platform }}
           bin_name: ${{ matrix.bin_name }}
           artifact_name: ${{ matrix.bin_name }}-binary
-          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
-          git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
-          git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-          event_name: ${{ github.event_name }}
-          actor: ${{ github.actor }}
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-
-  gha-riscv64:
-    runs-on: ubuntu-latest
-    needs: smoke-tests
-    env:
-      CI_ARCH: linux/riscv64
-      GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
-      GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-    steps:
-      -
-        name: Checkout code
-        uses: actions/checkout@v4.1.1
-      -
-        name: Build and test and deploy FTL
-        uses: ./.github/actions/build-and-test
-        with:
-          platform: linux/riscv64
-          bin_name: pihole-FTL-riscv64
-          artifact_name: pihole-FTL-riscv64-binary
           target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,148 +61,46 @@ jobs:
             bin_name: pihole-FTL-amd64
           - platform: linux/386
             bin_name: pihole-FTL-386
-
     env:
       CI_ARCH: ${{ matrix.platform }}
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
       GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-
     steps:
       -
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
-      -
-        name: Print directory contents
-        run: ls -l
-      -
-        name: Build and test FTL in ftl-build container (QEMU)
-        uses: Wandalen/wretry.action@v1.4.5
+        name: Build and test FTL
+        uses: ./.github/actions/build-and-test
         with:
-          attempt_limit: 3
-          action: docker/build-push-action@v5.0.0
-          with: |
-            platforms: ${{ matrix.platform }}
-            pull: true
-            push: false
-            context: .
-            target: result
-            file: .github/Dockerfile
-            outputs: |
-              type=tar,dest=build.tar
-            build-args: |
-              "CI_ARCH=${{ matrix.platform }}"
-              "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
-              "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
-      -
-        name: List files in current directory
-        run: ls -l
-      -
-        name: Extract FTL binary from container
-        run: |
-          tar -xf build.tar pihole-FTL
-      -
-        name: "Generate checksum file"
-        run: |
-          mv pihole-FTL "${{ matrix.bin_name }}"
-          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
-      -
-        name: Store binary artifacts for later deployoment
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: ${{ matrix.bin_name }}-binary
-          path: '${{ matrix.bin_name }}*'
-      -
-        name: Extract documentation files from container
-        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
-        run: |
-          tar -xf build.tar api-docs.tar.gz
-      -
-        name: Upload documentation artifacts for deployoment
-        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: pihole-api-docs
-          path: 'api-docs.tar.gz'
+          platform: ${{ matrix.platform }}
+          bin_name: ${{ matrix.bin_name }}
+          artifact_name: ${{ matrix.bin_name }}-binary
+          git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
+          git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
+          event_name: ${{ github.event_name }}
 
   build-gha-riscv64:
     runs-on: ubuntu-latest
     needs: smoke-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/riscv64
-            bin_name: pihole-FTL-riscv64
-
     env:
-      CI_ARCH: ${{ matrix.platform }}
+      CI_ARCH: linux/riscv64
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
       GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-
     steps:
       -
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
-      -
-        name: Print directory contents
-        run: ls -l
-      -
-        name: Build and test FTL in ftl-build container (QEMU)
-        uses: Wandalen/wretry.action@v1.4.5
+        name: Build and test FTL
+        uses: ./.github/actions/build-and-test
         with:
-          attempt_limit: 3
-          action: docker/build-push-action@v5.0.0
-          with: |
-            platforms: ${{ matrix.platform }}
-            pull: true
-            push: false
-            context: .
-            target: result
-            file: .github/Dockerfile
-            outputs: |
-              type=tar,dest=build.tar
-            build-args: |
-              "CI_ARCH=${{ matrix.platform }}"
-              "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
-              "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
-      -
-        name: List files in current directory
-        run: ls -l
-      -
-        name: Extract FTL binary from container
-        run: |
-          tar -xf build.tar pihole-FTL
-      -
-        name: "Generate checksum file"
-        run: |
-          mv pihole-FTL "${{ matrix.bin_name }}"
-          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
-      -
-        name: Store binary artifacts for later deployoment
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: riscv64-${{ matrix.bin_name }}-binary
-          path: '${{ matrix.bin_name }}*'
-      -
-        name: Extract documentation files from container
-        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
-        run: |
-          tar -xf build.tar api-docs.tar.gz
-      -
-        name: Upload documentation artifacts for deployoment
-        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: pihole-api-docs
-          path: 'api-docs.tar.gz'
+          platform: linux/riscv64
+          bin_name: pihole-FTL-riscv64
+          artifact_name: riscv64-pihole-FTL-riscv64-binary
+          git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
+          git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
+          event_name: ${{ github.event_name }}
 
   build-self-hosted:
     runs-on: self-hosted
@@ -217,72 +115,24 @@ jobs:
             bin_name: pihole-FTL-armv7
           - platform: linux/arm64/v8
             bin_name: pihole-FTL-arm64
-
     env:
       CI_ARCH: ${{ matrix.platform }}
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
       GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-
     steps:
       -
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
-      -
-        name: Print directory contents
-        run: ls -l
-      -
-        name: Build and test FTL in ftl-build container (QEMU)
-        uses: Wandalen/wretry.action@v1.4.5
+        name: Build and test FTL
+        uses: ./.github/actions/build-and-test
         with:
-          attempt_limit: 3
-          action: docker/build-push-action@v5.0.0
-          with: |
-            platforms: ${{ matrix.platform }}
-            pull: true
-            push: false
-            context: .
-            target: result
-            file: .github/Dockerfile
-            outputs: |
-              type=tar,dest=build.tar
-            build-args: |
-              "CI_ARCH=${{ matrix.platform }}"
-              "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
-              "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
-      -
-        name: List files in current directory
-        run: ls -l
-      -
-        name: Extract FTL binary from container
-        run: |
-          tar -xf build.tar pihole-FTL
-      -
-        name: "Generate checksum file"
-        run: |
-          mv pihole-FTL "${{ matrix.bin_name }}"
-          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
-      -
-        name: Store binary artifacts for later deployoment
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: ${{ matrix.bin_name }}-binary
-          path: '${{ matrix.bin_name }}*'
-      -
-        name: Extract documentation files from container
-        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
-        run: |
-          tar -xf build.tar api-docs.tar.gz
-      -
-        name: Upload documentation artifacts for deployoment
-        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: pihole-api-docs
-          path: 'api-docs.tar.gz'
+          platform: ${{ matrix.platform }}
+          bin_name: ${{ matrix.bin_name }}
+          artifact_name: ${{ matrix.bin_name }}-binary
+          git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
+          git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
+          event_name: ${{ github.event_name }}
 
   deploy:
     if: github.event_name != 'pull_request'
@@ -293,50 +143,17 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Get Binaries and documentation built in previous jobs
-        uses: actions/download-artifact@v4.1.4
-        id: download
+        name: Build and test FTL
+        uses: ./.github/actions/deploy
         with:
-          path: ftl_builds/
           pattern: pihole-*
-          merge-multiple: true
-      -
-        name: Display structure of downloaded files
-        run: ls -R
-        working-directory: ${{steps.download.outputs.download-path}}
-      -
-        name: Install SSH Key
-        uses: benoitchantre/setup-ssh-authentication-action@1.0.1
-        with:
-          private-key: ${{ secrets.SSH_KEY }}
-          known-hosts: ${{ secrets.KNOWN_HOSTS }}
-      -
-        name: Untar documentation files
-        working-directory: ftl_builds/
-        run: |
-          mkdir docs/
-          tar xzvf api-docs.tar.gz -C docs/
-      -
-        name: Display structure of files ready for upload
-        run: ls -R
-        working-directory: ftl_builds/
-      -
-        name: Transfer Builds to Pi-hole server for pihole checkout
-        if: github.actor != 'dependabot[bot]'
-        env:
-          USER: ${{ secrets.SSH_USER }}
-          HOST: ${{ secrets.SSH_HOST }}
-          TARGET_DIR: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
-          SOURCE_DIR: ftl_builds/
-        run: |
-          bash ./deploy.sh
-      -
-        name: Attach binaries to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ftl_builds/*
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
+          event_name: ${{ github.event_name }}
+          actor: ${{ github.actor }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
 
   deploy-riscv64:
     if: github.event_name != 'pull_request'
@@ -347,41 +164,14 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.1
       -
-        name: Get Binaries and documentation built in previous jobs
-        uses: actions/download-artifact@v4.1.4
-        id: download
+        name: Build and test FTL
+        uses: ./.github/actions/deploy
         with:
-          path: ftl_builds/
           pattern: riscv64-pihole-*
-          merge-multiple: true
-      -
-        name: Display structure of downloaded files
-        run: ls -R
-        working-directory: ${{steps.download.outputs.download-path}}
-      -
-        name: Install SSH Key
-        uses: benoitchantre/setup-ssh-authentication-action@1.0.1
-        with:
-          private-key: ${{ secrets.SSH_KEY }}
-          known-hosts: ${{ secrets.KNOWN_HOSTS }}
-      -
-        name: Display structure of files ready for upload
-        run: ls -R
-        working-directory: ftl_builds/
-      -
-        name: Transfer Builds to Pi-hole server for pihole checkout
-        if: github.actor != 'dependabot[bot]'
-        env:
-          USER: ${{ secrets.SSH_USER }}
-          HOST: ${{ secrets.SSH_HOST }}
-          TARGET_DIR: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
-          SOURCE_DIR: ftl_builds/
-        run: |
-          bash ./deploy.sh
-      -
-        name: Attach binaries to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ftl_builds/*
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
+          event_name: ${{ github.event_name }}
+          actor: ${{ github.actor }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: smoke-tests
     strategy:
       fail-fast: false
@@ -156,7 +156,6 @@ jobs:
         name: Display structure of downloaded files
         run: ls -R
         working-directory: ${{steps.download.outputs.download-path}}
-      
       -
         name: Install SSH Key
         uses: benoitchantre/setup-ssh-authentication-action@1.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
         shell: bash
 
-  build-x68:
+  build-gha-x86:
     runs-on: ubuntu-latest
     needs: smoke-tests
     strategy:
@@ -128,7 +128,83 @@ jobs:
           name: pihole-api-docs
           path: 'api-docs.tar.gz'
 
-  build-risc:
+  build-gha-riscv64:
+    runs-on: ubuntu-latest
+    needs: smoke-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/riscv64
+            bin_name: pihole-FTL-riscv64
+
+    env:
+      CI_ARCH: ${{ matrix.platform }}
+      GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
+      GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
+
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v4.1.1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.1.0
+      -
+        name: Print directory contents
+        run: ls -l
+      -
+        name: Build and test FTL in ftl-build container (QEMU)
+        uses: Wandalen/wretry.action@v1.4.5
+        with:
+          attempt_limit: 3
+          action: docker/build-push-action@v5.0.0
+          with: |
+            platforms: ${{ matrix.platform }}
+            pull: true
+            push: false
+            context: .
+            target: result
+            file: .github/Dockerfile
+            outputs: |
+              type=tar,dest=build.tar
+            build-args: |
+              "CI_ARCH=${{ matrix.platform }}"
+              "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
+              "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
+      -
+        name: List files in current directory
+        run: ls -l
+      -
+        name: Extract FTL binary from container
+        run: |
+          tar -xf build.tar pihole-FTL
+      -
+        name: "Generate checksum file"
+        run: |
+          mv pihole-FTL "${{ matrix.bin_name }}"
+          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
+      -
+        name: Store binary artifacts for later deployoment
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: riscv64-${{ matrix.bin_name }}-binary
+          path: '${{ matrix.bin_name }}*'
+      -
+        name: Extract documentation files from container
+        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
+        run: |
+          tar -xf build.tar api-docs.tar.gz
+      -
+        name: Upload documentation artifacts for deployoment
+        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: pihole-api-docs
+          path: 'api-docs.tar.gz'
+
+  build-self-hosted:
     runs-on: self-hosted
     needs: smoke-tests
     strategy:
@@ -141,8 +217,6 @@ jobs:
             bin_name: pihole-FTL-armv7
           - platform: linux/arm64/v8
             bin_name: pihole-FTL-arm64
-          - platform: linux/riscv64
-            bin_name: pihole-FTL-riscv64
 
     env:
       CI_ARCH: ${{ matrix.platform }}
@@ -212,7 +286,7 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
-    needs: [smoke-tests, build-x68, build-risc]
+    needs: [smoke-tests, build-gha-x86, build-self-hosted]
     runs-on: ubuntu-latest
     steps:
       -
@@ -242,6 +316,54 @@ jobs:
         run: |
           mkdir docs/
           tar xzvf api-docs.tar.gz -C docs/
+      -
+        name: Display structure of files ready for upload
+        run: ls -R
+        working-directory: ftl_builds/
+      -
+        name: Transfer Builds to Pi-hole server for pihole checkout
+        if: github.actor != 'dependabot[bot]'
+        env:
+          USER: ${{ secrets.SSH_USER }}
+          HOST: ${{ secrets.SSH_HOST }}
+          TARGET_DIR: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
+          SOURCE_DIR: ftl_builds/
+        run: |
+          bash ./deploy.sh
+      -
+        name: Attach binaries to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ftl_builds/*
+
+  deploy-riscv64:
+    if: github.event_name != 'pull_request'
+    needs: [smoke-tests, build-gha-riscv64]
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v4.1.1
+      -
+        name: Get Binaries and documentation built in previous jobs
+        uses: actions/download-artifact@v4.1.4
+        id: download
+        with:
+          path: ftl_builds/
+          pattern: riscv64-pihole-*
+          merge-multiple: true
+      -
+        name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{steps.download.outputs.download-path}}
+      -
+        name: Install SSH Key
+        uses: benoitchantre/setup-ssh-authentication-action@1.0.1
+        with:
+          private-key: ${{ secrets.SSH_KEY }}
+          known-hosts: ${{ secrets.KNOWN_HOSTS }}
       -
         name: Display structure of files ready for upload
         run: ls -R

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
           [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
         shell: bash
 
-  build:
-    runs-on: self-hosted
+  build-x68:
+    runs-on: ubuntu-latest
     needs: smoke-tests
     strategy:
       fail-fast: false
@@ -61,6 +61,80 @@ jobs:
             bin_name: pihole-FTL-amd64
           - platform: linux/386
             bin_name: pihole-FTL-386
+
+    env:
+      CI_ARCH: ${{ matrix.platform }}
+      GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
+      GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
+
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v4.1.1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.1.0
+      -
+        name: Print directory contents
+        run: ls -l
+      -
+        name: Build and test FTL in ftl-build container (QEMU)
+        uses: Wandalen/wretry.action@v1.4.5
+        with:
+          attempt_limit: 3
+          action: docker/build-push-action@v5.0.0
+          with: |
+            platforms: ${{ matrix.platform }}
+            pull: true
+            push: false
+            context: .
+            target: result
+            file: .github/Dockerfile
+            outputs: |
+              type=tar,dest=build.tar
+            build-args: |
+              "CI_ARCH=${{ matrix.platform }}"
+              "GIT_BRANCH=${{ needs.smoke-tests.outputs.GIT_BRANCH }}"
+              "GIT_TAG=${{ needs.smoke-tests.outputs.GIT_TAG }}"
+      -
+        name: List files in current directory
+        run: ls -l
+      -
+        name: Extract FTL binary from container
+        run: |
+          tar -xf build.tar pihole-FTL
+      -
+        name: "Generate checksum file"
+        run: |
+          mv pihole-FTL "${{ matrix.bin_name }}"
+          sha1sum pihole-FTL-* > ${{ matrix.bin_name }}.sha1
+      -
+        name: Store binary artifacts for later deployoment
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: ${{ matrix.bin_name }}-binary
+          path: '${{ matrix.bin_name }}*'
+      -
+        name: Extract documentation files from container
+        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
+        run: |
+          tar -xf build.tar api-docs.tar.gz
+      -
+        name: Upload documentation artifacts for deployoment
+        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64'
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: pihole-api-docs
+          path: 'api-docs.tar.gz'
+
+  build-risc:
+    runs-on: self-hosted
+    needs: smoke-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - platform: linux/arm/v6
             bin_name: pihole-FTL-armv6
           - platform: linux/arm/v7
@@ -138,7 +212,7 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
-    needs: [smoke-tests, build]
+    needs: [smoke-tests, build-x68, build-risc]
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,19 @@ jobs:
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
           event_name: ${{ github.event_name }}
+      -
+        name: Deploy
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/deploy
+        with:
+          pattern: ${{ matrix.bin_name }}-binary
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
+          event_name: ${{ github.event_name }}
+          actor: ${{ github.actor }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
 
   build-gha-riscv64:
     runs-on: ubuntu-latest
@@ -97,10 +110,23 @@ jobs:
         with:
           platform: linux/riscv64
           bin_name: pihole-FTL-riscv64
-          artifact_name: riscv64-pihole-FTL-riscv64-binary
+          artifact_name: pihole-FTL-riscv64-binary
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
           event_name: ${{ github.event_name }}
+      -
+        name: Deploy
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/deploy
+        with:
+          pattern: ${{ matrix.bin_name }}-binary
+          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
+          event_name: ${{ github.event_name }}
+          actor: ${{ github.actor }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
 
   build-self-hosted:
     runs-on: self-hosted
@@ -133,46 +159,15 @@ jobs:
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
           git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
           event_name: ${{ github.event_name }}
-
-  deploy:
-    if: github.event_name != 'pull_request'
-    needs: [smoke-tests, build-gha-x86, build-self-hosted]
-    runs-on: ubuntu-latest
-    steps:
       -
-        name: Checkout code
-        uses: actions/checkout@v4.1.1
-      -
-        name: Build and test FTL
+        name: Deploy
+        if: github.event_name != 'pull_request'
         uses: ./.github/actions/deploy
         with:
-          pattern: pihole-*
+          pattern: ${{ matrix.bin_name }}-binary
           target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           event_name: ${{ github.event_name }}
           actor: ${{ github.actor }}
-          upload_docs: true
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-
-  deploy-riscv64:
-    if: github.event_name != 'pull_request'
-    needs: [smoke-tests, build-gha-riscv64]
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout code
-        uses: actions/checkout@v4.1.1
-      -
-        name: Build and test FTL
-        uses: ./.github/actions/deploy
-        with:
-          pattern: riscv64-pihole-*
-          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
-          event_name: ${{ github.event_name }}
-          actor: ${{ github.actor }}
-          upload_docs: false
           SSH_KEY: ${{ secrets.SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
           SSH_USER: ${{ secrets.SSH_USER }}


### PR DESCRIPTION
# What does this implement/fix?

**Extra short summary:** Reduced build time for almost all binaries from ~30 min to ~3 min

---

**Longer description:**

Building FTL binaries using `buildx` slowed down our CI to roughly 16 minutes per build. If builds sporadically fail, they are repeated and the build needs half an hour. This is quite some unfortunate situation as we need to wait half an hour after pushing a fix until a user can try it.

This PR changes how Pi-hole builds binaries on the CI. Before, we built (and tested!) all binaries in parallel using GHA runners (`x86_64`). Only once all of them were finished, the binaries were uploaded:

![Screenshot-old-CI](https://github.com/pi-hole/FTL/assets/16748619/9217f14f-45c8-450d-afcb-35729dd911a5)

The new method has three partially independent branches:

1. We build `riscv64` on GHA runners
   ![Screenshot from 2024-03-08 09-23-23](https://github.com/pi-hole/FTL/assets/16748619/50574cf0-4060-4559-b8e4-de98a8e4b49e)
2. We build `x86_64` and `i386` in parallel on GHA runners
   ![Screenshot from 2024-03-08 09-23-26](https://github.com/pi-hole/FTL/assets/16748619/0fc0f054-08f7-4406-903f-03b6462d5ef8)
3. We build all `arm` binaries on **self-hosted ARM64-powered runners**
   ![Screenshot from 2024-03-08 09-23-29](https://github.com/pi-hole/FTL/assets/16748619/8b5ab5ea-52ad-4ef0-b08f-35ed1c742c53)

Once `x86_64`, `i386`, and all the `arm` builds are finished (typically **3 minutes** now), we deploy them. The `riscv64` binaries will take a much longer time (there are self-hosted servers available at this point and building them on `arm64` is even slower than on `x86`) but since they are not needed by the vast majority of users, we accept that there is still some larger delay here.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
7. I have commented my proposed changes within the code.
8. I am willing to help maintain this change if there are issues with it later.
9. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
10. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.