### PR TITLE
Fix file ownership after pihole-FTL --config as root

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -749,6 +749,10 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 		return false;
 	}
 
+	// Chown file if we are root
+	if(geteuid() == 0)
+		chown_pihole(DNSMASQ_TEMP_CONF, NULL);
+
 	log_debug(DEBUG_CONFIG, "Testing "DNSMASQ_TEMP_CONF);
 	if(test_config && !test_dnsmasq_config(errbuf))
 	{


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When calling _pihole-FTL --config key value_ as root, the resulting pihole.toml and dnsmasq.conf files in /etc/pihole are owned by root:root. It should be pihole:pihole.

**How does this PR accomplish the above?:**

**pihole.toml**: Root cause is that when openFTLtoml() is called with mode "w", it'll not open _pihole.toml_, but _pihole.toml.tmp_ instead. closeFTLtoml(), however, always calls chown_pihole() on _pihole.toml_. As in the next step _pihole.toml.tmp_ gets renamed to _pihole.toml_, its root:root ownership persists.

This patch evaluates the open mode in closeFTLtoml(), changing the ownership of _pihole.toml.tmp_ if the mode isn't O_RDONLY.

**dnsmasq.conf**: Add a call to chown_pihole() for the temporary file, if called as root.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
