### PR TITLE
Add queries per second (QPS) metric

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -143,6 +143,10 @@
 // Default: 2592000 (once per month)
 #define DATABASE_MACVENDOR_INTERVAL 2592000
 
+// Over how many seconds should the query-per-second (QPS) value be averaged?
+// Default: 30 (seconds)
+#define QPS_AVGLEN 30
+
 // Use out own syscalls handling functions that will detect possible errors
 // and report accordingly in the log. This will make debugging FTL crash
 // caused by insufficient memory or by code bugs (not properly dealing

--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -721,6 +721,10 @@ components:
               type: integer
               description: Currently used privacy level
               example: 0
+            query_frequency:
+              type: number
+              description: Average number of queries per second
+              example: 1.1
             clients:
               type: object
               properties:

--- a/src/api/docs/content/specs/stats.yaml
+++ b/src/api/docs/content/specs/stats.yaml
@@ -338,6 +338,10 @@ components:
               type: integer
               description: Number of queries replied to from cache or local configuration
               example: 9765
+            frequency:
+              type: number
+              description: Average number of queries per second
+              example: 1.1
             types:
               type: object
               description: Number of individual queries

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -548,6 +548,7 @@ static int get_ftl_obj(struct ftl_conn *api, cJSON *ftl)
 	const int db_denied = counters->database.domains.denied;
 	const int clients_total = counters->clients;
 	const int privacylevel = config.misc.privacylevel.v.privacy_level;
+	const double qps = get_qps();
 
 	// unique_clients: count only clients that have been active within the most recent 24 hours
 	int activeclients = 0;
@@ -575,6 +576,7 @@ static int get_ftl_obj(struct ftl_conn *api, cJSON *ftl)
 	JSON_ADD_ITEM_TO_OBJECT(ftl, "database", database);
 
 	JSON_ADD_NUMBER_TO_OBJECT(ftl, "privacy_level", privacylevel);
+	JSON_ADD_NUMBER_TO_OBJECT(ftl, "query_frequency", qps);
 
 	cJSON *clients = JSON_NEW_OBJECT();
 	JSON_ADD_NUMBER_TO_OBJECT(clients, "total",clients_total);

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -143,6 +143,8 @@ int api_stats_summary(struct ftl_conn *api)
 	JSON_ADD_NUMBER_TO_OBJECT(queries, "forwarded", forwarded);
 	JSON_ADD_NUMBER_TO_OBJECT(queries, "cached", cached);
 
+	JSON_ADD_NUMBER_TO_OBJECT(queries, "frequency", get_qps());
+
 	cJSON *types = JSON_NEW_OBJECT();
 	int ret = get_query_types_obj(api, types);
 	if(ret != 0)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -664,6 +664,9 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		return false;
 	}
 
+	// Update rolling window of queries per second
+	update_qps(querytimestamp);
+
 	// Interface name is only available for regular queries, not for
 	// automatically generated DNSSEC queries
 	const char *interface = internal_query ? "-" : next_iface.name;

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -31,6 +31,10 @@ typedef struct {
 	pid_t pid;
 	unsigned int global_shm_counter;
 	unsigned int next_str_pos;
+	struct {
+		unsigned int last;
+		unsigned int buf[QPS_AVGLEN];
+	} qps;
 } ShmSettings;
 
 typedef struct {
@@ -144,5 +148,8 @@ void set_per_client_regex(const int clientID, const int regexID, const bool valu
 
 // Used in dnsmasq/utils.c
 int is_shm_fd(const int fd);
+
+void update_qps(const double timestamp);
+double get_qps(void) __attribute__((pure));
 
 #endif //SHARED_MEMORY_SERVER_H


### PR DESCRIPTION
# What does this implement/fix?

Add queries per second (QPS) metric exposed via `GET /api/stats/summary` as `.queries.frequency` and `GET /api/info/ftl` as `.query_frequency`. The QPS value is averaged over 30 seconds.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.