### PR TITLE
Fix crash on multiple replies

### DIFF
--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1460,9 +1460,9 @@ void return_reply(time_t now, struct frec *forward, struct dns_header *header, s
 #ifdef HAVE_DUMPFILE
 		dump_packet_udp(DUMP_REPLY, daemon->packet, (size_t)nn, NULL, &src->source, src->fd);
 #endif
+		/* Pi-hole modification */
+		FTL_multiple_replies(src->log_id, &first_ID);
 	      }
-	  /* Pi-hole modification */
-	  FTL_multiple_replies(src->log_id, &first_ID);
 	}
     }
       


### PR DESCRIPTION
# What does this implement/fix?

Fixes #2140 by moving callback for multiple replies into the loop. This was recently broken in #2136 where some code refactoring by Simon Kelley unintentionally kicked a bit of FTL code out of the loop into a region where it shouldn't have been. Testing didn't reveal this as rather specific conditions need to be met to trigger a crash.

---

**Related issue or feature (if applicable):** #2140

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.