### PR TITLE
Add option to ignore unknown DHCP clients

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -320,6 +320,8 @@ components:
                   type: boolean
                 logging:
                   type: boolean
+                ignoreUnknownClients:
+                  type: boolean
                 hosts:
                   type: array
                   items:
@@ -653,6 +655,7 @@ components:
             rapidCommit: false
             multiDNS: false
             logging: false
+            ignoreUnknownClients: false
             hosts:
               - "11:22:33:44:55:66,192.168.1.123"
               - "11:22:33:44:55:67,192.168.1.124,hostname"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -785,6 +785,13 @@ void initConfig(struct config *conf)
 	conf->dhcp.logging.d.b = false;
 	conf->dhcp.logging.c = validate_stub; // Only type-based checking
 
+	conf->dhcp.ignoreUnknownClients.k = "dhcp.ignoreUnknownClients";
+	conf->dhcp.ignoreUnknownClients.h = "Ignore unknown DHCP clients.\n If this option is set, Pi-hole ignores all clients which are not explicitly configured through dhcp.hosts. This can be useful to prevent unauthorized clients from getting an IP address from the DHCP server.\n It should be noted that this option is not a security feature, as clients can still assign themselves an IP address and use the network. It is merely a convenience feature to prevent unknown clients from getting a valid IP configuration assigned automatically.\n Note that you will need to configure new clients manually in dhcp.hosts before they can use the network when this feature is enabled.";
+	conf->dhcp.ignoreUnknownClients.t = CONF_BOOL;
+	conf->dhcp.ignoreUnknownClients.f = FLAG_RESTART_FTL;
+	conf->dhcp.ignoreUnknownClients.d.b = false;
+	conf->dhcp.ignoreUnknownClients.c = validate_stub; // Only type-based checking
+
 	conf->dhcp.hosts.k = "dhcp.hosts";
 	conf->dhcp.hosts.h = "Per host parameters for the DHCP server. This allows a machine with a particular hardware address to be always allocated the same hostname, IP address and lease time or to specify static DHCP leases";
 	conf->dhcp.hosts.a = cJSON_CreateStringReference("Array of static leases each on in one of the following forms: \"[<hwaddr>][,id:<client_id>|*][,set:<tag>][,tag:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]\"");

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -187,6 +187,7 @@ struct config {
 		struct conf_item rapidCommit;
 		struct conf_item multiDNS;
 		struct conf_item logging;
+		struct conf_item ignoreUnknownClients;
 		struct conf_item hosts;
 	} dhcp;
 

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -582,6 +582,13 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 			fputs("log-dhcp\n\n", pihole_conf);
 		}
 
