### PR TITLE
Fix use after free warning in FTLrealloc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,8 @@ set(DEBUG_FLAGS "-rdynamic -fno-omit-frame-pointer")
 # -Wall: This enables all the warnings about constructions that some users consider questionable, and that are easy to avoid (or modify to prevent the warning), even in conjunction with macros. This also enables some language-specific warnings described in C++ Dialect Options and Objective-C and Objective-C++ Dialect Options.
 # -Wextra: This enables some extra warning flags that are not enabled by -Wall.
 # -Wno-unused-parameter: Disable warning for unused parameters. For threads that don't need arguments, we still have to provide a void* args which is then unused.
-set(WARN_FLAGS "-Wall -Wextra -Wno-unused-parameter")
+# -Wuse-after-free=3: Warn about uses of pointers to dynamically allocated objects that have been rendered indeterminate by a call to a deallocation function.
+set(WARN_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wuse-after-free=3")
 
 # Extra warning flags we apply only to the FTL part of the code (used not for foreign code such as dnsmasq and SQLite3)
 # -Werror: Halt on any warnings, useful for enforcing clean code without any warnings (we use it only for our code part)

--- a/src/syscalls/realloc.c
+++ b/src/syscalls/realloc.c
@@ -39,8 +39,8 @@ void __attribute__((alloc_size(2))) *FTLrealloc(void *ptr_in, const size_t size,
 
 	// Handle other errors than EINTR
 	if(ptr_out == NULL)
-		logg("FATAL: Memory reallocation (%p -> %zu) failed in %s() (%s:%i)",
-		     ptr_in, size, func, file, line);
+		logg("FATAL: Memory reallocation (%zu) failed in %s() (%s:%i)",
+		     size, func, file, line);
 
 	// Restore errno value
 	errno = _errno;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix `-Wuse-after-free` warning in FTLrealloc:

```
In file included from /home/william/scratch/public/FTL/src/syscalls/realloc.c:13:
/home/william/scratch/public/FTL/src/syscalls/realloc.c: In function ‘FTLrealloc’:
/home/william/scratch/public/FTL/src/syscalls/../log.h:30:27: error: pointer ‘ptr_in’ may be used after ‘realloc’ [-Werror=use-after-free]
   30 | #define logg(format, ...) _FTL_log(true, false, format, ## __VA_ARGS__)
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/william/scratch/public/FTL/src/syscalls/realloc.c:42:17: note: in expansion of macro ‘logg’
   42 |                 logg("FATAL: Memory reallocation (%p -> %zu) failed in %s() (%s:%i)",
      |                 ^~~~
/home/william/scratch/public/FTL/src/syscalls/realloc.c:31:27: note: call to ‘realloc’ here
   31 |                 ptr_out = realloc(ptr_in, size);
      |                           ^~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

**How does this PR accomplish the above?:**

Remove the reference to the indeterminate pointer after the call to `realloc`.
Increase the warning to `-Wuse-after-free=3`.

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
