### PR TITLE
Add new 2024 DNS root trust anchor

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -398,7 +398,12 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		fputs("# Use DNNSEC\n", pihole_conf);
 		fputs("dnssec\n", pihole_conf);
 		fputs("# 2017-02-02 root zone trust anchor\n", pihole_conf);
+		fputs("# https://www.iana.org/reports/2017/root-ksk-2017.pdf\n", pihole_conf);
 		fputs("trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n",
+		      pihole_conf);
+		fputs("# 2024-07-26 root zone trust anchor\n", pihole_conf);
+		fputs("# https://www.iana.org/reports/2024/root-ksk-2024.pdf\n", pihole_conf);
+		fputs("trust-anchor=.,38696,8,2,683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16\n",
 		      pihole_conf);
 		fputs("\n", pihole_conf);
 	}


### PR DESCRIPTION
# What does this implement/fix?

Earlier today, the IANA published the 2024 KSK:
[![grafik](https://github.com/user-attachments/assets/5b039be6-a3c5-48e7-95a7-aed2d825e41a)](https://www.iana.org/reports/2024/root-ksk-2024.pdf)
https://www.iana.org/reports/2024/root-ksk-2024.pdf
 

The currently used root key `20326` has no expiry, however, there are unconfirmed rumors that the currently used key will be rolled over late 2025 or 2026.

We should definitely add it already now, cfm. the DNS KSK procedures:
> Key distribution is REQUIRED to occur promptly after each Key Generation Ceremony. It MUST be completed before any key is taken into its Operational Period.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.