### PR TITLE
Improve NTP implementation

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -348,21 +348,23 @@ components:
                 sync:
                   type: object
                   properties:
+                    active:
+                      type: boolean
                     server:
                       type: string
                     interval:
                       type: integer
                     count:
                       type: integer
-                rtc:
-                  type: object
-                  properties:
-                    set:
-                      type: boolean
-                    device:
-                      type: string
-                    utc:
-                      type: boolean
+                    rtc:
+                      type: object
+                      properties:
+                        set:
+                          type: boolean
+                        device:
+                          type: string
+                        utc:
+                          type: boolean
             resolver:
               type: object
               properties:
@@ -708,13 +710,14 @@ components:
               active: true
               address: ""
             sync:
+              active: true
               server: "pool.ntp.org"
               interval: 3600
               count: 8
-            rtc:
-              set: true
-              device: ""
-              utc: true
+              rtc:
+                set: true
+                device: ""
+                utc: true
           resolver:
             resolveIPv4: true
             resolveIPv6: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -814,6 +814,13 @@ void initConfig(struct config *conf)
 	memset(&conf->ntp.ipv6.address.d.in6_addr, 0, sizeof(struct in6_addr));
 	conf->ntp.ipv6.address.c = validate_stub; // Only type-based checking
 
+	conf->ntp.sync.active.k = "ntp.sync.active";
+	conf->ntp.sync.active.h = "Should FTL try to synchronize the system time with an upstream NTP server?";
+	conf->ntp.sync.active.t = CONF_BOOL;
+	conf->ntp.sync.active.f = FLAG_RESTART_FTL;
+	conf->ntp.sync.active.d.b = true;
+	conf->ntp.sync.active.c = validate_stub; // Only type-based checking
+
 	conf->ntp.sync.server.k = "ntp.sync.server";
 	conf->ntp.sync.server.h = "NTP upstream server to sync with, e.g., \"pool.ntp.org\". Note that the NTP server should be located as close as possible to you in order to minimize the time offset possibly introduced by different routing paths.";
 	conf->ntp.sync.server.a = cJSON_CreateStringReference("valid NTP upstream server");
@@ -833,24 +840,24 @@ void initConfig(struct config *conf)
 	conf->ntp.sync.count.d.ui = 8;
 	conf->ntp.sync.count.c = validate_stub; // Only type-based checking
 
-	conf->ntp.rtc.set.k = "ntp.rtc.set";
-	conf->ntp.rtc.set.h = "Should FTL update a real-time clock (RTC) if available?";
-	conf->ntp.rtc.set.t = CONF_BOOL;
-	conf->ntp.rtc.set.d.b = true;
-	conf->ntp.rtc.set.c = validate_stub; // Only type-based checking
+	conf->ntp.sync.rtc.set.k = "ntp.sync.rtc.set";
+	conf->ntp.sync.rtc.set.h = "Should FTL update a real-time clock (RTC) if available?";
+	conf->ntp.sync.rtc.set.t = CONF_BOOL;
+	conf->ntp.sync.rtc.set.d.b = true;
+	conf->ntp.sync.rtc.set.c = validate_stub; // Only type-based checking
 
-	conf->ntp.rtc.device.k = "ntp.rtc.device";
-	conf->ntp.rtc.device.h = "Path to the RTC device to update. Leave empty for auto-discovery";
-	conf->ntp.rtc.device.a = cJSON_CreateStringReference("Path to the RTC device, e.g., \"/dev/rtc0\"");
-	conf->ntp.rtc.device.t = CONF_STRING;
-	conf->ntp.rtc.device.d.s = (char*)"";
-	conf->ntp.rtc.device.c = validate_stub; // Only type-based checking
+	conf->ntp.sync.rtc.device.k = "ntp.sync.rtc.device";
+	conf->ntp.sync.rtc.device.h = "Path to the RTC device to update. Leave empty for auto-discovery";
+	conf->ntp.sync.rtc.device.a = cJSON_CreateStringReference("Path to the RTC device, e.g., \"/dev/rtc0\"");
+	conf->ntp.sync.rtc.device.t = CONF_STRING;
+	conf->ntp.sync.rtc.device.d.s = (char*)"";
+	conf->ntp.sync.rtc.device.c = validate_stub; // Only type-based checking
 
-	conf->ntp.rtc.utc.k = "ntp.rtc.utc";
-	conf->ntp.rtc.utc.h = "Should the RTC be set to UTC?";
-	conf->ntp.rtc.utc.t = CONF_BOOL;
-	conf->ntp.rtc.utc.d.b = true;
-	conf->ntp.rtc.utc.c = validate_stub; // Only type-based checking
+	conf->ntp.sync.rtc.utc.k = "ntp.sync.rtc.utc";
+	conf->ntp.sync.rtc.utc.h = "Should the RTC be set to UTC?";
+	conf->ntp.sync.rtc.utc.t = CONF_BOOL;
+	conf->ntp.sync.rtc.utc.d.b = true;
+	conf->ntp.sync.rtc.utc.c = validate_stub; // Only type-based checking
 
 
 	// struct resolver

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -201,15 +201,16 @@ struct config {
 			struct conf_item address;
 		} ipv6;
 		struct {
+			struct conf_item active;
 			struct conf_item server;
 			struct conf_item interval;
 			struct conf_item count;
+			struct {
+				struct conf_item set;
+				struct conf_item device;
+				struct conf_item utc;
+			} rtc;
 		} sync;
