### PR TITLE
Fix compiling without mbedTLS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,15 +249,15 @@ add_custom_target(
         COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -P ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.cmake
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(FTL OBJECT ${sources})
-target_compile_options(FTL PRIVATE ${EXTRAWARN})
-target_compile_definitions(FTL PRIVATE DNSMASQ_VERSION=\"${DNSMASQ_VERSION}\")
-target_include_directories(FTL PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_dependencies(FTL gen_version)
+add_library(core OBJECT ${sources})
+target_compile_options(core PRIVATE ${EXTRAWARN})
+target_compile_definitions(core PRIVATE DNSMASQ_VERSION=\"${DNSMASQ_VERSION}\")
+target_include_directories(core PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_dependencies(core gen_version)
 
 
 add_executable(pihole-FTL
-        $<TARGET_OBJECTS:FTL>
+        $<TARGET_OBJECTS:core>
         $<TARGET_OBJECTS:api>
         $<TARGET_OBJECTS:api_docs>
         $<TARGET_OBJECTS:webserver>
@@ -303,15 +303,26 @@ if(LUA_DL STREQUAL "true")
     target_link_libraries(pihole-FTL ${LIBDL})
 endif()
 
+add_subdirectory(api)
+add_subdirectory(webserver)
+add_subdirectory(zip)
+add_subdirectory(database)
+add_subdirectory(dnsmasq)
+add_subdirectory(lua)
+add_subdirectory(lua/scripts)
+add_subdirectory(tre-regex)
+add_subdirectory(syscalls)
+add_subdirectory(config)
+add_subdirectory(tools)
+
 find_library(LIBREADLINE NAMES libreadline${CMAKE_STATIC_LIBRARY_SUFFIX} readline)
 find_library(LIBHISTORY NAMES libhistory${CMAKE_STATIC_LIBRARY_SUFFIX} history)
 find_library(LIBTERMCAP NAMES libtermcap${CMAKE_STATIC_LIBRARY_SUFFIX} termcap)
 if(LIBREADLINE AND LIBHISTORY AND LIBTERMCAP)
     message(STATUS "Building FTL with readline support: YES")
-    target_compile_definitions(FTL PRIVATE LUA_USE_READLINE)
-    target_compile_definitions(pihole-FTL PRIVATE LUA_USE_READLINE)
+    target_compile_definitions(lua PRIVATE LUA_USE_READLINE)
+    target_compile_definitions(sqlite3 PRIVATE HAVE_READLINE)
     target_link_libraries(pihole-FTL ${LIBREADLINE} ${LIBHISTORY} ${LIBTERMCAP})
-    set(HAVE_READLINE TRUE)
 else()
     message(STATUS "Building FTL with readline support: NO")
 endif()
@@ -342,9 +353,17 @@ find_library(LIBMBEDCRYPTO NAMES lmbedcrypto${CMAKE_STATIC_LIBRARY_SUFFIX} mbedc
 find_library(LIBMBEDX509 NAMES lmbedx509${CMAKE_STATIC_LIBRARY_SUFFIX} mbedx509)
 find_library(LIBMBEDTLS NAMES lmbedtls${CMAKE_STATIC_LIBRARY_SUFFIX} mbedtls)
 if(LIBMBEDCRYPTO AND LIBMBEDX509 AND LIBMBEDTLS)
+    # Enable TLS support in civetweb if mbedTLS is available
+    message(STATUS "Building FTL with TLS support: YES")
+    target_compile_definitions(core PRIVATE HAVE_MBEDTLS)
+    target_compile_definitions(civetweb PRIVATE USE_MBEDTLS)
+    target_compile_definitions(webserver PRIVATE HAVE_MBEDTLS)
     # Link against the mbedTLS libraries, the order is important (!)
-    target_compile_definitions(FTL PRIVATE HAVE_MBEDTLS)
     target_link_libraries(pihole-FTL ${LIBMBEDTLS} ${LIBMBEDX509} ${LIBMBEDCRYPTO})
+else()
+    # Disable TLS support in civetweb if mbedTLS is not available
+    message(STATUS "Building FTL with TLS support: NO")
+    target_compile_definitions(civetweb PRIVATE NO_SSL)
 endif()
 
 find_program(SETCAP setcap)
@@ -353,14 +372,3 @@ install(TARGETS pihole-FTL
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 install(CODE "execute_process(COMMAND ${SETCAP} CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN+eip \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/pihole-FTL)")
 
-add_subdirectory(api)
-add_subdirectory(webserver)
-add_subdirectory(zip)
-add_subdirectory(database)
-add_subdirectory(dnsmasq)
-add_subdirectory(lua)
-add_subdirectory(lua/scripts)
-add_subdirectory(tre-regex)
-add_subdirectory(syscalls)
-add_subdirectory(config)
-add_subdirectory(tools)

--- a/src/args.c
+++ b/src/args.c
@@ -750,11 +750,12 @@ void parse_args(int argc, char* argv[])
 			printf("\n");
 			printf("****************************** %s%sCivetWeb%s *****************************\n",
 			       yellow, bold, normal);
-#ifdef MBEDTLS_VERSION_STRING_FULL
+#ifdef HAVE_MBEDTLS
 			printf("Version:         %s%s%s%s with %smbed TLS %s%s"MBEDTLS_VERSION_STRING"%s\n",
 			       green, bold, mg_version(), normal, yellow, green, bold, normal);
 #else
-			printf("Version:         %s%s%s%s\n", green, bold, mg_version(), normal);
+			printf("Version:         %s%s%s%s%s without %smbed TLS%s\n",
+			       green, bold, mg_version(), normal, red, yellow, normal);
 #endif
 			printf("Features:        ");
 			if(mg_check_feature(MG_FEATURES_FILES))

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -78,11 +78,4 @@ if(LUA_DL STREQUAL "true")
     target_compile_definitions(lua PRIVATE LUA_USE_DLOPEN)
 endif()
 
-if(LIBREADLINE AND LIBHISTORY AND LIBTERMCAP)
-    message(STATUS "Embedded LUA will use readline for history: YES")
-    target_compile_definitions(lua PRIVATE LUA_USE_READLINE)
-else()
-    message(STATUS "Embedded LUA will use readline for history: NO")
-endif()
-
 target_include_directories(lua PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/src/lua)

--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -20,7 +20,7 @@
 #include "../files.h"
 // get_web_theme_str
 #include "../datastructure.h"
-#if HAVE_READLINE
+#if LUA_USE_READLINE
 #include <readline/history.h>
 #endif
 #include <wordexp.h>

--- a/src/webserver/civetweb/CMakeLists.txt
+++ b/src/webserver/civetweb/CMakeLists.txt
@@ -32,16 +32,5 @@ target_compile_definitions(civetweb PRIVATE NO_CGI
                                             USE_LUA
                                             TIMER_RESOLUTION=1000)
 
-if(LIBMBEDCRYPTO AND LIBMBEDX509 AND LIBMBEDTLS)
-    # Enable TLS support in civetweb if mbedTLS is available
-    message(STATUS "Building FTL with TLS support: YES")
-    target_compile_definitions(civetweb PRIVATE USE_MBEDTLS)
-    target_compile_definitions(webserver PRIVATE HAVE_TLS)
-else()
-    # Disable TLS support in civetweb if mbedTLS is not available
-    message(STATUS "Building FTL with TLS support: NO")
-    target_compile_definitions(civetweb PRIVATE NO_SSL)
-endif()
-
 include_directories(${PROJECT_SOURCE_DIR}/src/lua /usr/local/include)
 target_include_directories(civetweb PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -353,7 +353,7 @@ void http_init(void)
 	                        MG_FEATURES_IPV6 |
 	                        MG_FEATURES_CACHE;
 
-#ifdef HAVE_TLS
+#ifdef HAVE_MBEDTLS
 	features |= MG_FEATURES_TLS;
 #endif
 
@@ -419,7 +419,7 @@ void http_init(void)
 	// from the end of the array.
 	unsigned int next_option = ArraySize(options) - 6;
 
-#ifdef HAVE_TLS
+#ifdef HAVE_MBEDTLS
 	// Add TLS options if configured
 	if(config.webserver.tls.cert.v.s != NULL &&
 	   strlen(config.webserver.tls.cert.v.s) > 0)

--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -17,6 +17,12 @@
 # include <mbedtls/x509.h>
 # include <mbedtls/x509_crt.h>
 
+// We enforce at least mbedTLS v3.5.0 if we use it
+#if MBEDTLS_VERSION_NUMBER < 0x03050000
+# error "mbedTLS version 3.5.0 or later is required"
+#endif
+
+
 #define RSA_KEY_SIZE 4096
 #define BUFFER_SIZE 16000
 

--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -11,11 +11,11 @@
 #include "FTL.h"
 #include "log.h"
 #include "x509.h"
-#include <mbedtls/rsa.h>
-#include <mbedtls/x509.h>
-#include <mbedtls/x509_crt.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
+
+#ifdef HAVE_MBEDTLS
+# include <mbedtls/rsa.h>
+# include <mbedtls/x509.h>
+# include <mbedtls/x509_crt.h>
 
 #define RSA_KEY_SIZE 4096
 #define BUFFER_SIZE 16000
@@ -621,3 +621,19 @@ end:
 
 	return CERT_OKAY;
 }
+
+#else
+
+bool generate_certificate(const char* certfile, bool rsa, const char *domain)
+{
+	log_err("FTL was not compiled with mbedtls support");
+	return false;
+}
+
+enum cert_check read_certificate(const char* certfile, const char *domain, const bool private_key)
+{
+	log_err("FTL was not compiled with mbedtls support");
+	return CERT_FILE_NOT_FOUND;
+}
+
+#endif

--- a/src/webserver/x509.h
+++ b/src/webserver/x509.h
@@ -10,8 +10,10 @@
 #ifndef X509_H
 #define X509_H
 
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
+#ifdef HAVE_MBEDTLS
+# include <mbedtls/entropy.h>
+# include <mbedtls/ctr_drbg.h>
+#endif
 
 #include "enums.h"
 


### PR DESCRIPTION
# What does this implement/fix?

- Properly guard X.509 functions to allow compiling FTL when `mbedTLS` library is **not** available on the host
- Enforce minimum version of mbedTLS (3.5.0)


Note: This PR fixes a harmless warning concerning `READLINE` introduced in #1956 

---

**Related issue or feature (if applicable):** #1966 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.