### PR TITLE
Amend the help text of the TLS certificate

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1008,7 +1008,7 @@ static void initConfig(struct config *conf)
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.tls.cert.k = "webserver.tls.cert";
-	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. All directories of the path must be readable and accessible by the 'pihole' user. This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
+	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. All directories along the path must be readable and accessible by the user running FTL (typically 'pihole'). This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
 	conf->webserver.tls.cert.a = cJSON_CreateStringReference("<valid TLS certificate file (*.pem)>");
 	conf->webserver.tls.cert.f = FLAG_RESTART_FTL;
 	conf->webserver.tls.cert.t = CONF_STRING;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1008,7 +1008,7 @@ static void initConfig(struct config *conf)
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.tls.cert.k = "webserver.tls.cert";
-	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
+	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. All directories of the path must be readable and accessible by the 'pihole' user. This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
 	conf->webserver.tls.cert.a = cJSON_CreateStringReference("<valid TLS certificate file (*.pem)>");
 	conf->webserver.tls.cert.f = FLAG_RESTART_FTL;
 	conf->webserver.tls.cert.t = CONF_STRING;

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -668,7 +668,8 @@
     restore = true
 
   [webserver.tls]
-    # Path to the TLS (SSL) certificate file. This option is only required when at least
+    # Path to the TLS (SSL) certificate file. All directories along the path must be readable and accessible 
+    # by the user running FTL (typically 'pihole'). This option is only required when at least
     # one of webserver.port is TLS. The file must be in PEM format, and it must have both,
     # private key and certificate (the *.pem file created must contain a 'CERTIFICATE'
     # section as well as a 'RSA PRIVATE KEY' section).

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -668,11 +668,11 @@
     restore = true
 
   [webserver.tls]
-    # Path to the TLS (SSL) certificate file. All directories along the path must be readable and accessible 
-    # by the user running FTL (typically 'pihole'). This option is only required when at least
-    # one of webserver.port is TLS. The file must be in PEM format, and it must have both,
-    # private key and certificate (the *.pem file created must contain a 'CERTIFICATE'
-    # section as well as a 'RSA PRIVATE KEY' section).
+    # Path to the TLS (SSL) certificate file. All directories along the path must be
+    # readable and accessible by the user running FTL (typically 'pihole'). This option is
+    # only required when at least one of webserver.port is TLS. The file must be in PEM
+    # format, and it must have both, private key and certificate (the *.pem file created
+    # must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).
     # The *.pem file can be created using
     #     cp server.crt server.pem
     #     cat server.key >> server.pem


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Improve the help text  of the `webserver.tls.cert` config.

Fixes https://discourse.pi-hole.net/t/v6-self-signed-certificate-issues/73640

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