-		struct {
-			struct conf_item set;
-			struct conf_item device;
-			struct conf_item utc;
-		} rtc;
 	} ntp;
 
 	struct {

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -400,7 +400,11 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# 2017-02-02 root zone trust anchor\n", pihole_conf);
 		fputs("trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n",
 		      pihole_conf);
-		fputs("\n", pihole_conf);
+
+		// Prevent DNSSEC timestamp checks until either NTP synchronization has succeeded or
+		// the user has disabled the NTP client
+		fputs("# Do not check DNSSEC timestamps until NTP synchronization has succeeded\n", pihole_conf);
+		fputs("dnssec-no-timecheck\n\n", pihole_conf);
 	}
 
 	if(strlen(conf->dns.hostRecord.v.s) > 0)

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -400,11 +400,7 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# 2017-02-02 root zone trust anchor\n", pihole_conf);
 		fputs("trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n",
 		      pihole_conf);
-
-		// Prevent DNSSEC timestamp checks until either NTP synchronization has succeeded or
-		// the user has disabled the NTP client
-		fputs("# Do not check DNSSEC timestamps until NTP synchronization has succeeded\n", pihole_conf);
-		fputs("dnssec-no-timecheck\n\n", pihole_conf);
+		fputs("\n", pihole_conf);
 	}
 
 	if(strlen(conf->dns.hostRecord.v.s) > 0)

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -23,6 +23,8 @@
 #include <limits.h>
 // escape_json()
 #include "webserver/http-common.h"
+// chown_pihole()
+#include "files.h"
 
 // Open the TOML file for reading or writing
 FILE * __attribute((malloc)) __attribute((nonnull(1))) openFTLtoml(const char *mode, const unsigned int version)
@@ -96,26 +98,8 @@ void closeFTLtoml(FILE *fp)
 
 	// Chown file if we are root
 	if(geteuid() == 0)
-	{
-		// Get UID and GID of user with name "pihole"
-		struct passwd *pwd = getpwnam("pihole");
-		if(pwd == NULL)
-		{
-			log_warn("Cannot get UID and GID of user pihole: %s", strerror(errno));
-		}
-		else
-		{
-			const uid_t pihole_uid = pwd->pw_uid;
-			const gid_t pihole_gid = pwd->pw_gid;
-			// Chown file to pihole user
-			if(chown(GLOBALTOMLPATH, pihole_uid, pihole_gid) != 0)
-				log_warn("Cannot chown "GLOBALTOMLPATH" to pihole:pihole (%u:%u): %s",
-					(unsigned int)pihole_uid, (unsigned int)pihole_gid, strerror(errno));
-			else
-				log_debug(DEBUG_CONFIG, "Chown-ed "GLOBALTOMLPATH" to pihole:pihole (%u:%u)",
-					(unsigned int)pihole_uid, (unsigned int)pihole_gid);
-		}
-	}
+		chown_pihole(GLOBALTOMLPATH, NULL);
+
 	return;
 }
 

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -83,7 +83,6 @@ static bool analyze_database(sqlite3 *db)
 void *DB_thread(void *val)
 {
 	// Set thread name
-	thread_running[DB] = true;
 	prctl(PR_SET_NAME, thread_names[DB], 0, 0, 0);
 
 	// Save timestamp as we do not want to store immediately
@@ -241,6 +240,5 @@ void *DB_thread(void *val)
 		dbclose(&db);
 
 	log_info("Terminating database thread");
-	thread_running[DB] = false;
 	return NULL;
 }

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -293,6 +293,10 @@ static int _add_message(const enum message_type type,
 static int _add_message(const enum message_type type,
                         const char *message, const size_t count,...)
 {
+	// Log to database only if not in CLI mode
+	if(cli_mode)
+		return -1;
+
 	int rowid = -1;
 	// Return early if database is known to be broken
 	if(FTLDBerror())
@@ -1236,10 +1240,6 @@ void logg_regex_warning(const char *type, const char *warning, const int dbindex
 
 	// Log to FTL.log
 	log_warn("%s", buf);
-
-	// Log to database only if not in CLI mode
-	if(cli_mode)
-		return;
 
 	// Add to database
 	add_message(REGEX_MESSAGE, regex, type, warning, dbindex);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -41,6 +41,9 @@ static sqlite3_stmt **stmts[] = { &query_stmt,
                                   &forward_stmt,
                                   &addinfo_stmt };
 
+// Private prototypes
+static void load_queries_from_disk(void);
+
 // Return the maximum ID of the in-memory database
 unsigned long __attribute__((pure)) get_max_db_idx(void)
 {
@@ -219,6 +222,8 @@ bool init_memory_database(void)
 		log_err("init_memory_database(addinfo_by_id) - SQL error step: %s", sqlite3_errstr(rc));
 		return false;
 	}
+
+	load_queries_from_disk();
 
 	// Everything went well
 	return true;
@@ -1635,7 +1640,7 @@ bool queries_to_database(void)
 	return true;
 }
 
-void load_queries_from_disk(void)
+static void load_queries_from_disk(void)
 {
 	// Compensate for possible jumps in time
 	runGC(time(NULL), NULL, false);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -41,6 +41,9 @@ static sqlite3_stmt **stmts[] = { &query_stmt,
                                   &forward_stmt,
                                   &addinfo_stmt };
 
+// Private prototypes
+static bool import_linked_tables_from_disk(void);
+
 // Return the maximum ID of the in-memory database
 unsigned long __attribute__((pure)) get_max_db_idx(void)
 {
@@ -219,6 +222,9 @@ bool init_memory_database(void)
 		log_err("init_memory_database(addinfo_by_id) - SQL error step: %s", sqlite3_errstr(rc));
 		return false;
 	}
+
+	// Import linked-tables from disk database (domains, clients, ...)
+	import_linked_tables_from_disk();
 
 	// Everything went well
 	return true;
@@ -535,6 +541,24 @@ bool import_queries_from_disk(void)
 	// Finalize statement
 	sqlite3_finalize(stmt);
 
+	// End transaction
+	if((rc = sqlite3_exec(memdb, "END TRANSACTION", NULL, NULL, NULL)) != SQLITE_OK)
+	{
+		log_err("import_queries_from_disk(): Cannot end transaction: %s", sqlite3_errstr(rc));
+		return false;
+	}
+
+	// Get number of queries on disk before detaching
+	disk_db_num = get_number_of_queries_in_DB(memdb, "disk.query_storage");
+	mem_db_num = get_number_of_queries_in_DB(memdb, "query_storage");
+
+	log_info("Imported %u queries from the on-disk database (it has %u rows)", mem_db_num, disk_db_num);
+
+	return okay;
+}
+
+static bool import_linked_tables_from_disk(void)
+{
 	// Import linking tables and current AUTOINCREMENT values from the disk database
 	const char *subtable_names[] = {
 		"domain_by_id",
@@ -550,6 +574,15 @@ bool import_queries_from_disk(void)
 		"INSERT INTO addinfo_by_id SELECT * FROM disk.addinfo_by_id",
 		"INSERT OR REPLACE INTO sqlite_sequence SELECT * FROM disk.sqlite_sequence"
 	};
+
+	// Begin transaction
+	int rc;
+	sqlite3 *memdb = get_memdb();
+	if((rc = sqlite3_exec(memdb, "BEGIN TRANSACTION", NULL, NULL, NULL)) != SQLITE_OK)
+	{
+		log_err("import_queries_from_disk(): Cannot start transaction: %s", sqlite3_errstr(rc));
+		return false;
+	}
 
 	// Import linking tables
 	for(unsigned int i = 0; i < ArraySize(subtable_sql); i++)
@@ -567,13 +600,7 @@ bool import_queries_from_disk(void)
 		return false;
 	}
 
-	// Get number of queries on disk before detaching
-	disk_db_num = get_number_of_queries_in_DB(memdb, "disk.query_storage");
-	mem_db_num = get_number_of_queries_in_DB(memdb, "query_storage");
-
-	log_info("Imported %u queries from the on-disk database (it has %u rows)", mem_db_num, disk_db_num);
-
-	return okay;
+	return true;
 }
 
 // Export in-memory queries to disk - either due to periodic dumping (final =
@@ -1368,11 +1395,6 @@ bool queries_to_database(void)
 	if(counters->queries == 0)
 	{
 		log_debug(DEBUG_DATABASE, "Not storing query in database as there are none");
-		return true;
-	}
-	if(!store_in_database)
-	{
-		log_debug(DEBUG_DATABASE, "Not storing query in database as this is disabled");
 		return true;
 	}
 

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -119,7 +119,6 @@ bool add_additional_info_column(sqlite3 *db);
 void DB_read_queries(void);
 void update_disk_db_idx(void);
 bool queries_to_database(void);
-void load_queries_from_disk(void);
 
 bool optimize_queries_table(sqlite3 *db);
 bool create_addinfo_table(sqlite3 *db);

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -97,7 +97,6 @@ int main_dnsmasq (int argc, char **argv)
   sigaction(SIGUSR2, &sigact, NULL);
   sigaction(SIGHUP, &sigact, NULL);
   sigaction(SIGUSR6, &sigact, NULL); // Pi-hole modification
-  sigaction(SIGUSR7, &sigact, NULL); // Pi-hole modification
   sigaction(SIGALRM, &sigact, NULL);
   sigaction(SIGCHLD, &sigact, NULL);
   sigaction(SIGINT, &sigact, NULL);
@@ -1359,8 +1358,6 @@ static void sig_handler(int sig)
 	  else
 	    event = EVENT_TIME;
 	}