+		// Add option to ignore unknown clients if enabled
+		if(conf->dhcp.ignoreUnknownClients.v.b)
+		{
+			fputs("# Ignore clients not configured below\n", pihole_conf);
+			fputs("dhcp-ignore=tag:!known\n", pihole_conf);
+		}
+
 		// Add per-host parameters
 		if(cJSON_GetArraySize(conf->dhcp.hosts.v.json) > 0)
 		{

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,14 +1,11 @@
+# Pi-hole configuration file (v5.25.2-1891-g7ff016f2-dirty)
+# Encoding: UTF-8
 # This file is managed by pihole-FTL
-#
-# Do not edit the file while FTL is
-# running or your changes may be overwritten
-#
-# Last updated on 2023-01-23 14:51:44
-# by FTL v5.20.1-552-g5184ed28
+# Last updated on 2024-05-30 11:37:59
 
 [dns]
   # Array of upstream DNS servers used by Pi-hole
-  # Example: [ "8.8.8.8", "127.0.0.1#5353", "docker-resolver" ]
+  # Example: [ "8.8.8.8", "127.0.0.1#5335", "docker-resolver" ]
   #
   # Possible values are:
   #     array of IP addresses and/or hostnames, optionally with a port (#...)
@@ -57,16 +54,18 @@
   #       Pi-hole will not respond automatically on PTR requests to local interface
   #       addresses. Ensure pi.hole and/or hostname records exist elsewhere.
   #   - "HOSTNAME"
-  #       Pi-hole will not respond automatically on PTR requests to local interface
-  #       addresses. Ensure pi.hole and/or hostname records exist elsewhere.
+  #       Serve the machine's hostname. The hostname is queried from the kernel through
+  #       uname(2)->nodename. If the machine has multiple network interfaces, it can
+  #       also have multiple nodenames. In this case, it is unspecified and up to the
+  #       kernel which one will be returned. On Linux, the returned string is what has
+  #       been set using sethostname(2) which is typically what has been set in
+  #       /etc/hostname.
   #   - "HOSTNAMEFQDN"
-  #       Serve the machine's global hostname as fully qualified domain by adding the
-  #       local suffix. If no local suffix has been defined, FTL appends the local
-  #       domain .no_fqdn_available. In this case you should either add
-  #       domain=whatever.com to a custom config file inside /etc/dnsmasq.d/ (to set
-  #       whatever.com as local domain) or use domain=# which will try to derive the
-  #       local domain from /etc/resolv.conf (or whatever is set with resolv-file, when
-  #       multiple search directives exist, the first one is used).
+  #       Serve the machine's hostname (see limitations above) as fully qualified domain
+  #       by adding the local domain. If no local domain has been defined (config option
+  #       dns.domain), FTL tries to query the domain name from the kernel using
+  #       getdomainname(2). If this fails, FTL appends ".no_fqdn_available" to the
+  #       hostname.
   #   - "PI.HOLE"
   #       Respond with "pi.hole".
   piholePTR = "PI.HOLE"
@@ -140,7 +139,7 @@
   bogusPriv = true
 
   # Validate DNS replies using DNSSEC?
-  dnssec = true
+  dnssec = true ### CHANGED, default = false
 
   # Interface to use for DNS (see also dnsmasq.listening.mode) and DHCP (if enabled)
   #
@@ -197,11 +196,10 @@
   # given, it overwrites the value of local-ttl
   #
   # Possible values are:
-  #     Array of static leases each on in one of the following forms:
-  #     "<cname>,<target>[,<TTL>]"
+  #     Array of CNAMEs each on in one of the following forms: "<cname>,<target>[,<TTL>]"
   cnameRecords = [
-    "brücke.com,äste.com,2",
-  ]
+    "brücke.com,äste.com,2"
+  ] ### CHANGED, default = []
 
   # Port used by the DNS server
   port = 53
@@ -225,7 +223,10 @@
   # <domain>: Domain used for the reverse server feature (e.g., "fritz.box")
   # Example: "fritz.box"
   #
-  # A valid line could look like this: "true,192.168.0.0/24,192.168.0.1,fritz.box"
+  # Possible values are:
+  #     array of reverse servers each one in one of the following forms:
+  #     "<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>],<domain>", e.g.,
+  #     "true,192.168.0.0/24,192.168.0.1,fritz.box"
   revServers = []
 
   [dns.cache]
@@ -239,11 +240,15 @@
     # expired only recently, the data will be used anyway (a refreshing from upstream is
     # triggered). This can improve DNS query delays especially over unreliable Internet
     # connections. This feature comes at the expense of possibly sometimes returning
-    # out-of-date data and less efficient cache utilisation, since old data cannot be
+    # out-of-date data and less efficient cache utilization, since old data cannot be
     # flushed when its TTL expires, so the cache becomes mostly least-recently-used. To
     # mitigate issues caused by massively outdated DNS replies, the maximum overaging of
     # cached records is limited. We strongly recommend staying below 86400 (1 day) with
     # this option.
+    # Setting the TTL excess time to zero will serve stale cache data regardless how long
+    # it has expired. This is not recommended as it may lead to stale data being served
+    # for a long time. Setting this option to any negative value will disable this feature
+    # altogether.
     optimizer = 3600
 
   [dns.blocking]
@@ -259,7 +264,7 @@
     #       (0.0.0.0 or ::). The "unspecified address" is a reserved IP address specified
     #       by RFC 3513 - Internet Protocol Version 6 (IPv6) Addressing Architecture,
     #       section 2.5.2.
