### PR TITLE
actions: fix fork PR runs

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -101,6 +101,9 @@ runs:
     -
       name: Generate artifact attestation
       uses: actions/attest-build-provenance@v1
+      # Skip attestation if ACTIONS_ID_TOKEN_REQUEST_URL env variable is not
+      # available (e.g., PR originating from a fork)
+      if: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}
       with:
         subject-path: ${{ inputs.bin_name }}
     -
@@ -118,7 +121,11 @@ runs:
         path: 'api-docs.tar.gz'
     -
       name: Deploy
-      if: inputs.event_name != 'pull_request'
+      # Skip deployment step if:
+      # - this is a triggered by a PR event (we only push on commit to branch
+      #   events)
+      # - no SSH key is provided (this is a PR from a fork)
+      if: inputs.event_name != 'pull_request' && ${{ inputs.SSH_KEY != '' }}
       uses: ./.github/actions/deploy
       with:
         pattern: ${{ inputs.bin_name }}-binary


### PR DESCRIPTION
# What does this implement/fix?

Skip both the attestation and the deployment steps for fork-based PRs. As they have no access to secrets, these steps will always fails. This is also the reason why the recent external contribution https://github.com/pi-hole/FTL/pull/1971 failed.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.