### PR TITLE
Fix CI DNSSEC tests

### DIFF
--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -401,12 +401,6 @@
   [[ ${lines[@]} == *"status: NOERROR"* ]]
 }
 
-@test "DNSSEC: BOGUS domain is rejected" {
-  run bash -c "dig A fail01.dnssec.works @127.0.0.1"
-  printf "%s\n" "${lines[@]}"
-  [[ ${lines[@]} == *"status: SERVFAIL"* ]]
-}
-
 @test "Special domain: NXDOMAIN is returned" {
   run bash -c "dig A mask.icloud.com @127.0.0.1"
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
# What does this implement/fix?

`fail*.dnssec.works` changed its configuration from being `BOGUS` to `ABANDONNED` and cannot be used any longer for `BOGUS` testing

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.