### PR TITLE
Ensure v6 imports CNAME records when reading v5 archives

### DIFF
--- a/src/api/action.c
+++ b/src/api/action.c
@@ -128,10 +128,7 @@ int api_action_restartDNS(struct ftl_conn *api)
 		                       "Restarting DNS is not allowed",
 		                       "Check setting webserver.api.allow_destructive");
 
-	log_info("Restarting FTL due to API action request");
-	exit_code = RESTART_FTL_CODE;
-	// Send SIGTERM to FTL
-	kill(main_pid(), SIGTERM);
+	restart_ftl("API action request");
 
 	return send_json_success(api);
 }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -259,12 +259,7 @@ int api_handler(struct mg_connection *conn, void *ignored)
 
 	// Restart FTL if requested
 	if(api.ftl.restart)
-	{
-		log_info("Restarting FTL due to API config change");
-		exit_code = RESTART_FTL_CODE;
-		// Send SIGTERM to FTL
-		kill(main_pid(), SIGTERM);
-	}
+		restart_ftl(api.ftl.restart_reason);
 
 	return ret;
 }

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -807,7 +807,10 @@ static int api_config_patch(struct ftl_conn *api)
 		// If the privacy level was decreased, we need to restart
 		if(new_item == &newconf.misc.privacylevel &&
 		   new_item->v.privacy_level < conf_item->v.privacy_level)
+		{
+			api->ftl.restart_reason = "Privacy level decreased";
 			api->ftl.restart = true;
+		}
 
 		// Check if this item changed the password, if so, we need to
 		// invalidate all currently active sessions
@@ -823,7 +826,10 @@ static int api_config_patch(struct ftl_conn *api)
 		{
 			char errbuf[ERRBUF_SIZE] = { 0 };
 			if(write_dnsmasq_config(&newconf, true, errbuf))
+			{
+				api->ftl.restart_reason = "dnsmasq config changed";
 				api->ftl.restart = true;
+			}
 			else
 			{
 				free_config(&newconf);
@@ -1031,7 +1037,10 @@ static int api_config_put_delete(struct ftl_conn *api)
 		char errbuf[ERRBUF_SIZE] = { 0 };
 		// Request restart of FTL
 		if(write_dnsmasq_config(&newconf, true, errbuf))
+		{
+			api->ftl.restart_reason = "dnsmasq config changed";
 			api->ftl.restart = true;
+		}
 		else
 		{
 			// The new config did not work

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -27,6 +27,8 @@
 #include "files.h"
 //basename()
 #include <libgen.h>
+// restart_ftl()
+#include "signals.h"
 
 #define MAXFILESIZE (50u*1024*1024)
 
@@ -321,6 +323,10 @@ static int process_received_zip(struct ftl_conn *api, struct upload_data *data)
 
 	// Free allocated memory
 	free_upload_data(data);
+
+	// Signal FTL we want to restart for re-import
+	api->ftl.restart_reason = "Teleporter (ZIP) import";
+	api->ftl.restart = true;
 
 	// Send response
 	cJSON *json = JSON_NEW_OBJECT();
@@ -818,6 +824,7 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 	free_upload_data(data);
 
 	// Signal FTL we want to restart for re-import
+	api->ftl.restart_reason = "Teleporter (TAR.GZ) import";
 	api->ftl.restart = true;
 
 	// Send response

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -736,6 +736,9 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 			// i = 3
 			.archive_name = "setupVars.conf",
 			.destination = config.files.setupVars.v.s
+		},{
+			.archive_name = "dnsmasq.d/05-pihole-custom-cname.conf",
+			.destination = DNSMASQ_CNAMES
 		}
 	};
 	for(size_t i = 0; i < sizeof(extract_files) / sizeof(*extract_files); i++)

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -35,7 +35,10 @@
 #include "config/env.h"
 // sha256sum()
 #include "files.h"
+// restart_ftl()
+#include "signals.h"
 
+// Global variables
 struct config config = { 0 };
 static bool config_initialized = false;
 uint8_t last_checksum[SHA256_DIGEST_SIZE] = { 0 };
@@ -1867,12 +1870,7 @@ void reread_config(void)
 
 	// If we need to restart FTL, we do so now
 	if(restart)
-	{
-		log_info("Restarting FTL due to pihole.toml change");
-		exit_code = RESTART_FTL_CODE;
-		// Send SIGTERM to FTL
-		kill(main_pid(), SIGTERM);
-	}
+		restart_ftl("pihole.toml change");
 }
 
 // Very simple test of a port's availability by trying to bind a TCP socket to

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -595,7 +595,7 @@ void importsetupVarsConf(void)
 	else
 		log_info("Moved %s to %s", config.files.setupVars.v.s, setupVars_target);
 
