### PR TITLE
Fix possible crash due to incorrect setupVars.conf import

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -148,7 +148,7 @@
 // caused by insufficient memory or by code bugs (not properly dealing
 // with NULL pointers) much easier.
 #undef strdup // strdup() is a macro in itself, it needs special handling
-#define free(ptr) FTLfree((void**)&ptr, __FILE__,  __FUNCTION__,  __LINE__)
+#define free(ptr) { FTLfree(ptr, __FILE__,  __FUNCTION__,  __LINE__); ptr = NULL; }
 #define strdup(str_in) FTLstrdup(str_in, __FILE__,  __FUNCTION__,  __LINE__)
 #define calloc(numer_of_elements, element_size) FTLcalloc(numer_of_elements, element_size, __FILE__,  __FUNCTION__,  __LINE__)
 #define realloc(ptr, new_size) FTLrealloc(ptr, new_size, __FILE__,  __FUNCTION__,  __LINE__)

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -440,7 +440,6 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 				config.webserver.api.pwhash.v.s = new_hash;
 				config.webserver.api.pwhash.t = CONF_STRING_ALLOCATED;
 				writeFTLtoml(true);
-				free(new_hash);
 			}
 
 			// Successful logins do not count against rate-limiting

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -122,7 +122,6 @@ static void get_conf_bool_from_setupVars(const char *key, struct conf_item *conf
 
 static void get_revServer_from_setupVars(void)
 {
-	char *active = NULL;
 	char *cidr = NULL;
 	char *target = NULL;
 	char *domain = NULL;
@@ -144,7 +143,7 @@ static void get_revServer_from_setupVars(void)
 		clearSetupVarsArray();
 		return;
 	}
-	active = strdup(active_str);
+	bool active = strcasecmp(active_str, "true") == 0;
 
 	// Free memory, harmless to call if read_setupVarsconf() didn't return a result
 	clearSetupVarsArray();
@@ -186,16 +185,16 @@ static void get_revServer_from_setupVars(void)
 	clearSetupVarsArray();
 
 	// Only add the entry if all values are present and active
-	if(active != NULL && cidr != NULL && target != NULL && domain != NULL)
+	if(cidr != NULL && target != NULL && domain != NULL)
 	{
 		// Build comma-separated string of all values
 		// 9 = 3 commas, "true/false", and null terminator
 		char *old = calloc(strlen(cidr) + strlen(target) + strlen(domain) + 9, sizeof(char));
-		if(old)
+		if(old != NULL)
 		{
 			// Add to new config
 			// active is always true as we only add active entries
-			sprintf(old, "%s,%s,%s,%s", active_str, cidr, target, domain);
+			sprintf(old, "%s,%s,%s,%s", active ? "true" : "false", cidr, target, domain);
 			cJSON_AddItemToArray(config.dns.revServers.v.json, cJSON_CreateString(old));
 
 			// Parameter present in setupVars.conf
@@ -211,8 +210,6 @@ static void get_revServer_from_setupVars(void)
 	}
 
 	// Free memory
-	if(active != NULL)
-		free(active);
 	if(cidr != NULL)
 		free(cidr);
 	if(target != NULL)

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -543,7 +543,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_PTR_TYPE:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int ptr_type = get_ptr_type_val(val.u.s);
@@ -559,7 +559,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_BUSY_TYPE:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int busy_reply = get_busy_reply_val(val.u.s);
@@ -575,7 +575,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_BLOCKING_MODE:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int blocking_mode = get_blocking_mode_val(val.u.s);
@@ -591,7 +591,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_REFRESH_HOSTNAMES:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int refresh_hostnames = get_refresh_hostnames_val(val.u.s);
@@ -607,7 +607,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_LISTENING_MODE:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int listeningMode = get_listeningMode_val(val.u.s);
@@ -623,7 +623,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_WEB_THEME:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int web_theme = get_web_theme_val(val.u.s);
@@ -639,7 +639,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		}
 		case CONF_ENUM_TEMP_UNIT:
 		{
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				const int temp_unit = get_temp_unit_val(val.u.s);
@@ -665,7 +665,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		case CONF_STRUCT_IN_ADDR:
 		{
 			struct in_addr addr4 = { 0 };
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				if(strlen(val.u.s) == 0)
@@ -686,7 +686,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 		case CONF_STRUCT_IN6_ADDR:
 		{
 			struct in6_addr addr6 = { 0 };
-			const toml_datum_t val = toml_string_in(toml, key);
+			toml_datum_t val = toml_string_in(toml, key);
 			if(val.ok)
 			{
 				if(strlen(val.u.s) == 0)
@@ -717,7 +717,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_table_t *t
 				for(unsigned int i = 0; i < nelem; i++)
 				{
 					// Get string from TOML
-					const toml_datum_t d = toml_string_at(array, i);
+					toml_datum_t d = toml_string_at(array, i);
 					if(!d.ok)
 					{
 						log_warn("Config %s is an invalid array (found at index %u)", conf_item->k, i);

--- a/src/signals.c
+++ b/src/signals.c
@@ -29,7 +29,7 @@
 #define BINARY_NAME "pihole-FTL"
 
 volatile sig_atomic_t killed = 0;
-static volatile pid_t mpid = -1;
+static volatile pid_t mpid = 0;
 static time_t FTLstarttime = 0;
 volatile int exit_code = EXIT_SUCCESS;
 
@@ -253,7 +253,7 @@ static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, voi
 	log_info("Thank you for helping us to improve our FTL engine!");
 
 	// Terminate main process if crash happened in a TCP worker
-	if(mpid != getpid())
+	if(main_pid() != getpid())
 	{
 		// This is a forked process
 		log_info("Asking parent pihole-FTL (PID %i) to shut down", (int)mpid);
@@ -474,7 +474,7 @@ void handle_realtime_signals(void)
 // Return PID of the main FTL process
 pid_t main_pid(void)
 {
-	if(mpid > -1)
+	if(mpid > 0)
 		// Has already been set
 		return mpid;
 	else

--- a/src/syscalls/free.c
+++ b/src/syscalls/free.c
@@ -13,7 +13,7 @@
 #include "log.h"
 
 #undef free
-void FTLfree(void **ptr, const char *file, const char *func, const int line)
+bool FTLfree(void *ptr, const char *file, const char *func, const int line)
 {
 	// The free() function frees the memory space pointed  to  by  ptr,  which
 	// must  have  been  returned by a previous call to malloc(), calloc(), or
@@ -21,18 +21,12 @@ void FTLfree(void **ptr, const char *file, const char *func, const int line)
 	// undefined behavior occurs.  If ptr is NULL, no operation is performed.
 	if(ptr == NULL)
 	{
-		log_warn("Trying to free NULL memory location in %s() (%s:%i)", func, file, line);
-		return;
-	}
-	if(*ptr == NULL)
-	{
 		log_warn("Trying to free NULL pointer in %s() (%s:%i)", func, file, line);
-		return;
+		return false;
 	}
 
 	// Actually free the memory
-	free(*ptr);
+	free(ptr);
 
-	// Set the pointer to NULL
-	*ptr = NULL;
+	return true;
 }

--- a/src/syscalls/syscalls.h
+++ b/src/syscalls/syscalls.h
@@ -14,7 +14,7 @@
 char *FTLstrdup(const char *src, const char *file, const char *func, const int line) __attribute__((malloc));
 void *FTLcalloc(size_t n, size_t size, const char *file, const char *func, const int line) __attribute__((malloc)) __attribute__((alloc_size(1,2)));
 void *FTLrealloc(void *ptr_in, size_t size, const char *file, const char *func, const int line) __attribute__((alloc_size(2)));
-void FTLfree(void **ptr, const char*file, const char *func, const int line);
+bool FTLfree(void *ptr, const char*file, const char *func, const int line);
 int FTLfallocate(const int fd, const off_t offset, const off_t len, const char *file, const char *func, const int line);
 
 

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -303,6 +303,7 @@ unsigned short get_api_string(char **buf, const bool domain)
 		if(this_len < 0)
 		{
 			log_err("Failed to append API URL to buffer: %s", strerror(errno));
+			free(api_str);
 			return 0;
 		}
 
@@ -311,6 +312,7 @@ unsigned short get_api_string(char **buf, const bool domain)
 		if((size_t)this_len >= bufsz - len - 1)
 		{
 			log_err("API URL buffer too small!");
+			free(api_str);
 			return 0;
 		}
 
@@ -318,8 +320,8 @@ unsigned short get_api_string(char **buf, const bool domain)
 		if(memmem(*buf, len, api_str, this_len) != NULL)
 		{
 			// This string is already present, so skip it
-			free(api_str);
 			log_debug(DEBUG_API, "Skipping duplicate API URL: %s", api_str);
+			free(api_str);
 			continue;
 		}
 


### PR DESCRIPTION
# What does this implement/fix?

Fix incorrect parsing when importing `REV_SERVER` from legacy `setupVars.conf` files.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.