### PR TITLE
Avoid use-after-free warning

### DIFF
--- a/src/syscalls/realloc.c
+++ b/src/syscalls/realloc.c
@@ -29,6 +29,8 @@ void __attribute__((alloc_size(2))) *FTLrealloc(void *ptr_in, const size_t size,
 	{
 		errno = 0;
 		ptr_out = realloc(ptr_in, size);
+		if(ptr_out != NULL)
+			ptr_in = NULL;
 	}
 	// Try again to allocate memory if this failed due to an interruption by
 	// an incoming signal

--- a/src/tre-regex/xmalloc.c
+++ b/src/tre-regex/xmalloc.c
@@ -340,6 +340,7 @@ xrealloc_impl(void *ptr, size_t new_size, const char *file, int line,
   new_ptr = realloc(ptr, new_size);
   if (new_ptr != NULL)
     {
+      ptr = NULL;
       hash_table_del(xmalloc_table, ptr);
       hash_table_add(xmalloc_table, new_ptr, (int)new_size, file, line, func);
     }


### PR DESCRIPTION
More recent versions of GCC try to check for use after free. Realloc will take the input pointer, `ptr_in` and with free it after a successful allocation. However, it will not change the contents of the pointer, and thus GCC in some cases thinks it can/could be used. By explicitly setting `ptr_in` to NULL after an successful allocation, we can keep GCC happy and our codebase sane.

```
In file included from /workdir/src/FTL-5.25.2/src/syscalls/realloc.c:13:
/workdir/src/FTL-5.25.2/src/syscalls/realloc.c: In function 'FTLrealloc':
/workdir/src/FTL-5.25.2/src/syscalls/../log.h:30:27: error: pointer 'ptr_in' may be used after 'realloc' [-Werror=use-after-free]
   30 | #define logg(format, ...) _FTL_log(true, false, format, ## __VA_ARGS__)
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/workdir/src/FTL-5.25.2/src/syscalls/realloc.c:42:17: note: in expansion of macro 'logg'
   42 |                 logg("FATAL: Memory reallocation (%p -> %zu) failed in %s() (%s:%i)",
      |                 ^~~~
/workdir/src/FTL-5.25.2/src/syscalls/realloc.c:31:27: note: call to 'realloc' here
   31 |                 ptr_out = realloc(ptr_in, size);
      |                           ^~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
