### PR TITLE
Fix port 65535 for virtual cache and blocklist upstreams

### DIFF
--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -570,7 +570,7 @@ cJSON *get_top_upstreams(struct ftl_conn *api, const bool upstreams_only)
 	{
 		int count = 0;
 		const char* ip, *name;
-		in_port_t port = -1;
+		int port = -1; // Need signed data type here as -1 means: no port applicable
 		double responsetime = 0.0, uncertainty = 0.0;
 
 		if(i == -2)


### PR DESCRIPTION
# What does this implement/fix?

Fix value overflow (`2^16 - 1 = 65535`) in `get_top_upstreams()` due to `in_port_t` being an unsigned 16 bit integer where we need a signed data type. This is a regression of #2001

### `development-v6`

![image](https://github.com/user-attachments/assets/4f691b78-9af1-4bba-813f-59740d788f91)

### this branch

![image](https://github.com/user-attachments/assets/4f3da367-14f8-46ec-abc4-d00e75799600)

---

**Related issue or feature (if applicable):** See linked Discourse discussion

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.