### PR TITLE
 Add read-only config option

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -481,6 +481,8 @@ components:
                     type: string
                 extraLogging:
                   type: boolean
+                readOnly:
+                  type: boolean
                 check:
                   type: object
                   properties:
@@ -726,6 +728,7 @@ components:
             etc_dnsmasq_d: false
             dnsmasq_lines: [ ]
             extraLogging: false
+            readOnly: false
             check:
               load: true
               shmem: 90

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1238,6 +1238,13 @@ void initConfig(struct config *conf)
 	conf->misc.extraLogging.d.b = false;
 	conf->misc.extraLogging.c = validate_stub; // Only type-based checking
 
+	conf->misc.readOnly.k = "misc.readOnly";
+	conf->misc.readOnly.h = "Put configuration into read-only mode. This will prevent any changes to the configuration file via the API or CLI. This setting useful when a configuration is to be forced/modified by some third-party application (like infrastructure-as-code providers) and should not be changed by any means.";
+	conf->misc.readOnly.t = CONF_BOOL;
+	conf->misc.readOnly.f = FLAG_READ_ONLY;
+	conf->misc.readOnly.d.b = false;
+	conf->misc.readOnly.c = validate_stub; // Only type-based checking
+
 	// sub-struct misc.check
 	conf->misc.check.load.k = "misc.check.load";
 	conf->misc.check.load.h = "Pi-hole is very lightweight on resources. Nevertheless, this does not mean that you should run Pi-hole on a server that is otherwise extremely busy as queuing on the system can lead to unnecessary delays in DNS operation as the system becomes less and less usable as the system load increases because all resources are permanently in use. To account for this, FTL regularly checks the system load. To bring this to your attention, FTL warns about excessive load when the 15 minute system load average exceeds the number of cores.\n This check can be disabled with this setting.";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -96,6 +96,7 @@ enum conf_type {
 #define FLAG_WRITE_ONLY            (1 << 4)
 #define FLAG_ENV_VAR               (1 << 5)
 #define FLAG_CONF_IMPORTED         (1 << 6)
+#define FLAG_READ_ONLY             (1 << 7)
 
 struct conf_item {
 	const char *k;        // item Key
@@ -274,6 +275,7 @@ struct config {
 		struct conf_item etc_dnsmasq_d;
 		struct conf_item dnsmasq_lines;
 		struct conf_item extraLogging;
+		struct conf_item readOnly;
 		struct {
 			struct conf_item load;
 			struct conf_item shmem;

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -31,6 +31,12 @@ bool writeFTLtoml(const bool verbose)
 	if(config.misc.readOnly.v.b)
 	{
 		log_debug(DEBUG_CONFIG, "Config file is read-only, not writing");
+
+		// We need to (re-)calculate the checksum here as it'd otherwise
+		// be outdated (in non-read-only mode, it's calculated at the
+		// end of this function)
+		if(!sha256sum(GLOBALTOMLPATH, last_checksum))
+			log_err("Unable to create checksum of %s", GLOBALTOMLPATH);
 		return true;
 	}
 

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -27,6 +27,13 @@ extern uint8_t last_checksum[SHA256_DIGEST_SIZE];
 
 bool writeFTLtoml(const bool verbose)
 {
+	// Return early without writing if we are in config read-only mode
+	if(config.misc.readOnly.v.b)
+	{
+		log_debug(DEBUG_CONFIG, "Config file is read-only, not writing");
+		return true;
+	}
+
 	// Try to open a temporary config file for writing
 	FILE *fp;
 	if((fp = openFTLtoml("w", 0)) == NULL)

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -893,6 +893,12 @@
   # debugging and is not recommended for normal use.
   extraLogging = false
 
+  # Put configuration into read-only mode. This will prevent any changes to the
+  # configuration file via the API or CLI. This setting useful when a configuration is
+  # to be forced/modified by some third-party application (like infrastructure-as-code
+  # providers) and should not be changed by any means.
+  readOnly = false
+
   [misc.check]
     # Pi-hole is very lightweight on resources. Nevertheless, this does not mean that you
     # should run Pi-hole on a server that is otherwise extremely busy as queuing on the
@@ -1039,7 +1045,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 136 total entries out of which 82 entries are default
+# 137 total entries out of which 83 entries are default
 # --> 54 entries are modified
 # 2 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

Add new `misc.readOnly` config option to force the configuration to be read-only. It can only be modified through the config file but neither the API nor the CLI as long as read-only mode is enabled.

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/support-writing-to-pihole-toml-directly/70522/

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.