### PR TITLE
Fix rev-server crash

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -723,6 +723,12 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 	{
 		log_warn("New dnsmasq configuration is not valid (%s), config remains unchanged", errbuf);
 
+		if(debug_flags[DEBUG_ANY])
+		{
+			log_debug(DEBUG_ANY, "Temporary dnsmasq config file left in place for debugging purposes");
+			return false;
+		}
+
 		// Remove temporary config file
 		if(remove(DNSMASQ_TEMP_CONF) != 0)
 		{

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1193,10 +1193,10 @@ static char *domain_rev4(int from_file, char *server, struct in_addr *addr4, int
 		return  _("error");
 	    }
 
-	  if (sdetails.orig_hostinfo)
-	    freeaddrinfo(sdetails.orig_hostinfo);
 	}
     }
+    if (sdetails.orig_hostinfo)
+      freeaddrinfo(sdetails.orig_hostinfo);
   
   return NULL;
 }
@@ -1280,11 +1280,10 @@ static char *domain_rev6(int from_file, char *server, struct in6_addr *addr6, in
 	      if (!add_update_server(flags, &serv_addr, &source_addr, interface, domain, NULL))
 		return  _("error");
 	    }
-
-	  if (sdetails.orig_hostinfo)
-	    freeaddrinfo(sdetails.orig_hostinfo);
 	}
     }
+    if (sdetails.orig_hostinfo)
+      freeaddrinfo(sdetails.orig_hostinfo);
   
   return NULL;
 }


### PR DESCRIPTION
# What does this implement/fix?

Fix crash caused by double `free()` corruption encountered with `rev-server` addresses with prefix lengths `!= {8,16,24,32}`.

The patch submitted upstream is tracked here: https://github.com/pi-hole/dnsmasq/pull/15

We decide to merge this change now as nothing at all has happened on the mailing list for months by now and users came and asked for the status of our bug fix.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/todays-update-kills-pihole-v6/70739

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.