-    #   - "IP-NODATA-AAAA"
+    #   - "IP_NODATA_AAAA"
     #       In IP-NODATA-AAAA mode, blocked queries will be answered with the local IPv4
     #       addresses of your Pi-hole. Blocked AAAA queries will be answered with
     #       NODATA-IPV6 and clients will only try to reach your Pi-hole over its static
@@ -267,7 +272,7 @@
     #   - "IP"
     #       In IP mode, blocked queries will be answered with the local IP addresses of
     #       your Pi-hole.
-    #   - "NXDOMAIN"
+    #   - "NX"
     #       In NXDOMAIN mode, blocked queries will be answered with an empty response
     #       (i.e., there won't be an answer section) and status NXDOMAIN. A NXDOMAIN
     #       response should indicate that there is no such domain to the client making the
@@ -300,21 +305,21 @@
       # "pi.hole.<local domain>", "<the device's hostname>.<local domain>" ]
       force4 = true ### CHANGED, default = false
 
-      # Use a specific IPv6 address for the Pi-hole host? See description for the IPv4
-      # variant above for further details.
-      force6 = true ### CHANGED, default = false
-
       # Custom IPv4 address for the Pi-hole host
       #
       # Possible values are:
       #     <valid IPv4 address> or empty string ("")
-      IPv4 = "10.100.0.10" ### CHANGED, default = "0.0.0.0"
+      IPv4 = "10.100.0.10" ### CHANGED, default = ""
+
+      # Use a specific IPv6 address for the Pi-hole host? See description for the IPv4
+      # variant above for further details.
+      force6 = true ### CHANGED, default = false
 
       # Custom IPv6 address for the Pi-hole host
       #
       # Possible values are:
       #     <valid IPv6 address> or empty string ("")
-      IPv6 = "fe80::10" ### CHANGED, default = "::"
+      IPv6 = "fe80::10" ### CHANGED, default = ""
 
     [dns.reply.blocking]
       # Use a specific IPv4 address in IP blocking mode? By default, FTL determines the
@@ -325,26 +330,26 @@
       # blocked, regular expressions with the ;reply=IP regex extension.
       force4 = true ### CHANGED, default = false
 
-      # Use a specific IPv6 address in IP blocking mode? See description for the IPv4 variant
-      # above for further details.
-      force6 = true ### CHANGED, default = false
-
       # Custom IPv4 address for IP blocking mode
       #
       # Possible values are:
       #     <valid IPv4 address> or empty string ("")
-      IPv4 = "10.100.0.11" ### CHANGED, default = "0.0.0.0"
+      IPv4 = "10.100.0.11" ### CHANGED, default = ""
+
+      # Use a specific IPv6 address in IP blocking mode? See description for the IPv4 variant
+      # above for further details.
+      force6 = true ### CHANGED, default = false
 
       # Custom IPv6 address for IP blocking mode
       #
       # Possible values are:
       #     <valid IPv6 address> or empty string ("")
-      IPv6 = "fe80::11" ### CHANGED, default = "::"
+      IPv6 = "fe80::11" ### CHANGED, default = ""
 
   [dns.rateLimit]
     # Rate-limited queries are answered with a REFUSED reply and not further processed by
     # FTL.
-    #The default settings for FTL's rate-limiting are to permit no more than 1000 queries
+    # The default settings for FTL's rate-limiting are to permit no more than 1000 queries
     # in 60 seconds. Both numbers can be customized independently. It is important to note
     # that rate-limiting is happening on a per-client basis. Other clients can continue to
     # use FTL while rate-limited clients are short-circuited at the same time.
@@ -377,32 +382,33 @@
   # Start address of the DHCP address pool
   #
   # Possible values are:
-  #     <ip-addr>, e.g., "192.168.0.10"
+  #     <valid IPv4 address> or empty string (""), e.g., "192.168.0.10"
   start = ""
 
   # End address of the DHCP address pool
   #
   # Possible values are:
