### PR TITLE
Check and create v6 migration directory if not exists

### DIFF
--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -29,6 +29,8 @@
 #include <libgen.h>
 // restart_ftl()
 #include "signals.h"
+// create_migration_target_v6()
+#include "config/config.h"
 
 #define MAXFILESIZE (50u*1024*1024)
 
@@ -263,6 +265,9 @@ static int api_teleporter_POST(struct ftl_conn *api)
 		                       "ZIP archive too large",
 		                       NULL);
 	}
+
+	// Ensure v6 migration directory exists
+	create_migration_target_v6();
 
 	// Check if we received something that claims to be a ZIP archive
 	// - filename should end in ".zip"

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -39,6 +39,9 @@
 // Location of the legacy (pre-v6.0) config file
 #define GLOBALCONFFILE_LEGACY "/etc/pihole/pihole-FTL.conf"
 
+// Migration target for the legacy (pre-v6.0) config file
+#define MIGRATION_TARGET_V6 "/etc/pihole/migration_backup_v6"
+
 union conf_value {
 	bool b;                                     // boolean value
 	int i;                                      // integer value
@@ -363,6 +366,7 @@ bool check_paths_equal(char **paths1, char **paths2, unsigned int max_level) __a
 const char *get_conf_type_str(const enum conf_type type) __attribute__ ((const));
 void replace_config(struct config *newconf);
 void reread_config(void);
+bool create_migration_target_v6(void);
 
 // Defined in toml_reader.c
 bool readDebugSettings(void);

--- a/src/config/dnsmasq_config.h
+++ b/src/config/dnsmasq_config.h
@@ -24,12 +24,12 @@ bool write_custom_list(void);
 
 #define DNSMASQ_PH_CONFIG "/etc/pihole/dnsmasq.conf"
 #define DNSMASQ_TEMP_CONF "/etc/pihole/dnsmasq.conf.temp"
-#define DNSMASQ_STATIC_LEASES "/etc/pihole/migration_backup_v6/04-pihole-static-dhcp.conf"
-#define DNSMASQ_CNAMES "/etc/pihole/migration_backup_v6/05-pihole-custom-cname.conf"
+#define DNSMASQ_STATIC_LEASES MIGRATION_TARGET_V6"/04-pihole-static-dhcp.conf"
+#define DNSMASQ_CNAMES MIGRATION_TARGET_V6"/05-pihole-custom-cname.conf"
 #define DNSMASQ_HOSTSDIR "/etc/pihole/hosts"
 #define DNSMASQ_CUSTOM_LIST DNSMASQ_HOSTSDIR"/custom.list"
 #define DNSMASQ_CUSTOM_LIST_LEGACY "/etc/pihole/custom.list"
-#define DNSMASQ_CUSTOM_LIST_LEGACY_TARGET "/etc/pihole/migration_backup_v6/custom.list"
+#define DNSMASQ_CUSTOM_LIST_LEGACY_TARGET MIGRATION_TARGET_V6"/custom.list"
 #define DHCPLEASESFILE "/etc/pihole/dhcp.leases"
 
 #endif //DNSMASQ_CONFIG_H

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -589,7 +589,7 @@ void importsetupVarsConf(void)
 	get_conf_string_from_setupVars("WEB_PORTS", &config.webserver.port);
 
 	// Move the setupVars.conf file to the migration directory
-	const char *setupVars_target = "/etc/pihole/migration_backup_v6/setupVars.conf";
+	const char *setupVars_target = MIGRATION_TARGET_V6"/setupVars.conf";
 	if(rename(config.files.setupVars.v.s, setupVars_target) != 0)
 		log_warn("Could not move %s to %s", config.files.setupVars.v.s, setupVars_target);
 	else


### PR DESCRIPTION
# What does this implement/fix?

Check and create v6 migration directory before trying to move/write files there. This involves config migrations but also Teleporter importing

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/pi-hole/pull/5766

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.