### PR TITLE
Fix compilation support on Ubuntu 24.04.1 LTS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -D
 
 # Code hardening and debugging improvements
 # -fstack-protector-strong: The program will be resistant to having its stack overflowed
-# -Wp,-D_FORTIFY_SOURCE=2 and -O1 or higher: This causes certain unsafe glibc functions to be replaced with their safer counterparts
+# -Wp,-D_FORTIFY_SOURCE=3 and -O1 or higher: This causes certain unsafe glibc functions to be replaced with their safer counterparts. We may have to undefine _FORTIFY_SOURCE to avoid a warning about the redefinition of this macro
 # -Wl,-z,relro: reduces the possible areas of memory in a program that can be used by an attacker that performs a successful memory corruption exploit
 # -Wl,-z,now: When combined with RELRO above, this further reduces the regions of memory available to memory corruption attacks
 # -g3: More debugging information
@@ -51,7 +51,7 @@ set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -D
 # -Wl,-z,relro: Read-only segments after relocation
 # -fno-common: Emit globals without explicit initializer from `.bss` to `.data`. This causes GCC to reject multiple definitions of global variables. This is the new default from GCC-10 on.
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set(HARDENING_FLAGS "-fstack-protector-strong -Wp,-D_FORTIFY_SOURCE=2 -Wl,-z,relro,-z,now -fexceptions -funwind-tables -fasynchronous-unwind-tables -Wl,-z,defs -Wl,-z,now -Wl,-z,relro -fno-common")
+    set(HARDENING_FLAGS "-fstack-protector-strong -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3 -Wl,-z,relro,-z,now -fexceptions -funwind-tables -fasynchronous-unwind-tables -Wl,-z,defs -Wl,-z,now -Wl,-z,relro -fno-common")
     set(DEBUG_FLAGS "-rdynamic -fno-omit-frame-pointer")
 endif()
 


### PR DESCRIPTION
# What does this implement/fix?

Update source fortification from level 2 to 3:

> This new level detects more buffer overflows and bugs which mitigates security issues in applications at run time.

Furthermore, fix compilation support on recent Ubuntu: I upgraded my development Pi-hole to Ubuntu 24.04.1 LTS yesterday evening. Much to my surprise, I had to find out this morning that compiling FTL is no longer possible with these cryptic error messages being there even when running `./build.sh clean`:

![image](https://github.com/user-attachments/assets/533c5383-1345-49e4-8353-cbaf90c03870)

This is caused by several Linux distributions (e.g. [Fedora](https://fedoraproject.org/wiki/Changes/Add_FORTIFY_SOURCE%3D3_to_distribution_build_flags)) and then [`gcc-13`](https://bugs.launchpad.net/ubuntu/+source/gcc-13/+bug/2012440) and [Ubuntu 24.04](https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-D_FORTIFY_SOURCE.3D2) having switched internally to a higher fortification level by default.

gcc's rationale:

> `_FORTIFY_SOURCE` mitigates buffer overflows and is currently used in Ubuntu with [`_FORTIFY_SOURCE=2`](https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-D_FORTIFY_SOURCE.3D2). This newer option is [better at buffer size detection and has greater coverage](https://developers.redhat.com/articles/2022/09/17/gccs-new-fortification-level). When Fedora assessed changing `_FORTIFY_SOURCE=2` to `_FORTIFY_SOURCE=3`, they found mitigation coverage [increased 240% on average](https://fedoraproject.org/wiki/Changes/Add_FORTIFY_SOURCE%3D3_to_distribution_build_flags). **This is a default build flag in Gentoo Hardened (2022), Fedora (2023), OpenSUSE (2023), and has been approved to be enabled in [Arch (2023)](https://github.com/jvoisin/compiler-flags-distro)**. There is [no real-world performance difference](https://gotplt.org/posts/fortify-source-3-performance.html) between `_FORTIFY_SOURCE=2` and `_FORTIFY_SOURCE=3`.

Ubuntu's rationale:

> First enabled as `-D_FORTIFY_SOURCE=2` in Ubuntu 8.10 and **updated to _`-D_FORTIFY_SOURCE=3`_ in Ubuntu 24.04**. Updated to Provides compile-time best-practices errors for certain `libc` functions, and provides run-time checks of buffer lengths and memory regions. Only activated when compiled with `-O1` or higher. Most problems are related to common unsafe uses of certain `libc` functions.
(typos herein fixed by me)



---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.