### PR TITLE
Fix binary verification with modern cmake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,12 +82,18 @@ fi
 # Build the sources with the number of available cores
 cmake --build . -- -j $(nproc)
 
+# Checksum verification
+./pihole-FTL verify
+
 # If we are asked to install, we do this here (requires root privileges)
-# Otherwise, we simply copy the binary one level up
+# Otherwise, we simply copy the binary one level down
 if [[ -n "${install}" ]]; then
     echo "Installing pihole-FTL"
     SUDO=$(command -v sudo)
     ${SUDO} cmake --install .
+
+    # Verify checksum again after installation
+    /usr/bin/pihole-FTL verify
 else
     echo "Copying compiled pihole-FTL binary to repository root"
     cp pihole-FTL ../

--- a/build.sh
+++ b/build.sh
@@ -91,9 +91,6 @@ if [[ -n "${install}" ]]; then
     echo "Installing pihole-FTL"
     SUDO=$(command -v sudo)
     ${SUDO} cmake --install .
-
-    # Verify checksum again after installation
-    /usr/bin/pihole-FTL verify
 else
     echo "Copying compiled pihole-FTL binary to repository root"
     cp pihole-FTL ../

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,9 +387,13 @@ add_custom_command(TARGET pihole-FTL POST_BUILD COMMENT "Appending sha256sum to 
         COMMAND mv $<TARGET_FILE:pihole-FTL>.tmp $<TARGET_FILE:pihole-FTL>
         )
 
-find_program(SETCAP setcap)
+######### Installation target ############
+# Install the binary
 install(TARGETS pihole-FTL
         RUNTIME DESTINATION bin
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-install(CODE "execute_process(COMMAND ${SETCAP} CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN,CAP_SYS_TIME+eip \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/pihole-FTL)")
-
+find_program(SETCAP setcap)
+# After installing the binary, we set the capabilities on the binary ...
+install(CODE "execute_process(COMMAND ${SETCAP} CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN,CAP_SYS_TIME+eip \${CMAKE_INSTALL_PREFIX}/bin/pihole-FTL)")
+# ... and verify the binary integrity
+install(CODE "execute_process(COMMAND \${CMAKE_INSTALL_PREFIX}/bin/pihole-FTL verify)")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -376,6 +376,7 @@ endif()
 add_custom_command(TARGET pihole-FTL POST_BUILD COMMENT "Appending sha256sum to pihole-FTL"
         COMMAND echo -n "SHA256 checksum of pihole-FTL: " && sha256sum $<TARGET_FILE:pihole-FTL> | cut -d ' ' -f 1
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:pihole-FTL> $<TARGET_FILE_DIR:pihole-FTL>/pihole-FTL.tmp
+        COMMAND echo -n "sha256sum" >> $<TARGET_FILE:pihole-FTL>.tmp
         COMMAND sha256sum $<TARGET_FILE:pihole-FTL>.tmp | cut -d ' ' -f 1 | xxd -r -p >> $<TARGET_FILE:pihole-FTL>.tmp
         COMMAND mv $<TARGET_FILE:pihole-FTL>.tmp $<TARGET_FILE:pihole-FTL>
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,12 @@ if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
     endif()
 endif()
 
+# Do not add run time path information
+# This ensures CMake does not add rpath information to the binary and
+# subsequently strip it from the binary during install causing the binary
+# validation to fail. RPATH is not needed for the FTL binary
+SET(CMAKE_SKIP_RPATH TRUE)
+
 # Put runtime output, i.e. pihole-FTL, in the root of the build dir
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 

--- a/src/args.c
+++ b/src/args.c
@@ -562,11 +562,14 @@ void parse_args(int argc, char *argv[])
 	{
 		// Enable stdout printing
 		cli_mode = true;
-		const bool match = verify_FTL(true);
+		const enum verify_result match = verify_FTL(true);
 		printf("%s Binary integrity check: %s\n",
-		       match ? cli_tick() : cli_cross() ,
-		       match ? "OK" : "FAILED");
-		exit(match ? EXIT_SUCCESS : EXIT_FAILURE);
+		       match == VERIFY_OK ? cli_tick() :
+		         match == VERIFY_NO_CHECKSUM ? cli_qst() : cli_cross(),
+		       match == VERIFY_OK ? "OK" :
+		         match == VERIFY_NO_CHECKSUM ? "No checksum found" :
+		           match == VERIFY_ERROR ? "Error" : "Failed");
+		exit(match);
 	}
 
 	// Local reverse name resolver

--- a/src/enums.h
+++ b/src/enums.h
@@ -342,4 +342,11 @@ enum api_flags {
 	API_BATCHDELETE = 1 << 2,
 };
 
+enum verify_result {
+	VERIFY_OK = 0, // EXIT_SUCCESS
+	VERIFY_FAILED,
+	VERIFY_ERROR,
+	VERIFY_NO_CHECKSUM
+} __attribute__ ((packed));
+
 #endif // ENUMS_H

--- a/src/files.h
+++ b/src/files.h
@@ -37,7 +37,7 @@ bool chown_pihole(const char *path, struct passwd *pwd);
 void rotate_files(const char *path, char **first_file);
 bool files_different(const char *pathA, const char *pathB, unsigned int from);
 bool sha256sum(const char *path, uint8_t checksum[SHA256_DIGEST_SIZE], const bool skip_end);
-bool verify_FTL(bool verbose);
+enum verify_result verify_FTL(bool verbose);
 
 int parse_line(char *line, char **key, char **value);
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes #2101, there is much detail in this issue ticket so I won't duplicate it here. Short story is that CMake modifies the binary's run time path information during the first build and strips this away during install. This obviously modifies the checksum and the verification failed rightfully.

This PR disables modifying run time path information altogether as this is not needed for building FTL. Furthermore, it adds two checks during `./build.sh` to ensure this does not happen again in the future without us noticing immediately and hardening the entire `verify` procedure to skip verification when FTL was somehow built without the checksum actually being appended to the binary.

---

**Related issue or feature (if applicable):** Fixes #2101 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.