### PR TITLE
Expose EDE information via API if available

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -194,4 +194,7 @@
 #define max(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a > _b ? _a : _b; })
 #define min(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
 
+// defined in cache.c
+const char *edestr(int ede);
+
 #endif // FTL_H

--- a/src/api/docs/content/specs/queries.yaml
+++ b/src/api/docs/content/specs/queries.yaml
@@ -224,6 +224,17 @@ components:
                 type: string
                 description: IP or name + port of upstream server
                 nullable: true
+              ede:
+                type: object
+                description: Extended DNS Error (EDE) information
+                properties:
+                  code:
+                    type: integer
+                    description: EDE code
+                  text:
+                    type: string
+                    nullable: true
+                    description: EDE message (if available)
           example:
             - time: 1581907991.539157
               type: "A"
@@ -240,6 +251,9 @@ components:
               list_id: NULL
               upstream: "localhost#5353"
               dbid: 112421354
+              ede:
+                code: 0
+                text: null
             - time: 1581907871.583821
               type: "AAAA"
               domain: "api.github.com"
@@ -255,6 +269,9 @@ components:
               list_id: NULL
               upstream: "localhost#5353"
               dbid: 112421355
+              ede:
+                code: 0
+                text: null
         cursor:
           type: integer
           description: Database ID of most recent query to show

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -616,6 +616,21 @@ void db_init(void)
 		dbversion = db_get_int(db, DB_VERSION);
 	}
 
+	// Update to version 21 if lower
+	if(dbversion < 21)
+	{
+		// Update to version 21: Add additional column "ede" in the query_storage table
+		log_info("Updating long-term database to version 21");
+		if(!add_query_storage_column_ede(db))
+		{
+			log_info("Additional column 'ede' in the query_storage table cannot be added, database not available");
+			dbclose(&db);
+			return;
+		}
+		// Get updated version
+		dbversion = db_get_int(db, DB_VERSION);
+	}
+
 	/* * * * * * * * * * * * * IMPORTANT * * * * * * * * * * * * *
 	 * If you add a new database version, check if the in-memory
 	 * schema needs to be update as well (always recreated from

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -23,7 +23,7 @@
                                                        "client TEXT NOT NULL, " \
                                                        "forward TEXT );"
 
-#define MEMDB_VERSION 20
+#define MEMDB_VERSION 21
 #define CREATE_QUERY_STORAGE_TABLE "CREATE TABLE query_storage ( id INTEGER PRIMARY KEY AUTOINCREMENT, " \
                                                                 "timestamp INTEGER NOT NULL, " \
                                                                 "type INTEGER NOT NULL, " \
@@ -35,7 +35,8 @@
                                                                 "reply_type INTEGER, " \
                                                                 "reply_time REAL, " \
                                                                 "dnssec INTEGER, " \
-                                                                "list_id INTEGER );"
+                                                                "list_id INTEGER, " \
+                                                                "ede INTEGER );"
 
 #define CREATE_QUERIES_VIEW "CREATE VIEW queries AS " \
                                     "SELECT id, timestamp, type, status, " \
@@ -126,5 +127,6 @@ bool add_query_storage_columns(sqlite3 *db);
 bool add_query_storage_column_regex_id(sqlite3 *db);
 bool add_ftl_table_description(sqlite3 *db);
 bool rename_query_storage_column_regex_id(sqlite3 *db);
+bool add_query_storage_column_ede(sqlite3 *db);
 
 #endif //QUERY_TABLE_PRIVATE_H

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -1931,6 +1931,3 @@ int add_update_server(int flags,
 		      const char *interface,
 		      const char *domain,
 		      union all_addr *local_addr); 
-
-// Pi-hole modification
-const char *edestr(int ede);

--- a/src/dnsmasq/dnssec.c
+++ b/src/dnsmasq/dnssec.c
@@ -16,6 +16,7 @@
 */
 
 #include "dnsmasq.h"
+#include "log.h"
 
 #ifdef HAVE_DNSSEC
 
