### PR TITLE
Changes the `dns.domain` validation to accept an empty string as value

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -507,7 +507,7 @@ static void initConfig(struct config *conf)
 	conf->dns.domain.t = CONF_STRING;
 	conf->dns.domain.f = FLAG_RESTART_FTL;
 	conf->dns.domain.d.s = (char*)"lan";
-	conf->dns.domain.c = validate_domain;
+	conf->dns.domain.c = validate_dns_domain;
 
 	conf->dns.bogusPriv.k = "dns.bogusPriv";
 	conf->dns.bogusPriv.h = "Should all reverse lookups for private IP ranges (i.e., 192.168.x.y, etc) which are not found in /etc/hosts or the DHCP leases file be answered with \"no such domain\" rather than being forwarded upstream?";

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -155,6 +155,20 @@ bool validate_dns_cnames(union conf_value *val, const char *key, char err[VALIDA
 	return true;
 }
 
+// Validate dns.domain string
+// Accepts an empty string or a valid domain
+bool validate_dns_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	// Check if domain is valid
+	if(strlen(val->s)!=0 && !valid_domain(val->s, strlen(val->s), false))
+	{
+		snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: not a valid domain (\"%s\")", key, val->s);
+		return false;
+	}
+
+	return true;
+}
+
 // Validate IPs in CIDR notation
 bool validate_cidr(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
 {

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -17,6 +17,7 @@
 bool validate_stub(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]) __attribute__((const));
 bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_cnames(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+bool validate_dns_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_cidr(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix the #2111 issue, where an empty string is not accepted as value for `dns.domain` option.

### How does this PR accomplish the above?

Adding a new validation function.

### Link documentation PRs if any are needed to support this PR:

none

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
