### PR TITLE
Fix spilled queries in database

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -126,7 +126,7 @@
 
 // REPLY_TIMEOUT defines until how far back in the history of queries we are
 // checking for changed/updated queries. This value should not be set too high
-// to avoid unecessary spinning in the updating loop of the queries running
+// to avoid unnecessary spinning in the updating loop of the queries running
 // every second. The value should be set to a value that is high enough to
 // catch all queries that are still in the process of being resolved.
 // Default: 30 [seconds]

--- a/src/FTL.h
+++ b/src/FTL.h
@@ -124,12 +124,13 @@
 // Default: 180 [seconds]
 #define DELAY_UPTIME 180
 
-// DB_QUERY_MAX_ITER defines how many queries we check periodically for updates to be added
-// to the in-memory database. This value may need to be increased on *very* busy systems.
-// However, there is an algorithm in place that tries to ensure we are not missing queries
-// on systems with > 100 queries per second
-// Default: 100 (per second)
-#define DB_QUERY_MAX_ITER 100
+// REPLY_TIMEOUT defines until how far back in the history of queries we are
+// checking for changed/updated queries. This value should not be set too high
+// to avoid unecessary spinning in the updating loop of the queries running
+// every second. The value should be set to a value that is high enough to
+// catch all queries that are still in the process of being resolved.
+// Default: 30 [seconds]
+#define REPLY_TIMEOUT 30
 
 // Special exit code used to signal that FTL wants to restart
 #define RESTART_FTL_CODE 22


### PR DESCRIPTION
# What does this implement/fix?

Improve query storing algorithm to better cope with bursts of queries of arbitrary size and frequency. See related Discourse bug chasing for further details.

This is overall an improvement as the new strategy guarantees that no queries can be lost on one hand and drastically reduces the workload on the other hand by using persistent prepared statements instead of compiling them once per second.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.