### PR TITLE
Improve reverse proxy handling

### DIFF
--- a/src/api/auth.h
+++ b/src/api/auth.h
@@ -57,6 +57,7 @@ struct session {
 	time_t valid_until;
 	char remote_addr[48]; // Large enough for IPv4 and IPv6 addresses, hard-coded in civetweb.h as mg_request_info.remote_addr
 	char user_agent[128];
+	char x_forwarded_for[48]; // see remote_addr note
 	char sid[SID_SIZE];
 	char csrf[SID_SIZE];
 };

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -362,7 +362,12 @@ components:
                 description: IP address of the client
               user_agent:
                 type: string
-                description: User agent of the client
+                nullable: true
+                description: User agent of the client (optional)
+              x_forwarded_for:
+                type: string
+                nullable: true
+                description: IP address of the client (if behind a proxy, optional)
           example:
             - id: 1
               current_session: true
@@ -377,6 +382,7 @@ components:
               valid_until: 1580000300
               remote_addr: "192.168.0.34"
               user_agent: "Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0"
+              x_forwarded_for: null
     totp:
       type: object
       description: TOTP secret suggestion

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -413,8 +413,6 @@ components:
                 tls:
                   type: object
                   properties:
-                    rev_proxy:
-                      type: boolean
                     cert:
                       type: string
                 paths:
@@ -739,7 +737,6 @@ components:
               timeout: 300
               restore: true
             tls:
-              rev_proxy: false
               cert: "/etc/pihole/tls.pem"
             paths:
               webroot: "/var/www/html"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -972,12 +972,6 @@ void initConfig(struct config *conf)
 	conf->webserver.port.d.s = (char*)"80,[::]:80,443s,[::]:443s";
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
-	conf->webserver.tls.rev_proxy.k = "webserver.tls.rev_proxy";
-	conf->webserver.tls.rev_proxy.h = "Is Pi-hole running behind a reverse proxy? If yes, Pi-hole will not consider HTTP-only connections being insecure. This is useful if you are running Pi-hole in a trusted environment, for example, in a local network, and you are using a reverse proxy to provide TLS encryption, e.g., by using Traefik (docker). If you are using a reverse proxy, you can alternatively set webserver.tls.cert to the path of the TLS certificate file and let Pi-hole handle true end-to-end encryption.";
-	conf->webserver.tls.rev_proxy.t = CONF_BOOL;
-	conf->webserver.tls.rev_proxy.d.b = false;
-	conf->webserver.tls.rev_proxy.c = validate_stub; // Only type-based checking
-
 	conf->webserver.tls.cert.k = "webserver.tls.cert";
 	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
 	conf->webserver.tls.cert.a = cJSON_CreateStringReference("<valid TLS certificate file (*.pem)>");

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -240,7 +240,6 @@ struct config {
 			struct conf_item restore;
 		} session;
 		struct {
-			struct conf_item rev_proxy;
 			struct conf_item cert;
 		} tls;
 		struct {

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -590,6 +590,21 @@ void db_init(void)
 		dbversion = db_get_int(db, DB_VERSION);
 	}
 
