### PR TITLE
Fix blocking timer

### DIFF
--- a/src/api/dns.c
+++ b/src/api/dns.c
@@ -100,7 +100,7 @@ static int set_blocking(struct ftl_conn *api)
 		// The blocking status does not need to be changed
 
 		// Delete a possibly running timer
-		set_blockingmode_timer(-1.0, true);
+		set_blockingmode_timer(timer, true);
 
 		log_debug(DEBUG_API, "No change in blocking mode, resetting timer");
 	}


### PR DESCRIPTION
# What does this implement/fix?

Restart timer if set even if no blocking mode change was requested. This allows users to extend a temporary state, e.g. by running another "pihole disable 5m" shortly before the previous call reaches timeout. Previously, calling "pihole disable 1m" would make the change permanent which seems undesirable.

This has been discovered while testing https://github.com/pi-hole/pi-hole/pull/5689/commits/897e23089c10a6ac8c7c51dbfe5c897c7051c22c (part of https://github.com/pi-hole/pi-hole/pull/5689)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.