-	log_info("Migration complete");
+	log_info("setupVars.conf migration complete");
 }
 
 char* __attribute__((pure)) find_equals(char *s)

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -401,7 +401,10 @@ void cleanup(const int ret)
 
 	char buffer[42] = { 0 };
 	format_time(buffer, 0, timer_elapsed_msec(EXIT_TIMER));
-	log_info("########## FTL terminated after%s (code %i)! ##########", buffer, ret);
+	if(ret == RESTART_FTL_CODE)
+		log_info("########## FTL terminated after%s (internal restart)! ##########", buffer);
+	else
+		log_info("########## FTL terminated after%s (code %i)! ##########", buffer, ret);
 }
 
 static float last_clock = 0.0f;

--- a/src/main.c
+++ b/src/main.c
@@ -139,7 +139,7 @@ int main (int argc, char *argv[])
 			sleepms(100);
 	}
 
-	log_info("Shutting down... // exit code %d // jmpret %d", exit_code, jmpret);
+	log_debug(DEBUG_ANY, "Shutting down... // exit code %d // jmpret %d", exit_code, jmpret);
 	// Extra grace time is needed as dnsmasq script-helpers and the API may not
 	// be terminating immediately
 	sleepms(250);

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -614,12 +614,8 @@ static void *ntp_client_thread(void *arg)
 		double time_delta = fabs(after - before);
 		if(first_run && time_delta > GCinterval)
 		{
-			log_info("System time was updated by %.1f seconds, restarting FTL to import recent data",
-			         time_delta);
-			// Set the restart flag to true
-			exit_code = RESTART_FTL_CODE;
-			// Send SIGTERM to FTL
-			kill(main_pid(), SIGTERM);
+			log_info("System time was updated by %.1f seconds", time_delta);
+			restart_ftl("System time updated");
 		}
 
 		// Set first run to false

--- a/src/signals.c
+++ b/src/signals.c
@@ -523,3 +523,11 @@ int sigtest(void)
 	// Exit successfully
 	return EXIT_SUCCESS;
 }
+
+void restart_ftl(const char *reason)
+{
+	log_info("Restarting FTL: %s", reason);
+	exit_code = RESTART_FTL_CODE;
+	// Send SIGTERM to FTL
+	kill(main_pid(), SIGTERM);
+}

--- a/src/signals.h
+++ b/src/signals.h
@@ -21,6 +21,7 @@ pid_t main_pid(void);
 void thread_sleepms(const enum thread_types thread, const int milliseconds);
 void generate_backtrace(void);
 int sigtest(void);
+void restart_ftl(const char *reason);
 
 extern volatile int exit_code;
 extern volatile sig_atomic_t killed;

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -51,7 +51,8 @@ struct ftl_conn {
 		long unsigned int size;
 	} payload;
 	struct {
-		bool restart;
+		bool restart :1;
+		const char *restart_reason;
 	} ftl;
 	struct session *session;
 

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -39,6 +39,8 @@
 #include "events.h"
 // JSON_KEY_TRUE
 #include "webserver/json_macros.h"
+// exit_code
+#include "signals.h"
 
 // Tables to copy from the gravity database to the Teleporter database
 static const char *gravity_tables[] = {

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1965,21 +1965,12 @@
   run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "2" ]]
-  run bash -c 'grep -c "DEBUG_CONFIG: pihole.toml unchanged" /var/log/pihole/FTL.log'
-  printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "4" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]
-  run bash -c 'grep -c "DEBUG_CONFIG: dnsmasq.conf unchanged" /var/log/pihole/FTL.log'
-  printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "2" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/hosts/custom.list" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]
-  run bash -c 'grep -c "DEBUG_CONFIG: custom.list unchanged" /var/log/pihole/FTL.log'
-  printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "3" ]]
 }
 
 @test "Check NTP server is broadcasting correct time" {


### PR DESCRIPTION
# What does this implement/fix?

Add missing import instruction for CNAME records file (if present in the archive)

**Related issue or feature (if applicable):** https://github.com/pi-hole/web/issues/2964

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.