### PR TITLE
Fix possible heap-corruption bug

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -449,7 +449,8 @@ static char *__attribute__((malloc)) ngethostbyname(const int sock, struct socka
 // 3www6google3com -> www.google.com
 static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) name_fromDNS(unsigned char *reader, unsigned char *buffer, uint16_t *count)
 {
-	unsigned char *name = calloc(MAXHOSTNAMELEN, sizeof(char));
+	const size_t MAXNAMELEN = 256;
+	unsigned char *name = calloc(MAXNAMELEN, sizeof(char));
 	unsigned int p = 0, jumped = 0;
 
 	// Initialize count
@@ -462,7 +463,7 @@ static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) name_fro
 	// Instead, each label is preceded by a byte containing its length, and
 	// the name is terminated by a zero-length label representing the root
 	// zone.
-	while(*reader != 0)
+	while(*reader != 0 && p < MAXNAMELEN - 2)
 	{
 		if(*reader >= 0xC0)
 		{


### PR DESCRIPTION
# What does this implement/fix?

Fix very long DNS names (>64 bytes) potentially crashing the internal name resolving mechanism, the new limit is 256 bytes with proper boundary checking. No user reports are known. This came up during my regular [`valgrind`](https://docs.pi-hole.net/ftldns/valgrind/) checking of the `pihole-FTL` process. Looking at the `git blame` for this code, the broken code has been in there for half a year seemingly without anyone noticing it. Note that this bug affects only internal name resolution used by FTL to infer host names for clients and upstream servers. It is completely separated from normal DNS operation used by the clients in your network.

Heap overflows are exploitable in a different manner to that of stack-based overflows. Intentional exploitation is unlikely given ASLR ([Address Space Layout Randomization](https://en.wikipedia.org/wiki/Address_Space_Layout_Randomization)), however, not impossible. For this overflow to be abused the attacker needs to be in control of one of your specified upstream DNS server. As those are typically your router (conditional forwarding) and a large player (like Google or Cloudflare) or even another local software (like `unbound`), the likeliness for this is low. The overflow cannot be triggered externally, otherwise.

Even when a crash is much (!) more likely than anything else, this PR is marked with the SECURITY tag.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.