### PR TITLE
Improve pihole-FTL process concurrency

### DIFF
--- a/src/config/toml_reader.c
+++ b/src/config/toml_reader.c
@@ -141,12 +141,6 @@ bool readFTLtoml(struct config *oldconf, struct config *newconf,
 		struct conf_item *old_conf_item = oldconf != NULL ? get_conf_item(oldconf, i) : NULL;
 		struct conf_item *new_conf_item = get_conf_item(newconf, i);
 
-		// Do not read config.files.log.ftl from the TOML file if it has been
-		// set to NULL due to permissions issues during startup
-		if(config.files.log.ftl.v.s == NULL &&
-		   new_conf_item == &newconf->files.log.ftl)
-			continue;
-
 		// First try to read this config option from an environment variable
 		// Skip reading environment variables when importing from Teleporter
 		// If this succeeds, skip searching the TOML file for this config item

--- a/src/config/toml_reader.c
+++ b/src/config/toml_reader.c
@@ -141,6 +141,12 @@ bool readFTLtoml(struct config *oldconf, struct config *newconf,
 		struct conf_item *old_conf_item = oldconf != NULL ? get_conf_item(oldconf, i) : NULL;
 		struct conf_item *new_conf_item = get_conf_item(newconf, i);
 
+		// Do not read config.files.log.ftl from the TOML file if it has been
+		// set to NULL due to permissions issues during startup
+		if(config.files.log.ftl.v.s == NULL &&
+		   new_conf_item == &newconf->files.log.ftl)
+			continue;
+
 		// First try to read this config option from an environment variable
 		// Skip reading environment variables when importing from Teleporter
 		// If this succeeds, skip searching the TOML file for this config item

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -285,6 +285,7 @@ static void terminate_threads(void)
 			log_info("Thread %s (%d) is idle, terminating it.",
 			         thread_names[i], i);
 			pthread_cancel(threads[i]);
+			continue;
 		}
 
 		// Cancel thread if we cannot set a timeout for joining

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -34,6 +34,10 @@
 #include <sys/utsname.h>
 #endif
 
+/****** Pi-hole modification ******/
+extern int is_shm_fd(const int fd);
+/**********************************/
+
 /* SURF random number generator */
 
 static u32 seed[32];
@@ -815,6 +819,11 @@ void close_fds(long max_fd, int spare1, int spare2, int spare3)
 	      fd == spare1 || fd == spare2 || fd == spare3)
 	    continue;
 	  
+	  /****** Pi-hole modification ******/
+	  if(is_shm_fd(fd))
+	    continue;
+	  /**********************************/
+
 	  close(fd);
 	}
       

--- a/src/log.c
+++ b/src/log.c
@@ -53,8 +53,9 @@ void init_FTL_log(const char *name)
 		FILE *logfile = NULL;
 		if((logfile = fopen(config.files.log.ftl.v.s, "a+")) == NULL)
 		{
+			printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
+			       config.files.log.ftl.v.s, strerror(errno));
 			syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
-			printf("ERROR: Opening of FTL log (%s) failed!\n",config.files.log.ftl.v.s);
 			config.files.log.ftl.v.s = NULL;
 		}
 

--- a/src/log.c
+++ b/src/log.c
@@ -289,6 +289,7 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		va_end(args);
 		add_to_fifo_buffer(FIFO_FTL, buffer, prio, len > MAX_MSG_FIFO ? MAX_MSG_FIFO : len);
 
+		bool logged = false;
 		if(config.files.log.ftl.v.s != NULL)
 		{
 			// Open log file
@@ -310,6 +311,8 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 
 				// Close file after writing
 				fclose(logfile);
+
+				logged = true;
 			}
 			else if(!daemonmode)
 			{
@@ -317,7 +320,7 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 				syslog(LOG_ERR, "Writing to FTL\'s log file failed!");
 			}
 		}
