### PR TITLE
Migrate legacy files into /etc/pihole/migration_backup_v6

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1627,7 +1627,7 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 	const char *path = "";
 	if((path = readFTLlegacy(conf)) != NULL)
 	{
-		const char *target = "/etc/pihole/pihole-FTL.conf.bck";
+		const char *target = "/etc/pihole/migration_backup_v6/pihole-FTL.conf";
 		log_info("Moving %s to %s", path, target);
 		if(rename(path, target) != 0)
 			log_warn("Unable to move %s to %s: %s", path, target, strerror(errno));

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -917,7 +917,7 @@ bool read_legacy_custom_hosts_config(void)
 {
 	// Check if file exists, if not, there is nothing to do
 	const char *path = DNSMASQ_CUSTOM_LIST_LEGACY;
-	const char *target = DNSMASQ_CUSTOM_LIST_LEGACY".bck";
+	const char *target = DNSMASQ_CUSTOM_LIST_LEGACY_TARGET;
 	if(!file_exists(path))
 		return true;
 

--- a/src/config/dnsmasq_config.h
+++ b/src/config/dnsmasq_config.h
@@ -29,6 +29,7 @@ bool write_custom_list(void);
 #define DNSMASQ_HOSTSDIR "/etc/pihole/hosts"
 #define DNSMASQ_CUSTOM_LIST DNSMASQ_HOSTSDIR"/custom.list"
 #define DNSMASQ_CUSTOM_LIST_LEGACY "/etc/pihole/custom.list"
+#define DNSMASQ_CUSTOM_LIST_LEGACY_TARGET "/etc/pihole/migration_backup_v6/custom.list"
 #define DHCPLEASESFILE "/etc/pihole/dhcp.leases"
 
 #endif //DNSMASQ_CONFIG_H

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -591,20 +591,12 @@ void importsetupVarsConf(void)
 	// Ports may be temporarily stored when importing a legacy Teleporter v5 file
 	get_conf_string_from_setupVars("WEB_PORTS", &config.webserver.port);
 
-	// Move the setupVars.conf file to setupVars.conf.old
-	char *old_setupVars = calloc(strlen(config.files.setupVars.v.s) + 5, sizeof(char));
-	if(old_setupVars == NULL)
-	{
-		log_warn("Could not allocate memory for old_setupVars");
-		return;
-	}
-	strcpy(old_setupVars, config.files.setupVars.v.s);
-	strcat(old_setupVars, ".old");
-	if(rename(config.files.setupVars.v.s, old_setupVars) != 0)
-		log_warn("Could not move %s to %s", config.files.setupVars.v.s, old_setupVars);
+	// Move the setupVars.conf file to the migration directory
+	const char *setupVars_target = "/etc/pihole/migration_backup_v6/setupVars.conf";
+	if(rename(config.files.setupVars.v.s, setupVars_target) != 0)
+		log_warn("Could not move %s to %s", config.files.setupVars.v.s, setupVars_target);
 	else
-		log_info("Moved %s to %s", config.files.setupVars.v.s, old_setupVars);
-	free(old_setupVars);
+		log_info("Moved %s to %s", config.files.setupVars.v.s, setupVars_target);
 
 	log_info("Migration complete");
 }


### PR DESCRIPTION
# What does this implement/fix?

Migrate legacy files (`setupVars.conf`, `pihole-FTL.conf` and `custom.list`) into `/etc/pihole/migration_backup_v6` instead of leaving them inside `/etc/pihole` merely renaming them.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.