### PR TITLE
Fix gzip help text

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -106,6 +106,7 @@ const char** argv_dnsmasq = NULL;
 #define COL_BLUE	"\x1b[94m" // bright foreground color
 #define COL_PURPLE	"\x1b[95m" // bright foreground color
 #define COL_CYAN	"\x1b[96m" // bright foreground color
+#define CLI_OVER	"\r\x1b[K" // go back to beginning of line and erase to end of line
 
 static bool __attribute__ ((pure)) is_term(void)
 {
@@ -149,6 +150,16 @@ const char __attribute__ ((pure)) *cli_bold(void)
 	return is_term() ? COL_BOLD : "";
 }
 
+const char __attribute__ ((pure)) *cli_underline(void)
+{
+	return is_term() ? COL_ULINE : "";
+}
+
+const char __attribute__ ((pure)) *cli_italics(void)
+{
+	return is_term() ? COL_ITALIC : "";
+}
+
 // Resets font to normal
 const char __attribute__ ((pure)) *cli_normal(void)
 {
@@ -165,7 +176,7 @@ static const char __attribute__ ((pure)) *cli_color(const char *color)
 const char __attribute__ ((pure)) *cli_over(void)
 {
 	// \x1b[K is the ANSI escape sequence for "erase to end of line"
-	return is_term() ? "\r\x1b[K" : "\r";
+	return is_term() ? CLI_OVER : "\r";
 }
 
 static inline bool strEndsWith(const char *input, const char *end)
@@ -925,6 +936,7 @@ void parse_args(int argc, char* argv[])
 		if(strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "help") == 0 || strcmp(argv[i], "--help") == 0)
 		{
 			const char *bold = cli_bold();
+			const char *uline = cli_underline();
 			const char *normal = cli_normal();
 			const char *blue = cli_color(COL_BLUE);
 			const char *cyan = cli_color(COL_CYAN);
@@ -1019,14 +1031,13 @@ void parse_args(int argc, char* argv[])
 			printf("    - %sinfile%s is the file to be processed. If the filename ends\n", cyan, normal);
 			printf("      in %s.gz%s, FTL will uncompress, otherwise it will compress\n\n", yellow, normal);
 			printf("    - %s[outfile]%s is the optional target file.\n", purple, normal);
-			printf("      If omitted, FTL will modify the original filename:\n");
-			printf("      - FTL will remove %s.gz%s from the end of the filename, if present.\n", yellow, normal);
-			printf("      - otherwise, FTL will append %s.gz%s to the filename\n\n", yellow, normal);
+			printf("      If omitted, FTL will try to derive the target file from\n");
+			printf("      the source file.\n\n");
 			printf("    Examples:\n");
 			printf("      - %spihole-FTL --gzip %sfile.txt%s\n", green, cyan, normal);
-			printf("        compresses %sfile.txt%s to %sfile.txt.gz%s\n\n", cyan, normal, cyan, normal);
-			printf("      - %spihole-FTL --gzip %sfile.txt.gz%s\n", green, cyan, normal);
-			printf("        uncompresses %sfile.txt.gz%s to %sfile.txt%s\n\n", cyan, normal, cyan, normal);
+			printf("        compresses %sfile.txt%s to %sfile.txt%s.gz%s\n\n", cyan, normal, cyan, yellow, normal);
+			printf("      - %spihole-FTL --gzip %sfile.txt%s.gz%s\n", green, cyan, yellow, normal);
+			printf("        %sun%scompresses %sfile.txt%s.gz%s to %sfile.txt%s\n\n", uline, normal, cyan, yellow, normal, cyan, normal);
 
 			printf("%sTeleporter:%s\n", yellow, normal);
 			printf("\t%s--teleporter%s        Create a Teleporter archive in the\n", green, normal);

--- a/src/args.c
+++ b/src/args.c
@@ -1018,9 +1018,10 @@ void parse_args(int argc, char* argv[])
 			printf("    Usage: %spihole-FTL --gzip %sinfile %s[outfile]%s\n\n", green, cyan, purple, normal);
 			printf("    - %sinfile%s is the file to be processed. If the filename ends\n", cyan, normal);
 			printf("      in %s.gz%s, FTL will uncompress, otherwise it will compress\n\n", yellow, normal);
-			printf("    - %s[outfile]%s is the optional target. If omitted, FTL will\n", purple, normal);
-			printf("      - input is gz: use %sinfile%s.gz%s and remove %s.gz%s from the end\n", cyan, yellow, normal, purple, normal);
-			printf("      - otherwise: use %sinfile%s and append %s.gz%s at the end\n\n", cyan, normal, purple, normal);
+			printf("    - %s[outfile]%s is the optional target file.\n", purple, normal);
+			printf("      If omitted, FTL will modify the original filename:\n");
+			printf("      - FTL will remove %s.gz%s from the end of the filename, if present.\n", yellow, normal);
+			printf("      - otherwise, FTL will append %s.gz%s to the filename\n\n", yellow, normal);
 			printf("    Examples:\n");
 			printf("      - %spihole-FTL --gzip %sfile.txt%s\n", green, cyan, normal);
 			printf("        compresses %sfile.txt%s to %sfile.txt.gz%s\n\n", cyan, normal, cyan, normal);

--- a/src/args.c
+++ b/src/args.c
@@ -1015,12 +1015,17 @@ void parse_args(int argc, char* argv[])
 
 			printf("%sEmbedded GZIP un-/compressor:%s\n", yellow, normal);
 			printf("    A simple but fast in-memory gzip compressor\n\n");
-			printf("    Usage: %spihole-FTL --compress %sinfile %s[outfile]%s\n", green, cyan, purple, normal);
-			printf("    Usage: %spihole-FTL --uncompress %sinfile %s[outfile]%s\n\n", green, cyan, purple, normal);
-			printf("    - %sinfile%s is the file to be compressed.\n", cyan, normal);
+			printf("    Usage: %spihole-FTL --gzip %sinfile %s[outfile]%s\n\n", green, cyan, purple, normal);
+			printf("    - %sinfile%s is the file to be processed. If the filename ends\n", cyan, normal);
+			printf("      in %s.gz%s, FTL will uncompress, otherwise it will compress\n\n", yellow, normal);
 			printf("    - %s[outfile]%s is the optional target. If omitted, FTL will\n", purple, normal);
-			printf("      %s--compress%s:   use the %sinfile%s and append %s.gz%s at the end\n", green, normal, cyan, normal, cyan, normal);
-			printf("      %s--uncompress%s: use the %sinfile%s and remove %s.gz%s at the end\n\n", green, normal, cyan, normal, cyan, normal);
+			printf("      - input is gz: use %sinfile%s.gz%s and remove %s.gz%s from the end\n", cyan, yellow, normal, purple, normal);
+			printf("      - otherwise: use %sinfile%s and append %s.gz%s at the end\n\n", cyan, normal, purple, normal);
+			printf("    Examples:\n");
+			printf("      - %spihole-FTL --gzip %sfile.txt%s\n", green, cyan, normal);
+			printf("        compresses %sfile.txt%s to %sfile.txt.gz%s\n\n", cyan, normal, cyan, normal);
+			printf("      - %spihole-FTL --gzip %sfile.txt.gz%s\n", green, cyan, normal);
+			printf("        uncompresses %sfile.txt.gz%s to %sfile.txt%s\n\n", cyan, normal, cyan, normal);
 
 			printf("%sTeleporter:%s\n", yellow, normal);
 			printf("\t%s--teleporter%s        Create a Teleporter archive in the\n", green, normal);

--- a/src/args.h
+++ b/src/args.h
@@ -24,6 +24,8 @@ const char *cli_done(void) __attribute__ ((pure));
 const char *cli_bold(void) __attribute__ ((pure));
 const char *cli_normal(void) __attribute__ ((pure));
 const char *cli_over(void) __attribute__ ((pure));
+const char *cli_underline(void) __attribute__ ((pure));
+const char *cli_italics(void) __attribute__ ((pure));
 
 void test_dnsmasq_options(int argc, const char *argv[]);
 


### PR DESCRIPTION
# What does this implement/fix?

The previously described flags `--compress` and `--uncompress` never existed.

New help text:

![image](https://github.com/user-attachments/assets/8b77f6db-fc9a-4878-9de5-49639f2f4c41)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.