-  #     <ip-addr>, e.g., "192.168.0.250"
+  #     <valid IPv4 address> or empty string (""), e.g., "192.168.0.250"
   end = ""
 
   # Address of the gateway to be used (typically the address of your router in a home
   # installation)
   #
   # Possible values are:
-  #     <ip-addr>, e.g., "192.168.0.1"
+  #     <valid IPv4 address> or empty string (""), e.g., "192.168.0.1"
   router = ""
 
   # The netmask used by your Pi-hole. For directly connected networks (i.e., networks on
   # which the machine running Pi-hole has an interface) the netmask is optional and may
-  # be set to "0.0.0.0": it will then be determined from the interface configuration
-  # itself. For networks which receive DHCP service via a relay agent, we cannot
-  # determine the netmask itself, so it should explicitly be specified, otherwise
+  # be set to an empty string (""): it will then be determined from the interface
+  # configuration itself. For networks which receive DHCP service via a relay agent, we
+  # cannot determine the netmask itself, so it should explicitly be specified, otherwise
   # Pi-hole guesses based on the class (A, B or C) of the network address.
   #
   # Possible values are:
-  #     <any valid netmask>, e.g., "255.255.255.0" or "0.0.0.0" for auto-discovery
-  netmask = "0.0.0.0"
+  #     <any valid netmask> (e.g., "255.255.255.0") or empty string ("") for
+  #     auto-discovery
+  netmask = ""
 
   # If the lease time is given, then leases will be given for that length of time. If not
   # given, the default lease time is one hour for IPv4 and one day for IPv6.
@@ -433,6 +439,18 @@
   # the file specified by files.log.dnsmasq below.
   logging = false
 
+  # Ignore unknown DHCP clients.
+  # If this option is set, Pi-hole ignores all clients which are not explicitly
+  # configured through dhcp.hosts. This can be useful to prevent unauthorized clients
+  # from getting an IP address from the DHCP server.
+  # It should be noted that this option is not a security feature, as clients can still
+  # assign themselves an IP address and use the network. It is merely a convenience
+  # feature to prevent unknown clients from getting a valid IP configuration assigned
+  # automatically.
+  # Note that you will need to configure new clients manually in dhcp.hosts before they
+  # can use the network when this feature is enabled.
+  ignoreUnknownClients = false
+
   # Per host parameters for the DHCP server. This allows a machine with a particular
   # hardware address to be always allocated the same hostname, IP address and lease time
   # or to specify static DHCP leases
@@ -451,10 +469,11 @@
 
   # Control whether FTL should use the fallback option to try to obtain client names from
   # checking the network table. This behavior can be disabled with this option.
-  #Assume an IPv6 client without a host names. However, the network table knows - though
-  # the client's MAC address - that this is the same device where we have a host name
-  # for another IP address (e.g., a DHCP server managed IPv4 address). In this case, we
-  # use the host name associated to the other address as this is the same device.
+  # Assume an IPv6 client without a host names. However, the network table knows -
+  # though the client's MAC address - that this is the same device where we have a host
+  # name for another IP address (e.g., a DHCP server managed IPv4 address). In this
+  # case, we use the host name associated to the other address as this is the same
+  # device.
   networkNames = false ### CHANGED, default = true
 
   # With this option, you can change how (and if) hourly PTR requests are made to check
@@ -485,8 +504,7 @@
   DBimport = true
 
   # How long should queries be stored in the database [days]?
-  # Setting this to 0 disables exporting queries to the database.
-  maxDBdays = 365
+  maxDBdays = 91
 
   # How often do we store queries in FTL's database [seconds]?
   DBinterval = 60
@@ -508,7 +526,7 @@
     # How long should IP addresses be kept in the network_addresses table [days]? IP
     # addresses (and associated host names) older than the specified number of days are
     # removed to avoid dead entries in the network overview table.
-    expire = 365
+    expire = 91
 
 [webserver]
   # On which domain is the web interface served?
@@ -573,7 +591,7 @@
     # the total number of concurrent sessions is limited so setting this value too high
     # may result in users being rejected and unable to log in if there are already too
     # many sessions active.
