### PR TITLE
Improve QPS calculation

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -560,6 +560,15 @@ void *GC_thread(void *val)
 			reread_config();
 		}
 
+		// Intermediate cancellation-point
+		if(killed)
+			break;
+
+		// Reset the queries-per-second counter
+		lock_shm();
+		reset_qps(now);
+		unlock_shm();
+
 		thread_sleepms(GC, 1000);
 	}
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -504,6 +504,7 @@ void *GC_thread(void *val)
 	while(!killed)
 	{
 		const time_t now = time(NULL);
+		const double time_start = double_time();
 		if(config.dns.rateLimit.interval.v.ui > 0 &&
 		   (unsigned int)(now - lastRateLimitCleaner) >= config.dns.rateLimit.interval.v.ui)
 		{
@@ -569,7 +570,17 @@ void *GC_thread(void *val)
 		reset_qps(now);
 		unlock_shm();
 
-		thread_sleepms(GC, 1000);
+		// Intermediate cancellation-point
+		if(killed)
+			break;
+
+		// Sleep for the remaining time of the interval (if any)
+		const double time_end = double_time();
+		const double time_diff = time_end - time_start;
+		const double sleep_time = 1.0 - time_diff; // 1.0 second interval
+
+		if(sleep_time > 0)
+			thread_sleepms(GC, (unsigned int)(sleep_time*1000));
 	}
 
 	// Close inotify watcher

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -1219,11 +1219,12 @@ void update_qps(const time_t timestamp)
 	shmSettings->qps[slot]++;
 }
 
-// Reset queries per second (qps) value for a given timeslot
+// Reset queries per second (qps) value for the timeslot following the current
+// one
 void reset_qps(const time_t timestamp)
 {
 	// Get the timeslot for the current timestamp
-	const unsigned int slot = timestamp % QPS_AVGLEN;
+	const unsigned int slot = (timestamp + 1) % QPS_AVGLEN;
 
 	// Reset the query count
 	shmSettings->qps[slot] = 0;
@@ -1241,5 +1242,6 @@ double __attribute__((pure)) get_qps(void)
 	for(unsigned int i = 0; i < QPS_AVGLEN; i++)
 		qps += shmSettings->qps[i];
 
+	// Return the computed value divided by N (the number of slots)
 	return qps / QPS_AVGLEN;
 }

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -1210,29 +1210,23 @@ int __attribute__((pure)) is_shm_fd(const int fd)
 // Update queries per second (qps) value
 // This is done in shared memory to allow for both UDP and TCP workers to
 // contribute.
-void update_qps(const double timestamp)
+void update_qps(const time_t timestamp)
 {
 	// Get the timeslot for the current timestamp
-	const unsigned int slot = (unsigned int)timestamp % QPS_AVGLEN;
-
-	// Check if the timestamp is in the same slot as the last one
-	if(shmSettings->qps.last != slot)
-	{
-		// Reset all the slots in between
-		// This is relevant if less than one query per second is
-		// received and the intermediate slots are not updated
-		for(unsigned int i = (shmSettings->qps.last + 1) % QPS_AVGLEN; i != slot; i = (i + 1) % QPS_AVGLEN)
-			shmSettings->qps.buf[i] = 0;
-
-		// Reset the current slot
-		shmSettings->qps.buf[slot] = 0;
-
-		// Update the last slot index
-		shmSettings->qps.last = slot;
-	}
+	const unsigned int slot = timestamp % QPS_AVGLEN;
 
 	// Add the query
-	shmSettings->qps.buf[slot]++;
+	shmSettings->qps[slot]++;
+}
+
+// Reset queries per second (qps) value for a given timeslot
+void reset_qps(const time_t timestamp)
+{
+	// Get the timeslot for the current timestamp
+	const unsigned int slot = timestamp % QPS_AVGLEN;
+
+	// Reset the query count
+	shmSettings->qps[slot] = 0;
 }
 
 // Compute queries per second (qps) value
@@ -1245,7 +1239,7 @@ double __attribute__((pure)) get_qps(void)
 	//
 	double qps = 0.0;
 	for(unsigned int i = 0; i < QPS_AVGLEN; i++)
-		qps += shmSettings->qps.buf[i];
+		qps += shmSettings->qps[i];
 
 	return qps / QPS_AVGLEN;
 }

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -31,10 +31,7 @@ typedef struct {
 	pid_t pid;
 	unsigned int global_shm_counter;
 	unsigned int next_str_pos;
-	struct {
-		unsigned int last;
-		unsigned int buf[QPS_AVGLEN];
-	} qps;
+	unsigned int qps[QPS_AVGLEN];
 } ShmSettings;
 
 typedef struct {
@@ -155,7 +152,8 @@ void set_per_client_regex(const int clientID, const int regexID, const bool valu
 // Used in dnsmasq/utils.c
 int is_shm_fd(const int fd);
 
-void update_qps(const double timestamp);
+void update_qps(const time_t timestamp);
+void reset_qps(const time_t timestamp);
 double get_qps(void) __attribute__((pure));
 
 #endif //SHARED_MEMORY_SERVER_H


### PR DESCRIPTION
# What does this implement/fix?

Outsource counter resetting into a dedicated function periodically run by the GC thread to make the average computation independent from external trigger sources. This solves the problem of artificially high QPS values when no queries are processed by FTL.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.