### PR TITLE
Check if the newly set password is the same as the old one

### DIFF
--- a/src/config/password.c
+++ b/src/config/password.c
@@ -601,6 +601,13 @@ int run_performance_test(void)
 
 bool set_and_check_password(struct conf_item *conf_item, const char *password)
 {
+	// Check if the newly set password is the same as the old one
+	if(verify_password(password, config.webserver.api.pwhash.v.s, false) == PASSWORD_CORRECT)
+	{
+		log_debug(DEBUG_CONFIG, "Password unchanged, not updating");
+		return true;
+	}
+
 	// Get password hash as allocated string (an empty string is hashed to an empty string)
 	char *pwhash = strlen(password) > 0 ? create_password(password) : strdup("");
 

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -601,8 +601,11 @@ int run_performance_test(void)
 
 bool set_and_check_password(struct conf_item *conf_item, const char *password)
 {
-	// Check if the newly set password is the same as the old one
-	if(verify_password(password, config.webserver.api.pwhash.v.s, false) == PASSWORD_CORRECT)
+	// Check if the user wants to set an empty password but the password is
+	// already empty, or if the newly set password is the same as the old
+	// one
+	if((strlen(password) == 0 && strlen(config.webserver.api.pwhash.v.s) == 0) ||
+	   verify_password(password, config.webserver.api.pwhash.v.s, false) == PASSWORD_CORRECT)
 	{
 		log_debug(DEBUG_CONFIG, "Password unchanged, not updating");
 		return true;


### PR DESCRIPTION
# What does this implement/fix?

This is especially worth adding in the context of forced passwords (via env var) as the password is always "set" on each config change. This PR effectively prevents FTL from wiping all sessions and forcing the user to re-login when changing even settings which are 100% unrelated to the API.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.