### PR TITLE
Restart FTL to enforce flushing the cache when dns.piholePTR is changed

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -442,7 +442,7 @@ static void initConfig(struct config *conf)
 	conf->dns.analyzeOnlyAandAAAA.c = validate_stub; // Only type-based checking
 
 	conf->dns.piholePTR.k = "dns.piholePTR";
-	conf->dns.piholePTR.h = "Controls whether and how FTL will reply with for address for which a local interface exists.";
+	conf->dns.piholePTR.h = "Controls whether and how FTL will reply with for address for which a local interface exists. Changing this setting causes FTL to restart.";
 	{
 		struct enum_options piholePTR[] =
 		{
@@ -455,6 +455,7 @@ static void initConfig(struct config *conf)
 	}
 	conf->dns.piholePTR.t = CONF_ENUM_PTR_TYPE;
 	conf->dns.piholePTR.d.ptr_type = PTR_PIHOLE;
+	conf->dns.piholePTR.f = FLAG_RESTART_FTL;
 	conf->dns.piholePTR.c = validate_stub; // Only type-based checking
 
 	conf->dns.replyWhenBusy.k = "dns.replyWhenBusy";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -47,7 +47,7 @@
   analyzeOnlyAandAAAA = false
 
   # Controls whether and how FTL will reply with for address for which a local interface
-  # exists.
+  # exists. Changing this setting causes FTL to restart.
   #
   # Possible values are:
   #   - "NONE"


### PR DESCRIPTION
# What does this implement/fix?

See title. This fixes a regression of https://github.com/pi-hole/FTL/commit/e942301897840c5b9df19196d72c62ef87f17645 which needs a manual cache flushing after changing this setting.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.