### PR TITLE
Make webserver ports optional by default

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1640,13 +1640,13 @@ static void get_web_port(struct config *conf)
 		return;
 	}
 	// Create the string
-	snprintf(ports, 32, "%d,%ds", http_port, https_port);
+	snprintf(ports, 32, "%do,%dos", http_port, https_port);
 
 	// Append IPv6 ports if IPv6 is enabled
 	const bool have_ipv6 = ipv6_enabled();
 	if(have_ipv6)
 		snprintf(ports + strlen(ports), 32 - strlen(ports),
-			",[::]:%d,[::]:%ds", http_port, https_port);
+			",[::]:%do,[::]:%dos", http_port, https_port);
 
 	// Set default values for webserver ports
 	if(conf->webserver.port.t == CONF_STRING_ALLOCATED)

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1004,7 +1004,7 @@ static void initConfig(struct config *conf)
 	conf->webserver.port.a = cJSON_CreateStringReference("comma-separated list of <[ip_address:]port>");
 	conf->webserver.port.f = FLAG_RESTART_FTL;
 	conf->webserver.port.t = CONF_STRING;
-	conf->webserver.port.d.s = (char*)"80,[::]:80,443s,[::]:443s";
+	conf->webserver.port.d.s = (char*)"80o,[::]:80o,443so,[::]:443so";
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.threads.k = "webserver.threads";

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -230,7 +230,6 @@ static void get_server_ports(void)
 
 	// Loop over all listening ports
 	struct mg_server_port mgports[MAXPORTS] = { 0 };
-	unsigned int ports_avail = 0;
 	const int ports = mg_get_server_ports(ctx, MAXPORTS, mgports);
 
 	// Stop if no ports are configured
@@ -258,15 +257,13 @@ static void get_server_ports(void)
 			https_port = mgports[i].port;
 
 		// Print port information
-		if(ports_avail == 0)
+		if(i == 0)
 			log_info("Web server ports:");
 		log_info("  - %d (HTTP%s, IPv%s%s)",
 		         mgports[i].port, mgports[i].is_ssl ? "S" : "",
 		         mgports[i].protocol == 1 ? "4" : (mgports[i].protocol == 3 ? "6" : "4+6"),
 		         mgports[i].is_redirect ? ", redirecting" : "");
 
-		// Increase number of available ports
-		ports_avail++;
 	}
 }
 

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -268,9 +268,6 @@ static void get_server_ports(void)
 		// Increase number of available ports
 		ports_avail++;
 	}
-
-	if(ports_avail == 0)
-		log_warn("No web server ports available!");
 }
 
 in_port_t __attribute__((pure)) get_https_port(void)

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -210,6 +210,19 @@ static struct serverports
 	in_port_t port;
 } server_ports[MAXPORTS] = { 0 };
 static in_port_t https_port = 0;
