### PR TITLE
Allow spaces also in PUT /api/groups

### DIFF
--- a/src/api/list.c
+++ b/src/api/list.c
@@ -184,7 +184,8 @@ static int api_list_write(struct ftl_conn *api,
 	if(json_ret != 0)
 		return json_ret;
 
-	bool spaces_allowed = false;
+	// Spaces are allowed in groups
+	const bool spaces_allowed = listtype == GRAVITY_GROUPS;
 	bool allocated_json = false;
 	if(api->method == HTTP_POST)
 	{
@@ -218,7 +219,6 @@ static int api_list_write(struct ftl_conn *api,
 
 			case GRAVITY_GROUPS:
 			{
-				spaces_allowed = true;
 				cJSON *json_name = cJSON_GetObjectItemCaseSensitive(api->payload.json, "name");
 				if(cJSON_IsString(json_name) && strlen(json_name->valuestring) > 0)
 				{


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug reported on Discourse:
![image](https://github.com/user-attachments/assets/5b763d5b-fa50-4836-b57a-d885d1166f6a)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.