### PR TITLE
Fix a crash resulting from a bad interaction between PRs #1928 and #1930

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1418,7 +1418,7 @@ void log_connection_error(const char *server, const char *reason, const char *er
 	log_warn("%s", buf);
 
 	// Log to database
-	const int rowid = add_message(CONNECTION_ERROR_MESSAGE, server, 2, reason, error);
+	const int rowid = add_message(CONNECTION_ERROR_MESSAGE, server, reason, error);
 
 	if(rowid == -1)
 		log_err("logg_connection_error(): Failed to add message to database");


### PR DESCRIPTION
# What does this implement/fix?

Fix a crash resulting from a bad interaction between PRs #1928 and #1930. The fix is very simple: #1928 made it unnecessary to specify the number of following arguments. Unfortunately, current `development-v6` misinterprets this causing a crash as reported in #1935 

**Related issue or feature (if applicable):** fixes #1935 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.