### PR TITLE
Fix CPU % calculation

### DIFF
--- a/src/api/info.c
+++ b/src/api/info.c
@@ -12,7 +12,7 @@
 #include "webserver/http-common.h"
 #include "webserver/json_macros.h"
 #include "api/api.h"
-// sysinfo()
+// sysinfo(), get_nprocs_conf()
 #include <sys/sysinfo.h>
 // get_blockingstatus()
 #include "config/setupVars.h"
@@ -159,7 +159,11 @@ int api_info_database(struct ftl_conn *api)
 
 int get_system_obj(struct ftl_conn *api, cJSON *system)
 {
-	const int nprocs = get_nprocs();
+	// Use total number of processors
+	// This difference is important for virtualized systems where the number
+	// of available (= online) processors can be lower than the total number
+	//  (= configured) of processors
+	const int nprocs = get_nprocs_conf();
 	struct sysinfo info;
 	if(sysinfo(&info) != 0)
 		return send_json_error(api, 500, "error", strerror(errno), NULL);

--- a/src/gc.c
+++ b/src/gc.c
@@ -262,8 +262,8 @@ static void check_load(void)
 	if (getloadavg(load, 3) == -1)
 		return;
 
-	// Get number of CPU cores
-	const int nprocs = get_nprocs();
+	// Get total number of CPU cores
+	const int nprocs = get_nprocs_conf();
 
 	// Warn if 15 minute average of load exceeds number of available
 	// processors

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -396,6 +396,13 @@ void http_init(void)
 	//   send no referrer information.
 	// The latter four headers are set as expected by https://securityheaders.io
 	char num_threads[3] = { 0 };
+	// Use 16 threads if more than 8 cores are available, otherwise use
+	// 2*cores. This is to prevent overloading the system with too many
+	// threads.
+	// We use the number of available (= online) cores which may be less
+	// than the total number of cores in the system, e.g., if a
+	// virtualization environment is used and fewer cores are assigned to
+	// the VM than are available on the host.
 	sprintf(num_threads, "%d", get_nprocs() > 8 ? 16 : 2*get_nprocs());
 	const char *options[] = {
 		"document_root", config.webserver.paths.webroot.v.s,


### PR DESCRIPTION
# What does this implement/fix?

Use total number of *configured* (= existing) cores rather then the number of available (= online and assigned) cores when computing the CPU utilization of the system. This fixes the displayed CPU % in case a container got fewer cores assigned to it than are available on the host system.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/cpu-usage-is-wrong-shown-calculated-on-lxc-debian-container/71999

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.