### PR TITLE
Fix error message mentioning wrong file

### DIFF
--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -181,7 +181,7 @@ const char *generate_teleporter_zip(mz_zip_archive *zip, char filename[128], voi
 	if(file_exists(file_path) && !mz_zip_writer_add_file(zip, file_path+1, file_path, file_comment, (uint16_t)strlen(file_comment), MZ_BEST_COMPRESSION))
 	{
 		mz_zip_writer_end(zip);
-		return "Failed to add /etc/hosts to heap ZIP archive!";
+		return "Failed to add /etc/pihole/dhcp.leases to heap ZIP archive!";
 	}
 
 	const char *directory = "/etc/dnsmasq.d";


### PR DESCRIPTION
While browsing through the code I noticed this:

```c
// Add /etc/pihole/dhcp.lease to the ZIP archive if it exists
file_comment = "DHCP leases file";
file_path = "/etc/pihole/dhcp.leases";
if(file_exists(file_path) && !mz_zip_writer_add_file(zip, file_path+1, file_path, file_comment, (uint16_t)strlen(file_comment), MZ_BEST_COMPRESSION))
{
	mz_zip_writer_end(zip);
	return "Failed to add /etc/hosts to heap ZIP archive!"; // <--- definitely should not mention /etc/hosts here
}
```

This might lead to user confusion one day so it's better to correct it.

---

**What does this PR aim to accomplish?:**

Corrects error message mentioning `/etc/hosts` instead of `/etc/pihole/dhcp.leases` in [teleporter.c:184](https://github.com/pi-hole/FTL/blob/development-v6/src/zip/teleporter.c#L184).

**How does this PR accomplish the above?:**

I edited it.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*