### PR TITLE
CI: Remove NTP test

### DIFF
--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -2087,11 +2087,3 @@
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]
 }
-
-@test "Check NTP server is broadcasting correct time" {
-  # Run this test at the very end of the test suite
-  # to ensure the NTP server has been started
-  run bash -c './pihole-FTL ntp 127.0.0.1'
-  printf "%s\n" "${lines[@]}"
-  [[ $status == 0 ]]
-}


### PR DESCRIPTION
# What does this implement/fix?

This PR removes the NTP test from FTL's CI testing suite. The reason for this is that this test is failing > 75% of the time, triggering automatic retries unnecessarily lengthening the overall build process and wasting resources.

![image](https://github.com/user-attachments/assets/15620e99-3228-4ff0-bb6e-e3a692383e8b)

But it is actually not only wasting resources but also causes more than 80% of the `docker-base-images/ftl-build` to fail at least one of the jobs, preventing updating the build container altogether.

There simply seems to be no reliable way to get this working. The underlying issue is somewhat hard to analyze, however, it seems that the NTP server simply is firewalled away on most (but not all) GHA runners.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.