### PR TITLE
Don't set RTC time by default

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -878,7 +878,7 @@ static void initConfig(struct config *conf)
 	conf->ntp.sync.rtc.set.k = "ntp.sync.rtc.set";
 	conf->ntp.sync.rtc.set.h = "Should FTL update a real-time clock (RTC) if available?";
 	conf->ntp.sync.rtc.set.t = CONF_BOOL;
-	conf->ntp.sync.rtc.set.d.b = true;
+	conf->ntp.sync.rtc.set.d.b = false;
 	conf->ntp.sync.rtc.set.c = validate_stub; // Only type-based checking
 
 	conf->ntp.sync.rtc.device.k = "ntp.sync.rtc.device";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -518,7 +518,7 @@
 
     [ntp.sync.rtc]
       # Should FTL update a real-time clock (RTC) if available?
-      set = true
+      set = false
 
       # Path to the RTC device to update. Leave empty for auto-discovery
       #


### PR DESCRIPTION
# What does this implement/fix?

Change default value of `ntp.sync.rtc.set` to `false`. The motivation of this change was a recent discussion with @Bucking-Horn that brought to light that there are systems where the RTC is expected to be set to local time (instead of UTC) for coexistence with other operating systems (such as Windows).

This is not *really* a problem here as we also have `ntp.sync.rtc.utc` to control whether the RTC should be set to, well, UTC (`true`) or local time (`false`), however, there exists no standardized way to obtain if the RTC *is meant* to be set in local time or not. The RTC itself doesn't know this and, hence, cannot be queried. To avoid such conflicts, we decide to not set the RTC by default but only if users specifically want it. If they do, they can also set the UTC/localtime option.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.