### PR TITLE
Fix incorrect unification of regex warnings

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -137,9 +137,9 @@ static enum message_type get_message_type_from_string(const char *typestr)
 
 static unsigned char message_blob_types[MAX_MESSAGE][5] =
 	{
-		{	// REGEX_MESSAGE: The message column contains the regex warning text
+		{	// REGEX_MESSAGE: The message column contains the regex text (the erroring regex filter itself)
 			SQLITE_TEXT, // regex type ("deny", "allow")
-			SQLITE_TEXT, // regex text (the erroring regex filter itself)
+			SQLITE_TEXT, // regex warning text
 			SQLITE_INTEGER, // database index of regex (so the dashboard can show a link)
 			SQLITE_NULL, // not used
 			SQLITE_NULL // not used
@@ -993,9 +993,9 @@ bool format_messages(cJSON *array)
 		{
 			case REGEX_MESSAGE:
 			{
-				const char *warning = (const char*)sqlite3_column_text(stmt, 3);
+				const char *regex = (const char*)sqlite3_column_text(stmt, 3);
 				const char *type = (const char*)sqlite3_column_text(stmt, 4);
-				const char *regex = (const char*)sqlite3_column_text(stmt, 5);
+				const char *warning = (const char*)sqlite3_column_text(stmt, 5);
 				const int dbindex = sqlite3_column_int(stmt, 6);
 
 				format_regex_message(plain, sizeof(plain), html, sizeof(html),
@@ -1206,7 +1206,7 @@ void logg_regex_warning(const char *type, const char *warning, const int dbindex
 		return;
 
 	// Add to database
-	const int rowid = add_message(REGEX_MESSAGE, warning, type, regex, dbindex);
+	const int rowid = add_message(REGEX_MESSAGE, regex, type, warning, dbindex);
 	if(rowid == -1)
 		log_err("logg_regex_warning(): Failed to add message to database");
 }

--- a/src/regex.c
+++ b/src/regex.c
@@ -788,7 +788,7 @@ static void read_regex_table(const enum regex_type regexid)
 		if(!compile_regex(regex_string, &regex[index], &message) && message != NULL)
 		{
 			logg_regex_warning(regextype[regexid], message,
-			                   regex->database_id, regex_string);
+			                   rowid, regex_string);
 			free(message);
 		}
 


### PR DESCRIPTION
# What does this implement/fix?

Current `development-v6` singles out regex warnings by the warning itself rather than the regex itself. This leads to the defect that multiple warnings get incorrectly summarized together when they are affected by the same warning.

How to reproduce:

Add domains via the `sqlite3` CLI to the `gravity.db` database, e.g.
``` sql
INSERT INTO domainlist (type,domain) VALUES (3,'[[[');
INSERT INTO domainlist (type,domain) VALUES (3,'[[[[');
INSERT INTO domainlist (type,domain) VALUES (3,'[[[[[');
INSERT INTO domainlist (type,domain) VALUES (3,'[[[[[[');
```

On `development-v6`: Only one entry is created in the diagnosis system
On this branch: All warnings are shown, e.g.,
![image](https://github.com/pi-hole/FTL/assets/16748619/ff918451-9a36-4110-9dc4-eefcd20a7c7e)

We don't need to update anything in any other repo as FTL is now the only responsible player in generating messages. 

----

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.