### PR TITLE
Fix disk space checking on macOS hosts

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -443,14 +443,22 @@ static void format_regex_message(char *plain, const int sizeof_plain, char *html
 	char *escaped_regex = escape_html(regex);
 	char *escaped_warning = escape_html(warning);
 
+	// Return early if memory allocation failed
+	if(escaped_regex == NULL || escaped_warning == NULL)
+	{
+		if(escaped_regex != NULL)
+			free(escaped_regex);
+		if(escaped_warning != NULL)
+			free(escaped_warning);
+		return;
+	}
+
 	if(snprintf(html, sizeof_html, "Encountered an error when processing <a href=\"groups-domains.lp?domainid=%d\">regex %s filter with ID %d</a>: <pre>%s</pre>Error message: <pre>%s</pre>",
 	            dbindex, type, dbindex, escaped_regex, escaped_warning))
 		log_warn("format_regex_message(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_regex != NULL)
-		free(escaped_regex);
-	if(escaped_warning != NULL)
-		free(escaped_warning);
+	free(escaped_regex);
+	free(escaped_warning);
 }
 
 static void format_subnet_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html, const char *ip, const int matching_count, const char *names, const char *matching_ids, const char *chosen_match_text, const int chosen_match_id)
@@ -469,17 +477,26 @@ static void format_subnet_message(char *plain, const int sizeof_plain, char *htm
 	char *escaped_ids = escape_html(matching_ids);
 	char *escaped_names = escape_html(names);
 
+	// Return early if memory allocation failed
+	if(escaped_ip == NULL || escaped_ids == NULL || escaped_names == NULL)
+	{
+		if(escaped_ip != NULL)
+			free(escaped_ip);
+		if(escaped_ids != NULL)
+			free(escaped_ids);
+		if(escaped_names != NULL)
+			free(escaped_names);
+		return;
+	}
+
 	if(snprintf(html, sizeof_html, "Client <code>%s</code> is managed by %i groups (IDs [%s]), all describing the same subnet:<pre>%s</pre>"
 	            "FTL chose the most recent entry (ID %i) to obtain the group configuration for this client.",
 	            escaped_ip, matching_count, escaped_ids, escaped_names, chosen_match_id) > sizeof_html)
 		log_warn("format_subnet_message(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_ip != NULL)
-		free(escaped_ip);
-	if(escaped_ids != NULL)
-		free(escaped_ids);
-	if(escaped_names != NULL)
-		free(escaped_names);
+	free(escaped_ip);
+	free(escaped_ids);
+	free(escaped_names);
 }
 
 static void format_hostname_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html, const char *ip, const char *name, const int pos)
