### PR TITLE
Allow upper case letters in domains/hosts

### DIFF
--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -54,7 +54,7 @@ inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t 
 		// Domain must not contain any character other than [a-zA-Z0-9.-_]
 		if(domain[i] != '-' && domain[i] != '.' && domain[i] != '_' &&
 		   (domain[i] < 'a' || domain[i] > 'z') &&
-//		   (domain[i] < 'A' || domain[i] > 'Z') && // not needed as all domains are converted to lowercase
+		   (domain[i] < 'A' || domain[i] > 'Z') &&
 		   (domain[i] < '0' || domain[i] > '9'))
 			return false;
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Uncomment some previously commented out code that prevents domains from including upper case letters. See https://discourse.pi-hole.net/t/local-dns-settings-x-invalid-value/68985 for details

Before:

![image](https://github.com/pi-hole/FTL/assets/1998970/c4c3c64b-b9a8-49fa-9eff-bb63a9018abe)

After:

![image](https://github.com/pi-hole/FTL/assets/1998970/16838066-5e84-46d1-af32-a029dac6d64c)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_