-      else if (sig == SIGUSR7) // Pi-hole modified
-	event = EVENT_TIME;
       else
 	return;
 

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -97,6 +97,7 @@ int main_dnsmasq (int argc, char **argv)
   sigaction(SIGUSR2, &sigact, NULL);
   sigaction(SIGHUP, &sigact, NULL);
   sigaction(SIGUSR6, &sigact, NULL); // Pi-hole modification
+  sigaction(SIGUSR7, &sigact, NULL); // Pi-hole modification
   sigaction(SIGALRM, &sigact, NULL);
   sigaction(SIGCHLD, &sigact, NULL);
   sigaction(SIGINT, &sigact, NULL);
@@ -1358,6 +1359,8 @@ static void sig_handler(int sig)
 	  else
 	    event = EVENT_TIME;
 	}
+      else if (sig == SIGUSR7) // Pi-hole modified
+	event = EVENT_TIME;
       else
 	return;
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1803,7 +1803,7 @@ void FTL_dnsmasq_reload(void)
 	// This function is called by the dnsmasq code on receive of SIGHUP
 	// *before* clearing the cache and re-reading the lists
 	if(reload++ > 0)
-		log_info("Received SIGHUP, flushing cache and re-reading config");
+		log_info("Flushing cache and re-reading config");
 
 	// Gravity database updates
 	// - (Re-)open gravity database connection

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2963,26 +2963,16 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 		// we're actually dropping root (user/group may be set to root)
 		if(ent_pw != NULL && ent_pw->pw_uid != 0)
 		{
-			log_info("FTL is going to drop from root to user %s (UID %u)",
-			         ent_pw->pw_name, ent_pw->pw_uid);
+			log_info("FTL is going to drop from root to user pihole");
 
 			// Change ownership of shared memory objects
 			chown_all_shmem(ent_pw);
 
 			// Configured FTL log file
-			if(chown(config.files.log.ftl.v.s, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			{
-				log_warn("Setting ownership (%u:%u) of %s failed: %s (%i)",
-				         ent_pw->pw_uid, ent_pw->pw_gid, config.files.log.ftl.v.s, strerror(errno), errno);
-			}
+			chown_pihole(config.files.log.ftl.v.s, ent_pw);
 
 			// Configured FTL database file
-			if(chown(config.files.database.v.s, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			{
-				log_warn("Setting ownership (%u:%u) of %s failed: %s (%i)",
-				         ent_pw->pw_uid, ent_pw->pw_gid, config.files.database.v.s, strerror(errno), errno);
-
-			}
+			chown_pihole(config.files.database.v.s, ent_pw);
 
 			// Check if auxiliary files exist and change ownership
 			char *extrafile = calloc(strlen(config.files.database.v.s) + 5, sizeof(char));
@@ -2995,20 +2985,14 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 			// Check <database>-wal file (write-ahead log)
 			strcpy(extrafile, config.files.database.v.s);
 			strcat(extrafile, "-wal");
-			if(file_exists(extrafile) && chown(extrafile, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			{
-				log_warn("Setting ownership (%u:%u) of %s failed: %s (%i)",
-				         ent_pw->pw_uid, ent_pw->pw_gid, extrafile, strerror(errno), errno);
-			}
+			if(file_exists(extrafile))
+				chown_pihole(extrafile, ent_pw);
 
 			// Check <database>-shm file (mmapped shared memory)
 			strcpy(extrafile, config.files.database.v.s);
 			strcat(extrafile, "-shm");
-			if(file_exists(extrafile) && chown(extrafile, ent_pw->pw_uid, ent_pw->pw_gid) == -1)
-			{
-				log_warn("Setting ownership (%u:%u) of %s failed: %s (%i)",
-				         ent_pw->pw_uid, ent_pw->pw_gid, extrafile, strerror(errno), errno);
-			}
+			if(file_exists(extrafile))
+				chown_pihole(extrafile, ent_pw);
 
 			// Free allocated memory
 			free(extrafile);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2912,16 +2912,11 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 	// so they will not listen to real-time signals
 	handle_realtime_signals();
 
-	// We will use the attributes object later to start all threads in
-	// detached mode
 	pthread_attr_t attr;
 	// Initialize thread attributes object with default attribute values
 	// Do NOT detach threads as we want to join them during shutdown with a
 	// fixed timeout to give them time to clean up and finish their work
 	pthread_attr_init(&attr);
-
-	// Initialize NTP server
-	ntp_server_start(&attr);
 
 	// Start NTP sync thread
 	ntp_start_sync_thread(&attr);

--- a/src/enums.h
+++ b/src/enums.h
@@ -250,7 +250,9 @@ enum thread_types {
 	GC,
 	DNSclient,
 	TIMER,
-	NTP,
+	NTP_CLIENT,
+	NTP_SERVER4,
+	NTP_SERVER6,
 	THREADS_MAX
 } __attribute__ ((packed));
 

--- a/src/files.h
+++ b/src/files.h
@@ -16,6 +16,8 @@
 #include <mntent.h>
 // SHA256_DIGEST_SIZE
 #include <nettle/sha2.h>
+// getpwuid()
+#include <pwd.h>
 
 #define MAX_ROTATIONS 15
 #define BACKUP_DIR "/etc/pihole/config_backups"
@@ -31,6 +33,7 @@ void ls_dir(const char* path);
 unsigned int get_path_usage(const char *path, char buffer[64]);
 struct mntent *get_filesystem_details(const char *path);
 bool directory_exists(const char *path);
+bool chown_pihole(const char *path, struct passwd *pwd);
 void rotate_files(const char *path, char **first_file);
 bool files_different(const char *pathA, const char* pathB, unsigned int from);
 bool sha256sum(const char *path, uint8_t checksum[SHA256_DIGEST_SIZE]);

--- a/src/gc.c
+++ b/src/gc.c
@@ -481,7 +481,6 @@ static bool check_files_on_same_device(const char *path1, const char *path2)
 void *GC_thread(void *val)
 {
 	// Set thread name
-	thread_running[GC] = true;
 	prctl(PR_SET_NAME, thread_names[GC], 0, 0, 0);
 
 	// Remember when we last ran the actions
@@ -567,6 +566,5 @@ void *GC_thread(void *val)
 	watch_config(false);
 
 	log_info("Terminating GC thread");
-	thread_running[GC] = false;
 	return NULL;
 }

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -603,6 +603,12 @@ static void *ntp_client_thread(void *arg)
 		{
 			load_queries_from_disk();
 
+			// If this was the first run and NTP time synchronization was
+			// successful, we send SIGUSR7 to the embedded dnsmasq instance
+			// to signal time is now guaranteed to be correct
+			if(success)
+				kill(main_pid(), SIGUSR7);
+
 			first_run = false;
 		}
 
@@ -634,6 +640,9 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 	   config.ntp.sync.interval.v.ui == 0)
 	{
 		log_info("NTP sync is disabled - NTP server will not be available");
+		// Send SIGUSR7 to embedded dnsmasq instance to signal time is
+		// assumed to be correct
+		kill(main_pid(), SIGUSR7);
 		load_queries_from_disk();
 		return false;
 	}

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -657,7 +657,7 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 	// in starting the thread.
 	if(!check_capability(CAP_SYS_TIME))
 	{
-		log_warn("Insufficient permissions to set system time, NTP client not available");
+		log_warn("Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available");
 		// Send SIGUSR7 to embedded dnsmasq instance to signal time is
 		// assumed to be correct
 		kill(main_pid(), SIGUSR7);

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -605,13 +605,16 @@ static void *ntp_client_thread(void *arg)
 		// Get time after NTP sync
 		const time_t after = time(NULL);
 
-		// If the time was updated by more than one hour, restart FTL to
-		// import recent data. This is relevant when the system time was
-		// set to an incorrect value (e.g., due to a dead CMOS battery
-		// or overall missing RTC) and the time was off.
-		if(first_run && after - before > 3600)
+		// If the time was updated by more than a certain amount,
+		// restart FTL to import recent data. This is relevant when the
+		// system time was set to an incorrect value (e.g., due to a
+		// dead CMOS battery or overall missing RTC) and the time was
+		// off.
+		double time_delta;
+		if(first_run && (time_delta = fabs((double)after - before)) > GCinterval)
 		{
-			log_info("System time was updated by more than one hour, restarting FTL to import recent data");
+			log_info("System time was updated by %.1f seconds, restarting FTL to import recent data",
+			         time_delta);
 			// Set the restart flag to true
 			exit_code = RESTART_FTL_CODE;
 			// Send SIGTERM to FTL

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -605,12 +605,6 @@ static void *ntp_client_thread(void *arg)
 		{
 			load_queries_from_disk();
 
-			// If this was the first run and NTP time synchronization was
-			// successful, we send SIGUSR7 to the embedded dnsmasq instance
-			// to signal time is now guaranteed to be correct
-			if(success)
-				kill(main_pid(), SIGUSR7);
-
 			first_run = false;
 		}
 
@@ -642,10 +636,7 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 	   strlen(config.ntp.sync.server.v.s) == 0 ||
 	   config.ntp.sync.interval.v.ui == 0)
 	{
-		log_info("NTP sync is disabled");
-		// Send SIGUSR7 to embedded dnsmasq instance to signal time is
-		// assumed to be correct
-		kill(main_pid(), SIGUSR7);
+		log_info("NTP sync is disabled - NTP server will not be available");
 		load_queries_from_disk();
 		ntp_server_start();
 		return false;

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -588,8 +588,7 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 static void *ntp_client_thread(void *arg)
 {
 	// Set thread name
-	thread_running[NTP] = true;
-	prctl(PR_SET_NAME, thread_names[NTP], 0, 0, 0);
+	prctl(PR_SET_NAME, thread_names[NTP_CLIENT], 0, 0, 0);
 
 	// Run NTP client
 	bool first_run = true;
@@ -619,11 +618,10 @@ static void *ntp_client_thread(void *arg)
 		BREAK_IF_KILLED();
 
 		// Sleep before retrying
-		thread_sleepms(NTP, 1000 * config.ntp.sync.interval.v.ui);
+		thread_sleepms(NTP_CLIENT, 1000 * config.ntp.sync.interval.v.ui);
 	}
 
 	log_info("Terminating NTP thread");
-	thread_running[NTP] = false;
 
 	return NULL;
 }
@@ -641,7 +639,7 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 	}
 
 	// Create thread
-	if(pthread_create(&threads[NTP], attr, ntp_client_thread, NULL) != 0)
+	if(pthread_create(&threads[NTP_CLIENT], attr, ntp_client_thread, NULL) != 0)
 	{
 		log_err("Cannot create NTP client thread - NTP server will not be available");
 		load_queries_from_disk();

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -576,7 +576,7 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 		ntp_root_dispersion = D2FP(theta_stdev);
 
 		// Finally, adjust RTC if configured
-		if(config.ntp.rtc.set.v.b)
+		if(config.ntp.sync.rtc.set.v.b)
 			ntp_sync_rtc();
 	}
 
@@ -635,7 +635,8 @@ static void *ntp_client_thread(void *arg)
 bool ntp_start_sync_thread(pthread_attr_t *attr)
 {
 	// Return early if NTP client is disabled
-	if(config.ntp.sync.server.v.s == NULL ||
+	if(config.ntp.sync.active.v.b == false ||
+	   config.ntp.sync.server.v.s == NULL ||
 	   strlen(config.ntp.sync.server.v.s) == 0 ||
 	   config.ntp.sync.interval.v.ui == 0)
 	{

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -597,21 +597,21 @@ static void *ntp_client_thread(void *arg)
 	while(!killed)
 	{
 		// Get time before NTP sync
-		const time_t before = time(NULL);
+		const double before = double_time();
 
 		// Run NTP client
 		const bool success = ntp_client(config.ntp.sync.server.v.s, true, false);
 
 		// Get time after NTP sync
-		const time_t after = time(NULL);
+		const double after = double_time();
 
 		// If the time was updated by more than a certain amount,
 		// restart FTL to import recent data. This is relevant when the
 		// system time was set to an incorrect value (e.g., due to a
 		// dead CMOS battery or overall missing RTC) and the time was
 		// off.
-		double time_delta;
-		if(first_run && (time_delta = fabs((double)after - before)) > GCinterval)
+		double time_delta = fabs(after - before);
+		if(first_run && time_delta > GCinterval)
 		{
 			log_info("System time was updated by %.1f seconds, restarting FTL to import recent data",
 			         time_delta);

--- a/src/ntp/ntp.h
+++ b/src/ntp/ntp.h
@@ -27,7 +27,7 @@ uint64_t gettime64(void);
 void print_debug_time(const char *label, const uint32_t *u32p, const uint64_t ntp_time);
 
 // Start NTP server
-bool ntp_server_start(pthread_attr_t *attr);
+bool ntp_server_start(void);
 
 // Start NTP client
 bool ntp_client(const char *server, const bool settime, const bool print);

--- a/src/ntp/rtc.c
+++ b/src/ntp/rtc.c
@@ -82,7 +82,8 @@ static int open_rtc(void)
 			if(chown(config.ntp.sync.rtc.device.v.s, uid, gid) == -1)
 			{
 				log_debug(DEBUG_NTP, "chown(\"%s\", %u, %u) failed: %s",
-				          config.ntp.sync.rtc.device.v.s, uid, gid, strerror(errno));
+				          config.ntp.sync.rtc.device.v.s, uid, gid,
+				          errno == EPERM ? "Insufficient permissions (CAP_CHOWN required)" : strerror(errno));
 				return -1;
 			}
 
@@ -97,7 +98,8 @@ static int open_rtc(void)
 			if(chown(config.ntp.sync.rtc.device.v.s, st.st_uid, st.st_gid) == -1)
 			{
 				log_debug(DEBUG_NTP, "chown(\"%s\", %u, %u) failed: %s",
-						config.ntp.sync.rtc.device.v.s, st.st_uid, st.st_gid, strerror(errno));
+				          config.ntp.sync.rtc.device.v.s, st.st_uid, st.st_gid,
+				          errno == EPERM ? "Insufficient permissions (CAP_CHOWN required)" : strerror(errno));
 				return -1;
 			}
 
@@ -139,7 +141,8 @@ static int open_rtc(void)
 			if(chown(rtc_devices[i], uid, gid) == -1)
 			{
 				log_debug(DEBUG_NTP, "chown(\"%s\", %u, %u) failed: %s",
-				          rtc_devices[i], uid, gid, strerror(errno));
+				          rtc_devices[i], uid, gid,
+				          errno == EPERM ? "Insufficient permissions (CAP_CHOWN required)" : strerror(errno));
 				return -1;
 			}
 
@@ -154,7 +157,8 @@ static int open_rtc(void)
 			if(chown(rtc_devices[i], st.st_uid, st.st_gid) == -1)
 			{
 				log_debug(DEBUG_NTP, "chown(\"%s\", %u, %u) failed: %s",
-						rtc_devices[i], st.st_uid, st.st_gid, strerror(errno));
+				          rtc_devices[i], st.st_uid, st.st_gid, 
+				          errno == EPERM ? "Insufficient permissions (CAP_CHOWN required)" : strerror(errno));
 				return -1;
 			}
 

--- a/src/ntp/rtc.c
+++ b/src/ntp/rtc.c
@@ -51,15 +51,15 @@ static int open_rtc(void)
 	const gid_t gid = getgid();
 
 	// If the user has specified an RTC device, try to open it
-	if(config.ntp.rtc.device.v.s != NULL &&
-	   strlen(config.ntp.rtc.device.v.s) > 0)
+	if(config.ntp.sync.rtc.device.v.s != NULL &&
+	   strlen(config.ntp.sync.rtc.device.v.s) > 0)
 	{
 		// Open the RTC device
-		rtc_fd = open(config.ntp.rtc.device.v.s, O_RDONLY);
+		rtc_fd = open(config.ntp.sync.rtc.device.v.s, O_RDONLY);
 		if (rtc_fd != -1)
 		{
 			log_debug(DEBUG_NTP, "Successfully opened RTC at \"%s\"",
-			          config.ntp.rtc.device.v.s);
+			          config.ntp.sync.rtc.device.v.s);
 			return rtc_fd;
 		}
 
@@ -72,32 +72,32 @@ static int open_rtc(void)
 		{
 			// Get current owner of the device
 			struct stat st = { 0 };
-			if(stat(config.ntp.rtc.device.v.s, &st) == -1)
+			if(stat(config.ntp.sync.rtc.device.v.s, &st) == -1)
 			{
 				log_debug(DEBUG_NTP, "stat(\"%s\") failed: %s",
-				          config.ntp.rtc.device.v.s, strerror(errno));
+				          config.ntp.sync.rtc.device.v.s, strerror(errno));
 				return -1;
 			}
 
-			if(chown(config.ntp.rtc.device.v.s, uid, gid) == -1)
+			if(chown(config.ntp.sync.rtc.device.v.s, uid, gid) == -1)
 			{
 				log_debug(DEBUG_NTP, "chown(\"%s\", %u, %u) failed: %s",
-				          config.ntp.rtc.device.v.s, uid, gid, strerror(errno));
+				          config.ntp.sync.rtc.device.v.s, uid, gid, strerror(errno));
 				return -1;
 			}
 
-			rtc_fd = open(config.ntp.rtc.device.v.s, O_RDONLY);
+			rtc_fd = open(config.ntp.sync.rtc.device.v.s, O_RDONLY);
 			if (rtc_fd != -1)
 			{
 				log_debug(DEBUG_NTP, "Successfully opened RTC at \"%s\"",
-				          config.ntp.rtc.device.v.s);
+				          config.ntp.sync.rtc.device.v.s);
 			}
 
 			// Chown the device back to the original owner
-			if(chown(config.ntp.rtc.device.v.s, st.st_uid, st.st_gid) == -1)
+			if(chown(config.ntp.sync.rtc.device.v.s, st.st_uid, st.st_gid) == -1)
 			{
 				log_debug(DEBUG_NTP, "chown(\"%s\", %u, %u) failed: %s",
-						config.ntp.rtc.device.v.s, st.st_uid, st.st_gid, strerror(errno));
+						config.ntp.sync.rtc.device.v.s, st.st_uid, st.st_gid, strerror(errno));
 				return -1;
 			}
 
@@ -106,7 +106,7 @@ static int open_rtc(void)
 		}
 
 		log_debug(DEBUG_NTP, "Failed to open RTC at \"%s\": %s",
-		          config.ntp.rtc.device.v.s, strerror(errno));
+		          config.ntp.sync.rtc.device.v.s, strerror(errno));
 
 		return -1;
 	}
@@ -255,7 +255,7 @@ bool ntp_sync_rtc(void)
 	// Time to which we will set Hardware Clock, in broken down format
 	struct tm new_time = { 0 };
 	const time_t newtime = time(NULL);
-	if(config.ntp.rtc.utc.v.b)
+	if(config.ntp.sync.rtc.utc.v.b)
 		// UTC
 		gmtime_r(&newtime, &new_time);
 	else

--- a/src/ntp/server.c
+++ b/src/ntp/server.c
@@ -373,7 +373,7 @@ static void *ntp_bind_and_listen(void *param)
 }
 
 // Start the NTP server