-    timeout = 300
+    timeout = 300 ### CHANGED, default = 1800
 
     # Should Pi-hole backup and restore sessions from the database? This is useful if you
     # want to keep your sessions after a restart of the web interface.
@@ -599,7 +617,7 @@
     #
     # Possible values are:
     #     <valid TLS certificate file (*.pem)>
-    cert = "/etc/pihole/test.pem"
+    cert = "/etc/pihole/test.pem" ### CHANGED, default = "/etc/pihole/tls.pem"
 
   [webserver.paths]
     # Server root on the host
@@ -622,23 +640,24 @@
     #
     # Possible values are:
     #   - "default-auto"
-    #       Pi-hole auto theme (light/dark, default)
+    #       Pi-hole auto
     #   - "default-light"
-    #       Pi-hole day theme (light)
+    #       Pi-hole day
     #   - "default-dark"
-    #       Pi-hole midnight theme (dark)
+    #       Pi-hole midnight
     #   - "default-darker"
-    #       Pi-hole deep-midnight theme (dark)
+    #       Pi-hole deep-midnight
     #   - "high-contrast"
-    #       High-contrast theme (light)
+    #       High-contrast light
     #   - "high-contrast-dark"
-    #       High-contrast theme (dark)
+    #       High-contrast dark
     #   - "lcars"
-    #       Star Trek LCARS theme (dark)
+    #       Star Trek LCARS
     theme = "default-auto"
 
   [webserver.api]
-    # Does local clients need to authenticate to access the API?
+    # Do local clients need to authenticate to access the API? This settings allows local
+    # clients to use the API without authentication.
     localAPIauth = true
 
     # Do local clients need to authenticate to access the search API? This settings allows
@@ -708,13 +727,15 @@
     #     array of regular expressions describing domains
     excludeDomains = []
 
-    # How much history should be imported from the database [seconds]? (max 24*60*60 =
-    # 86400)
+    # How much history should be imported from the database and returned by the API
+    # [seconds]? (max 24*60*60 = 86400)
     maxHistory = 86400
 
     # Up to how many clients should be returned in the activity graph endpoint
     # (/api/history/clients)?
-    # This setting can be overwritten at run-time using the parameter N
+    # This setting can be overwritten at run-time using the parameter N. Setting this to 0
+    # will always send all clients. Be aware that this may be challenging for the GUI if
+    # you have many (think > 1.000 clients) in your network
     maxClients = 10
 
     # How should the API compute the most active clients? If set to true, the API will
@@ -765,7 +786,7 @@
   # directory must be writable by the user running gravity (typically pihole).
   #
   # Possible values are:
-  #     <any world-writable writable directory>
+  #     <any existing world-writable writable directory>
   gravity_tmp = "/tmp"
 
   # The database containing MAC -> Vendor information for the network table
@@ -774,7 +795,7 @@
   #     <any Pi-hole macvendor database>
   macvendor = "/etc/pihole/macvendor.db"
 
-  # The config file of Pi-hole
+  # The old config file of Pi-hole used before v6.0
   #
   # Possible values are:
   #     <any Pi-hole setupVars file>
@@ -812,11 +833,11 @@
 
 [misc]
   # Using privacy levels you can specify which level of detail you want to see in your
-  # Pi-hole statistics.
+  # Pi-hole statistics. Changing this setting will trigger a restart of FTL
   #
   # Possible values are:
   #   - 0
-  #       Doesn't hide anything, all statistics are available.
+  #       Don't hide anything, all statistics are available.
   #   - 1
   #       Hide domains. This setting disables Top Domains and Top Ads
   #   - 2
@@ -841,7 +862,7 @@
   # CPU scheduler to favor or disfavor a process in scheduling decisions. The range of
   # the nice value varies across UNIX systems. On modern Linux, the range is -20 (high
   # priority = not very nice to other processes) to +19 (low priority).
-  nice = -999 ### CHANGED, default = -10
+  nice = -11 ### CHANGED (env), default = -10
 
   # Should FTL translate its own stack addresses into code lines during the bug
   # backtrace? This improves the analysis of crashed significantly. It is recommended to
