### PR TITLE
Be more verbose in which tables are imported during teleporter importing

### DIFF
--- a/src/api/docs/content/specs/teleporter.yaml
+++ b/src/api/docs/content/specs/teleporter.yaml
@@ -150,4 +150,6 @@ components:
       value:
         processed:
           - etc/pihole/pihole.toml
-          - etc/pihole/gravity.db
+          - etc/pihole/gravity.db->group
+          - etc/pihole/gravity.db->adlist
+          - etc/pihole/gravity.db->adlist_by_group

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -11,6 +11,7 @@
 
 import io
 import ipaddress
+import json
 import random
 import zipfile
 from libs.openAPI import openApi
@@ -23,7 +24,7 @@ class ResponseVerifyer():
 	# Translate between OpenAPI and Python types
 	YAML_TYPES = { "string": [str], "integer": [int], "number": [int, float], "boolean": [bool], "array": [list] }
 	TELEPORTER_FILES_EXPORT = ["etc/pihole/gravity.db", "etc/pihole/pihole.toml", "etc/pihole/pihole-FTL.db", "etc/hosts"]
-	TELEPORTER_FILES_IMPORT = ['etc/pihole/pihole.toml', 'etc/pihole/dhcp.leases', 'etc/pihole/gravity.db']
+	TELEPORTER_FILES_IMPORT = ['etc/pihole/pihole.toml', 'etc/pihole/dhcp.leases', 'etc/pihole/gravity.db->group', 'etc/pihole/gravity.db->adlist', 'etc/pihole/gravity.db->adlist_by_group', 'etc/pihole/gravity.db->domainlist', 'etc/pihole/gravity.db->domainlist_by_group', 'etc/pihole/gravity.db->client', 'etc/pihole/gravity.db->client_by_group' ]
 
 	auth_method = "?"
 	teleporter_archive = None
@@ -229,6 +230,7 @@ class ResponseVerifyer():
 		for expected_file in self.TELEPORTER_FILES_IMPORT:
 			if expected_file not in FTLresponse['files']:
 				self.errors.append("File " + expected_file + " is missing in FTL response")
+				self.errors.append(json.dumps(FTLresponse['files'], indent=4))
 
 		return self.errors
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1788,9 +1788,15 @@
 #  [[ $status == 0 ]]
   run bash -c "./pihole-FTL --teleporter ${filename}"
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[-3]}" == "Imported etc/pihole/pihole.toml" ]]
-  [[ "${lines[-2]}" == "Imported etc/pihole/dhcp.leases" ]]
-  [[ "${lines[-1]}" == "Imported etc/pihole/gravity.db" ]]
+  [[ "${lines[-9]}" == "Imported etc/pihole/pihole.toml" ]]
+  [[ "${lines[-8]}" == "Imported etc/pihole/dhcp.leases" ]]
+  [[ "${lines[-7]}" == "Imported etc/pihole/gravity.db->group" ]]
+  [[ "${lines[-6]}" == "Imported etc/pihole/gravity.db->adlist" ]]
+  [[ "${lines[-5]}" == "Imported etc/pihole/gravity.db->adlist_by_group" ]]
+  [[ "${lines[-4]}" == "Imported etc/pihole/gravity.db->domainlist" ]]
+  [[ "${lines[-3]}" == "Imported etc/pihole/gravity.db->domainlist_by_group" ]]
+  [[ "${lines[-2]}" == "Imported etc/pihole/gravity.db->client" ]]
+  [[ "${lines[-1]}" == "Imported etc/pihole/gravity.db->client_by_group" ]]
   [[ $status == 0 ]]
   run bash -c "rm ${filename}"
 }


### PR DESCRIPTION
# What does this implement/fix?

See title.

#### Before
![grafik](https://github.com/pi-hole/FTL/assets/16748619/d1efd319-99f6-4e9c-82cf-3cf515704f73)

#### After
![grafik](https://github.com/pi-hole/FTL/assets/16748619/33082468-fcb7-462c-8079-df30a3227da7)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.