### PR TITLE
Fix pipe transmission

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -89,19 +89,21 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 		// Read readirected STDERR until EOF
 		if(errbuf != NULL)
 		{
-			// We are only interested in the last pipe line
 			while(read(pipefd[0], errbuf, ERRBUF_SIZE) > 0)
 			{
-				// Remove initial newline character (if present)
-				if(errbuf[0] == '\n')
-					memmove(errbuf, &errbuf[1], ERRBUF_SIZE-1);
+				char *ptr = errbuf;
+				// Remove initial newline characters and '~'s (if present)
+				while(*ptr == '\n' || *ptr == '~') ptr++;
+				memmove(errbuf, ptr, ERRBUF_SIZE - (ptr - errbuf));
+
 				// Strip newline character (if present)
 				if(errbuf[strlen(errbuf)-1] == '\n')
 					errbuf[strlen(errbuf)-1] = '\0';
+
 				// Replace any possible internal newline characters by spaces
-				char *ptr = errbuf;
 				while((ptr = strchr(ptr, '\n')) != NULL)
 					*ptr = ' ';
+
 				log_debug(DEBUG_CONFIG, "dnsmasq pipe: %s", errbuf);
 			}
 		}

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -332,6 +332,16 @@ void my_syslog(int priority, const char *format, ...)
 
   if (echo_stderr) 
     {
+      /********** Pi-hole modification *************/
+      if(only_testing)
+        // Print 32 bytes filled with '~' to the pipe to signal the
+        // beginning of the output. This is necessary as sometimes the
+        // very first bytes of the output are lost in the pipe and we
+        // need to know where the output starts
+        for(int i = 0; i < 32; i++)
+          fputc('~', stderr);
+      /*********************************************/
+
       fprintf(stderr, "dnsmasq%s: ", func);
       va_start(ap, format);
       vfprintf(stderr, format, ap);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1524,7 +1524,7 @@
 
   run bash -c './pihole-FTL --config dns.revServers "[\"true,1.1.1.1,def,ghi\"]"'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == 'New dnsmasq configuration is not valid ('*'Name does not resolve at line '*' of /etc/pihole/dnsmasq.conf.temp: "rev-server=1.1.1.1,def"), config remains unchanged' ]]
+  [[ ${lines[0]} == 'New dnsmasq configuration is not valid (dnsmasq: Name does not resolve at line '*' of /etc/pihole/dnsmasq.conf.temp: "rev-server=1.1.1.1,def"), config remains unchanged' ]]
   [[ $status == 3 ]]
 
   run bash -c './pihole-FTL --config webserver.api.excludeClients "[\".*\",\"$$$\",\"[[[\"]"'


### PR DESCRIPTION
# What does this implement/fix?

Fix pipe transmission from forked dnsmasq process validation changed configurations. This had no real consequences but could lead to missing characters in error messages describing how a new config is invalid (if a user added something invalid). However, as we are testing for this, the CI sometimes automatically retried the jobs *most often* resulting in a success, eventually.

Example for such an issue:
![Screenshot from 2024-03-16 09-21-09](https://github.com/pi-hole/FTL/assets/16748619/a6414082-50eb-49ae-b8be-22675112fb62)
(mind the missing initial 'N' of `Name does not...`)

This PR ensures we properly flush the pipe (by sending 32 bytes of Domestos down the line) before using it so no dirt gets stuck on its way.

Note: Interestingly enough, this has never happened on any of the native builds (not even on the ARM builds on the new ARM64 self-hosted runners) but always only in the emulated `buildx` environments. Currently, this only affects `riscv64`.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.