### PR TITLE
Disentangle info/ftl database domain numbers

### DIFF
--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -717,6 +717,17 @@ components:
                       type: integer
                       description: Number of denied domains
                       example: 3
+                regex:
+                  type: object
+                  properties:
+                    allowed:
+                      type: integer
+                      description: Number of allowed regex filters
+                      example: 4
+                    denied:
+                      type: integer
+                      description: Number of denied regex filters
+                      example: 2
             privacy_level:
               type: integer
               description: Currently used privacy level

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -544,8 +544,10 @@ static int get_ftl_obj(struct ftl_conn *api, cJSON *ftl)
 	const int db_groups = counters->database.groups;
 	const int db_lists = counters->database.lists;
 	const int db_clients = counters->database.clients;
-	const int db_allowed = counters->database.domains.allowed;
-	const int db_denied = counters->database.domains.denied;
+	const int db_allowed_exact = counters->database.domains.allowed.exact;
+	const int db_denied_exact = counters->database.domains.denied.exact;
+	const int db_allowed_regex = counters->database.domains.allowed.regex;
+	const int db_denied_regex = counters->database.domains.denied.regex;
 	const int clients_total = counters->clients;
 	const int privacylevel = config.misc.privacylevel.v.privacy_level;
 	const double qps = get_qps();
@@ -570,9 +572,14 @@ static int get_ftl_obj(struct ftl_conn *api, cJSON *ftl)
 	JSON_ADD_NUMBER_TO_OBJECT(database, "clients", db_clients);
 
 	cJSON *domains = JSON_NEW_OBJECT();
-	JSON_ADD_NUMBER_TO_OBJECT(domains, "allowed", db_allowed);
-	JSON_ADD_NUMBER_TO_OBJECT(domains, "denied", db_denied);
+	JSON_ADD_NUMBER_TO_OBJECT(domains, "allowed", db_allowed_exact);
+	JSON_ADD_NUMBER_TO_OBJECT(domains, "denied", db_denied_exact);
 	JSON_ADD_ITEM_TO_OBJECT(database, "domains", domains);
+
+	cJSON *regex = JSON_NEW_OBJECT();
+	JSON_ADD_NUMBER_TO_OBJECT(regex, "allowed", db_allowed_regex);
+	JSON_ADD_NUMBER_TO_OBJECT(regex, "denied", db_denied_regex);
+	JSON_ADD_ITEM_TO_OBJECT(database, "regex", regex);
 	JSON_ADD_ITEM_TO_OBJECT(ftl, "database", database);
 
 	JSON_ADD_NUMBER_TO_OBJECT(ftl, "privacy_level", privacylevel);

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1112,12 +1112,6 @@ int gravityDB_count(const enum gravity_tables list)
 		case ADLISTS_TABLE:
 			querystr = "SELECT COUNT(1) FROM adlist WHERE enabled != 0";
 			break;
-		case DENIED_DOMAINS_TABLE:
-			querystr = "SELECT COUNT(1) FROM domainlist WHERE (type = 0 OR type = 2) AND enabled != 0";
-			break;
-		case ALLOWED_DOMAINS_TABLE:
-			querystr = "SELECT COUNT(1) FROM domainlist WHERE (type = 1 OR type = 3) AND enabled != 0";
-			break;
 		case UNKNOWN_TABLE:
 			log_err("List type %u unknown!", list);
 			gravityDB_close();

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -594,8 +594,10 @@ void FTL_reload_all_domainlists(void)
 	counters->database.groups = gravityDB_count(GROUPS_TABLE);
 	counters->database.clients = gravityDB_count(CLIENTS_TABLE);
 	counters->database.lists = gravityDB_count(ADLISTS_TABLE);
-	counters->database.domains.allowed = gravityDB_count(DENIED_DOMAINS_TABLE);
-	counters->database.domains.denied = gravityDB_count(ALLOWED_DOMAINS_TABLE);
+	counters->database.domains.allowed.exact = gravityDB_count(EXACT_WHITELIST_TABLE);
+	counters->database.domains.denied.exact = gravityDB_count(EXACT_BLACKLIST_TABLE);
+	counters->database.domains.allowed.regex = gravityDB_count(REGEX_ALLOW_TABLE);
+	counters->database.domains.denied.regex = gravityDB_count(REGEX_DENY_TABLE);
 
 	// Read and compile possible regex filters
 	// only after having called gravityDB_reopen()

--- a/src/enums.h
+++ b/src/enums.h
@@ -193,8 +193,6 @@ enum gravity_tables {
 	CLIENTS_TABLE,
 	GROUPS_TABLE,
 	ADLISTS_TABLE,
-	DENIED_DOMAINS_TABLE,
-	ALLOWED_DOMAINS_TABLE,
 	UNKNOWN_TABLE
 } __attribute__ ((packed));
 

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -62,8 +62,14 @@ typedef struct {
 		int groups;
 		int lists;
 		struct {
-			int allowed;
-			int denied;
+			struct {
+				int exact;
+				int regex;
+			} allowed;
+			struct {
+				int exact;
+				int regex;
+			} denied;
 		} domains;
 	} database;
 	int querytype[TYPE_MAX];


### PR DESCRIPTION
# What does this implement/fix?

See title. Splits the currently existing `ftl.database.domains` (sums of exact and regex entries) into `ftl.database.domains` (domains only) and the newly added `ftl.database.regex` object.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.