### PR TITLE
Fix leap year check

### DIFF
--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -240,7 +240,7 @@ bool generate_certificate(const char* certfile, bool rsa, const char *domain)
 	tm->tm_year += 30; // 30 years from now
 	// Check for leap year, and adjust the date accordingly
 	const bool isLeapYear = tm->tm_year % 4 == 0 && (tm->tm_year % 100 != 0 || tm->tm_year % 400 == 0);
-	tm->tm_mday = tm->tm_mon == 2 && tm->tm_mday == 29 && !isLeapYear ? 28 : tm->tm_mday;
+	tm->tm_mday = tm->tm_mon == 1 && tm->tm_mday == 29 && !isLeapYear ? 28 : tm->tm_mday;
 	strftime(not_after, sizeof(not_after), "%Y%m%d%H%M%S", tm);
 
 	// 1. Create CA certificate


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix leap year check when creating x509 certificate. tm_mon is zero-based, see [man page](https://www.man7.org/linux//man-pages/man3/tm.3type.html).

**How does this PR accomplish the above?:**

Replace tm->tm_mon _== 2_ with tm->tm_mon _== 1_.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
