### PR TITLE
Prevent calling strcmp with NULL pointer

### DIFF
--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -548,16 +548,19 @@ int get_config_from_CLI(const char *key, const bool quiet)
 	// We first loop over all config options to check if the one we are
 	// looking for is an exact match, use partial match otherwise
 	bool exactMatch = false;
-	for(unsigned int i = 0; i < CONFIG_ELEMENTS; i++)
+	if(key != NULL)
 	{
-		// Get pointer to memory location of this conf_item
-		struct conf_item *item = get_conf_item(&config, i);
-
-		// Check if item.k is identical with key
-		if(strcmp(item->k, key) == 0)
+		for(unsigned int i = 0; i < CONFIG_ELEMENTS; i++)
 		{
-			exactMatch = true;
-			break;
+			// Get pointer to memory location of this conf_item
+			struct conf_item *item = get_conf_item(&config, i);
+
+			// Check if item.k is identical with key
+			if(strcmp(item->k, key) == 0)
+			{
+				exactMatch = true;
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When calling _pihole-FTL --config_ one gets dozens of errors
```
Trying to compare a NULL (R) string in get_config_from_CLI()
```
If no specific key is given when reading the configuration, the key parameter to get_config_from_CLI() is passed as NULL, thus causing strcmp() to croak. This PR avoids these errors.

**How does this PR accomplish the above?:**

Run the first pass to detect an exact key match only if the key parameter is not NULL.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
