### PR TITLE
Update --gen-x509 help text

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -1062,7 +1062,10 @@ void parse_args(int argc, char *argv[])
 			printf("    By default, this new certificate is based on the elliptic\n");
 			printf("    curve secp521r1. If the optional flag %s[rsa]%s is specified,\n", purple, normal);
 			printf("    an RSA (4096 bit) key will be generated instead.\n\n");
-			printf("    Usage: %spihole-FTL --gen-x509 %soutfile %s[rsa]%s\n\n", green, cyan, purple, normal);
+			printf("    An optional %s[domain]%s can be given to specify the domain\n", blue, normal);
+			printf("    for which the certificate is valid. If omitted, the domain\n");
+			printf("    is set to %spi.hole%s.\n\n", blue, normal);
+			printf("    Usage: %spihole-FTL --gen-x509 %soutfile %s[domain] %s[rsa]%s\n\n", green, cyan, blue, purple, normal);
 
 			printf("%sTLS X.509 certificate parser:%s\n", yellow, normal);
 			printf("    Parse the given X.509 certificate and optionally check if\n");


### PR DESCRIPTION
# What does this implement/fix?

Adds description for optional `[domain]`:

![image](https://github.com/user-attachments/assets/245eb5b2-fc16-43d2-aa77-0a6744b7e047)

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/fix-pihole-ftl-help-output-for-gen-x509-option-with-domain-parameter/73622

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.