+	// Update to version 19 if lower
+	if(dbversion < 19)
+	{
+		// Update to version 19: Add x_forwarded_for column to session table
+		log_info("Updating long-term database to version 19");
+		if(!add_session_x_forwarded_for_column(db))
+		{
+			log_info("Session table cannot be updated, database not available");
+			dbclose(&db);
+			return;
+		}
+		// Get updated version
+		dbversion = db_get_int(db, DB_VERSION);
+	}
+
 	/* * * * * * * * * * * * * IMPORTANT * * * * * * * * * * * * *
 	 * If you add a new database version, check if the in-memory
 	 * schema needs to be update as well (always recreated from

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -23,7 +23,7 @@
                                                        "client TEXT NOT NULL, " \
                                                        "forward TEXT );"
 
-#define MEMDB_VERSION 18
+#define MEMDB_VERSION 19
 #define CREATE_QUERY_STORAGE_TABLE "CREATE TABLE query_storage ( id INTEGER PRIMARY KEY AUTOINCREMENT, " \
                                                                 "timestamp INTEGER NOT NULL, " \
                                                                 "type INTEGER NOT NULL, " \

--- a/src/database/session-table.c
+++ b/src/database/session-table.c
@@ -86,6 +86,27 @@ bool add_session_cli_column(sqlite3 *db)
 	return true;
 }
 
+bool add_session_x_forwarded_for_column(sqlite3 *db)
+{
+	// Start transaction of database update
+	SQL_bool(db, "BEGIN TRANSACTION;");
+
+	// Create session table
+	SQL_bool(db, "ALTER TABLE session ADD COLUMN x_forwarded_for TEXT;");
+
+	// Update database version to 18
+	if(!db_set_FTL_property(db, DB_VERSION, 19))
+	{
+		log_err("add_session_x_forwarded_for_column(): Failed to update database version!");
+		return false;
+	}
+
+	// Finish transaction
+	SQL_bool(db, "COMMIT");
+
+	return true;
+}
+
 // Store all session in database
 bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 {
@@ -104,7 +125,7 @@ bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 
 	// Insert session into database
 	sqlite3_stmt *stmt = NULL;
-	if(sqlite3_prepare_v2(db, "INSERT INTO session (login_at, valid_until, remote_addr, user_agent, sid, csrf, tls_login, tls_mixed, app, cli) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", -1, &stmt, 0) != SQLITE_OK)
+	if(sqlite3_prepare_v2(db, "INSERT INTO session (login_at, valid_until, remote_addr, user_agent, sid, csrf, tls_login, tls_mixed, app, cli, x_forwarded_for) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", -1, &stmt, 0) != SQLITE_OK)
 	{
 		log_err("SQL error in backup_db_sessions(): %s (%d)",
 		        sqlite3_errmsg(db), sqlite3_errcode(db));
@@ -126,70 +147,77 @@ bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 		if(sqlite3_bind_int64(stmt, 1, sess->login_at) != SQLITE_OK)
 		{
 			log_err("Cannot bind login_at = %ld in backup_db_sessions(): %s (%d)",
-					(long int)sess->login_at, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        (long int)sess->login_at, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 2: valid_until
 		if(sqlite3_bind_int64(stmt, 2, sess->valid_until) != SQLITE_OK)
 		{
 			log_err("Cannot bind valid_until = %ld in backup_db_sessions(): %s (%d)",
-					(long int)sess->valid_until, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        (long int)sess->valid_until, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 3: remote_addr
 		if(sqlite3_bind_text(stmt, 3, sess->remote_addr, -1, SQLITE_STATIC) != SQLITE_OK)
 		{
 			log_err("Cannot bind remote_addr = %s in backup_db_sessions(): %s (%d)",
-					sess->remote_addr, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->remote_addr, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 4: user_agent
 		if(sqlite3_bind_text(stmt, 4, sess->user_agent, -1, SQLITE_STATIC) != SQLITE_OK)
 		{
 			log_err("Cannot bind user_agent = %s in backup_db_sessions(): %s (%d)",
-					sess->user_agent, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->user_agent, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 5: sid
 		if(sqlite3_bind_text(stmt, 5, sess->sid, -1, SQLITE_STATIC) != SQLITE_OK)
 		{
 			log_err("Cannot bind sid = %s in backup_db_sessions(): %s (%d)",
-					sess->sid, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->sid, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 6: csrf
 		if(sqlite3_bind_text(stmt, 6, sess->csrf, -1, SQLITE_STATIC) != SQLITE_OK)
 		{
 			log_err("Cannot bind csrf = %s in backup_db_sessions(): %s (%d)",
-					sess->csrf, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->csrf, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 7: tls_login
 		if(sqlite3_bind_int(stmt, 7, sess->tls.login ? 1 : 0) != SQLITE_OK)
 		{
 			log_err("Cannot bind tls_login = %d in backup_db_sessions(): %s (%d)",
-					sess->tls.login ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->tls.login ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 8: tls_mixed
 		if(sqlite3_bind_int(stmt, 8, sess->tls.mixed ? 1 : 0) != SQLITE_OK)
 		{
 			log_err("Cannot bind tls_mixed = %d in backup_db_sessions(): %s (%d)",
-					sess->tls.mixed ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->tls.mixed ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 9: app
 		if(sqlite3_bind_int(stmt, 9, sess->app ? 1 : 0) != SQLITE_OK)
 		{
 			log_err("Cannot bind app = %d in backup_db_sessions(): %s (%d)",
-					sess->app ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->app ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 		// 10: cli
 		if(sqlite3_bind_int(stmt, 10, sess->cli ? 1 : 0) != SQLITE_OK)
 		{
 			log_err("Cannot bind cli = %d in backup_db_sessions(): %s (%d)",
-					sess->cli ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sess->cli ? 1 : 0, sqlite3_errmsg(db), sqlite3_errcode(db));
+			return false;
+		}
+		// 11: x_forwarded_for
+		if(sqlite3_bind_text(stmt, 11, sess->x_forwarded_for, -1, SQLITE_STATIC) != SQLITE_OK)
+		{
+			log_err("Cannot bind x_forwarded_for = %s in backup_db_sessions(): %s (%d)",
+			        sess->x_forwarded_for, sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 
@@ -197,7 +225,7 @@ bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 		if(sqlite3_step(stmt) != SQLITE_DONE)
 		{
 			log_err("SQL error in backup_db_sessions(): %s (%d)",
-					sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 
@@ -205,7 +233,7 @@ bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 		if(sqlite3_clear_bindings(stmt) != SQLITE_OK)
 		{
 			log_err("SQL error in backup_db_sessions(): %s (%d)",
-					sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 
@@ -213,7 +241,7 @@ bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions)
 		if(sqlite3_reset(stmt) != SQLITE_OK)
 		{
 			log_err("SQL error in backup_db_sessions(): %s (%d)",
-					sqlite3_errmsg(db), sqlite3_errcode(db));
+			        sqlite3_errmsg(db), sqlite3_errcode(db));
 			return false;
 		}
 
@@ -253,7 +281,7 @@ bool restore_db_sessions(struct session *sessions, const uint16_t max_sessions)
 
 	// Get all sessions from database
 	sqlite3_stmt *stmt = NULL;
-	if(sqlite3_prepare_v2(memdb, "SELECT login_at, valid_until, remote_addr, user_agent, sid, csrf, tls_login, tls_mixed, app, cli FROM disk.session;", -1, &stmt, 0) != SQLITE_OK)
+	if(sqlite3_prepare_v2(memdb, "SELECT login_at, valid_until, remote_addr, user_agent, sid, csrf, tls_login, tls_mixed, app, cli, x_forwarded_for FROM disk.session;", -1, &stmt, 0) != SQLITE_OK)
 	{
 		log_err("SQL error in restore_db_sessions(): %s (%d)",
 		        sqlite3_errmsg(memdb), sqlite3_errcode(memdb));
@@ -312,11 +340,19 @@ bool restore_db_sessions(struct session *sessions, const uint16_t max_sessions)
 		// 8: tls_mixed
 		sess->tls.mixed = sqlite3_column_int(stmt, 7) == 1 ? true : false;
 
-		// 8: app
+		// 9: app
 		sess->app = sqlite3_column_int(stmt, 8) == 1 ? true : false;
 
-		// 9: cli
+		// 10: cli
 		sess->cli = sqlite3_column_int(stmt, 9) == 1 ? true : false;
+
+		// 11: x_forwarded_for
+		const char *x_forwarded_for = (const char *)sqlite3_column_text(stmt, 10);
+		if(x_forwarded_for != NULL)
+		{
+			strncpy(sess->x_forwarded_for, x_forwarded_for, sizeof(sess->x_forwarded_for)-1);
+			sess->x_forwarded_for[sizeof(sess->x_forwarded_for)-1] = '\0';
+		}
 
 		// Mark session as used
 		sess->used = true;

--- a/src/database/session-table.h
+++ b/src/database/session-table.h
@@ -17,6 +17,7 @@
 bool create_session_table(sqlite3 *db);
 bool add_session_app_column(sqlite3 *db);
 bool add_session_cli_column(sqlite3 *db);
+bool add_session_x_forwarded_for_column(sqlite3 *db);
 bool backup_db_sessions(struct session *sessions, const uint16_t max_sessions);
 bool restore_db_sessions(struct session *sessions, const uint16_t max_sessions);
 

--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -240,12 +240,6 @@ static int pihole_needLogin(lua_State *L) {
 	return 1; // number of results
 }
 
-// pihole.rev_proxy()
-static int pihole_rev_proxy(lua_State *L) {
-	lua_pushboolean(L, config.webserver.tls.rev_proxy.v.b);
-	return 1; // number of results
-}
-
 static const luaL_Reg piholelib[] = {
 	{"ftl_version", pihole_ftl_version},
 	{"hostname", pihole_hostname},
@@ -255,7 +249,6 @@ static const luaL_Reg piholelib[] = {
 	{"include", pihole_include},
 	{"boxedlayout", pihole_boxedlayout},
 	{"needLogin", pihole_needLogin},
-	{"rev_proxy", pihole_rev_proxy},
 	{NULL, NULL}
 };
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -649,14 +649,6 @@
     restore = true
 
   [webserver.tls]
-    # Is Pi-hole running behind a reverse proxy? If yes, Pi-hole will not consider
-    # HTTP-only connections being insecure. This is useful if you are running Pi-hole in a
-    # trusted environment, for example, in a local network, and you are using a reverse
-    # proxy to provide TLS encryption, e.g., by using Traefik (docker). If you are using a
-    # reverse proxy, you can alternatively set webserver.tls.cert to the path of the TLS
-    # certificate file and let Pi-hole handle true end-to-end encryption.
-    rev_proxy = false
-
     # Path to the TLS (SSL) certificate file. This option is only required when at least
     # one of webserver.port is TLS. The file must be in PEM format, and it must have both,
     # private key and certificate (the *.pem file created must contain a 'CERTIFICATE'
@@ -1105,7 +1097,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 149 total entries out of which 94 entries are default
+# 148 total entries out of which 93 entries are default
 # --> 55 entries are modified
 # 2 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -440,7 +440,7 @@
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network\" (id INTEGER PRIMARY KEY NOT NULL, hwaddr TEXT UNIQUE NOT NULL, interface TEXT NOT NULL, firstSeen INTEGER NOT NULL, lastQuery INTEGER NOT NULL, numQueries INTEGER NOT NULL, macVendor TEXT, aliasclient_id INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network_addresses\" (network_id INTEGER NOT NULL, ip TEXT UNIQUE NOT NULL, lastSeen INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), name TEXT, nameUpdated INTEGER, FOREIGN KEY(network_id) REFERENCES network(id));"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE aliasclient (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, comment TEXT);"* ]]
-  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,18,'Database version');"* ]]
+  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,19,'Database version');"* ]]
   # vvv This has been added in version 10 vvv
   [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info, reply_type, reply_time, dnssec, list_id FROM query_storage q;"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE domain_by_id (id INTEGER PRIMARY KEY, domain TEXT NOT NULL);"* ]]
@@ -452,7 +452,7 @@
   [[ "${lines[@]}" == *"CREATE TABLE addinfo_by_id (id INTEGER PRIMARY KEY, type INTEGER NOT NULL, content NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE UNIQUE INDEX addinfo_by_id_idx ON addinfo_by_id(type,content);"* ]]
   # vvv This has been added in version 15 vvv
-  [[ "${lines[@]}" == *"CREATE TABLE session (id INTEGER PRIMARY KEY, login_at TIMESTAMP NOT NULL, valid_until TIMESTAMP NOT NULL, remote_addr TEXT NOT NULL, user_agent TEXT, sid TEXT NOT NULL, csrf TEXT NOT NULL, tls_login BOOL, tls_mixed BOOL, app BOOL, cli BOOL);"* ]]
+  [[ "${lines[@]}" == *"CREATE TABLE session (id INTEGER PRIMARY KEY, login_at TIMESTAMP NOT NULL, valid_until TIMESTAMP NOT NULL, remote_addr TEXT NOT NULL, user_agent TEXT, sid TEXT NOT NULL, csrf TEXT NOT NULL, tls_login BOOL, tls_mixed BOOL, app BOOL, cli BOOL, x_forwarded_for TEXT);"* ]]
 }
 
 @test "Ownership, permissions and type of pihole-FTL.db correct" {


### PR DESCRIPTION
# What does this implement/fix?

Improve session handling in the vicinity of reverse proxies and remove ill-fated manual config option `webserver.tls.rev_proxy`.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/webui-behind-lighttpd-reverse-proxy/71239/8

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.