### PR TITLE
 Fix NTP synchronization on devices not knowing the NTP service type

### DIFF
--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -389,7 +389,8 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 	// Resolve server address
 	int eai;
 	struct addrinfo *saddr;
-	if((eai = getaddrinfo(server, "ntp", NULL, &saddr)) != 0)
+	// Resolve server address, port 123 is used for NTP
+	if((eai = getaddrinfo(server, "123", NULL, &saddr)) != 0)
 	{
 		char errbuf[1024];
 		strncpy(errbuf, "Cannot resolve NTP server address: ", sizeof(errbuf));


### PR DESCRIPTION
# What does this implement/fix?

Directly specify NTP port instead of service by name. Having checked the actual implementation of `getaddrinfo()`, we see that this avoids iterating over /etc/services ensuring we don't get "Unknown service" errors on systems that - for any reason - either lack the file or somehow lack the particular NTP service line.

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/cannot-resolve-ntp-server-address-unrecognized-service/71653

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.