+/**
+ * @brief Retrieves and logs the server ports configuration.
+ *
+ * This function checks if the server context is initialized and then retrieves
+ * the configured server ports. It logs the port information and stores the
+ * details in the `server_ports` array. It also identifies and stores the first
+ * HTTPS port if available.
+ *
+ * @note If no ports are configured, a warning is logged and the function returns.
+ *
+ * @param void This function does not take any parameters.
+ * @return void This function does not return any value.
+ */
 static void get_server_ports(void)
 {
 	if(ctx == NULL)
@@ -217,31 +230,47 @@ static void get_server_ports(void)
 
 	// Loop over all listening ports
 	struct mg_server_port mgports[MAXPORTS] = { 0 };
-	if(mg_get_server_ports(ctx, MAXPORTS, mgports) > 0)
+	unsigned int ports_avail = 0;
+	const int ports = mg_get_server_ports(ctx, MAXPORTS, mgports);
+
+	// Stop if no ports are configured
+	if(ports < 1)
 	{
-		// Loop over all ports
-		for(unsigned int i = 0; i < MAXPORTS; i++)
-		{
-			// Stop if no more ports are configured
-			if(mgports[i].protocol == 0)
-				break;
-
-			// Store port information
-			server_ports[i].port = mgports[i].port;
-			server_ports[i].is_secure = mgports[i].is_ssl;
-			server_ports[i].is_redirect = mgports[i].is_redirect;
-			server_ports[i].protocol = mgports[i].protocol;
-
-			// Store HTTPS port if not already set
-			if(mgports[i].is_ssl && https_port == 0)
-				https_port = mgports[i].port;
-
-			// Print port information
-			log_debug(DEBUG_API, "Listening on port %d (HTTP%s, IPv%s)",
-			          mgports[i].port, mgports[i].is_ssl ? "S" : "",
-			          mgports[i].protocol == 1 ? "4" : (mgports[i].protocol == 3 ? "6" : "4+6"));
-		}
+		log_warn("No web server ports configured!");
+		return;
 	}
+
+	// Loop over all ports
+	for(unsigned int i = 0; i < (unsigned int)ports; i++)
+	{
+		// Stop if no more ports are configured
+		if(mgports[i].protocol == 0)
+			break;
+
+		// Store port information
+		server_ports[i].port = mgports[i].port;
+		server_ports[i].is_secure = mgports[i].is_ssl;
+		server_ports[i].is_redirect = mgports[i].is_redirect;
+		server_ports[i].protocol = mgports[i].protocol;
+
+		// Store (first) HTTPS port if not already set
+		if(mgports[i].is_ssl && https_port == 0)
+			https_port = mgports[i].port;
+
+		// Print port information
+		if(ports_avail == 0)
+			log_info("Web server ports:");
+		log_info("  - %d (HTTP%s, IPv%s%s)",
+		         mgports[i].port, mgports[i].is_ssl ? "S" : "",
+		         mgports[i].protocol == 1 ? "4" : (mgports[i].protocol == 3 ? "6" : "4+6"),
+		         mgports[i].is_redirect ? ", redirecting" : "");
+
+		// Increase number of available ports
+		ports_avail++;
+	}
+
+	if(ports_avail == 0)
+		log_warn("No web server ports available!");
 }
 
 in_port_t __attribute__((pure)) get_https_port(void)
@@ -532,6 +561,9 @@ void http_init(void)
 		return;
 	}
 
+	// Get server ports
+	get_server_ports();
+
 	// Register API handler
 	mg_set_request_handler(ctx, "/api", api_handler, NULL);
 
@@ -560,9 +592,6 @@ void http_init(void)
 
 	// Prepare prerequisites for Lua
 	allocate_lua();
-
-	// Get server ports
-	get_server_ports();
 
 	// Restore sessions from database
 	init_api();

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -657,7 +657,7 @@
   #
   # Possible values are:
   #     comma-separated list of <[ip_address:]port>
-  port = "80,[::]:80,443s,[::]:443s"
+  port = "80o,[::]:80o,443so,[::]:443so"
 
   # Maximum number of worker threads allowed.
   # The Pi-hole web server handles each incoming connection in a separate thread.

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -2049,7 +2049,7 @@
   [[ "${lines[0]}" == "[ 1.1.1.1 abc-custom.com def-custom.de, 2.2.2.2 äste.com steä.com ]" ]]
   run bash -c './pihole-FTL --config webserver.port'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "80,[::]:80,443s,[::]:443s" ]]
+  [[ "${lines[0]}" == "80o,[::]:80o,443so,[::]:443so" ]]
 }
 
 @test "Create, verify and re-import Teleporter file via CLI" {


### PR DESCRIPTION
# What does this implement/fix?

See title. Related to ongoing Discourse discussion.

Exemplary additional `FTL.log` output:
```
2024-12-20 09:57:19.691 CET [1902269M] INFO: Web server ports:
2024-12-20 09:57:19.691 CET [1902269M] INFO:   - 80 (HTTP, IPv4, redirecting)
2024-12-20 09:57:19.691 CET [1902269M] INFO:   - 80 (HTTP, IPv6, redirecting)
2024-12-20 09:57:19.691 CET [1902269M] INFO:   - 443 (HTTPS, IPv4)
2024-12-20 09:57:19.691 CET [1902269M] INFO:   - 443 (HTTPS, IPv6)
```

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/why-ca-i-not-access-dev-releases-on-new-setup/74613/7

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.