### PR TITLE
Provide human-readable message for session status

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -113,6 +113,7 @@ int api_handler(struct mg_connection *conn, void *ignored)
 		http_method(conn),
 		NULL,
 		NULL,
+		NULL,
 		API_AUTH_UNAUTHORIZED,
 		double_time(),
 		{ false, NULL, NULL, NULL, 0u },

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -82,7 +82,7 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 	// This may be allowed without authentication depending on the configuration
 	if(!config.webserver.api.localAPIauth.v.b && is_local_api_user(api->request->remote_addr))
 	{
-		api->message = "no auth for local user";
+		api->message = "no auth required for local user";
 		add_request_info(api, NULL);
 		return API_AUTH_LOCALHOST;
 	}

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -280,6 +280,7 @@ components:
             - sid
             - csrf
             - validity
+            - message
             - totp
           properties:
             valid:
@@ -299,6 +300,10 @@ components:
             validity:
               type: integer
               description: Remaining lifetime of this session unless refreshed (seconds)
+            message:
+              type: string
+              description: Human-readable message describing the session status
+              nullable: true
 
     password:
       type: object
@@ -431,7 +436,7 @@ components:
 
   examples:
     auth_okay:
-      summary: Authentication valid
+      summary: Session valid
       value:
         session:
           valid: true
@@ -439,6 +444,7 @@ components:
           sid: null
           csrf: null
           validity: 300
+          message: null
     login_okay:
       summary: Login successful
       value:
@@ -448,6 +454,7 @@ components:
           sid: "vFA+EP4MQ5JJvJg+3Q2Jnw="
           csrf: "Ux87YTIiMOf/GKCefVIOMw="
           validity: 300
+          message: correct password
     no_login_required:
       summary: No login required for this client
       value:
@@ -457,6 +464,7 @@ components:
           sid: null
           csrf: null
           validity: -1
+          message: no auth for local user
     login_required:
       summary: Login required, 2FA disabled
       value:
@@ -466,6 +474,7 @@ components:
           sid: null
           csrf: null
           validity: -1
+          message: password incorrect
     login_required_2fa:
       summary: Login required, 2FA enabled
       value:
@@ -475,6 +484,7 @@ components:
           sid: null
           csrf: null
           validity: -1
+          message: password incorrect
     login_failed:
       summary: Login failed
       value:
@@ -484,6 +494,7 @@ components:
           sid: null
           csrf: null
           validity: -1
+          message: no SID provided
     errors:
       no_payload:
         summary: Bad request (no valid JSON payload)

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -37,6 +37,7 @@ struct ftl_conn {
 	const enum http_method method;
 	char *action_path;
 	const char *item;
+	const char *message;
 	int user_id;
 	double now;
 	struct {

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -162,8 +162,10 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 			free(target);
 
 			// User is not authenticated, redirect to login page
-			log_web("Authentication required, redirecting to %slogin?target=%s", config.webserver.paths.webhome.v.s, encoded_target);
-			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %slogin?target=%s\r\n\r\n", config.webserver.paths.webhome.v.s, encoded_target);
+			log_web("Authentication required, redirecting to %slogin?target=%s",
+			        config.webserver.paths.webhome.v.s, encoded_target);
+			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %slogin?target=%s\r\n\r\n",
+			          config.webserver.paths.webhome.v.s, encoded_target);
 			free(encoded_target);
 			return 302;
 		}


### PR DESCRIPTION
# What does this implement/fix?

Improve debugging for users developing third-party applications/interfaces that need to authenticate with the Pi-hole API.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.