### PR TITLE
Show Unauthorized warnings only in debug mode

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -713,7 +713,7 @@ static int api_config_patch(struct ftl_conn *api)
 			return send_json_error_free(api, 400,
 			                            "bad_request",
 			                            "This config option can only be set in pihole.toml, not via the API",
-			                            key, true);
+			                            key, true, true);
 		}
 
 		// Check if this is a write-only config item with the placeholder value
@@ -744,7 +744,7 @@ static int api_config_patch(struct ftl_conn *api)
 			return send_json_error_free(api, 400,
 			                            "bad_request",
 			                            "Config item is invalid",
-			                            hint, true);
+			                            hint, true, true);
 		}
 
 		// Get pointer to memory location of this conf_item (global)
@@ -759,7 +759,7 @@ static int api_config_patch(struct ftl_conn *api)
 			return send_json_error_free(api, 400,
 			                            "bad_request",
 			                            "Config items set via environment variables cannot be changed via the API",
-			                            key, true);
+			                            key, true, true);
 		}
 
 		// Skip processing if value didn't change compared to current value
@@ -922,7 +922,7 @@ static int api_config_put_delete(struct ftl_conn *api)
 			return send_json_error_free(api, 400,
 			                            "bad_request",
 			                            "Config items set via environment variables cannot be changed via the API",
-			                            key, true);
+			                            key, true, true);
 		}
 
 		// Check if this entry exists in the array

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -461,7 +461,7 @@ static int api_list_write(struct ftl_conn *api,
 		return send_json_error_free(api, 400, // 400 Bad Request
 		                            "regex_error",
 		                            "Regex validation failed",
-		                            regex_msg, true);
+		                            regex_msg, true, true);
 	}
 
 	// Try to add item(s) to table

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -316,7 +316,7 @@ static int process_received_zip(struct ftl_conn *api, struct upload_data *data)
 		return send_json_error_free(api, 400,
 		                            "bad_request",
 		                            "Invalid request",
-		                            msg, true);
+		                            msg, true, true);
 	}
 
 	// Free allocated memory

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -68,27 +68,33 @@ int send_http_code(struct ftl_conn *api, const char *mime_type,
 
 int send_json_unauthorized(struct ftl_conn *api)
 {
-	return send_json_error(api, 401,
-                               "unauthorized",
-                               "Unauthorized",
-                               NULL);
+	// Log API warnings only if debug.api is true
+	return send_json_error_free(api, 401,
+	                            "unauthorized",
+	                            "Unauthorized",
+	                            NULL, false,
+	                            config.debug.api.v.b);
 }
 
 int send_json_error(struct ftl_conn *api, const int code,
                     const char *key, const char* message,
                     const char *hint)
 {
-	return send_json_error_free(api, code, key, message, (char*)hint, false);
+	return send_json_error_free(api, code, key, message,
+	                            (char*)hint, false, true);
 }
 
 int send_json_error_free(struct ftl_conn *api, const int code,
                          const char *key, const char* message,
-                         char *hint, bool free_hint)
+                         char *hint, const bool free_hint, const bool log)
 {
-	if(hint != NULL)
-		log_warn("API: %s (%s)", message, hint);
-	else
-		log_warn("API: %s", message);
+	if(log)
+	{
+		if(hint != NULL)
+			log_warn("API: %s (%s)", message, hint);
+		else
+			log_warn("API: %s", message);
+	}
 
 	cJSON *error = JSON_NEW_OBJECT();
 	JSON_REF_STR_IN_OBJECT(error, "key", key);

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -70,7 +70,7 @@ int send_json_error(struct ftl_conn *api, const int code,
                     const char *hint);
 int send_json_error_free(struct ftl_conn *api, const int code,
                          const char *key, const char* message,
-                         char *hint, bool free_hint);
+                         char *hint, bool free_hint, const bool log);
 int send_json_success(struct ftl_conn *api);
 const char *get_http_method_str(const enum http_method method) __attribute__((const));
 

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -95,8 +95,7 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 		return send_json_error_free(&api, 400,
 		                            "bad_request",
 		                            "Bad request",
-		                            hint,
-		                            true);
+		                            hint, true, true);
 	}
 
 	// Check if last part of the URI contains a dot (is a file)


### PR DESCRIPTION
# What does this implement/fix?

Log API Unauthorized warnings caused by `send_json_error()` only if `debug.api` is `true`.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.