### PR TITLE
Add missing validator for database.useWAL

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -866,6 +866,7 @@ void initConfig(struct config *conf)
 	// (like the query database).
 	conf->database.useWAL.f = FLAG_ADVANCED_SETTING | FLAG_RESTART_FTL;
 	conf->database.useWAL.d.b = true;
+	conf->database.useWAL.c = validate_stub; // Only type-based checking
 
 	// sub-struct database.network
 	conf->database.network.parseARPcache.k = "database.network.parseARPcache";


### PR DESCRIPTION
# What does this implement/fix?

https://github.com/pi-hole/FTL/pull/1773 recently added config validation enforcing every config option to have a validator assigned to it. After this PR was created, another https://github.com/pi-hole/FTL/pull/1868 added the new option `database.useWAL` which is now lacking such a validator, causing current `development-v6` builds to fail the tests. This PR fixes this.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.