@@ -853,11 +874,15 @@
   # Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?
   etc_dnsmasq_d = true ### CHANGED, default = false
 
-  # Additional lines to inject into the generated dnsmasq configuration. Warning: This is
-  # an advanced setting and should only be used with care. Incorrectly formatted or
-  # duplicated lines as well as lines conflicting with the automatic configuration of
-  # Pi-hole can break the embedded dnsmasq and will stop DNS resolution from working.
+  # Additional lines to inject into the generated dnsmasq configuration.
+  # Warning: This is an advanced setting and should only be used with care. Incorrectly
+  # formatted or duplicated lines as well as lines conflicting with the automatic
+  # configuration of Pi-hole can break the embedded dnsmasq and will stop DNS resolution
+  # from working.
   # Use this option with extra care.
+  #
+  # Possible values are:
+  #     array of valid dnsmasq config line options
   dnsmasq_lines = []
 
   # Log additional information about queries and replies to pihole.log
@@ -937,7 +962,7 @@
   # when debugging specific API issues and can be helpful, e.g., when a client cannot
   # connect due to an obscure API error. Furthermore, this setting enables logging of
   # all API requests (auth log) and details about user authentication attempts.
-  api = true ### CHANGED, default = false
+  api = true ### CHANGED (env), default = false
 
   # Print extra debugging information about TLS connections. This includes the TLS
   # version, the cipher suite, the certificate chain and much more. This very verbose
@@ -997,7 +1022,7 @@
   # Debug monitoring of /etc/pihole filesystem events
   inotify = true ### CHANGED, default = false
 
-  # Logging of webserver (CivetWeb) debug messages
+  # Debug monitoring of the webserver (CivetWeb) events
   webserver = true ### CHANGED, default = false
 
   # Temporary flag that may print additional information. This debug flag is meant to be
@@ -1013,3 +1038,9 @@
   # *remaining* debug flags but unsetting it will disable *all* debug flags.
   all = true ### CHANGED, default = false
 
+# Configuration statistics:
+# 136 total entries out of which 82 entries are default
+# --> 54 entries are modified
+# 2 entries are forced through environment:
+#   - misc.nice
+#   - debug.api

--- a/test/run.sh
+++ b/test/run.sh
@@ -23,13 +23,12 @@ done
 rm -rf /etc/pihole /var/log/pihole /dev/shm/FTL-*
 
 # Create necessary directories and files
-mkdir -p /home/pihole /etc/pihole /run/pihole /var/log/pihole
+mkdir -p /home/pihole /etc/pihole /run/pihole /var/log/pihole /etc/pihole/config_backups
 echo "" > /var/log/pihole/FTL.log
 echo "" > /var/log/pihole/pihole.log
 touch /run/pihole-FTL.pid /run/pihole-FTL.port dig.log ptr.log
-touch /var/log/pihole/HTTP_info.log /var/log/pihole/PH7.log /etc/pihole/dhcp.leases
-chown pihole:pihole /etc/pihole /run/pihole /var/log/pihole/pihole.log /var/log/pihole/FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port
-chown pihole:pihole /var/log/pihole/HTTP_info.log /var/log/pihole/PH7.log /etc/pihole/dhcp.leases
+touch /var/log/pihole/HTTP_info.log /etc/pihole/dhcp.leases
+chown -R pihole:pihole /etc/pihole /run/pihole /var/log/pihole
 
 # Copy binary into a location the new user pihole can access
 cp ./pihole-FTL /home/pihole/pihole-FTL
@@ -127,9 +126,6 @@ if [[ $RET != 0 ]]; then
   echo ""
   echo -n "HTTP_info.log: "
   curl_to_tricorder /var/log/pihole/HTTP_info.log
-  echo ""
-  echo -n "PH7.log: "
-  curl_to_tricorder /var/log/pihole/PH7.log
   echo ""
   echo -n "pihole.toml: "
   curl_to_tricorder /etc/pihole/pihole.toml

