### PR TITLE
Ensure we close netlink sockets

### DIFF
--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -1128,6 +1128,7 @@ static int nlquery(const int type, cJSON *json, const bool detailed)
 	if(!nlrequest(fd, &sa, type))
 	{
 		log_info("nlrequest error: %s", strerror(errno));
+		close(fd);
 		return -1;
 	}
 
@@ -1138,6 +1139,7 @@ static int nlquery(const int type, cJSON *json, const bool detailed)
 		nl_msg_type = parse_nl_msg(buf, len, json, detailed);
 	} while (nl_msg_type != NLMSG_DONE && nl_msg_type != NLMSG_ERROR);
 
+	close(fd);
 	return 0;
 
 }


### PR DESCRIPTION
# What does this implement/fix?

Fix a slow but progressing exhaustion of file descriptors when heavily using https://pi.hole/admin/interfaces by ensuring that each `socket` is closed after we're done with it.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/error-500-internal-server-error-error-cannot-open-script-file-var-www-html-admin-login-lp/73698/

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.