### PR TITLE
Self-contained DNSSEC CI tests

### DIFF
--- a/test/pdns/pdns.conf
+++ b/test/pdns/pdns.conf
@@ -19,5 +19,8 @@ launch=gsqlite3
 # Database location
 gsqlite3-database=/var/lib/powerdns/pdns.sqlite3
 
+# Enable DNSSEC in the backend
+gsqlite3-dnssec=yes
+
 # Used when creating a new zone
 default-soa-content=ns1.@ hostmaster.@ 0 10800 3600 604800 3600

--- a/test/pdns/recursor.conf
+++ b/test/pdns/recursor.conf
@@ -10,8 +10,8 @@
 # Local DNS address and port
 local-address=127.0.0.1:5555
 
-# Use authoritative server for ftl. and arpa. zones
-forward-zones=ftl=127.0.0.1:5554,168.192.in-addr.arpa=127.0.0.1:5554,ip6.arpa=127.0.0.1:5554
+# Use authoritative server for ftl., dnssec. and arpa. zones
+forward-zones=ftl=127.0.0.1:5554,168.192.in-addr.arpa=127.0.0.1:5554,ip6.arpa=127.0.0.1:5554,dnssec=127.0.0.1:5554,bogus=127.0.0.1:5554
 
 # In this mode the Recursor acts as a “security aware, non-validating”
 # nameserver, meaning it will set the DO-bit on outgoing queries and will

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -396,9 +396,15 @@
 }
 
 @test "DNSSEC: SECURE domain is resolved" {
-  run bash -c "dig A dnssec.works @127.0.0.1"
+  run bash -c "dig A a.dnssec @127.0.0.1"
   printf "%s\n" "${lines[@]}"
   [[ ${lines[@]} == *"status: NOERROR"* ]]
+}
+
+@test "DNSSEC: BOGUS domain is rejected" {
+  run bash -c "dig A a.bogus @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"status: SERVFAIL"* ]]
 }
 
 @test "Special domain: NXDOMAIN is returned" {


### PR DESCRIPTION
# What does this implement/fix?

See title. This is implemented by defining two internal DNSSEC zones in our CI tests - one for which we add the trust-anchor (`SECURE`) and one were not (`BOGUS`). This is a final solution to the recurring issues we have every now and then with external DNSSEC providers. The entire code is dynamic, i.e., the zones are always newly created so there are no problems with expiry, etc.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.