--- a/test/run.sh
+++ b/test/run.sh
@@ -26,9 +26,11 @@ rm -rf /etc/pihole /var/log/pihole /dev/shm/FTL-*
 mkdir -p /home/pihole /etc/pihole /run/pihole /var/log/pihole /etc/pihole/config_backups
 echo "" > /var/log/pihole/FTL.log
 echo "" > /var/log/pihole/pihole.log
-touch /run/pihole-FTL.pid /run/pihole-FTL.port dig.log ptr.log
-touch /var/log/pihole/HTTP_info.log /etc/pihole/dhcp.leases
+echo "" > /var/log/pihole/webserver.log
+touch /run/pihole-FTL.pid dig.log ptr.log
+touch /etc/pihole/dhcp.leases
 chown -R pihole:pihole /etc/pihole /run/pihole /var/log/pihole
+chown pihole:pihole /run/pihole-FTL.pid
 
 # Copy binary into a location the new user pihole can access
 cp ./pihole-FTL /home/pihole/pihole-FTL
@@ -124,8 +126,8 @@ if [[ $RET != 0 ]]; then
   echo -n "ptr.log: "
   curl_to_tricorder ./ptr.log
   echo ""
-  echo -n "HTTP_info.log: "
-  curl_to_tricorder /var/log/pihole/HTTP_info.log
+  echo -n "webserver.log: "
+  curl_to_tricorder /var/log/pihole/webserver.log
   echo ""
   echo -n "pihole.toml: "
   curl_to_tricorder /etc/pihole/pihole.toml

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1,30 +1,13 @@
 #!./test/libs/bats/bin/bats
 
-#@test "Version, Tag, Branch, Hash, Date is reported" {
-#  run bash -c 'echo ">version >quit" | nc -v 127.0.0.1 4711'
-#  printf "%s\n" "${lines[@]}"
-#  [[ ${lines[1]} == "version "* ]]
-#  [[ ${lines[2]} == "tag "* ]]
-#  [[ ${lines[3]} == "branch "* ]]
-#  [[ ${lines[4]} == "hash "* ]]
-#  [[ ${lines[5]} == "date "* ]]
-#  [[ ${lines[6]} == "" ]]
-#}
-#
-#@test "DNS server port is reported over Telnet API" {
-#  run bash -c 'echo ">dns-port >quit" | nc -v 127.0.0.1 4711'
-#  printf "%s\n" "${lines[@]}"
-#  [[ ${lines[1]} == "53" ]]
-#  [[ ${lines[2]} == "" ]]
-#}
-#
-#@test "Maxlogage value is reported over Telnet API" {
-#  run bash -c 'echo ">maxlogage >quit" | nc -v 127.0.0.1 4711'
-#  printf "%s\n" "${lines[@]}"
-#  [[ ${lines[1]} == "86400" ]]
-#  [[ ${lines[2]} == "" ]]
-#}
-#
+@test "Compare template and test TOML config files" {
+  # We skip the first 5 lines of the files as they contain the version and
+  # timestamp of the file creation/modification
+  run bash -c 'diff <(tail -n +6 test/pihole.toml) <(tail -n +6 /etc/pihole/pihole.toml)'
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[@]}" == "" ]]
+}
+
 @test "Running a second instance is detected and prevented" {
   run bash -c 'su pihole -s /bin/sh -c "/home/pihole/pihole-FTL -f"'
   printf "%s\n" "${lines[@]}"
@@ -1793,10 +1776,10 @@
 @test "Expected number of config file rotations" {
   run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "3" ]]
+  [[ ${lines[0]} == "2" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: pihole.toml unchanged" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "3" ]]
+  [[ ${lines[0]} == "4" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]


### PR DESCRIPTION
# What does this implement/fix?

Add new `dhcp.ignoreUnknownClients` option which has been requested on Discourse. It works as follows:

![Screenshot from 2024-05-30 19-04-33](https://github.com/pi-hole/FTL/assets/16748619/71cd3710-dbca-4b1b-864f-c7a7c748f1be)

This PR also features a second commit updating forgotten changes into `test/pihole.toml` and adds a CI test to prevent forgetting to update this file in the future.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/add-checkbox-to-block-dhcp-for-unknown-hosts/70485

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.