### PR TITLE
Skip certificate domain check when TLS is not actually used

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -421,7 +421,17 @@ void http_init(void)
 
 #ifdef HAVE_MBEDTLS
 	// Add TLS options if configured
-	if(config.webserver.tls.cert.v.s != NULL &&
+
+	// TLS is used when webserver.port contains "s" (e.g. "443s")
+	const bool tls_used = config.webserver.port.v.s != NULL &&
+	                      strchr(config.webserver.port.v.s, 's') != NULL;
+
+	// Check certificate domain if
+	// - TLS is used
+	// - A certificate is configured
+	// - The certificate is readable
+	if(tls_used &&
+	   config.webserver.tls.cert.v.s != NULL &&
 	   strlen(config.webserver.tls.cert.v.s) > 0)
 	{
 		// Try to generate certificate if not present
@@ -439,6 +449,8 @@ void http_init(void)
 			}
 		}
 
+		// Check if the certificate is readable (we may have just
+		// created it)
 		if(file_readable(config.webserver.tls.cert.v.s))
 		{
 			if(read_certificate(config.webserver.tls.cert.v.s, config.webserver.domain.v.s, false) != CERT_DOMAIN_MATCH)


### PR DESCRIPTION
# What does this implement/fix?

Skip certificate domain check when TLS is not actually used even if a certificate is available

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.