### PR TITLE
Fix possible double-free and avoid memory leaking

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -279,6 +279,7 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 				free(conf_item->v.s);
 			// Set item
 			conf_item->v.s = strdup(elem->valuestring);
+			conf_item->t = CONF_STRING_ALLOCATED; // allocated now
 			log_debug(DEBUG_CONFIG, "%s = \"%s\"", conf_item->k, conf_item->v.s);
 			break;
 		}

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -182,7 +182,7 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 
 			// Free old password hash if it was allocated
 			if(conf_item->t == CONF_STRING_ALLOCATED)
-					free(conf_item->v.s);
+				free(conf_item->v.s);
 
 			// Store new password hash
 			conf_item->v.s = pwhash;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -348,8 +348,6 @@ extern struct config config;
 // Defined in config.c
 void set_debug_flags(struct config *conf);
 void set_all_debug(struct config *conf, const bool status);
-void initConfig(struct config *conf);
-void reset_config(struct conf_item *conf_item);
 bool readFTLconf(struct config *conf, const bool rewrite);
 bool getLogFilePath(void);
 struct conf_item *get_conf_item(struct config *conf, const unsigned int n);

--- a/src/config/legacy_reader.c
+++ b/src/config/legacy_reader.c
@@ -66,6 +66,10 @@ bool getLogFilePathLegacy(struct config *conf, FILE *fp)
 	// No option set => use default log location
 	if(buffer == NULL)
 	{
+		// Free previously allocated memory (if any)
+		if(conf->files.log.ftl.t == CONF_STRING_ALLOCATED)
+			free(conf->files.log.ftl.v.s);
+
 		// Use standard path if no custom path was obtained from the config file
 		conf->files.log.ftl.v.s = strdup("/var/log/pihole/FTL.log");
 		conf->files.log.ftl.t = CONF_STRING_ALLOCATED;
@@ -92,6 +96,10 @@ bool getLogFilePathLegacy(struct config *conf, FILE *fp)
 		conf->files.log.ftl.v.s = NULL;
 		conf->files.log.ftl.t = CONF_STRING;
 		log_info("Using syslog facility");
+
+		// Free buffer
+		if(val_buffer != NULL)
+			free(val_buffer);
 	}
 
 	// Set string if memory allocation was successful and a value was read

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -553,7 +553,7 @@ void importsetupVarsConf(void)
 	get_conf_string_from_setupVars("DHCP_LEASETIME", &config.dhcp.leaseTime);
 
 	// If the DHCP lease time is set to "24", it is interpreted as "24h".
-	// This is some relic from the past that may still be present in some
+	// This is some relict from the past that may still be present in some
 	// setups
 	if(strcmp(config.dhcp.leaseTime.v.s, "24") == 0)
 	{


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a possible double `free`s that can crash FTL. It can happen when a client hostname contains invalid characters (e.g., spaces), reported and confirmed [here](https://discourse.pi-hole.net/t/pihole-6-0-beta-and-sqlite-issue/71586/26).

The issue we are dealing with here is ensuring that the `allocated = yes/no` for config strings has been checked at every location where memory is allocated and free'd. In some places, we had to change things to avoid memory being leaked.

---

**Related issue or feature (if applicable):** see above

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.