### PR TITLE
Implement DNS caching for queries blocked upstream

### DIFF
--- a/.github/.codespellignore
+++ b/.github/.codespellignore
@@ -12,3 +12,4 @@ dnsmasq
 iif
 prefered
 padd
+rabit

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -239,7 +239,7 @@ components:
                       type: integer
                     optimizer:
                       type: integer
-                    upstreamTTL:
+                    upstreamBlockedTTL:
                       type: integer
                 revServers:
                   type: array
@@ -665,7 +665,7 @@ components:
             cache:
               size: 10000
               optimizer: 3600
-              upstreamTTL: 86400
+              upstreamBlockedTTL: 86400
             revServers:
               - "true,192.168.0.0/24,192.168.0.1,lan"
             blocking:

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -239,6 +239,8 @@ components:
                       type: integer
                     optimizer:
                       type: integer
+                    upstreamTTL:
+                      type: integer
                 revServers:
                   type: array
                   items:
@@ -663,6 +665,7 @@ components:
             cache:
               size: 10000
               optimizer: 3600
+              upstreamTTL: 86400
             revServers:
               - "true,192.168.0.0/24,192.168.0.1,lan"
             blocking:

--- a/src/api/padd.c
+++ b/src/api/padd.c
@@ -52,7 +52,7 @@ int api_padd(struct ftl_conn *api)
 		// Find most recently blocked query
 		for(int queryID = counters->queries - 1; queryID > 0 ; queryID--)
 		{
-			const queriesData* query = getQuery(queryID, true);
+			const queriesData *query = getQuery(queryID, true);
 			if(query == NULL)
 				continue;
 

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -748,7 +748,7 @@ int api_stats_recentblocked(struct ftl_conn *api)
 	cJSON *blocked = JSON_NEW_ARRAY();
 	for(int queryID = counters->queries - 1; queryID > 0 ; queryID--)
 	{
-		const queriesData* query = getQuery(queryID, true);
+		const queriesData *query = getQuery(queryID, true);
 		if(query == NULL)
 			continue;
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -580,6 +580,12 @@ void initConfig(struct config *conf)
 	conf->dns.cache.optimizer.d.i = 3600u;
 	conf->dns.cache.optimizer.c = validate_stub; // Only type-based checking
 
+	conf->dns.cache.upstreamTTL.k = "dns.cache.upstreamTTL";
+	conf->dns.cache.upstreamTTL.h = "This setting allows you to specify the TTL used for queries blocked upstream. Once the TTL expires, the query will be forwarded to the upstream server again to check if the block is still valid. Defaults to caching for one day (86400 seconds). Setting this value to zero disables caching of queries blocked upstream.";
+	conf->dns.cache.upstreamTTL.t = CONF_UINT;
+	conf->dns.cache.upstreamTTL.d.ui = 86400;
+	conf->dns.cache.upstreamTTL.c = validate_stub; // Only type-based checking
+
 	// sub-struct dns.blocking
 	conf->dns.blocking.active.k = "dns.blocking.active";
 	conf->dns.blocking.active.h = "Should FTL block queries?";

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -580,11 +580,11 @@ void initConfig(struct config *conf)
 	conf->dns.cache.optimizer.d.i = 3600u;
 	conf->dns.cache.optimizer.c = validate_stub; // Only type-based checking
 
-	conf->dns.cache.upstreamTTL.k = "dns.cache.upstreamTTL";
-	conf->dns.cache.upstreamTTL.h = "This setting allows you to specify the TTL used for queries blocked upstream. Once the TTL expires, the query will be forwarded to the upstream server again to check if the block is still valid. Defaults to caching for one day (86400 seconds). Setting this value to zero disables caching of queries blocked upstream.";
-	conf->dns.cache.upstreamTTL.t = CONF_UINT;
-	conf->dns.cache.upstreamTTL.d.ui = 86400;
-	conf->dns.cache.upstreamTTL.c = validate_stub; // Only type-based checking
+	conf->dns.cache.upstreamBlockedTTL.k = "dns.cache.upstreamBlockedTTL";
+	conf->dns.cache.upstreamBlockedTTL.h = "This setting allows you to specify the TTL used for queries blocked upstream. Once the TTL expires, the query will be forwarded to the upstream server again to check if the block is still valid. Defaults to caching for one day (86400 seconds). Setting this value to zero disables caching of queries blocked upstream.";
+	conf->dns.cache.upstreamBlockedTTL.t = CONF_UINT;
+	conf->dns.cache.upstreamBlockedTTL.d.ui = 86400;
+	conf->dns.cache.upstreamBlockedTTL.c = validate_stub; // Only type-based checking
 
 	// sub-struct dns.blocking
 	conf->dns.blocking.active.k = "dns.blocking.active";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -147,7 +147,7 @@ struct config {
 		struct {
 			struct conf_item size;
 			struct conf_item optimizer;
-			struct conf_item upstreamTTL;
+			struct conf_item upstreamBlockedTTL;
 		} cache;
 		struct {
 			struct conf_item active;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -147,6 +147,7 @@ struct config {
 		struct {
 			struct conf_item size;
 			struct conf_item optimizer;
+			struct conf_item upstreamTTL;
 		} cache;
 		struct {
 			struct conf_item active;

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -69,7 +69,7 @@ int findQueryID(const int id)
 	// Check UUIDs of queries
 	for(int i = start; i >= until; i--)
 	{
-		const queriesData* query = getQuery(i, true);
+		const queriesData *query = getQuery(i, true);
 
 		// Check if the returned pointer is valid before trying to access it
 		if(query == NULL)
@@ -462,7 +462,7 @@ bool isValidIPv6(const char *addr)
 
 // Privacy-level sensitive subroutine that returns the domain name
 // only when appropriate for the requested query
-const char *getDomainString(const queriesData* query)
+const char *getDomainString(const queriesData *query)
 {
 	// Check if the returned pointer is valid before trying to access it
 	if(query == NULL || query->domainID < 0)
@@ -486,7 +486,7 @@ const char *getDomainString(const queriesData* query)
 
 // Privacy-level sensitive subroutine that returns the domain name
 // only when appropriate for the requested query
-const char *getCNAMEDomainString(const queriesData* query)
+const char *getCNAMEDomainString(const queriesData *query)
 {
 	// Check if the returned pointer is valid before trying to access it
 	if(query == NULL || query->CNAME_domainID < 0)
@@ -510,7 +510,7 @@ const char *getCNAMEDomainString(const queriesData* query)
 
 // Privacy-level sensitive subroutine that returns the client IP
 // only when appropriate for the requested query
-const char *getClientIPString(const queriesData* query)
+const char *getClientIPString(const queriesData *query)
 {
 	// Check if the returned pointer is valid before trying to access it
 	if(query == NULL || query->clientID < 0)
@@ -534,7 +534,7 @@ const char *getClientIPString(const queriesData* query)
 
 // Privacy-level sensitive subroutine that returns the client host name
 // only when appropriate for the requested query
-const char *getClientNameString(const queriesData* query)
+const char *getClientNameString(const queriesData *query)
 {
 	// Check if the returned pointer is valid before trying to access it
 	if(query == NULL || query->clientID < 0)

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -114,6 +114,7 @@ typedef struct {
 	int domainID;
 	int clientID;
 	int list_id;
+	time_t expires;
 	char *cname_target;
 } DNSCacheData;
 

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -145,10 +145,10 @@ void _query_set_status(queriesData *query, const enum query_status new_status, c
 void FTL_reload_all_domainlists(void);
 void FTL_reset_per_client_domain_data(void);
 
-const char *getDomainString(const queriesData* query);
-const char *getCNAMEDomainString(const queriesData* query);
-const char *getClientIPString(const queriesData* query);
-const char *getClientNameString(const queriesData* query);
+const char *getDomainString(const queriesData *query);
+const char *getCNAMEDomainString(const queriesData *query);
+const char *getClientIPString(const queriesData *query);
+const char *getClientNameString(const queriesData *query);
 
 void change_clientcount(clientsData *client, int total, int blocked, int overTimeIdx, int overTimeMod);
 const char *get_query_type_str(const enum query_type type, const queriesData *query, char buffer[20]);
@@ -171,7 +171,7 @@ int __attribute__ ((pure)) get_temp_unit_val(const char *temp_unit);
 
 // Pointer getter functions
 #define getQuery(queryID, checkMagic) _getQuery(queryID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
-queriesData* _getQuery(int queryID, bool checkMagic, int line, const char *func, const char *file);
+queriesData *_getQuery(int queryID, bool checkMagic, int line, const char *func, const char *file);
 #define getClient(clientID, checkMagic) _getClient(clientID, checkMagic, __LINE__, __FUNCTION__, __FILE__)
 clientsData* _getClient(int clientID, bool checkMagic, int line, const char *func, const char *file);
 #define getDomain(domainID, checkMagic) _getDomain(domainID, checkMagic, __LINE__, __FUNCTION__, __FILE__)

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -781,7 +781,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
 	}
     }
   
-  FTL_header_analysis(header->hb4, rcode, server, daemon->log_display_id);
+  FTL_header_analysis(header->hb4, server, daemon->log_display_id);
   
   /* RFC 4035 sect 4.6 para 3 */
   if (!is_sign && !option_bool(OPT_DNSSEC_PROXY))
@@ -1206,7 +1206,7 @@ void reply_query(int fd, time_t now)
 
   server = daemon->serverarray[c];
 
-  FTL_header_analysis(header->hb4, RCODE(header), server, daemon->log_display_id);
+  FTL_header_analysis(header->hb4, server, daemon->log_display_id);
 
   if (RCODE(header) != REFUSED)
     daemon->serverarray[first]->last_server = c;
@@ -2166,7 +2166,7 @@ static int tcp_key_recurse(time_t now, int status, struct dns_header *header, si
   unsigned char *packet = NULL;
   struct dns_header *new_header = NULL;
   
-  FTL_header_analysis(header->hb4, RCODE(header), server, daemon->log_display_id);
+  FTL_header_analysis(header->hb4, server, daemon->log_display_id);
 
   while (1)
     {

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1033,7 +1033,7 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 		if(FTL_check_reply(RCODE(header), flags, &addr, daemon->log_display_id))
 		  {
  		    // Found while processing a reply from upstream
- 		    log_query(F_UPSTREAM, name, NULL, "blocked due to upstream response (IP)", 0);
+ 		    log_query(F_UPSTREAM, name, NULL, "blocked due to upstream response (answer)", 0);
  		    return 99;
  		  }
 		/********************************************/

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -792,6 +792,17 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 	flags |= F_RR;
       else
 	insert = 0; /* NOTE: do not cache data from CNAME queries. */
+
+      /*********** Pi-hole modification ***********/
+      if(FTL_check_reply(RCODE(header), flags, NULL, daemon->log_display_id))
+	{
+	  // Found while processing a reply from upstream. We prevent cache insertion here
+	  // This query is to be blocked as we found a blocked
+	  // domain while walking the CNAME path. Log to pihole.log here
+	  log_query(F_UPSTREAM, name, NULL, "blocked due to upstream response (header)", 0);
+	  return 99;
+	}
+      /********************************************/
       
     cname_loop1:
       if (!(p1 = skip_questions(header, qlen)))
@@ -1017,6 +1028,15 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 			log_query((flags & (F_IPV4 | F_IPV6)) | F_IPSET, nftsets->domain, &addr, *nftsets_cur, 0);
 #endif
 		}
+
+		/*********** Pi-hole modification ***********/
+		if(FTL_check_reply(RCODE(header), flags, &addr, daemon->log_display_id))
+		  {
+ 		    // Found while processing a reply from upstream
+ 		    log_query(F_UPSTREAM, name, NULL, "blocked due to upstream response (IP)", 0);
+ 		    return 99;
+ 		  }
+		/********************************************/
 	      
 	      if (insert)
 		{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1149,14 +1149,14 @@ static void set_dnscache_blockingstatus(DNSCacheData *dns_cache, enum domain_cli
 	// Set expiration time for this cache entry (if applicable)
 	// We set this only if not already set to avoid extending the TTL of an
 	// existing entry
-	if(config.dns.cache.upstreamTTL.v.ui > 0 &&
+	if(config.dns.cache.upstreamBlockedTTL.v.ui > 0 &&
 	   dns_cache->expires == 0 &&
 	   (new_status == UPSTREAM_BLOCKED_NXRA ||
 	    new_status == UPSTREAM_BLOCKED_NULL ||
 	    new_status == UPSTREAM_BLOCKED_IP))
 	{
 		// Set expiration time for this cache entry
-		dns_cache->expires = time(NULL) + config.dns.cache.upstreamTTL.v.ui;
+		dns_cache->expires = time(NULL) + config.dns.cache.upstreamBlockedTTL.v.ui;
 	}
 
 	if(!config.debug.queries.v.b)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -64,12 +64,11 @@
 // Private prototypes
 static void print_flags(const unsigned int flags);
 #define query_set_reply(flags, reply, addr, query, response) _query_set_reply(flags, reply, addr, query, response, __FILE__, __LINE__)
-static void _query_set_reply(const unsigned int flags, const enum reply_type reply, const union all_addr *addr, queriesData* query,
+static void _query_set_reply(const unsigned int flags, const enum reply_type reply, const union all_addr *addr, queriesData *query,
                              const struct timeval response, const char *file, const int line);
 #define FTL_check_blocking(queryID, domainID, clientID) _FTL_check_blocking(queryID, domainID, clientID, __FILE__, __LINE__)
 static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const char* file, const int line);
-static enum query_status detect_blocked_IP(const unsigned short flags, const union all_addr *addr, const queriesData *query, const domainsData *domain);
-static void query_blocked(queriesData* query, domainsData* domain, clientsData* client, const enum query_status new_status);
+static void query_blocked(queriesData *query, domainsData* domain, clientsData* client, const enum query_status new_status);
 static void FTL_forwarded(const unsigned int flags, const char *name, const union all_addr *addr, unsigned short port, const int id, const char* file, const int line);
 static void FTL_reply(const unsigned int flags, const char *name, const union all_addr *addr, const char* arg, unsigned short type, const int id, const char* file, const int line);
 static void FTL_upstream_error(const union all_addr *addr, const unsigned int flags, const int id, const char* file, const int line);
@@ -83,7 +82,7 @@ static char *get_ptrname(struct in_addr *addr);
 static const char *check_dnsmasq_name(const char *name);
 
 // Static blocking metadata
-static bool adbit = false;
+static bool adbit = false, rabit = false;
 static const char *blockingreason = "";
 static enum reply_type force_next_DNS_reply = REPLY_UNKNOWN;
 static int last_regex_idx = -1;
@@ -462,6 +461,9 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 	if (trunc)
 		header->hb3 |= HB3_TC;
 
+	// Unset the blocking reason
+	blockingreason = "<not set>";
+
 	return p - (unsigned char *)header;
 }
 
@@ -728,7 +730,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	const int domainID = findDomainID(domainString, true);
 
 	// Save everything
-	queriesData* query = getQuery(queryID, false);
+	queriesData *query = getQuery(queryID, false);
 	if(query == NULL)
 	{
 		// Encountered memory error, skip query
@@ -1137,14 +1139,19 @@ static void check_pihole_PTR(char *domain)
 	}
 }
 
-inline static void set_dnscache_blockingstatus(DNSCacheData * dns_cache, clientsData *client,
-                                               enum domain_client_status new_status, const char *domain)
+inline static void set_dnscache_blockingstatus(DNSCacheData * dns_cache, enum domain_client_status new_status,
+                                               const char *client, const char *domain)
 {
 	// Memorize blocking status DNS cache for the domain/client combination
 	dns_cache->blocking_status = new_status;
 
-	const char *clientip = client ? getstr(client->ippos) : "N/A";
-	log_debug(DEBUG_QUERIES, "DNS cache: %s/%s is %s", clientip, domain, blockingreason);
+	if(!config.debug.queries.v.b)
+		return;
+
+	// Debug logging
+	const char *qtype = get_query_type_str(dns_cache->query_type, NULL, NULL);
+	const char *clientstr = client ? client : "<unknown>";
+	log_debug(DEBUG_QUERIES, "DNS cache: %s/%s/%s is %s", qtype, clientstr, domain, blockingreason);
 }
 
 static bool check_domain_blocked(const char *domain, const int clientID,
@@ -1164,7 +1171,7 @@ static bool check_domain_blocked(const char *domain, const int clientID,
 		blockingreason = "exactly denied";
 
 		// Mark domain as exactly denied for this client
-		set_dnscache_blockingstatus(dns_cache, client, DENYLIST_BLOCKED, domain);
+		set_dnscache_blockingstatus(dns_cache, DENYLIST_BLOCKED, client ? getstr(client->ippos) : NULL, domain);
 
 		// We block this domain
 		return true;
@@ -1202,7 +1209,7 @@ static bool check_domain_blocked(const char *domain, const int clientID,
 		blockingreason = "gravity blocked";
 
 		// Mark domain as gravity blocked for this client
-		set_dnscache_blockingstatus(dns_cache, client, GRAVITY_BLOCKED, domain);
+		set_dnscache_blockingstatus(dns_cache, GRAVITY_BLOCKED, client ? getstr(client->ippos) : NULL, domain);
 
 		log_debug(DEBUG_QUERIES, "Blocking query due to gravity match (list ID %i)", list_id);
 
@@ -1262,7 +1269,7 @@ static bool check_domain_blocked(const char *domain, const int clientID,
 		blockingreason = "regex denied";
 
 		// Mark domain as regex matched for this client
-		set_dnscache_blockingstatus(dns_cache, client, REGEX_BLOCKED, domain);
+		set_dnscache_blockingstatus(dns_cache, REGEX_BLOCKED, client ? getstr(client->ippos) : NULL, domain);
 
 		// Regex may be overwriting reply type for this domain
 		if(dns_cache->force_reply != REPLY_UNKNOWN)
@@ -1362,9 +1369,8 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 
 	// Skip the entire chain of tests if we already know the answer for this
 	// particular client
-	unsigned char blockingStatus = dns_cache->blocking_status;
 	char *domainstr = (char*)getstr(domain->domainpos);
-	switch(blockingStatus)
+	switch(dns_cache->blocking_status)
 	{
 		case UNKNOWN_BLOCKED:
 			// New domain/client combination.
@@ -1451,6 +1457,23 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 
 			return false;
 			break;
+
+		case UPSTREAM_BLOCKED_IP:
+		case UPSTREAM_BLOCKED_NULL:
+		case UPSTREAM_BLOCKED_NXRA:
+			// Known as upstream blocked, we return this result
+			// early, skipping all the lengthy tests below
+			blockingreason = "upstream blocked";
+			log_debug(DEBUG_QUERIES, "%s is known as %s", domainstr, blockingreason);
+
+			force_next_DNS_reply = dns_cache->force_reply;
+			const enum query_status qstat = dns_cache->blocking_status == UPSTREAM_BLOCKED_IP ?
+			                                QUERY_EXTERNAL_BLOCKED_IP :
+			                                dns_cache->blocking_status == UPSTREAM_BLOCKED_NULL ?
+			                                 QUERY_EXTERNAL_BLOCKED_NULL : QUERY_EXTERNAL_BLOCKED_NXRA;
+			query_blocked(query, domain, client, qstat);
+			return true;
+			break;
 	}
 
 	// Skip all checks and continue if we hit already at least one allowlist in the chain
@@ -1501,7 +1524,7 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 	// (defaulting to true)
 	if(config.dns.blockESNI.v.b &&
 	   !query->flags.allowed && blockDomain == NOT_FOUND &&
-	    strlen(domainstr) > 6 && strncasecmp(domainstr, "_esni.", 6u) == 0)
+	   strlen(domainstr) > 6 && strncasecmp(domainstr, "_esni.", 6u) == 0)
 	{
 		blockDomain = check_domain_blocked(domainstr + 6u, clientID, client, query, dns_cache, &new_status, &db_okay);
 
@@ -1544,7 +1567,8 @@ static bool _FTL_check_blocking(int queryID, int domainID, int clientID, const c
 
 		// Debug output
 		// client is guaranteed to be non-NULL above
-		log_debug(DEBUG_QUERIES, "DNS cache: %s/%s is %s (domainlist ID: %i)", getstr(client->ippos),
+		log_debug(DEBUG_QUERIES, "DNS cache: %s/%s/%s is %s (domainlist ID: %i)",
+		          get_query_type_str(query->type, NULL, NULL), getstr(client->ippos),
 		          domainstr, query->flags.allowed ? "allowed" : "not blocked", dns_cache->list_id);
 	}
 
@@ -1580,7 +1604,7 @@ bool _FTL_CNAME(const char *dst, const char *src, const int id, const char* file
 
 	// Get query pointer so we can later extract the client requesting this domain for
 	// the per-client blocking evaluation
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		// Nothing to be done here
@@ -1740,7 +1764,7 @@ static void FTL_forwarded(const unsigned int flags, const char *name, const unio
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		free(upstreamIP);
@@ -2061,7 +2085,7 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 	}
 
 	// Get and check query pointer
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		// Nothing to be done here
@@ -2125,17 +2149,6 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 		// Set status of this query only if this is not a blocked query
 		if(!is_blocked(query->status))
 			query_set_status(query, qs);
-
-		// Detect if returned IP indicates that this query was blocked
-		const enum query_status new_status = detect_blocked_IP(flags, addr, query, domain);
-
-		// Update status of this query if detected as external blocking
-		if(new_status != query->status)
-		{
-			clientsData *client = getClient(query->clientID, true);
-			if(client != NULL)
-				query_blocked(query, domain, client, new_status);
-		}
 
 		// Save reply type and update individual reply counters
 		query_set_reply(flags, 0, addr, query, response);
@@ -2227,21 +2240,6 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 		// Save reply type and update individual reply counters
 		query_set_reply(reply_flags, 0, addr, query, response);
 
-		// Further checks if this is an IP address
-		if(addr)
-		{
-			// Detect if returned IP indicates that this query was blocked
-			const enum query_status new_status = detect_blocked_IP(flags, addr, query, domain);
-
-			// Update status of this query if detected as external blocking
-			if(new_status != query->status)
-			{
-				clientsData *client = getClient(query->clientID, true);
-				if(client != NULL)
-					query_blocked(query, domain, client, new_status);
-			}
-		}
-
 		// Mark query for updating in the database
 		query->flags.database.changed = true;
 	}
@@ -2304,14 +2302,9 @@ static void FTL_reply(const unsigned int flags, const char *name, const union al
 	unlock_shm();
 }
 
-static enum query_status detect_blocked_IP(const unsigned short flags, const union all_addr *addr, const queriesData *query, const domainsData *domain)
+static enum query_status detect_blocked_IP(const unsigned short flags, const union all_addr *addr)
 {
 	// Compare returned IP against list of known blocking splash pages
-
-	if (!addr)
-	{
-		return query->status;
-	}
 
 	// First, we check if we want to skip this result even before comparing against the known IPs
 	if(flags & F_HOSTS || flags & F_REVERSE)
@@ -2320,18 +2313,18 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 		// count gravity.list blocked queries as externally blocked.
 		// Also: Do not mark responses of PTR requests as externally blocked.
 		const char *cause = (flags & F_HOSTS) ? "origin is HOSTS" : "query is PTR";
-		log_debug(DEBUG_QUERIES, "Skipping detection of external blocking IP for ID %i as %s", query->id, cause);
+		log_debug(DEBUG_QUERIES, "Skipping detection of external blocking IP as %s", cause);
 
 		// Return early, do not compare against known blocking page IP addresses below
-		return query->status;
+		return QUERY_UNKNOWN;
 	}
 
 	// If received one of the following IPs as reply, OpenDNS
 	// (Cisco Umbrella) blocked this query
-	// See https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses-
+	// See https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses
 	// for a full list of these IP addresses
-	in_addr_t ipv4Addr = ntohl(addr->addr4.s_addr);
-	in_addr_t ipv6Addr = ntohl(addr->addr6.s6_addr32[3]);
+	const in_addr_t ipv4Addr = flags & F_IPV4 ? ntohl(addr->addr4.s_addr) : 0;
+	const in_addr_t ipv6Addr = flags & F_IPV6 ? ntohl(addr->addr6.s6_addr32[3]) : 0;
 	// Check for IP block 146.112.61.104 - 146.112.61.110
 	if((flags & F_IPV4) && ipv4Addr >= 0x92703d68 && ipv4Addr <= 0x92703d6e)
 	{
@@ -2339,14 +2332,14 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 		{
 			char answer[ADDRSTRLEN]; answer[0] = '\0';
 			inet_ntop(AF_INET, addr, answer, ADDRSTRLEN);
-			log_debug(DEBUG_QUERIES, "Upstream responded with known blocking page (IPv4), ID %i:\n\t\"%s\" -> \"%s\"",
-			          query->id, getstr(domain->domainpos), answer);
+			blockingreason = "blocked upstream with known address (IPv4)";
+			log_debug(DEBUG_QUERIES, "%s -> \"%s\"", blockingreason, answer);
 		}
 
 		// Update status
 		return QUERY_EXTERNAL_BLOCKED_IP;
 	}
-	// Check for IP block :ffff:146.112.61.104 - :ffff:146.112.61.110
+	// Check for IP block ::ffff:146.112.61.104 - ::ffff:146.112.61.110
 	else if(flags & F_IPV6 &&
 	        addr->addr6.s6_addr32[0] == 0 &&
 	        addr->addr6.s6_addr32[1] == 0 &&
@@ -2357,8 +2350,8 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 		{
 			char answer[ADDRSTRLEN]; answer[0] = '\0';
 			inet_ntop(AF_INET6, addr, answer, ADDRSTRLEN);
-			log_debug(DEBUG_QUERIES, "Upstream responded with known blocking page (IPv6), ID %i:\n\t\"%s\" -> \"%s\"",
-			          query->id, getstr(domain->domainpos), answer);
+			blockingreason = "blocked upstream with known address (IPv6)";
+			log_debug(DEBUG_QUERIES, "%s -> \"%s\"", blockingreason, answer);
 		}
 
 		// Update status
@@ -2372,8 +2365,8 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 	{
 		if(config.debug.queries.v.b)
 		{
-			log_debug(DEBUG_QUERIES, "Upstream responded with 0.0.0.0, ID %i:\n\t\"%s\" -> \"0.0.0.0\"",
-			          query->id, getstr(domain->domainpos));
+			blockingreason = "blocked upstream with 0.0.0.0";
+			log_debug(DEBUG_QUERIES, "%s", blockingreason);
 		}
 
 		// Update status
@@ -2387,8 +2380,8 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 	{
 		if(config.debug.queries.v.b)
 		{
-			log_debug(DEBUG_QUERIES, "Upstream responded with ::, ID %i:\n\t\"%s\" -> \"::\"",
-			          query->id, getstr(domain->domainpos));
+			blockingreason = "blocked upstream with ::";
+			log_debug(DEBUG_QUERIES, "%s", blockingreason);
 		}
 
 		// Update status
@@ -2396,14 +2389,33 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 	}
 
 	// Nothing happened here
-	return query->status;
+	return QUERY_UNKNOWN;
 }
 
-static void query_blocked(queriesData* query, domainsData* domain, clientsData* client, const enum query_status new_status)
+static void query_blocked(queriesData *query, domainsData *domain, clientsData *client, const enum query_status new_status)
 {
 	// Get response time
 	struct timeval response;
 	gettimeofday(&response, 0);
+
+	// Memorize this in the DNS cache if blocked due to the response
+	if(new_status == QUERY_EXTERNAL_BLOCKED_IP ||
+	   new_status == QUERY_EXTERNAL_BLOCKED_NULL ||
+	   new_status == QUERY_EXTERNAL_BLOCKED_NXRA)
+	{
+		const int cacheID = findCacheID(query->domainID, query->clientID, query->type, true);
+		DNSCacheData *dns_cache = getDNSCache(cacheID, true);
+		if(dns_cache != NULL)
+		{
+			// Update status
+			enum domain_client_status cache_status = new_status == QUERY_EXTERNAL_BLOCKED_IP ? UPSTREAM_BLOCKED_IP :
+			                                         new_status == QUERY_EXTERNAL_BLOCKED_NULL ? UPSTREAM_BLOCKED_NULL :
+			                                         UPSTREAM_BLOCKED_NXRA; // can be nothing else due to if above
+			set_dnscache_blockingstatus(dns_cache, cache_status,
+			                            client ? getstr(client->ippos) : NULL,
+			                            domain ? getstr(domain->domainpos) : NULL);
+		}
+	}
 
 	// Adjust counters if we recorded a non-blocking status
 	if(query->status == QUERY_FORWARDED)
@@ -2454,7 +2466,7 @@ static void FTL_dnssec(const char *arg, const union all_addr *addr, const int id
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		// Memory error, skip this DNSSEC details
@@ -2536,7 +2548,7 @@ static void FTL_upstream_error(const union all_addr *addr, const unsigned int fl
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		// Memory error, skip this query
@@ -2637,7 +2649,7 @@ static void FTL_upstream_error(const union all_addr *addr, const unsigned int fl
 	unlock_shm();
 }
 
-static void FTL_mark_externally_blocked(const int id, const char* file, const int line)
+static void FTL_NXRA(const int id, const char* file, const int line)
 {
 	// Lock shared memory
 	lock_shm();
@@ -2652,7 +2664,7 @@ static void FTL_mark_externally_blocked(const int id, const char* file, const in
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		// Memory error, skip this query
@@ -2677,6 +2689,9 @@ static void FTL_mark_externally_blocked(const int id, const char* file, const in
 		log_debug(DEBUG_QUERIES, "**** %s externally blocked (ID %i, FTL %i, %s:%i)", domainname, id, queryID, file, line);
 	}
 
+	// Set blocking reason
+	blockingreason = "blocked upstream with NXDOMAIN and unset RA bit";
+
 	// Get response time
 	struct timeval response;
 	gettimeofday(&response, 0);
@@ -2696,10 +2711,10 @@ static void FTL_mark_externally_blocked(const int id, const char* file, const in
 	unlock_shm();
 }
 
-void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode, const struct server *server,
-                          const int id, const char* file, const int line)
+int _FTL_check_reply(const unsigned int rcode, const unsigned short flags,
+                     const union all_addr *addr,
+                     const int id, const char* file, const int line)
 {
-	// Analyze DNS header bits
 
 	// Check if RA bit is unset in DNS header and rcode is NXDOMAIN
 	// If the response code (rcode) is NXDOMAIN, we may be seeing a response from
@@ -2708,14 +2723,77 @@ void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode,
 	// FTL_reply() is never getting called from within the cache routines.
 	// Hence, we have to store the necessary information about the NXDOMAIN
 	// reply already here.
-	if(!(header4 & 0x80) && rcode == NXDOMAIN)
+	if(addr == NULL && !rabit && rcode == NXDOMAIN)
+	{
 		// RA bit is not set and rcode is NXDOMAIN
-		FTL_mark_externally_blocked(id, file, line);
+		FTL_NXRA(id, file, line);
+
+		// Query is blocked
+		return 1;
+	}
+	// Further checks if this is an IP address
+	else if(addr != NULL)
+	{
+		// Detect if returned IP indicates that this query was blocked
+		const enum query_status new_status = detect_blocked_IP(flags, addr);
+
+		// Update status of this query if detected as external blocking
+		if(new_status != QUERY_UNKNOWN)
+		{
+			// Lock shared memory
+			lock_shm();
+
+			// Save status in corresponding query identified by dnsmasq's ID
+			const int queryID = findQueryID(id);
+			if(queryID < 0)
+			{
+				// This may happen e.g. if the original query was "pi.hole"
+				log_debug(DEBUG_QUERIES, "FTL_check_reply(): Query %i has not been found", id);
+				unlock_shm();
+				return 0;
+			}
+
+			// Get query pointer
+			queriesData *query = getQuery(queryID, true);
+			if(query == NULL)
+			{
+				// Memory error, skip this query
+				log_debug(DEBUG_QUERIES, "FTL_check_reply(): Memory error (ID %i)", id);
+				unlock_shm();
+				return 0;
+			}
+			clientsData *client = getClient(query->clientID, true);
+			domainsData *domain = getDomain(query->domainID, true);
+			if(client != NULL && domain != NULL)
+				query_blocked(query, domain, client, new_status);
+			
+			// Mark query for updating in the database
+			query->flags.database.changed = true;
+
+			// Unlock shared memory
+			unlock_shm();
+
+			// Query is blocked
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+void _FTL_header_analysis(const unsigned char header4, const struct server *server,
+                          const int id, const char* file, const int line)
+{
+	// Analyze DNS header bits
 
 	// Check if AD bit is set in DNS header
 	adbit = header4 & HB4_AD;
 
-	// Store server which sent this reply
+	// Check if RA bit is set in DNS header. We do it here as it is it is
+	// forced by dnsmasq shortly after calling FTL_header_analysis()
+	rabit = header4 & HB4_RA;
+
+	// Store server which sent this reply (if applicable)
 	if(server)
 	{
 		memcpy(&last_server, &server->addr, sizeof(last_server));
@@ -2724,13 +2802,15 @@ void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode,
 			char ip[ADDRSTRLEN+1] = { 0 };
 			in_port_t port = 0;
 			mysockaddr_extract_ip_port(&last_server, ip, &port);
-			log_debug(DEBUG_EXTRA, "Got forward address: %s#%u (%s:%i)", ip, port, short_path(file), line);
+			log_debug(DEBUG_EXTRA, "Got forward address: %s#%u for ID %i (%s:%i)",
+			          ip, port, id, short_path(file), line);
 		}
 	}
 	else
 	{
 		memset(&last_server, 0, sizeof(last_server));
-		log_debug(DEBUG_EXTRA, "Got forward address: NO");
+		log_debug(DEBUG_EXTRA, "Got forward address: NO for ID %i (%s:%i)",
+		          id, short_path(file), line);
 	}
 }
 
@@ -3148,7 +3228,7 @@ void FTL_forwarding_retried(const struct server *serv, const int oldID, const in
 	if(queryID >= 0)
 	{
 		// Get query pointer
-		queriesData* query = getQuery(queryID, true);
+		queriesData *query = getQuery(queryID, true);
 
 		// Set retried status
 		if(query != NULL)
@@ -3406,7 +3486,7 @@ void FTL_query_in_progress(const int id)
 	}
 
 	// Get query pointer
-	queriesData* query = getQuery(queryID, true);
+	queriesData *query = getQuery(queryID, true);
 	if(query == NULL)
 	{
 		// Memory error, skip this DNSSEC details
@@ -3475,9 +3555,9 @@ void FTL_multiple_replies(const int id, int *firstID)
 	// Get (read-only) pointer of the query that contains all relevant
 	// information (all others are mere duplicates and were only added to the
 	// list of duplicates rather than havong been forwarded on their own)
-	const queriesData* source_query = getQuery(*firstID, true);
+	const queriesData *source_query = getQuery(*firstID, true);
 	// Get query pointer of duplicated reply
-	queriesData* duplicated_query = getQuery(queryID, true);
+	queriesData *duplicated_query = getQuery(queryID, true);
 
 	if(duplicated_query == NULL || source_query == NULL)
 	{

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -27,8 +27,11 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 #define FTL_new_query(flags, name, addr, arg, qtype, id, proto) _FTL_new_query(flags, name, addr, arg, qtype, id, proto, __FILE__, __LINE__)
 bool _FTL_new_query(const unsigned int flags, const char *name, union mysockaddr *addr, char *arg, const unsigned short qtype, const int id, enum protocol proto, const char* file, const int line);
 
-#define FTL_header_analysis(header4, rcode, server, id) _FTL_header_analysis(header4, rcode, server, id, __FILE__, __LINE__)
-void _FTL_header_analysis(const unsigned char header4, const unsigned int rcode, const struct server *server, const int id, const char* file, const int line);
+#define FTL_header_analysis(header4, server, id) _FTL_header_analysis(header4, server, id, __FILE__, __LINE__)
+void _FTL_header_analysis(const unsigned char header4, const struct server *server, const int id, const char* file, const int line);
+
+#define FTL_check_reply(rcode, flags, addr, id) _FTL_check_reply(rcode, flags, addr, id, __FILE__, __LINE__)
+int _FTL_check_reply(const unsigned int rcode, const unsigned short flags, const union all_addr *addr, const int id, const char* file, const int line);
 
 void FTL_forwarding_retried(const struct server *server, const int oldID, const int newID, const bool dnssec);
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -130,6 +130,9 @@ enum domain_client_status {
 	REGEX_BLOCKED,
 	ALLOWED,
 	SPECIAL_DOMAIN,
+	UPSTREAM_BLOCKED_NXRA,
+	UPSTREAM_BLOCKED_NULL,
+	UPSTREAM_BLOCKED_IP,
 	NOT_BLOCKED
 } __attribute__ ((packed));
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -62,7 +62,7 @@ static void recycle(void)
 	// and recycle them
 	for(int queryID = 0; queryID < counters->queries; queryID++)
 	{
-		queriesData* query = getQuery(queryID, true);
+		queriesData *query = getQuery(queryID, true);
 		if(query == NULL)
 			continue;
 
@@ -308,7 +308,7 @@ void runGC(const time_t now, time_t *lastGCrun, const bool flush)
 	unsigned int removed = 0;
 	for(long int i = 0; i < counters->queries; i++)
 	{
-		queriesData* query = getQuery(i, true);
+		queriesData *query = getQuery(i, true);
 		if(query == NULL)
 			continue;
 

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -1024,7 +1024,7 @@ static inline bool check_magic(int ID, bool checkMagic, unsigned char magic, con
 	return true;
 }
 
-queriesData* _getQuery(int queryID, bool checkMagic, int line, const char *func, const char *file)
+queriesData *_getQuery(int queryID, bool checkMagic, int line, const char *func, const char *file)
 {
 	// This does not exist, return a NULL pointer
 	if(queryID == -1)

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -124,6 +124,11 @@ pdnsutil add-record ftl. noerror A
 pdnsutil add-record ftl. umbrella A 146.112.61.104
 pdnsutil add-record ftl. umbrella AAAA ::ffff:146.112.61.104
 
+# Special record which consists of both blocked and non-blocked IP
+pdnsutil add-record ftl. umbrella-multi A 1.2.3.4
+pdnsutil add-record ftl. umbrella-multi A 146.112.61.104
+pdnsutil add-record ftl. umbrella-multi A 8.8.8.8
+
 # Null address
 pdnsutil add-record ftl. null A 0.0.0.0
 pdnsutil add-record ftl. null AAAA ::

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -117,6 +117,17 @@ pdnsutil add-record ftl. regex-notMultiple AAAA fe80::3f41
 # TXT
 pdnsutil add-record ftl. any TXT "\"Some example text\""
 
+# NOERROR
+pdnsutil add-record ftl. noerror A
+
+# Blocked Cisco Umbrella IP (https://support.opendns.com/hc/en-us/articles/227986927-What-are-the-Cisco-Umbrella-Block-Page-IP-Addresses)
+pdnsutil add-record ftl. umbrella A 146.112.61.104
+pdnsutil add-record ftl. umbrella AAAA ::ffff:146.112.61.104
+
+# Null address
+pdnsutil add-record ftl. null A 0.0.0.0
+pdnsutil add-record ftl. null AAAA ::
+
 # Create valid internal DNSSEC zone
 pdnsutil create-zone dnssec ns1.ftl
 pdnsutil add-record dnssec. a A 192.168.4.1

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -255,7 +255,7 @@
     # the TTL expires, the query will be forwarded to the upstream server again to check
     # if the block is still valid. Defaults to caching for one day (86400 seconds).
     # Setting this value to zero disables caching of queries blocked upstream.
-    upstreamTTL = 86400
+    upstreamBlockedTTL = 86400
 
   [dns.blocking]
     # Should FTL block queries?

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -251,6 +251,12 @@
     # altogether.
     optimizer = 3600
 
+    # This setting allows you to specify the TTL used for queries blocked upstream. Once
+    # the TTL expires, the query will be forwarded to the upstream server again to check
+    # if the block is still valid. Defaults to caching for one day (86400 seconds).
+    # Setting this value to zero disables caching of queries blocked upstream.
+    upstreamTTL = 86400
+
   [dns.blocking]
     # Should FTL block queries?
     active = true
@@ -1097,7 +1103,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 148 total entries out of which 93 entries are default
+# 149 total entries out of which 94 entries are default
 # --> 55 entries are modified
 # 2 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -573,6 +573,30 @@
   [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl AAAA ::\""* ]]
 }
 
+@test "Externally blocked domain: IP is recognized (multi)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig A umbrella-multi.ftl @127.0.0.1"
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella-multi.ftl is not blocked (domainlist ID: -1)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded umbrella-multi.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella-multi.ftl is blocked upstream with known address (IPv4)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella-multi.ftl A 0.0.0.0\""* ]]
+}
+
 @test "ABP-style matching working as expected" {
   run bash -c "dig A special.gravity.ftl @127.0.0.1 +short"
   printf "%s\n" "${lines[@]}"

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -418,6 +418,161 @@
   [[ ${lines[@]} == *"status: NOERROR"* ]]
 }
 
+# NXRA + RA unset cannot be tested with PowerDNS as upstream provider
+
+@test "Externally blocked domain: NULL is recognized" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig A null.ftl @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"status: NOERROR"* ]]
+  [[ ${lines[@]} == *"null.ftl."*"2"*"IN"*"A"*"0.0.0.0"* ]]
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/null.ftl is not blocked (domainlist ID: -1)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded null.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/null.ftl is blocked upstream with 0.0.0.0"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"null.ftl A 0.0.0.0\""* ]]
+}
+
+@test "Externally blocked domain: NULL is recognized (cached)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig A null.ftl @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"status: NOERROR"* ]]
+  [[ ${lines[@]} == *"null.ftl."*"2"*"IN"*"A"*"0.0.0.0"* ]]
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: null.ftl is known as upstream blocked"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/null.ftl is upstream blocked"* ]]
+  [[ ${lines[@]} != *"DEBUG_QUERIES: **** forwarded null.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"null.ftl A 0.0.0.0\""* ]]
+}
+
+@test "Externally blocked domain: NULL is recognized (IPv6)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig AAAA null.ftl @127.0.0.1"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"status: NOERROR"* ]]
+  [[ ${lines[@]} == *"null.ftl."*"2"*"IN"*"AAAA"*"::"* ]]
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: AAAA/127.0.0.1/null.ftl is not blocked (domainlist ID: -1)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded null.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: AAAA/127.0.0.1/null.ftl is blocked upstream with ::"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"null.ftl AAAA ::\""* ]]
+}
+
+@test "Externally blocked domain: IP is recognized" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig A umbrella.ftl @127.0.0.1"
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella.ftl is not blocked (domainlist ID: -1)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded umbrella.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella.ftl is blocked upstream with known address (IPv4)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl A 0.0.0.0\""* ]]
+}
+
+@test "Externally blocked domain: IP is recognized (cached)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig A umbrella.ftl @127.0.0.1"
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: umbrella.ftl is known as upstream blocked"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella.ftl is upstream blocked"* ]]
+  [[ ${lines[@]} != *"DEBUG_QUERIES: **** forwarded umbrella.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl A 0.0.0.0\""* ]]
+}
+
+@test "Externally blocked domain: IP is recognized (IPv6)" {
+  # Get number of lines in the log before the test
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Run test
+  run bash -c "dig AAAA umbrella.ftl @127.0.0.1"
+
+  # Get number of lines in the log after the test
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+
+  # Extract relevant log lines
+  log="$(sed -n "${before},${after}p" /var/log/pihole/FTL.log)"
+  # Split log into array by newline
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<< "${log}"
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: AAAA/127.0.0.1/umbrella.ftl is not blocked (domainlist ID: -1)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded umbrella.ftl to 127.0.0.1#5555"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: AAAA/127.0.0.1/umbrella.ftl is blocked upstream with known address (IPv6)"* ]]
+  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl AAAA ::\""* ]]
+}
+
 @test "ABP-style matching working as expected" {
   run bash -c "dig A special.gravity.ftl @127.0.0.1 +short"
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
# What does this implement/fix?

Implement DNS caching for queries blocked upstream (`NXDOMAIN + no RA bit, `0.0.0.0/::`, and known Umbrella IP blocking pages) accompanied with suitable CI testing. This change improves handling of externally blocked queries in two ways:

1. Once we know the domain is externally blocked, we don't forward it again for the same client (it is currently forwarded each time)
2. We can recognize cache content with the specified addresses/flags as being upstream blocked and don't return them as "OK (cached)" through the API/in the database

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.