### PR TITLE
Harden dnsmasq syntax checking against signals

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pi-hole/ftl-build:v2.10 AS builder
+FROM ghcr.io/pi-hole/ftl-build:v2.11 AS builder
 
 WORKDIR /app
 

--- a/src/args.c
+++ b/src/args.c
@@ -668,7 +668,7 @@ void parse_args(int argc, char *argv[])
 		}
 
 		// Implement dnsmasq's test function, no need to prepare the entire FTL
-		// environment (initialize shared memory, lead queries from long-term
+		// environment (initialize shared memory, load queries from long-term
 		// database, ...) when the task is a simple (dnsmasq) syntax check
 		if(strcmp(argv[i], "dnsmasq-test") == 0 ||
 		   strcmp(argv[i], "--test") == 0)

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -110,10 +110,15 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 		int status;
 		while(waitpid(cpid, &status, 0) == -1)
 		{
-			log_debug(DEBUG_CONFIG, "Waiting for dnsmasq test returned: %s", strerror(errno));
-			if(errno != EINTR)
+			const int err = errno;
+			log_debug(DEBUG_CONFIG, "Waiting for dnsmasq test returned: %s", strerror(err));
+
+			// We can ignore EINTR as it just means that the wait
+			// was interrupted, so we just try again. All other
+			// errors are fatal and we break out of the loop
+			if(err != EINTR)
 			{
-				log_err("Cannot wait for dnsmasq test: %s", strerror(errno));
+				log_err("Cannot wait for dnsmasq test: %s", strerror(err));
 				break;
 			}
 		}


### PR DESCRIPTION
# What does this implement/fix?

Retry to wait for result of dnsmasq syntax test if interrupted by a signal

---

**Related issue or feature (if applicable):** #2149 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.