### PR TITLE
Ensure thread-safety for cJSON engine

### DIFF
--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -461,19 +461,9 @@ int api_auth(struct ftl_conn *api)
 	if(api->method == HTTP_POST)
 	{
 		// Try to extract response from payload
-		if (api->payload.json == NULL)
-		{
-			if (api->payload.json_error == NULL)
-				return send_json_error(api, 400,
-				                       "bad_request",
-				                       "No request body data",
-				                       NULL);
-			else
-				return send_json_error(api, 400,
-				                       "bad_request",
-				                       "Invalid request body data (no valid JSON), error before hint",
-				                       api->payload.json_error);
-		}
+		const int ret = check_json_payload(api);
+		if(ret != 0)
+			return ret;
 
 		// Check if password is available
 		cJSON *json_password;

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -656,19 +656,9 @@ static int api_config_get(struct ftl_conn *api)
 static int api_config_patch(struct ftl_conn *api)
 {
 	// Is there a payload with valid JSON data?
-	if (api->payload.json == NULL)
-	{
-		if (api->payload.json_error == NULL)
-			return send_json_error(api, 400,
-			                       "bad_request",
-			                       "No request body data",
-			                       NULL);
-		else
-			return send_json_error(api, 400,
-			                       "bad_request",
-			                       "Invalid request body data (no valid JSON), error before hint",
-			                       api->payload.json_error);
-	}
+	const int ret = check_json_payload(api);
+	if(ret != 0)
+		return ret;
 
 	// Is there a "config" object at the root of the received JSON payload?
 	cJSON *conf = cJSON_GetObjectItem(api->payload.json, "config");

--- a/src/api/dns.c
+++ b/src/api/dns.c
@@ -74,19 +74,10 @@ static int set_blocking(struct ftl_conn *api)
 		                       NULL);
 	}
 
-	if (api->payload.json == NULL)
-	{
-		if (api->payload.json_error == NULL)
-			return send_json_error(api, 400,
-			                       "bad_request",
-			                       "No request body data",
-			                       NULL);
-		else
-			return send_json_error(api, 400,
-			                       "bad_request",
-			                       "Invalid request body data (no valid JSON), error before hint",
-			                       api->payload.json_error);
-	}
+	// Check if the payload is valid JSON
+	const int ret = check_json_payload(api);
+	if(ret != 0)
+		return ret;
 
 	cJSON *elem = cJSON_GetObjectItemCaseSensitive(api->payload.json, "blocking");
 	if (!cJSON_IsBool(elem))

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -15,6 +15,8 @@
 #include "database/gravity-db.h"
 // match_regex()
 #include "regex_r.h"
+// parse_groupIDs()
+#include "webserver/http-common.h"
 #include <idn2.h>
 
 #define MAX_SEARCH_RESULTS 10000u