-bool ntp_server_start(pthread_attr_t *attr)
+bool ntp_server_start(void)
 {
 	// Spawn two pthreads, one for IPv4 and one for IPv6
 
@@ -382,7 +382,7 @@ bool ntp_server_start(pthread_attr_t *attr)
 	{
 		// Create a thread for the IPv4 NTP server
 		pthread_t thread;
-		if (pthread_create(&thread, attr, ntp_bind_and_listen, (void *)0) != 0)
+		if (pthread_create(&thread, NULL, ntp_bind_and_listen, (void *)0) != 0)
 		{
 			log_ntp_message(true, true, "Cannot create NTP server thread for IPv4");
 			return false;
@@ -394,7 +394,7 @@ bool ntp_server_start(pthread_attr_t *attr)
 	{
 		// Create a thread for the IPv6 NTP server
 		pthread_t thread;
-		if (pthread_create(&thread, attr, ntp_bind_and_listen, (void *)1) != 0)
+		if (pthread_create(&thread, NULL, ntp_bind_and_listen, (void *)1) != 0)
 		{
 			log_ntp_message(true, true, "Cannot create NTP server thread for IPv6");
 			return false;

--- a/src/ntp/server.c
+++ b/src/ntp/server.c
@@ -39,6 +39,10 @@
 #include <inttypes.h>
 // log_ntp_message()
 #include "database/message-table.h"
+// NTP_SERVER_IPV4,6
+#include "enums.h"
+// threads
+#include "signals.h"
 
 uint64_t ntp_last_sync = 0u;
 uint32_t ntp_root_delay = 0u;
@@ -224,7 +228,7 @@ static bool ntp_reply(const int socket_fd, const struct sockaddr *saddr_p, const
 }
 
 // Process incoming NTP requests
-static void request_process_loop(int fd, const char *ipstr, const int protocol)
+static void request_process_loop(const int fd, const char *ipstr, const int protocol)
 {
 	log_info("NTP server listening on %s:123 (%s)", ipstr, protocol == AF_INET ? "IPv4" : "IPv6");
 	while (true)
@@ -280,9 +284,12 @@ static void request_process_loop(int fd, const char *ipstr, const int protocol)
 // Start the NTP server
 static void *ntp_bind_and_listen(void *param)
 {
-	const int protocol = param == 0 ? AF_INET : AF_INET6;
+	// Set thread name
+	const unsigned int thread_id = param == 0 ? NTP_SERVER4 : NTP_SERVER6;
+	prctl(PR_SET_NAME, thread_names[thread_id], 0, 0, 0);
 
   	// Create a socket
+	const int protocol = param == 0 ? AF_INET : AF_INET6;
 	errno = 0;
 	const int s = socket(protocol, SOCK_DGRAM, IPPROTO_UDP);
 	if(s == -1)
@@ -301,8 +308,7 @@ static void *ntp_bind_and_listen(void *param)
 	memset(ipstr, 0, sizeof(ipstr));
 	if(protocol == AF_INET)
 	{
-		// IPv4 - set thread name
-		prctl(PR_SET_NAME, "NTP (IPv4)", 0, 0, 0);
+		// IPv4 NTP server
 
 		// Prepare the bind address
 		struct sockaddr_in bind_addr;
@@ -327,8 +333,7 @@ static void *ntp_bind_and_listen(void *param)
 	}
 	else
 	{
-		// IPv6 - set thread name
-		prctl(PR_SET_NAME, "NTP (IPv6)", 0, 0, 0);
+		// IPv6 NTP server
 
 		// Set socket options to allow IPv6 only, otherwise it will bind
 		// to both IPv4 and IPv6 and show IPv4 addresses as

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -1053,14 +1053,12 @@ static void resolveUpstreams(const bool onlynew)
 void *DNSclient_thread(void *val)
 {
 	// Set thread name
-	thread_running[DNSclient] = true;
 	prctl(PR_SET_NAME, thread_names[DNSclient], 0, 0, 0);
 
 	// Test struct sizes
 	if(!check_struct_sizes())
 	{
 		log_err("Struct sizes do not match expected sizes, aborting resolver thread");
-		thread_running[DNSclient] = false;
 		return NULL;
 	}
 
@@ -1124,6 +1122,5 @@ void *DNSclient_thread(void *val)
 	}
 
 	log_info("Terminating resolver thread");
-	thread_running[DNSclient] = false;
 	return NULL;
 }

--- a/src/signals.c
+++ b/src/signals.c
@@ -322,6 +322,11 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *unused)
 	// {
 	// 	// Signal internally used to signal dnsmasq it has to stop
 	// }
+	// else if(rtsig == 7)
+	// {
+	//      // Signal internally used to signal dnsmasq it should do
+	//      // DNSSEC timestamp checks
+	// }
 
 	// Restore errno before returning back to previous context
 	errno = _errno;
@@ -448,9 +453,8 @@ void handle_realtime_signals(void)
 	// Catch all real-time signals
 	for(int signum = SIGRTMIN; signum <= SIGRTMAX; signum++)
 	{
-		if(signum == SIGUSR6)
-			// Skip SIGUSR6 as it is used internally to signify
-			// dnsmasq to stop
+		if(signum == SIGUSR6 || signum == SIGUSR7)
+			// Skip SIGUSR6 as it is used internally by dnsmasq
 			continue;
 
 		struct sigaction SIGACTION = { 0 };

--- a/src/signals.c
+++ b/src/signals.c
@@ -322,11 +322,6 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *unused)
 	// {
 	// 	// Signal internally used to signal dnsmasq it has to stop
 	// }
-	// else if(rtsig == 7)
-	// {
-	//      // Signal internally used to signal dnsmasq it should do
-	//      // DNSSEC timestamp checks
-	// }
 
 	// Restore errno before returning back to previous context
 	errno = _errno;
@@ -453,8 +448,9 @@ void handle_realtime_signals(void)
 	// Catch all real-time signals
 	for(int signum = SIGRTMIN; signum <= SIGRTMAX; signum++)
 	{
-		if(signum == SIGUSR6 || signum == SIGUSR7)
-			// Skip SIGUSR6 as it is used internally by dnsmasq
+		if(signum == SIGUSR6)
+			// Skip SIGUSR6 as it is used internally to signify
+			// dnsmasq to stop
 			continue;
 
 		struct sigaction SIGACTION = { 0 };

--- a/src/signals.c
+++ b/src/signals.c
@@ -34,13 +34,14 @@ static time_t FTLstarttime = 0;
 volatile int exit_code = EXIT_SUCCESS;
 
 volatile sig_atomic_t thread_cancellable[THREADS_MAX] = { false };
-volatile sig_atomic_t thread_running[THREADS_MAX] = { false };
 const char * const thread_names[THREADS_MAX] = {
 	"database",
 	"housekeeper",
 	"dns-client",
 	"timer",
-	"ntp-client"
+	"ntp-client",
+	"ntp-server4",
+	"ntp-server6",
  };
 
 // Return the (null-terminated) name of the calling thread

--- a/src/signals.h
+++ b/src/signals.h
@@ -13,6 +13,7 @@
 #include "enums.h"
 
 #define SIGUSR6 (SIGRTMIN + 6)
+#define SIGUSR7 (SIGRTMIN + 7)
 
 // defined in dnsmasq/dnsmasq.h
 extern volatile char FTL_terminate;

--- a/src/signals.h
+++ b/src/signals.h
@@ -29,7 +29,6 @@ extern volatile sig_atomic_t want_to_reimport_aliasclients;
 extern volatile sig_atomic_t want_to_reload_lists;
 
 extern volatile sig_atomic_t thread_cancellable[THREADS_MAX];
-extern volatile sig_atomic_t thread_running[THREADS_MAX];
 extern const char * const thread_names[THREADS_MAX];
 
 #define BREAK_IF_KILLED() { if(killed) break; }

--- a/src/signals.h
+++ b/src/signals.h
@@ -13,7 +13,6 @@
 #include "enums.h"
 
 #define SIGUSR6 (SIGRTMIN + 6)
-#define SIGUSR7 (SIGRTMIN + 7)
 
 // defined in dnsmasq/dnsmasq.h
 extern volatile char FTL_terminate;

--- a/src/timers.c
+++ b/src/timers.c
@@ -84,7 +84,6 @@ void get_blockingmode_timer(double *delay, bool *target_status)
 void *timer(void *val)
 {
 	// Set thread name
-	thread_running[GC] = true;
 	prctl(PR_SET_NAME, thread_names[TIMER], 0, 0, 0);
 
 	// Save timestamp as we do not want to store immediately
@@ -110,7 +109,6 @@ void *timer(void *val)
 	}
 
 	log_info("Terminating timer thread");
-	thread_running[GC] = false;
 	return NULL;
 }
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -481,6 +481,9 @@
     address = ""
 
   [ntp.sync]
+    # Should FTL try to synchronize the system time with an upstream NTP server?
+    active = true
+
     # NTP upstream server to sync with, e.g., "pool.ntp.org". Note that the NTP server
     # should be located as close as possible to you in order to minimize the time offset
     # possibly introduced by different routing paths.
@@ -495,18 +498,18 @@
     # Number of NTP syncs to perform and average before updating the system time
     count = 8
 
-  [ntp.rtc]
-    # Should FTL update a real-time clock (RTC) if available?
-    set = true
+    [ntp.sync.rtc]
+      # Should FTL update a real-time clock (RTC) if available?
+      set = true
 
-    # Path to the RTC device to update. Leave empty for auto-discovery
-    #
-    # Possible values are:
-    #     Path to the RTC device, e.g., "/dev/rtc0"
-    device = ""
+      # Path to the RTC device to update. Leave empty for auto-discovery
+      #
+      # Possible values are:
+      #     Path to the RTC device, e.g., "/dev/rtc0"
+      device = ""
 
-    # Should the RTC be set to UTC?
-    utc = true
+      # Should the RTC be set to UTC?
+      utc = true
 
 [resolver]
   # Should FTL try to resolve IPv4 addresses to hostnames?
@@ -1102,7 +1105,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 148 total entries out of which 93 entries are default
+# 149 total entries out of which 94 entries are default
 # --> 55 entries are modified
 # 2 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -481,7 +481,7 @@
 }
 
 @test "No WARNING messages in FTL.log (besides known warnings)" {
-  run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|(Cannot set process priority)|FTLCONF_"'
+  run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|(Cannot set process priority)|FTLCONF_|(Insufficient permissions to set system time, NTP client not available)"'
   printf "%s\n" "${lines[@]}"
   [[ "${lines[@]}" == "" ]]
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1353,12 +1353,6 @@
   [[ ${lines[0]} == '{"error":{"key":"bad_request","message":"Config items set via environment variables cannot be changed via the API","hint":"misc.nice"},"took":'*'}' ]]
 }
 
-@test "Check NTP server is broadcasting correct time" {
-  run bash -c './pihole-FTL ntp 127.0.0.1 --dry-run'
-  printf "%s\n" "${lines[@]}"
-  [[ $status == 0 ]]
-}
-
 # We cannot easily test IPv6 as it may not be available in docker (CI)
 
 @test "API domain search: Non-existing domain returns expected JSON" {
@@ -1816,4 +1810,12 @@
   run bash -c 'grep -c "DEBUG_CONFIG: custom.list unchanged" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "3" ]]
+}
+
+@test "Check NTP server is broadcasting correct time" {
+  # Run this test at the very end of the test suite
+  # to ensure the NTP server has been started
+  run bash -c './pihole-FTL ntp 127.0.0.1'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -481,7 +481,7 @@
 }
 
 @test "No WARNING messages in FTL.log (besides known warnings)" {
-  run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|(Cannot set process priority)|FTLCONF_|(Insufficient permissions to set system time, NTP client not available)"'
+  run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|FTLCONF_"'
   printf "%s\n" "${lines[@]}"
   [[ "${lines[@]}" == "" ]]
 }


### PR DESCRIPTION
# What does this implement/fix?

Start NTP server thread(s) only after the first successful NTP time sync. This ensures the time we offer is correct. As a by-product this also gives some time for alternative NTP servers (e.g., `crony`) to finish their startup so we don't take the port before they can do it. Also, disable DNSSEC time-windows validation until first sync succeeded to avoid DNSSEC-related issues during NTP sync.

If the time is updated by a large amount, restart FTL to ensure we load the correct history window.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.