### PR TITLE
Restart FTL on change of webserver.api.cli_pw

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1086,6 +1086,7 @@ void initConfig(struct config *conf)
 	conf->webserver.api.cli_pw.k = "webserver.api.cli_pw";
 	conf->webserver.api.cli_pw.h = "Should FTL create a temporary CLI password? This password is stored in clear in /etc/pihole and can be used by the CLI (pihole ...  commands) to authenticate against the API. Note that the password is only valid for the current session and regenerated on each FTL restart. Sessions initiated with this password cannot modify the Pi-hole configuration (change passwords, etc.) for security reasons but can still use the API to query data and manage lists.";
 	conf->webserver.api.cli_pw.t = CONF_BOOL;
+	conf->webserver.api.cli_pw.f = FLAG_RESTART_FTL;
 	conf->webserver.api.cli_pw.d.b = true;
 	conf->webserver.api.cli_pw.c = validate_stub; // Only type-based checking
 

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -758,6 +758,13 @@ bool create_cli_password(void)
 
 bool remove_cli_password(void)
 {
+	// Remove the CLI password from memory (if allocated)
+	if(cli_password != NULL)
+	{
+		free(cli_password);
+		cli_password = NULL;
+	}
+
 	// Empty the CLI password file
 	FILE *file = fopen(CLI_PW_FILE, "w");
 	if(file == NULL)
@@ -769,8 +776,13 @@ bool remove_cli_password(void)
 	// Close file
 	fclose(file);
 
-	// Remove the CLI password from memory
-	free(cli_password);
+	// Remove the CLI password file from disk
+	// If the file does not exist, we returned above already
+	if(unlink(CLI_PW_FILE) < 0)
+	{
+		log_err("Failed to remove CLI password file: %s", strerror(errno));
+		return false;
+	}
 
 	log_debug(DEBUG_API, "CLI password removed");
 	return true;


### PR DESCRIPTION
# What does this implement/fix?

Very simple PR, fixes #2040

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.