### PR TITLE
Add searching for domains and clients in the Query Log

### DIFF
--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -293,6 +293,8 @@ int api_queries(struct ftl_conn *api)
 	char sort_dir[16] = { 0 };
 	char sort_col[16] = { 0 };
 
+	char search[2][512] = { { 0 }, { 0 } };
+
 	// We start with the most recent query at the beginning (until the cursor is changed)
 	unsigned long cursor, largest_db_index, mem_dbnum, disk_dbnum;
 	db_counts(&largest_db_index, &mem_dbnum, &disk_dbnum);
@@ -434,6 +436,72 @@ int api_queries(struct ftl_conn *api)
 			else
 				log_warn("Sorting by column %d (%s) requested, but column name not found",
 				         sort_column, sort_dir);
+		}
+
+		// Column searching?
+		// ID 3 = domain, ID 4 = client, every other combination is requested
+		for(unsigned int j = 0; j < 2; j++)
+		{
+			// Encoded URI string: %5B = [ and %5D = ]
+			// columns[X][search][value] is the search string for column X
+			char search_col[] = "columns%5BX%5D%5Bsearch%5D%5Bvalue%5D";
+			search_col[10] = '3' + j;
+			if(GET_STR(search_col, search[j], api->request->query_string) > 0)
+			{
+				// columns[X][data] is the name of column X
+				char search_col_id[] = "columns%5BX%5D%5Bdata%5D";
+				search_col_id[10] = '3' + j;
+
+				// Encoded URI string: %5B = [ and %5D = ]
+				char search_col_id_str[32] = { 0 };
+				if(GET_VAR(search_col_id, search_col_id_str, api->request->query_string) > 0)
+				{
+					size_t searchlen = min(strlen(search[j]), sizeof(search[j]) - 2);
+
+					// Replace "*" by SQLite3 wildcard character "%"
+					for(unsigned int i = 0; i < searchlen; i++)
+					{
+						if(search[j][i] == '*')
+							search[j][i] = '%';
+					}
+
+					// Add % at the end of the search string to
+					// make it a wildcard if there is none
+					if(search[j][searchlen - 1] != '%')
+					{
+						search[j][searchlen] = '%';
+						search[j][searchlen + 1] = '\0';
+						searchlen++;
+					}
+
+					// Add % at the beginning of the search
+					// string to make it a wildcard if there
+					// is none
+					if(search[j][0] != '%')
+					{
+						memmove(search[j] + 1, search[j], searchlen + 1);
+						search[j][0] = '%';
+					}
+
+					// Apply the search string to the query if this is an allowed column
+					if(j == 0 && strcasecmp(search_col_id_str, "domain") == 0)
+					{
+						log_debug(DEBUG_API, "Searching column domain: \"%s\"", search[j]);
+						add_querystr_string(api, querystr, "d.domain LIKE", ":domain_search", &where);
+					}
+					else if(j == 1 && (strcasecmp(search_col_id_str, "client.ip") == 0 || strcasecmp(search_col_id_str, "client") == 0))
+					{
+						log_debug(DEBUG_API, "Searching column client: \"%s\"", search[j]);
+						// We search both client IP and name
+						add_querystr_string(api, querystr, "c.ip LIKE :client_search OR c.name LIKE", ":client_search", &where);
+					}
+					else
+						log_warn("Column %u with name \"%s\" is not searchable (allowed: 3 = domain, 4 = client)",
+						         3 + j, search_col_id_str);
+				}
+				else
+					log_warn("Column %u is not searchable (allowed: 3 = domain, 4 = client)", 3 + j);
+			}
 		}
 	}
 
@@ -716,6 +784,36 @@ int api_queries(struct ftl_conn *api)
 				return send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind count to SQL query",
+				                       sqlite3_errstr(rc));
+			}
+		}
+		idx = sqlite3_bind_parameter_index(read_stmt, ":domain_search");
+		if(idx > 0)
+		{
+			log_debug(DEBUG_API, "adding :domain_search = \"%s\" to query", search[0]);
+			filtering = true;
+			if((rc = sqlite3_bind_text(read_stmt, idx, search[0], -1, SQLITE_STATIC)) != SQLITE_OK)
+			{
+				sqlite3_reset(read_stmt);
+				sqlite3_finalize(read_stmt);
+				return send_json_error(api, 500,
+				                       "internal_error",
+				                       "Internal server error, failed to bind domain_search to SQL query",
+				                       sqlite3_errstr(rc));
+			}
+		}
+		idx = sqlite3_bind_parameter_index(read_stmt, ":client_search");
+		if(idx > 0)
+		{
+			log_debug(DEBUG_API, "adding :client_search = \"%s\" to query", search[1]);
+			filtering = true;
+			if((rc = sqlite3_bind_text(read_stmt, idx, search[1], -1, SQLITE_STATIC)) != SQLITE_OK)
+			{
+				sqlite3_reset(read_stmt);
+				sqlite3_finalize(read_stmt);
+				return send_json_error(api, 500,
+				                       "internal_error",
+				                       "Internal server error, failed to bind client_search to SQL query",
 				                       sqlite3_errstr(rc));
 			}
 		}


### PR DESCRIPTION
# What does this implement/fix?

Add searching for domains and clients in the Query Log. Wildcards (*) are supported everywhere in the search string.

>[!NOTE]
> See https://github.com/pi-hole/web/pull/2980 for further details.

We do not add documentation to the API as this PR merely implements yet another piece of the extremely extensive server-side processing specification of [DataTables](https://datatables.net/).

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.