### PR TITLE
Ensure env vars survive restart

### DIFF
--- a/src/config/env.c
+++ b/src/config/env.c
@@ -44,9 +44,14 @@ void getEnvVars(void)
 		// Check if this is a FTLCONF_ variable
 		if(strncmp(*env, FTLCONF_PREFIX, sizeof(FTLCONF_PREFIX) - 1) == 0)
 		{
-			// Split key and value
-			char *key = strtok(*env, "=");
-			char *value = strtok(NULL, "=");
+			// Make a copy of the environment variable to avoid
+			// modifying the original string
+			char *env_copy = strdup(*env);
+
+			// Split key and value using strtok_r
+			char *saveptr = NULL;
+			char *key = strtok_r(env_copy, "=", &saveptr);
+			char *value = strtok_r(NULL, "=", &saveptr);
 
 			// Log warning if value is missing
 			if(value == NULL)
@@ -64,6 +69,9 @@ void getEnvVars(void)
 			new_item->allowed = NULL;
 			new_item->next = env_list;
 			env_list = new_item;
+
+			// Free the copy of the environment variable
+			free(env_copy);
 		}
 	}
 


### PR DESCRIPTION
# What does this implement/fix?

Work on a copy of the env vars instead of using `strtok` (modifying the original string) to prevent issues down the line when FTL restarts internally and re-reads them.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.