### PR TITLE
Fix Github Actions if statement

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -129,7 +129,7 @@ runs:
       # - this is a triggered by a PR event (we only push on commit to branch
       #   events)
       # - no SSH key is provided (this is a PR from a fork)
-      if: inputs.event_name != 'pull_request' && ${{ inputs.SSH_KEY != '' }}
+      if: inputs.event_name != 'pull_request' && inputs.SSH_KEY != ''
       uses: ./.github/actions/deploy
       with:
         pattern: ${{ inputs.bin_name }}-binary


### PR DESCRIPTION
# What does this implement/fix?

See title. See here: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions

Emphasis on:

![image](https://github.com/user-attachments/assets/92977587-d080-43c6-967f-15b7fbe8c6db)

and

> When you use expressions in an `if` conditional, you can, optionally, omit the `${{ }}` expression syntax because GitHub Actions automatically evaluates the `if` conditional as an expression. However, this exception does not apply everywhere.

from here: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idif

---

**Related issue or feature (if applicable):** Recent fork-based PRs failing the build steps related to deployment.

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.