### PR TITLE
Exit after fatal dnsmasq errors

### DIFF
--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -511,4 +511,6 @@ void die(char *message, char *arg1, int exit_code)
   /********** Pi-hole modification *************/
   FTL_log_dnsmasq_fatal(message, arg1, errmess);
   /*********************************************/
+
+  exit(exit_code);
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug introduced in https://github.com/pi-hole/FTL/pull/1881 where fatal `dnsmasq` config line errors can lead to FTL crashing after logging that there is a fatal event. The expected behavior is to cleanly return an error code instead of crashing which is restored by this PR.

This small fix is meant to go out as **FTL v5.25.2**

---

**Related issue or feature (if applicable):** Fixes #1942 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.