### PR TITLE
Improve network table error handling

### DIFF
--- a/src/api/network.c
+++ b/src/api/network.c
@@ -185,6 +185,9 @@ static int api_network_devices_GET(struct ftl_conn *api)
 	const char *sql_msg = NULL;
 	if(!networkTable_readDevices(db, &device_stmt, &sql_msg))
 	{
+		networkTable_readDevicesFinalize(device_stmt);
+		dbclose(&db);
+	
 		// Add SQL message (may be NULL = not available)
 		return send_json_error(api, 500,
 		                       "database_error",
@@ -231,6 +234,11 @@ static int api_network_devices_GET(struct ftl_conn *api)
 			{
 				cJSON_Delete(ips);
 				cJSON_Delete(devices);
+
+				networkTable_readIPsFinalize(ip_stmt);
+				networkTable_readDevicesFinalize(device_stmt);
+				dbclose(&db);
+
 				return send_json_error(api, 500,
 				                       "database_error",
 				                       "Could not read network details from database table (getting IP records)",
@@ -250,6 +258,9 @@ static int api_network_devices_GET(struct ftl_conn *api)
 
 	if(sql_msg != NULL)
 	{
+		networkTable_readDevicesFinalize(device_stmt);
+		dbclose(&db);
+
 		cJSON_Delete(devices);
 		return send_json_error(api, 500,
 		                       "database_error",

--- a/src/api/stats_database.c
+++ b/src/api/stats_database.c
@@ -57,7 +57,7 @@ int api_history_database(struct ftl_conn *api)
 
 
 	// Prepare SQLite statement
-	sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt = NULL;
 	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
 		log_err("api_stats_database_history() - SQL error prepare (%i): %s",
@@ -282,7 +282,7 @@ int api_stats_database_top_items(struct ftl_conn *api)
 
 
 	// Prepare SQLite statement
-	sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt = NULL;
 	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
 		log_err("api_stats_database_history() - SQL error prepare (%i): %s",
@@ -470,7 +470,7 @@ int api_history_database_clients(struct ftl_conn *api)
 	                       "ORDER BY client DESC";
 
 	// Prepare SQLite statement
-	sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt = NULL;
 	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
 		log_err("api_stats_database_clients() - SQL error prepare outer (%i): %s",
@@ -727,7 +727,7 @@ int api_stats_database_upstreams(struct ftl_conn *api)
 	           "GROUP BY forward ORDER BY forward";
 
 	// Prepare SQLite statement
-	sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt = NULL;
 	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
 		log_err("api_stats_database_clients() - SQL error prepare (%i): %s",

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -16,7 +16,7 @@ bool create_network_table(sqlite3 *db);
 bool create_network_addresses_table(sqlite3 *db);
 bool create_network_addresses_with_names_table(sqlite3 *db);
 void parse_neighbor_cache(sqlite3 *db);
-void updateMACVendorRecords(sqlite3 *db);
+bool updateMACVendorRecords(sqlite3 *db);
 bool unify_hwaddr(sqlite3 *db);
 char *getMACfromIP(sqlite3 *db, const char* ipaddr) __attribute__((malloc));
 int getAliasclientIDfromIP(sqlite3 *db, const char *ipaddr);


### PR DESCRIPTION
# What does this implement/fix?

Go through network-table.c and ensure error handling is uniform, there were some cases in which an early returning caused by an error could have left prepared SQLite3 statements un-finalized. Whether this is the cause for occasional database locking we are seeing is unclear. However, the change

![image](https://github.com/user-attachments/assets/0bbc79f7-2020-4cf9-9179-0a1abe53fd8f)

is specifically tailored to fix the cause of recently reported `ERROR: add_netDB_network_address(-1, "192.168.0.168"): Failed to step (error 19): constraint failed` messages.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.