### PR TITLE
Improve automatic PTR handling code

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -248,7 +248,7 @@ void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg)
 	// Note: pArg is NULL and not used
 	// See https://sqlite.org/rescode.html#extrc for details
 	// concerning the return codes returned here
-	if(strncmp(zMsg, "file renamed while open: ", sizeof("file renamed while open: ")-1) == 0)
+	if(zMsg != NULL && strncmp(zMsg, "file renamed while open: ", sizeof("file renamed while open: ")-1) == 0)
 	{
 		// This happens when gravity.db is replaced while FTL is running
 		// We can safely ignore this warning
@@ -612,7 +612,7 @@ void db_init(void)
 	// Last check after all migrations, if this happens, it will cause the
 	// CI to fail the tests
 	if(dbversion != MEMDB_VERSION)
-		log_err("Database version %i does not match MEMDB_VERSION %i", dbversion, MEMDB_VERSION);
+		log_err("Expected query database version %d but found %d", MEMDB_VERSION, dbversion);
 
 	lock_shm();
 	import_aliasclients(db);

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1298,6 +1298,7 @@ void parse_neighbor_cache(sqlite3* db)
 		if((arpfp = popen(cmd, "r")) == NULL)
 		{
 			log_warn("Command \"%s\" failed: %s", cmd, strerror(errno));
+			free(client_status);
 			return;
 		}
 

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -481,14 +481,6 @@ int get_number_of_queries_in_DB(sqlite3 *db, const char *tablename)
 	rc = sqlite3_step(stmt);
 	if( rc == SQLITE_ROW )
 		num = sqlite3_column_int(stmt, 0);
-	else
-	{
-		log_err("get_number_of_queries_in_DB(%s): Step error: %s",
-		        tablename, sqlite3_errstr(rc));
-		free(querystr);
-		sqlite3_finalize(stmt);
-		return false;
-	}
 	sqlite3_finalize(stmt);
 	free(querystr);
 

--- a/src/dnsmasq/dhcp.c
+++ b/src/dnsmasq/dhcp.c
@@ -162,7 +162,7 @@ void dhcp_packet(time_t now, int pxe_fd)
 #elif defined(HAVE_BSD_NETWORK) 
     char control[CMSG_SPACE(sizeof(struct sockaddr_dl))];
 #endif
-  } control_u;
+  } control_u = { 0 };
   struct dhcp_bridge *bridge, *alias;
 
   msg.msg_controllen = sizeof(control_u);

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1310,7 +1310,10 @@ int main_dnsmasq (int argc, char **argv)
 
 static void sig_handler(int sig)
 {
-  log_debug(DEBUG_ANY, "dnsmasq received signal %d", sig);
+  /**** Pi-hole modification ****/
+  send_event(pipewrite, EVENT_SIGNAL, sig, NULL);
+  /******************************/
+
   if (pid == 0)
     {
       /* ignore anything other than TERM during startup
@@ -1569,6 +1572,12 @@ static void async_event(int pipe, time_t now)
       case EVENT_EXITED:
 	my_syslog(LOG_WARNING, _("script process exited with status %d"), ev.data);
 	break;
+
+  /**** Pi-hole modification ****/
+      case EVENT_SIGNAL:
+	log_debug(DEBUG_ANY, "dnsmasq received signal %d", ev.data);
+	break;
+  /**************************** */
 
       case EVENT_EXEC_ERR:
 	my_syslog(LOG_ERR, _("failed to execute %s: %s"), 

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -200,6 +200,9 @@ struct event_desc {
 #define EVENT_SCRIPT_LOG 25
 #define EVENT_TIME       26
 
+// Pi-hole
+#define EVENT_SIGNAL     255
+
 /* Exit codes. */
 #define EC_GOOD        0
 #define EC_BADCONF     1

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -36,7 +36,7 @@ int send_from(int fd, int nowild, char *packet, size_t len,
 	      union mysockaddr *to, union all_addr *source,
 	      unsigned int iface)
 {
-  struct msghdr msg;
+  struct msghdr msg = { 0 };
   struct iovec iov[1]; 
   union {
     struct cmsghdr align; /* this ensures alignment */
@@ -46,7 +46,7 @@ int send_from(int fd, int nowild, char *packet, size_t len,
     char control[CMSG_SPACE(sizeof(struct in_addr))];
 #endif
     char control6[CMSG_SPACE(sizeof(struct in6_pktinfo))];
-  } control_u;
+  } control_u = { 0 };
   
   iov[0].iov_base = packet;
   iov[0].iov_len = len;

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -868,7 +868,7 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 		return 2;
 	      
 	      // ****************************** Pi-hole modification ******************************
-	      const char *src = cpp != NULL ? cpp->flags & F_BIGNAME ? cpp->name.bname->name : cpp->name.sname : NULL;
+	      const char *src = cpp != NULL ? cache_get_name(cpp) : NULL;
 	      if(FTL_CNAME(name, src, daemon->log_display_id))
 		{
 		  // Found while processing a reply from upstream. We prevent cache insertion here
@@ -2047,7 +2047,7 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 			log_query(stale_flag | (crecp->flags & ~F_REVERSE), name, &crecp->addr,
 				  record_source(crecp->uid), 0);
 			    // ****************************** Pi-hole modification ******************************
-			    const char *src = crecp != NULL ? crecp->flags & F_BIGNAME ? crecp->name.bname->name : crecp->name.sname : NULL;
+			    const char *src = crecp != NULL ? cache_get_name(crecp) : NULL;
 			    if(FTL_CNAME(name, src, daemon->log_display_id))
 			      {
 			        // Served from cache. This can happen if a domain hidden in the CNAME path


### PR DESCRIPTION
# What does this implement/fix?

This PR improves the automagic PTR generation code. So far, we ensures that there is always a certain PTR in the cache we can set to whatever we deem appropriate to ensure Pi-hole replies with "`pi.hole`" (or whatever the user wants - there is a configuration setting for controlling this) on all interface addresses the machine running Pi-hole has.

For three years we have been reusing always the same PTR record and replaced in during runtime with whatever we needed, e.g., `PTR 1.0.168.192.in-addr.arpa -> pi.hole`, then on the next query to the another address, we freed this and inserted `PTR 1.0.0.10.in-addr.arpa -> pi.hole` instead.

The new way of doing this is simply adding suitable PTR records whenever they are needed in a linked list and *not* free previous entries. This has the enormous benefit of requiring work per address (limited number) instead of requiring the same work on each and every individual PTR query (supposedly many more).

There are a few drive-by changes such as minor reduction of code duplication in `database/query-table.c`, a rewording of an error message in  `database/common.c`, or fixing a small memory leak in a very unlikely ("cold") code path in `database/network-table.c` which didn't justify PRs on their own.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.