### PR TITLE
Delay IPv6 client name lookups

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -138,6 +138,12 @@
 // Default: 30 (seconds)
 #define QPS_AVGLEN 30
 
+// How long should IPv6 client host name resolution be postponed?
+// This is done to ensure that the network table had time to catch up on new
+// clients in the network
+// Default: 2 x database.DBinterval (seconds) = 120 s
+#define DELAY_V6_RESOLUTION 2*config.database.DBinterval.v.ui
+
 // Use out own syscalls handling functions that will detect possible errors
 // and report accordingly in the log. This will make debugging FTL crash
 // caused by insufficient memory or by code bugs (not properly dealing

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -895,6 +895,21 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 		if((ipaddr = getstr(ippos)) != NULL && strstr(ipaddr,":") != NULL)
 			IPv6 = true;
 
+		// If onlynew flag is set, we will only resolve new clients.
+		// However, if this is a IPv6 client, we postpone the resolution
+		// slightly to ensure the network table has had time to possibly
+		// correlate the IPv6 address via a related other address (e.g.,
+		// IPv4 address) though an identical MAC address.
+		if(onlynew && newflag && IPv6 && client->firstSeen + DELAY_V6_RESOLUTION > now)
+		{
+			log_debug(DEBUG_RESOLVER, "Postponing resolution of new client %s (IPv6) for at least %.0f more seconds",
+			          getstr(ippos), now - client->firstSeen + DELAY_V6_RESOLUTION);
+
+			unlock_shm();
+			skipped++;
+			continue;
+		}
+
 		unlock_shm();
 
 		// If we're in refreshing mode (onlynew == false), we skip clients if


### PR DESCRIPTION
# What does this implement/fix?

This PR is an attempt to fix #2124 

The described issue is that some IPv6 clients don't show a host name in the Query Log even when the network table has one.

The reason for this is timing. When a client issues a query over IPv6 quickly after it got this address, the first query arrived
the Pi-hole *before* the client is known to the network table. When FTL now tries to resolve this address's name, it cannot find a name. A few moments later, when the ARP cache is parsed for the next time, FTL may be able to correlate this new address through an identical MAC address to an existing address having a host name. However, as the default value of `resolver.refreshNames` is `IPV4_ONLY`, FTL actually never tries to resolve the address so it never gets to know the IPv6 client's host name.

The attempt we are doing here is *postponing* name resolution of IPv6 clients by two times the ARP processing interval - this should give plenty time for the network table to catch up so that - when the client name is tried to be resolved for the first (and only!) time - we can get it right away.

By default, ARP cache interpretation is run at the `database.DBinterval` interval.

---

**Related issue or feature (if applicable):** #2124 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.