@@ -77,19 +79,9 @@ static int search_table(struct ftl_conn *api, const char *item,
 
 		if(table.group_ids != NULL)
 		{
-			// Black magic at work here: We build a JSON array from
-			// the group_concat result delivered from the database,
-			// parse it as valid array and append it as row to the
-			// data
-			const size_t buflen = strlen(table.group_ids)+3u;
-			char *group_ids_str = calloc(buflen, sizeof(char));
-			group_ids_str[0] = '[';
-			strcpy(group_ids_str+1u , table.group_ids);
-			group_ids_str[buflen-2u] = ']';
-			group_ids_str[buflen-1u] = '\0';
-			cJSON * group_ids = cJSON_Parse(group_ids_str);
-			free(group_ids_str);
-			JSON_ADD_ITEM_TO_OBJECT(row, "groups", group_ids);
+			const int ret = parse_groupIDs(api, &table, row);
+			if(ret != 0)
+				return ret;
 		}
 		else
 		{

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -637,9 +637,17 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 		size_t fileSize = 0u;
 		cJSON *json = NULL;
 		const char *file = find_file_in_tar(archive, archive_size, teleporter_v5_files[i].filename, &fileSize);
-		if(file != NULL && fileSize > 0u && (json = cJSON_ParseWithLength(file, fileSize)) != NULL)
+		const char *json_error = NULL;
+		if(file != NULL && fileSize > 0u && (json = cJSON_ParseWithLengthOpts(file, fileSize, &json_error, false)) != NULL)
+		{
 			if(import_json_table(json, &teleporter_v5_files[i]))
 				JSON_COPY_STR_TO_ARRAY(imported_files, teleporter_v5_files[i].filename);
+		}
+		else if(json_error != NULL)
+		{
+			log_err("Unable to parse JSON file \"%s\", error at: %s",
+			        teleporter_v5_files[i].filename, json_error);
+		}
 	}
 
 	// Temporarily write further files to to disk so we can import them on restart

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -342,10 +342,11 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 		}
 		case CONF_JSON_STRING_ARRAY:
 		{
-			cJSON *elem = cJSON_Parse(value);
+			const char *json_error = NULL;
+			cJSON *elem = cJSON_ParseWithOpts(value, &json_error, 0);
 			if(elem == NULL)
 			{
-				log_err("Config setting %s is invalid: not valid JSON, error before: %s", conf_item->k, cJSON_GetErrorPtr());
+				log_err("Config setting %s is invalid: not valid JSON, error at: %s", conf_item->k, json_error);
 				return false;
 			}
 			if(!cJSON_IsArray(elem))

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -11,11 +11,9 @@
 #define GRAVITY_H
 
 // clients data structure
-#include "../datastructure.h"
-// enum http_method
-#include "../webserver/http-common.h"
+#include "datastructure.h"
 // Definition of struct regexData
-#include "../regex_r.h"
+#include "regex_r.h"
 
 // Table row record, not all fields are used by all tables
 typedef struct {

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -29,6 +29,8 @@
 #include "files.h"
 // get_memdb()
 #include "database/query-table.h"
+// escape_html()
+#include "webserver/http-common.h"
 
 static const char *get_message_type_str(const enum message_type type)
 {

--- a/src/dnsmasq/config.h
+++ b/src/dnsmasq/config.h
@@ -31,7 +31,7 @@
 #define FORWARD_TEST 1000 /* try all servers every 1000 queries */
 #define FORWARD_TIME 600 /* or 10 minutes */
 #define UDP_TEST_TIME 60 /* How often to reset our idea of max packet size. */
-#define SERVERS_LOGGED 30 /* Only log this many servers when logging state */
+#define SERVERS_LOGGED 300 /* Only log this many servers when logging state */
 #define LOCALS_LOGGED 8 /* Only log this many local addresses when logging state */
 #define LEASE_RETRY 60 /* on error, retry writing leasefile after LEASE_RETRY seconds */
 #define CACHESIZ 150 /* default cache size */

--- a/src/enums.h
+++ b/src/enums.h
@@ -323,4 +323,21 @@ enum cert_check {
 	CERT_OKAY
 } __attribute__ ((packed));
 
+enum http_method {
+	HTTP_UNKNOWN = 0,
+	HTTP_GET = 1 << 0,
+	HTTP_POST = 1 << 1,
+	HTTP_PUT = 1 << 2,
+	HTTP_PATCH = 1 << 3,
+	HTTP_DELETE = 1 << 4,
+	HTTP_OPTIONS = 1 << 5,
+};
+
+enum api_flags {
+	API_FLAG_NONE = 0,
+	API_DOMAINS = 1 << 0,
+	API_PARSE_JSON = 1 << 1,
+	API_BATCHDELETE = 1 << 2,
+};
+
 #endif // ENUMS_H

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -15,6 +15,8 @@
 #include "webserver/cJSON/cJSON.h"
 // enum fifo_logs
 #include "enums.h"
+// tablerow
+#include "database/gravity-db.h"
 
 // strlen()
 #include <string.h>
@@ -23,22 +25,6 @@
 
 // Maximum size of received and processed payload: 64 KB
 #define MAX_PAYLOAD_BYTES 64*1024
-enum http_method {
-	HTTP_UNKNOWN = 0,
-	HTTP_GET = 1 << 0,
-	HTTP_POST = 1 << 1,
-	HTTP_PUT = 1 << 2,
-	HTTP_PATCH = 1 << 3,
-	HTTP_DELETE = 1 << 4,
-	HTTP_OPTIONS = 1 << 5,
-};
-
-enum api_flags {
-	API_FLAG_NONE = 0,
-	API_DOMAINS = 1 << 0,
-	API_PARSE_JSON = 1 << 1,
-	API_BATCHDELETE = 1 << 2,
-};
 
 struct api_options {
 	enum api_flags flags;
@@ -109,5 +95,7 @@ enum http_method __attribute__((pure)) http_method(struct mg_connection *conn);
 const char* __attribute__((pure)) startsWith(const char *path, struct ftl_conn *api);
 void read_and_parse_payload(struct ftl_conn *api);
 char * __attribute__((malloc)) escape_html(const char *string);
+int check_json_payload(struct ftl_conn *api);
+int parse_groupIDs(struct ftl_conn *api, tablerow *table, cJSON *row);
 
 #endif // HTTP_H

--- a/src/webserver/json_macros.h
+++ b/src/webserver/json_macros.h
@@ -12,10 +12,10 @@
 // logging routines
 #include "log.h"
 
-#define JSON_NEW_OBJECT() cJSON_CreateObject();
-#define JSON_NEW_ARRAY() cJSON_CreateArray();
+#define JSON_NEW_OBJECT() cJSON_CreateObject()
+#define JSON_NEW_ARRAY() cJSON_CreateArray()
 
-#define JSON_ADD_ITEM_TO_ARRAY(array, item) cJSON_AddItemToArray(array, item);
+#define JSON_ADD_ITEM_TO_ARRAY(array, item) cJSON_AddItemToArray(array, item)
 
 #define JSON_COPY_STR_TO_OBJECT(object, key, string)({ \
 	cJSON *string_item = NULL; \

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1368,6 +1368,15 @@
   [[ ${lines[1]} == *"WARNING:     - FTLCONF_dns_upstreams" ]]
 }
 
+@test "cJSON_GetErrorPtr and cJSON_InitHooks are never used (for thread-safety reasons)" {
+  # cJSON_GetErrorPtr() is not thread-safe but can be replaces by cJSON_ParseWithOpts()
+  # cJSON_InitHooks() is only thread-safe if used before any other cJSON function in a thread
+  # We grep for the two functions recursively and exclude cJSON.{c,h} where they are defined
+  run bash -c 'grep -rE "(cJSON_GetErrorPtr)|(cJSON_InitHooks)" src/ | grep -vE "^src/webserver/cJSON/cJSON."'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "" ]]
+}
+
 @test "CLI complains about unknown config key and offers a suggestion" {
   run bash -c './pihole-FTL --config dbg.all'
   [[ ${lines[0]} == "Unknown config option dbg.all, did you mean:" ]]
@@ -1472,7 +1481,7 @@
 
   run bash -c './pihole-FTL --config dns.revServers "abc"'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == 'Config setting dns.revServers is invalid: not valid JSON, error before: abc' ]]
+  [[ ${lines[0]} == 'Config setting dns.revServers is invalid: not valid JSON, error at: abc' ]]
   [[ $status == 2 ]]
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Ensure `cJSON` is used in a thread-safe manner and add CI tests ensuring this. Also ensure every JSON parsing is performing error checking and reduce some code duplication. No functional change.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.