### PR TITLE
Slightly simplify the CI tests

### DIFF
--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1524,7 +1524,7 @@
 
   run bash -c './pihole-FTL --config dns.revServers "[\"true,1.1.1.1,def,ghi\"]"'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == 'New dnsmasq configuration is not valid ('*'Name does not resolve at line '*' of /etc/pihole/dnsmasq.conf.temp: "rev-server=1.1.1.1,def"), config remains unchanged' ]]
+  [[ ${lines[0]} == 'New dnsmasq configuration is not valid ('*'resolve at line '*' of /etc/pihole/dnsmasq.conf.temp: "rev-server=1.1.1.1,def"), config remains unchanged' ]]
   [[ $status == 3 ]]
 
   run bash -c './pihole-FTL --config webserver.api.excludeClients "[\".*\",\"$$$\",\"[[[\"]"'


### PR DESCRIPTION
# What does this implement/fix?

**No functional change**

This PR slightly simplifies the CI tests causing the RISCV64 builds to fail quite frequently. The reason for this is that a few character get lost on their way through the pipe between the testing fork and the controlling process. So far, I do not know why this is happening and first attempts to fix this have failed. When I can find more time to get a proper fix, we will restore this. Until then, this PR ensures we do not have to restart the CI tests a dozen times until they finally succeed by pure luck (because said bytes do not get lost).

This doesn't happen on any other architecture so it may even be a problem with our `qemu` emulation of the processor screwing something up.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.