### PR TITLE
Add GET /api/stats/summary -> .gravity.last_update

### DIFF
--- a/src/api/docs/content/specs/stats.yaml
+++ b/src/api/docs/content/specs/stats.yaml
@@ -560,6 +560,10 @@ components:
               type: integer
               description: Number of domain on your Pi-hole's gravity list
               example: 104756
+            last_update:
+              type: integer
+              description: Unix timestamp of last gravity update (may be `0` if unknown)
+              example: 1725194639
     upstreams:
       type: object
       properties:

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -165,6 +165,7 @@ int api_stats_summary(struct ftl_conn *api)
 
 	cJSON *gravity = JSON_NEW_OBJECT();
 	JSON_ADD_NUMBER_TO_OBJECT(gravity, "domains_being_blocked", num_gravity);
+	JSON_ADD_NUMBER_TO_OBJECT(gravity, "last_update", gravity_last_updated());
 
 	cJSON *json = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(json, "queries", queries);

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2796,3 +2796,8 @@ bool gravity_updated(void)
 
 	return changed;
 }
+
+time_t __attribute__((pure)) gravity_last_updated(void)
+{
+	return last_updated > 0 ? (time_t)last_updated : 0;
+}

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -70,4 +70,6 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
                            const tablerow *row, const char **message);
 
+time_t gravity_last_updated(void) __attribute__((pure));
+
 #endif //GRAVITY_H


### PR DESCRIPTION
# What does this implement/fix?

Add `GET /api/stats/summary -> .gravity.last_update` timestamp exposing the last gravity update via the API.

This re-adds a functionality that was [implemented in PHP](https://github.com/pi-hole/web/blob/be05b0f61d3fcf796dae4cc3f89f8540b2359325/scripts/pi-hole/php/gravity.php) and - apparently - forgotten when porting all the functions over into the new v6 API.


### Example
```
d@r:~$ pihole api stats/summary
```
```
Requesting: GET http://localhost:80/api/stats/summary

Status: 200
Data:
{
  "queries": {
    "total": 83371,
    "blocked": 2079,
    "percent_blocked": 2.4936728477478027,
    "unique_domains": 2077,
    "forwarded": 61486,
    "cached": 19594,
    "types": {
      "A": 44317,
      "AAAA": 6610,
      "ANY": 0,
      "SRV": 15,
      "SOA": 0,
      "PTR": 452,
      "TXT": 12,
      "NAPTR": 0,
      "MX": 0,
      "DS": 1010,
      "RRSIG": 0,
      "DNSKEY": 29391,
      "NS": 0,
      "SVCB": 47,
      "HTTPS": 1517,
      "OTHER": 0
    },
    "status": {
      "UNKNOWN": 0,
      "GRAVITY": 1975,
      "FORWARDED": 61484,
      "CACHE": 10054,
      "REGEX": 0,
      "DENYLIST": 0,
      "EXTERNAL_BLOCKED_IP": 0,
      "EXTERNAL_BLOCKED_NULL": 0,
      "EXTERNAL_BLOCKED_NXRA": 0,
      "GRAVITY_CNAME": 74,
      "REGEX_CNAME": 0,
      "DENYLIST_CNAME": 0,
      "RETRIED": 2,
      "RETRIED_DNSSEC": 0,
      "IN_PROGRESS": 212,
      "DBBUSY": 0,
      "SPECIAL_DOMAIN": 30,
      "CACHE_STALE": 9540
    },
    "replies": {
      "UNKNOWN": 89,
      "NODATA": 32998,
      "NXDOMAIN": 396,
      "CNAME": 6033,
      "IP": 13724,
      "DOMAIN": 394,
      "RRNAME": 10,
      "SERVFAIL": 5,
      "REFUSED": 0,
      "NOTIMP": 0,
      "OTHER": 0,
      "DNSSEC": 725,
      "NONE": 28911,
      "BLOB": 86
    }
  },
  "clients": {
    "active": 20,
    "total": 20
  },
  "gravity": {
    "domains_being_blocked": 236457,
    "last_update": 1725153123                   <-------------------------------
  },
  "took": 0.000253915786743164
}
```

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/domains-on-adlists-doesnt-show-last-gravity-update/72082

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.