### PR TITLE
Add artifact attestation

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -99,6 +99,11 @@ runs:
         name: ${{ inputs.artifact_name }}
         path: '${{ inputs.bin_name }}*'
     -
+      name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: ${{ inputs.bin_name }}
+    -
       name: Extract documentation files from container
       if: inputs.event_name != 'pull_request' && inputs.platform == 'linux/amd64'
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build, Test, Deploy
 
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
# What does this implement/fix?

Creating a tamper-proof papertrail for all FTL binaries we build on Github Actions:



```
$ gh attestation verify pihole-FTL-amd64 -o pi-hole

Loaded digest sha256:67e7d2451a29ff3cd21c4a7c489ac4b1d43993f4a69bf9fbe989dda47f24685e for file://pihole-FTL-amd64
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:67e7d2451a29ff3cd21c4a7c489ac4b1d43993f4a69bf9fbe989dda47f24685e was attested by:
REPO         PREDICATE_TYPE                  WORKFLOW                                                        
pi-hole/FTL  https://slsa.dev/provenance/v1  .github/workflows/build.yml@refs/heads/new/artifact_attestations
```

tested using `gh 2.49.2` on Ubuntu 24.04 LTS

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.