### PR TITLE
Add new dhcp.logging option

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -318,6 +318,8 @@ components:
                   type: boolean
                 multiDNS:
                   type: boolean
+                logging:
+                  type: boolean
                 hosts:
                   type: array
                   items:
@@ -647,9 +649,10 @@ components:
             router: "192.168.0.1"
             netmask: "0.0.0.0"
             leaseTime: "24h"
-            ipv6: true
-            rapidCommit: true
-            multiDNS: true
+            ipv6: false
+            rapidCommit: false
+            multiDNS: false
+            logging: false
             hosts:
               - "11:22:33:44:55:66,192.168.1.123"
               - "11:22:33:44:55:67,192.168.1.124,hostname"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -778,6 +778,13 @@ void initConfig(struct config *conf)
 	conf->dhcp.rapidCommit.d.b = false;
 	conf->dhcp.rapidCommit.c = validate_stub; // Only type-based checking
 
+	conf->dhcp.logging.k = "dhcp.logging";
+	conf->dhcp.logging.h = "Enable logging for DHCP. This will log all relevant DHCP-related activity, including, e.g., all the options sent to DHCP clients and the tags used to determine them (if any). This can be useful for debugging DHCP issues. The generated output is saved to the file specified by files.log.dnsmasq below.";
+	conf->dhcp.logging.t = CONF_BOOL;
+	conf->dhcp.logging.f = FLAG_RESTART_FTL;
+	conf->dhcp.logging.d.b = false;
+	conf->dhcp.logging.c = validate_stub; // Only type-based checking
+
 	conf->dhcp.hosts.k = "dhcp.hosts";
 	conf->dhcp.hosts.h = "Per host parameters for the DHCP server. This allows a machine with a particular hardware address to be always allocated the same hostname, IP address and lease time or to specify static DHCP leases";
 	conf->dhcp.hosts.a = cJSON_CreateStringReference("Array of static leases each on in one of the following forms: \"[<hwaddr>][,id:<client_id>|*][,set:<tag>][,tag:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]\"");

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -191,6 +191,7 @@ struct config {
 		struct conf_item ipv6;
 		struct conf_item rapidCommit;
 		struct conf_item multiDNS;
+		struct conf_item logging;
 		struct conf_item hosts;
 	} dhcp;
 

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -574,6 +574,15 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 			fprintf(pihole_conf, "dhcp-range=::,constructor:%s,ra-names,ra-stateless,64\n", interface);
 		}
 		fputs("\n", pihole_conf);
+
+		// Enable DHCP logging if requested
+		if(conf->dhcp.logging.v.b)
+		{
+			fputs("# Enable DHCP logging\n", pihole_conf);
+			fputs("log-dhcp\n\n", pihole_conf);
+		}
+
+		// Add per-host parameters
 		if(cJSON_GetArraySize(conf->dhcp.hosts.v.json) > 0)
 		{
 			fputs("# Per host parameters for the DHCP server\n", pihole_conf);

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -427,6 +427,12 @@
   # clients, which should prevent this from happening.
   multiDNS = false
 
+  # Enable logging for DHCP. This will log all relevant DHCP-related activity, including,
+  # e.g., all the options sent to DHCP clients and the tags used to determine them (if
+  # any). This can be useful for debugging DHCP issues. The generated output is saved to
+  # the file specified by files.log.dnsmasq below.
+  logging = false
+
   # Per host parameters for the DHCP server. This allows a machine with a particular
   # hardware address to be always allocated the same hostname, IP address and lease time
   # or to specify static DHCP leases


### PR DESCRIPTION
# What does this implement/fix?

See title. Relevant for debugging/tracing down DHCP issues with a much lower entrance barrier compared to running Wireshark capturing on a remote device (when your Pi-hole is a headless system).

This option default to `false` and be activated as any other config option, too, via
- the API, or
- the CLI (like `sudo pihole-FTL --config dhcp.logging true`), or
- direct interaction with `/etc/pihole/pihole.toml`, or
- by importing a teleporter file where this is already active.

---

**Related issue or feature (if applicable):** See Discourse thread mentioned below.

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.