### PR TITLE
Demote hwmon warning log to debug

### DIFF
--- a/src/api/info.c
+++ b/src/api/info.c
@@ -368,7 +368,7 @@ static int get_hwmon_sensors(struct ftl_conn *api, cJSON *sensors)
 	if(hwmon_dir == NULL)
 	{
 		// Nothing to read here, leave array empty
-		log_warn("Cannot open %s: %s", dirname, strerror(errno));
+		log_debug(DEBUG_API, "Cannot open %s: %s", dirname, strerror(errno));
 		return 0;
 	}
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

While testing various branches and avenues in Docker Desktop on windows - I note the message  "Cannot open /sys/class/hwmon..." pops up every now and again and can fill the log.

Suggested change is to move it to DEBUG_API, unless there is a reason that this should fill up the log when not detected?

Before
![image](https://github.com/pi-hole/FTL/assets/1998970/88c91f38-4a14-4961-8eec-9ccf5c821dfe)

After
![image](https://github.com/pi-hole/FTL/assets/1998970/1fe06dd8-7785-4449-bd28-5c8e9f858e00)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_