### PR TITLE
Improve API /clients documentation

### DIFF
--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -11,7 +11,7 @@ components:
           - "Client management"
         operationId: "get_clients"
         description: |
-          `{client}` is optional. Specifying it will result in only the requested client being returned.
+          `{client}` is optional. If it is specified, it will result in only the requested client being returned. This parameter needs to be URI-encoded.
 
           Valid combinations are:
           - `/api/clients` (all clients)
@@ -42,7 +42,7 @@ components:
           - "Client management"
         operationId: "replace_client"
         description: |
-          Items may be updated by replacing them. `{client}` is required.
+          Items may be updated by replacing them. `{client}` is required and needs to be URI-encoded.
 
           Ensure to send all the required parameters (such as `comment` or `groups`) to ensure these properties are retained.
           The read-only fields `id` and `date_added` are preserved, `date_modified` is automatically updated on success.
@@ -91,7 +91,7 @@ components:
           - "Client management"
         operationId: "delete_client"
         description: |
-          *Note:* There will be no content on success.
+          *Note:* There will be no content on success. `{client}` is required and needs to be URI-encoded.
         responses:
           '204':
             description: Item deleted
@@ -383,6 +383,12 @@ components:
           type: integer
           readOnly: true
           example: 1611239099
+        name:
+          description: hostname (only if available)
+          type: string
+          readOnly: true
+          nullable: true
+          example: localhost
     lists_processed:
       type: object
       properties:


### PR DESCRIPTION
# What does this implement/fix?

Documentation-only change for API `/clients`: Add note that `{client}` needs to be URI-encoded (if specified) and add documentation of read-only optional `{name}` field.

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/1943

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.