@@ -519,14 +536,24 @@ static void format_hostname_message(char *plain, const int sizeof_plain, char *h
 	char *escaped_ip = escape_html(ip);
 	char *escaped_name = escape_html(namep);
 
+	// Return early if memory allocation failed
+	if(escaped_ip == NULL || escaped_name == NULL)
+	{
+		if(escaped_ip != NULL)
+			free(escaped_ip);
+		if(escaped_name != NULL)
+			free(escaped_name);
+		if(namep != NULL)
+			free(namep);
+		return;
+	}
+
 	if(snprintf(html, sizeof_html, "Host name of client <code>%s</code> => <code>%s</code> contains (at least) one invalid character (hex %02x) at position %i",
 			escaped_ip, escaped_name, (unsigned char)name[pos], pos) > sizeof_html)
 		log_warn("format_hostname_message(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_ip != NULL)
-		free(escaped_ip);
-	if(escaped_name != NULL)
-		free(escaped_name);
+	free(escaped_ip);
+	free(escaped_name);
 	if(namep != NULL)
 		free(namep);
 }
@@ -542,11 +569,14 @@ static void format_dnsmasq_config_message(char *plain, const int sizeof_plain, c
 
 	char *escaped_message = escape_html(message);
 
+	// Return early if memory allocation failed
+	if(escaped_message == NULL)
+		return;
+
 	if(snprintf(html, sizeof_html, "FTL failed to start due to %s.", escaped_message) > sizeof_html)
 		log_warn("format_dnsmasq_config_message(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_message != NULL)
-		free(escaped_message);
+	free(escaped_message);
 }
 
 static void format_rate_limit_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html, const char *clientIP, const unsigned int count, const unsigned int interval, const time_t turnaround)
@@ -561,12 +591,15 @@ static void format_rate_limit_message(char *plain, const int sizeof_plain, char 
 
 	char *escaped_clientIP = escape_html(clientIP);
 
+	// Return early if memory allocation failed
+	if(escaped_clientIP == NULL)
+		return;
+
 	if(snprintf(html, sizeof_html, "Client <code>%s</code> has been rate-limited for at least %lu second%s (current limit: %u queries per %u seconds)",
 			escaped_clientIP, (unsigned long int)turnaround, turnaround == 1 ? "" : "s", count, interval) > sizeof_html)
 		log_warn("format_rate_limit_message(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_clientIP != NULL)
-		free(escaped_clientIP);
+	free(escaped_clientIP);
 }
 
 static void format_dnsmasq_warn_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html, const char *message)
@@ -610,14 +643,22 @@ static void format_shmem_message(char *plain, const int sizeof_plain, char *html
 	char *escaped_path = escape_html(path);
 	char *escaped_msg = escape_html(msg);
 
+	// Return early if memory allocation failed
+	if(escaped_path == NULL || escaped_msg == NULL)
+	{
+		if(escaped_path != NULL)
+			free(escaped_path);
+		if(escaped_msg != NULL)
+			free(escaped_msg);
+		return;
+	}
+
 	if(snprintf(html, sizeof_html, "Shared memory shortage (<code>%s</code>) ahead: <strong>%d%%</strong> is used<br>%s",
 	            escaped_path, shmem, escaped_msg) > sizeof_html)
 		log_warn("log_resource_shortage(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_path != NULL)
-		free(escaped_path);
-	if(escaped_msg != NULL)
-		free(escaped_msg);
+	free(escaped_path);
+	free(escaped_msg);
 }
 
 static void format_disk_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html,
@@ -634,10 +675,22 @@ static void format_disk_message(char *plain, const int sizeof_plain, char *html,
 	char *escaped_path = escape_html(path);
 	char *escaped_msg = escape_html(msg);
 
+	// Return early if memory allocation failed
+	if(escaped_path == NULL || escaped_msg == NULL)
+	{
+		if(escaped_path != NULL)
+			free(escaped_path);
+		if(escaped_msg != NULL)
+			free(escaped_msg);
+		return;
+	}
 
 	if(snprintf(html, sizeof_html, "Disk shortage ahead: <strong>%d%%</strong> is used (%s) on partition containing the file <code>%s</code>",
 	            disk, escaped_msg, escaped_path) > sizeof_html)
 		log_warn("format_disk_message(): Buffer too small to hold HTML message, warning truncated");
+
+	free(escaped_path);
+	free(escaped_msg);
 }
 
 static void format_disk_message_extended(char *plain, const int sizeof_plain, char *html, const int sizeof_html,
@@ -655,16 +708,25 @@ static void format_disk_message_extended(char *plain, const int sizeof_plain, ch
 	char *escaped_mnt_dir = escape_html(mnt_dir);
 	char *escaped_msg = escape_html(msg);
 
+	// Return early if memory allocation failed
+	if(escaped_mnt_type == NULL || escaped_mnt_dir == NULL || escaped_msg == NULL)
+	{
+		if(escaped_mnt_type != NULL)
+			free(escaped_mnt_type);
+		if(escaped_mnt_dir != NULL)
+			free(escaped_mnt_dir);
+		if(escaped_msg != NULL)
+			free(escaped_msg);
+		return;
+	}
+
 	if(snprintf(html, sizeof_html, "Disk shortage ahead: <strong>%d%%</strong> is used (%s) on %s filesystem mounted at <code>%s</code>",
 	            disk, escaped_msg, escaped_mnt_type, escaped_mnt_dir) > sizeof_html)
 		log_warn("format_disk_message_extended(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_mnt_type != NULL)
-		free(escaped_mnt_type);
-	if(escaped_mnt_dir != NULL)
-		free(escaped_mnt_dir);
-	if(escaped_msg != NULL)
-		free(escaped_msg);
+	free(escaped_mnt_type);
+	free(escaped_mnt_dir);
+	free(escaped_msg);
 }
 
 static void format_inaccessible_adlist_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html,
@@ -680,12 +742,15 @@ static void format_inaccessible_adlist_message(char *plain, const int sizeof_pla
 
 	char *escaped_address = escape_html(address);
 
+	// Return early if memory allocation failed
+	if(escaped_address == NULL)
+		return;
+
 	if(snprintf(html, sizeof_html, "<a href=\"groups/lists?listid=%i\">List with ID <strong>%d</strong> (<code>%s</code>)</a> was inaccessible during last gravity run",
 	            dbindex, dbindex, escaped_address) > sizeof_html)
 		log_warn("format_inaccessible_adlist_message(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_address != NULL)
-		free(escaped_address);
+	free(escaped_address);
 }
 
 static void format_certificate_domain_mismatch(char *plain, const int sizeof_plain, char *html, const int sizeof_html,
@@ -701,13 +766,21 @@ static void format_certificate_domain_mismatch(char *plain, const int sizeof_pla
 	char *escaped_certfile = escape_html(certfile);
 	char *escaped_domain = escape_html(domain);
 
+	// Return early if memory allocation failed
+	if(escaped_certfile == NULL || escaped_domain == NULL)
+	{
+		if(escaped_certfile != NULL)
+			free(escaped_certfile);
+		if(escaped_domain != NULL)
+			free(escaped_domain);
+		return;
+	}
+
 	if(snprintf(html, sizeof_html, "SSL/TLS certificate %s does not match domain <strong>%s</strong>!", escaped_certfile, escaped_domain) > sizeof_html)
 		log_warn("format_certificate_domain_mismatch(): Buffer too small to hold HTML message, warning truncated");
 
-	if(escaped_certfile != NULL)
-		free(escaped_certfile);
-	if(escaped_domain != NULL)
-		free(escaped_domain);
+	free(escaped_certfile);
+	free(escaped_domain);
 }
 
 int count_messages(const bool filter_dnsmasq_warnings)

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1234,7 +1234,7 @@ void log_resource_shortage(const double load, const int nprocs, const int shmem,
 
 		// Log to database
 		const int rowid = fsdetails != NULL ?
-			add_message(DISK_MESSAGE_EXTENDED, path, 4, disk, fsdetails->mnt_type, fsdetails->mnt_dir) :
+			add_message(DISK_MESSAGE_EXTENDED, path, 4, disk, msg, fsdetails->mnt_type, fsdetails->mnt_dir) :
 			add_message(DISK_MESSAGE, path, 2, disk, msg);
 
 		if(rowid == -1)

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1206,6 +1206,23 @@ void log_resource_shortage(const double load, const int nprocs, const int shmem,
 		// Get filesystem details for this path
 		struct mntent *fsdetails = get_filesystem_details(path);
 
+		// Log filesystem details if in debug mode
+		if(config.debug.gc.v.b)
+		{
+			if(fsdetails != NULL)
+			{
+				log_debug(DEBUG_GC, "Disk details for path \"%s\":", path);
+				log_debug(DEBUG_GC, "  Device or server for filesystem: %s", fsdetails->mnt_fsname);
+				log_debug(DEBUG_GC, "  Directory mounted on: %s", fsdetails->mnt_dir);
+				log_debug(DEBUG_GC, "  Type of filesystem: %s", fsdetails->mnt_type);
+				log_debug(DEBUG_GC, "  Comma-separated options for fs: %s", fsdetails->mnt_opts);
+				log_debug(DEBUG_GC, "  Dump frequency (in days): %d", fsdetails->mnt_freq);
+				log_debug(DEBUG_GC, "  Pass number for `fsck': %d", fsdetails->mnt_passno);
+			}
+			else
+				log_debug(DEBUG_GC, "Failed to get filesystem details for path \"%s\"", path);
+		}
+
 		// Create plain message
 		if(fsdetails != NULL)
 			format_disk_message_extended(buf, sizeof(buf), NULL, 0, disk, msg, fsdetails->mnt_type, fsdetails->mnt_dir);

--- a/src/files.c
+++ b/src/files.c
@@ -252,6 +252,23 @@ unsigned int get_path_usage(const char *path, char buffer[64])
 	const unsigned long long free = (unsigned long long)f.f_bavail * f.f_bsize;
 	const unsigned long long used = size - free;
 
+	// Print statvfs() results if in debug.gc mode
+	if(config.debug.gc.v.b)
+	{
+		log_debug(DEBUG_GC, "Statvfs() results for %s:", path);
+		log_debug(DEBUG_GC, "  Block size: %lu", f.f_bsize);
+		log_debug(DEBUG_GC, "  Fragment size: %lu", f.f_frsize);
+		log_debug(DEBUG_GC, "  Total blocks: %lu", f.f_blocks);
+		log_debug(DEBUG_GC, "  Free blocks: %lu", f.f_bfree);
+		log_debug(DEBUG_GC, "  Available blocks: %lu", f.f_bavail);
+		log_debug(DEBUG_GC, "  Total inodes: %lu", f.f_files);
+		log_debug(DEBUG_GC, "  Free inodes: %lu", f.f_ffree);
+		log_debug(DEBUG_GC, "  Available inodes: %lu", f.f_favail);
+		log_debug(DEBUG_GC, "  Filesystem ID: %lu", f.f_fsid);
+		log_debug(DEBUG_GC, "  Mount flags: %lu", f.f_flag);
+		log_debug(DEBUG_GC, "  Maximum filename length: %lu", f.f_namemax);
+	}
+
 	// Create human-readable total size
 	char prefix_size[2] = { 0 };
 	double formatted_size = 0.0;

--- a/src/files.c
+++ b/src/files.c
@@ -249,11 +249,13 @@ unsigned int get_path_usage(const char *path, char buffer[64])
 		return 0;
 	}
 
-	// Explicitly cast the block counts to unsigned long long to avoid
-	// overflowing with drives larger than 4 GB on 32bit systems
-	const unsigned long long size = (unsigned long long)f.f_blocks * f.f_frsize;
-	const unsigned long long free = (unsigned long long)f.f_bavail * f.f_bsize;
-	const unsigned long long used = size - free;
+	// Explicitly cast the block counts to uint64_t to avoid overflowing
+	// with drives larger than 4 GB on 32bit systems. Multiply the block
+	// count with the fragment size to get the total size in bytes, see
+	// https://github.com/torvalds/linux/blob/39cd87c4eb2b893354f3b850f916353f2658ae6f/fs/nfs/super.c#L285-L291
+	const uint64_t size = (uint64_t)f.f_blocks * f.f_frsize;
+	const uint64_t free = (uint64_t)f.f_bavail * f.f_frsize;
+	const uint64_t used = size - free;
 
 	// Print statvfs() results if in debug.gc mode
 	if(config.debug.gc.v.b)

--- a/src/files.c
+++ b/src/files.c
@@ -269,11 +269,12 @@ unsigned int get_path_usage(const char *path, char buffer[64])
 	// If size is 0, we return 0% to avoid division by zero below
 	if(size == 0)
 		return 0;
-	// If used is larger than size, we return 100%
-	if(used > size)
-		return 100;
+
 	// Return percentage of used memory at this path (rounded down)
-	return (used*100)/(size + 1);
+	// If the used size is larger than the total size, this intentionally
+	// returns more than 100% so that the caller can handle this case
+	// (this can happen with docker on macOS)
+	return (used * 100) / size;
 }
 
 // Get the filesystem where the given path is located

--- a/src/log.c
+++ b/src/log.c
@@ -407,19 +407,18 @@ void FTL_log_helper(const unsigned char n, ...)
 	free(arg);
 }
 
-void format_memory_size(char prefix[2], const unsigned long long int bytes,
-                        double * const formatted)
+void format_memory_size(char prefix[2], const uint64_t bytes, double * const formatted)
 {
 	unsigned int i;
 	*formatted = bytes;
 	// Determine exponent for human-readable display
-	for(i = 0; i < 7; i++)
+	const char prefixes[] = { '\0', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', '?' };
+	for(i = 0; i < sizeof(prefixes)/sizeof(*prefixes) - 1; i++)
 	{
 		if(*formatted <= 1e3)
 			break;
 		*formatted /= 1e3;
 	}
-	const char prefixes[8] = { '\0', 'K', 'M', 'G', 'T', 'P', 'E', '?' };
 	// Chose matching SI prefix
 	prefix[0] = prefixes[i];
 	prefix[1] = '\0';

--- a/src/log.h
+++ b/src/log.h
@@ -15,6 +15,8 @@
 // enums
 #include "enums.h"
 #include <sys/syslog.h>
+// uint64_t
+#include <stdint.h>
 
 #define DEBUG_ANY 0
 #define TIMESTR_SIZE 84
@@ -43,8 +45,7 @@ extern bool only_testing;
 void clear_debug_flags(void);
 void init_FTL_log(const char *name);
 void log_counter_info(void);
-void format_memory_size(char prefix[2], unsigned long long int bytes,
-                        double * const formatted);
+void format_memory_size(char prefix[2], const uint64_t bytes, double * const formatted);
 void format_time(char buffer[42], unsigned long seconds, double milliseconds);
 unsigned int get_year(const time_t timein);
 const char *get_FTL_version(void);


### PR DESCRIPTION
# What does this implement/fix?

Reintroduce a workaround for docker on macOS accidentally removed in bd266d6 and install proper safeguards around HTML escape code during message generation.

---

**Related issue or feature (if applicable):** #1925 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.