@@ -512,12 +513,18 @@ static int validate_rrset(time_t now, struct dns_header *header, size_t plen, in
 	{
 	  /* We must explicitly check against wanted values, because of SERIAL_UNDEF */
 	  if (serial_compare_32(curtime, sig_inception) == SERIAL_LT)
+	  {
+	    log_debug(DEBUG_DNSSEC, "Signature inception time is %f seconds in the future", difftime(sig_inception, curtime));
 	    continue;
+	  }
 	  else
 	    failflags &= ~DNSSEC_FAIL_NYV;
 	  
 	  if (serial_compare_32(curtime, sig_expiration) == SERIAL_GT)
+	  {
+	    log_debug(DEBUG_DNSSEC, "Signature expiration time is %f seconds in the past", difftime(curtime, sig_expiration));
 	    continue;
+	  }
 	  else
 	    failflags &= ~DNSSEC_FAIL_EXP;
 	}

--- a/test/api/libs/responseVerifyer.py
+++ b/test/api/libs/responseVerifyer.py
@@ -295,6 +295,11 @@ class ResponseVerifyer():
 			return False
 		YAMLprop = YAMLprops[props[-1]]
 
+		# Check if FTL returned null when an object was expected
+		if FTLprops is None:
+			self.errors.append("FTL's response is null in " + flat_path)
+			return False
+
 		# Check if the property is defined in the FTL response
 		if props[-1] not in FTLprops:
 			self.errors.append("Property '" + flat_path + "' missing in FTL's response")

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -692,16 +692,16 @@
 @test "pihole-FTL.db schema is as expected" {
   run bash -c './pihole-FTL sqlite3 /etc/pihole/pihole-FTL.db .dump'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"query_storage\" (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain INTEGER NOT NULL, client INTEGER NOT NULL, forward INTEGER, additional_info INTEGER, reply_type INTEGER, reply_time REAL, dnssec INTEGER, list_id INTEGER);"* ]]
+  [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"query_storage\" (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, type INTEGER NOT NULL, status INTEGER NOT NULL, domain INTEGER NOT NULL, client INTEGER NOT NULL, forward INTEGER, additional_info INTEGER, reply_type INTEGER, reply_time REAL, dnssec INTEGER, list_id INTEGER, ede INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE INDEX idx_queries_timestamps ON \"query_storage\" (timestamp);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE ftl (id INTEGER PRIMARY KEY NOT NULL, value BLOB NOT NULL, description TEXT);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE counters (id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network\" (id INTEGER PRIMARY KEY NOT NULL, hwaddr TEXT UNIQUE NOT NULL, interface TEXT NOT NULL, firstSeen INTEGER NOT NULL, lastQuery INTEGER NOT NULL, numQueries INTEGER NOT NULL, macVendor TEXT, aliasclient_id INTEGER);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE IF NOT EXISTS \"network_addresses\" (network_id INTEGER NOT NULL, ip TEXT UNIQUE NOT NULL, lastSeen INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), name TEXT, nameUpdated INTEGER, FOREIGN KEY(network_id) REFERENCES network(id));"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE aliasclient (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, comment TEXT);"* ]]
-  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,20,'Database version');"* ]]
+  [[ "${lines[@]}" == *"INSERT INTO ftl VALUES(0,21,'Database version');"* ]]
   # vvv This has been added in version 10 vvv
-  [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info, reply_type, reply_time, dnssec, list_id FROM query_storage q;"* ]]
+  [[ "${lines[@]}" == *"CREATE VIEW queries AS SELECT id, timestamp, type, status, CASE typeof(domain) WHEN 'integer' THEN (SELECT domain FROM domain_by_id d WHERE d.id = q.domain) ELSE domain END domain,CASE typeof(client) WHEN 'integer' THEN (SELECT ip FROM client_by_id c WHERE c.id = q.client) ELSE client END client,CASE typeof(forward) WHEN 'integer' THEN (SELECT forward FROM forward_by_id f WHERE f.id = q.forward) ELSE forward END forward,CASE typeof(additional_info) WHEN 'integer' THEN (SELECT content FROM addinfo_by_id a WHERE a.id = q.additional_info) ELSE additional_info END additional_info, reply_type, reply_time, dnssec, list_id, ede FROM query_storage q;"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE domain_by_id (id INTEGER PRIMARY KEY, domain TEXT NOT NULL);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE client_by_id (id INTEGER PRIMARY KEY, ip TEXT NOT NULL, name TEXT);"* ]]
   [[ "${lines[@]}" == *"CREATE TABLE forward_by_id (id INTEGER PRIMARY KEY, forward TEXT NOT NULL);"* ]]


### PR DESCRIPTION
# What does this implement/fix?

Expose extended DNS error codes (and human-readable textual interpretation if available) via the`queries` API. This is especially useful in the vicinity of DNSSEC issues like `BOGUS` as it can provide further reasoning such as `DNSSEC signature expired`:

![image](https://github.com/user-attachments/assets/9b527713-8c5d-4c7c-be3a-01b476bf006c)

![2024-12-18_10-57](https://github.com/user-attachments/assets/f9647b4a-7449-4885-aad1-f0fb1831ce23)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.