-		else
+		if(!logged)
 		{
 			// Syslog logging
 			va_start(args, format);

--- a/src/main.c
+++ b/src/main.c
@@ -72,6 +72,10 @@ int main (int argc, char *argv[])
 	if(readFTLconf(&config, true))
 		log_info("Parsed config file "GLOBALTOMLPATH" successfully");
 
+	// Check if another FTL process is already running
+	if(another_FTL())
+		return EXIT_FAILURE;
+
 	// Set process priority
 	set_nice();
 
@@ -79,8 +83,6 @@ int main (int argc, char *argv[])
 	if(!init_shmem())
 	{
 		log_crit("Initialization of shared memory failed.");
-		// Check if there is already a running FTL process
-		check_running_FTL();
 		return EXIT_FAILURE;
 	}
 

--- a/src/procps.c
+++ b/src/procps.c
@@ -117,7 +117,7 @@ static bool get_process_creation_time(const pid_t pid, char timestr[TIMESTR_SIZE
 // This function prints an info message about if another FTL process is already
 // running. It returns true if another FTL process is already running, false
 // otherwise.
-bool check_running_FTL(void)
+bool another_FTL(void)
 {
 	DIR *dirPos;
 	struct dirent *entry;
@@ -144,7 +144,7 @@ bool check_running_FTL(void)
 				{
 					// Note: kill(pid, 0) does not send a
 					// signal, but merely checks if the
-					// process exists If the process does
+					// process exists. If the process does
 					// not exist, kill() returns -1 and sets
 					// errno to ESRCH. However, if the
 					// process exists, but security
@@ -162,20 +162,22 @@ bool check_running_FTL(void)
 			}
 			else
 			{
-				log_debug(DEBUG_SHMEM, "Failed to parse PID in PID file");
+				log_debug(DEBUG_SHMEM, "Failed to parse PID in PID file: %s",
+				          strerror(errno));
 			}
 			fclose(pidFile);
 		}
 		else
 		{
-			log_debug(DEBUG_SHMEM, "Failed to open PID file");
+			log_debug(DEBUG_SHMEM, "Failed to open PID file \"%s\": %s",
+			          config.files.pid.v.s, strerror(errno));
 		}
 	}
 
 	// If already_running is true, we are done
 	if(already_running)
 	{
-		log_info("%s is already running (PID %d)!", PROCESS_NAME, pid);
+		log_crit("%s is already running (PID %d)!", PROCESS_NAME, pid);
 		return true;
 	}
 
@@ -238,7 +240,7 @@ bool check_running_FTL(void)
 		if(!already_running)
 		{
 			already_running = true;
-			log_info("%s is already running!", PROCESS_NAME);
+			log_crit("%s is already running!", PROCESS_NAME);
 		}
 
 		if(last_pid != ppid)

--- a/src/procps.h
+++ b/src/procps.h
@@ -10,7 +10,7 @@
 
 #ifndef PROCPS_H
 #define PROCPS_H
-bool check_running_FTL(void);
+bool another_FTL(void);
 
 struct proc_mem {
 	// Memory currently resident in RAM (in kB)

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -22,6 +22,8 @@ typedef struct {
     const char *name;
     size_t size;
     void *ptr;
+    int fd;
+    struct flock lock;
 } SharedMemory;
 
 typedef struct {
@@ -139,5 +141,8 @@ void add_per_client_regex(unsigned int clientID);
 void reset_per_client_regex(const int clientID);
 bool get_per_client_regex(const int clientID, const int regexID);
 void set_per_client_regex(const int clientID, const int regexID, const bool value);
+
+// Used in dnsmasq/utils.c
+int is_shm_fd(const int fd);
 
 #endif //SHARED_MEMORY_SERVER_H

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -11,8 +11,7 @@
 @test "Running a second instance is detected and prevented" {
   run bash -c 'su pihole -s /bin/sh -c "./pihole-FTL -f"'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[@]}" == *"CRIT: Initialization of shared memory failed."* ]]
-  [[ "${lines[@]}" == *"INFO: pihole-FTL is already running"* ]]
+  [[ "${lines[@]}" == *"CRIT: pihole-FTL is already running"* ]]
 }
 
 @test "dnsmasq options as expected" {
@@ -486,8 +485,16 @@
   [[ "${lines[@]}" == "" ]]
 }
 
+@test "No ERROR messages in FTL.log (besides known/intended error)" {
+  run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log | grep -c -v -E "(index\.html)|(Failed to create shared memory object)|(FTLCONF_debug_api is invalid)|(Failed to set|adjust time during NTP sync: Insufficient permissions)"'
+  printf "count: %s\n" "${lines[@]}"
+  [[ ${lines[0]} == "0" ]]
+}
+
 @test "No CRIT messages in FTL.log (besides error due to starting FTL more than once)" {
-  run bash -c 'grep "CRIT:" /var/log/pihole/FTL.log | grep -v "CRIT: Initialization of shared memory failed"'
+  run bash -c 'grep "CRIT:" /var/log/pihole/FTL.log | grep -v "CRIT: pihole-FTL is already running"'
   printf "%s\n" "${lines[@]}"
   [[ "${lines[@]}" == "" ]]
 }
@@ -1160,22 +1167,6 @@
   run bash -c "bash test/hostnames.sh | tee ptr.log"
   printf "%s\n" "${lines[@]}"
   [[ "${lines[@]}" != *"ERROR"* ]]
-}
-
-@test "No ERROR messages in FTL.log (besides known/intended error)" {
-  run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log'
-  printf "%s\n" "${lines[@]}"
-  run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log | grep -c -v -E "(index\.html)|(Failed to create shared memory object)|(FTLCONF_debug_api is invalid)|(Failed to set|adjust time during NTP sync: Insufficient permissions)"'
-  printf "count: %s\n" "${lines[@]}"
-  [[ ${lines[0]} == "0" ]]
-}
-
-@test "No CRIT messages in FTL.log (besides error due to testing to start FTL more than once)" {
-  run bash -c 'grep "CRIT: " /var/log/pihole/FTL.log'
-  printf "%s\n" "${lines[@]}"
-  run bash -c 'grep "CRIT: " /var/log/pihole/FTL.log | grep -c -v "Initialization of shared memory failed."'
-  printf "count: %s\n" "${lines[@]}"
-  [[ ${lines[0]} == "0" ]]
 }
 
 @test "No missing config items in pihole.toml" {


### PR DESCRIPTION
# What does this implement/fix?

FTL is trying hard to prevent you from starting another instance of itself. It does so by creating a PID file in `/run/pihole-FTL.pid` and checking for its existence. If the file is present, FTL assumes that another instance is already running and exits. It also checks for the existence of the shared memory objects `/dev/shm/FTL-*` and exits if they are present.

These checks can be fooled by manually removing the PID file or shared memory objects (needs `root` privileges). This can lead to multiple instances of FTL running at the same time, which can cause various issues. The most commonly seen issue is that, when the first process needs more memory, its original shared memory objects are already gone. Hence, it actually tries to resize the shared memory objects of the second instance which, on the other hand, doesn't expect this and crashes. As the first process was not able to allocate more memory, this process will eventually crash as well.

This commit resolves this by:
1. **Improve support for concurrent `pihole-FTL` instances**
   Even when this continues to be somewhat discouraged, it is now possible to run multiple instances of `pihole-FTL` at the same time. This is achieved by ensuring that we keep the shared memory object file descriptors open as long as the process is running. This way, the shared memory objects are not removed until the process exits. This also means that the shared memory objects are not *hard* removed when they are deleted from the outside of the process (in Linux, a file continues to exist as long as there is at least one open file descriptor pointing to it).
    A hypothetical second instance of `pihole-FTL` will now be able to create new shared memory objects without interfering with the first instance. This is a more robust solution than the previous one, as it doesn't rely on the existence of the PID file or shared memory objects which might have been removed by external influences.
3. **Check for a potential second instance earlier in the code**
   We move the check to before even trying to create shared memory objects. This way, we can exit early if we detect that another instance is already running. This is a more efficient solution than the previous one, as we don't need to create shared memory objects just to find out that we can't use them.
5. **Add an exclusive lock on the shared memory objects**
   Even when this is not strictly necessary, it is a good practice to prevent other processes from interfering with the shared memory objects. This is especially important on systems which isolate processes from each other and is a safety net in rare cases such as multiple Docker containers (isolating processes from one another by default) with (incorrectly!) host-mounted shared memory folders.
   Once they remove the mounting of `dev/shm`, they will again be able to run multiple `pihole-FTL` across multiple containers.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
3. I have commented my proposed changes within the code.
4. I am willing to help maintain this change if there are issues with it later.
7. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
8. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.