### PR TITLE
Upstream lookups should always check for the magic byte while searching

### DIFF
--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -146,7 +146,7 @@ int _findUpstreamID(const char *upstreamString, const in_port_t port, int line, 
 	for(unsigned int upstreamID = 0; upstreamID < counters->upstreams; upstreamID++)
 	{
 		// Get upstream pointer
-		const upstreamsData *upstream = _getUpstream(upstreamID, false, line, func, file);
+		const upstreamsData *upstream = _getUpstream(upstreamID, true, line, func, file);
 
 		// Check if the returned pointer is valid before trying to access it
 		if(upstream == NULL)


### PR DESCRIPTION
# What does this implement/fix?

Fixes https://github.com/pi-hole/FTL/issues/2106

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/issues/2106

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.