### PR TITLE
Update dnsmasq to v2.91test6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,6 @@ set(CMAKE_C_STANDARD 17)
 
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.91test4)
+set(DNSMASQ_VERSION pi-hole-v2.91test6)
 
 add_subdirectory(src)

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -2134,11 +2134,11 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
 	if (daemon->tcp_pids[i] == 0 && daemon->tcp_pipes[i] == -1)
 	  break;
       
-      /* No slots */
-      if (i < 0)
-	return STAT_ABANDONED;
-      
-      if (pipe(pipefd) == 0 && (p = fork()) != 0)
+      /* No slots or no pipe */
+      if (i < 0 || pipe(pipefd) != 0)
+	return STAT_ABANDONED;`
+				
+      if ((p = fork()) != 0)
 	{
 	  close(pipefd[1]); /* parent needs read pipe end. */
 	  if (p == -1)

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -2136,7 +2136,7 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
       
       /* No slots or no pipe */
       if (i < 0 || pipe(pipefd) != 0)
-	return STAT_ABANDONED;`
+	return STAT_ABANDONED;
 				
       if ((p = fork()) != 0)
 	{

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -68,6 +68,7 @@ int main_dnsmasq (int argc, char **argv)
   int need_cap_net_admin = 0;
   int need_cap_net_raw = 0;
   int need_cap_net_bind_service = 0;
+  int have_cap_chown = 0;
   char *bound_device = NULL;
   int did_bind = 0;
   struct server *serv;
@@ -563,6 +564,8 @@ int main_dnsmasq (int argc, char **argv)
   data = safe_malloc(sizeof(*data) * capsize);
   capget(hdr, data); /* Get current values, for verification */
 
+  have_cap_chown = data->permitted & (1 << CAP_CHOWN);
+
   if (need_cap_net_admin && !(data->permitted & (1 << CAP_NET_ADMIN)))
     fail = "NET_ADMIN";
   else if (need_cap_net_raw && !(data->permitted & (1 << CAP_NET_RAW)))
@@ -878,7 +881,14 @@ int main_dnsmasq (int argc, char **argv)
   my_syslog(LOG_INFO, _("compile time options: %s"), compile_opts);
 
   if (chown_warn != 0)
-    my_syslog(LOG_WARNING, "chown of PID file %s failed: %s", daemon->runfile, strerror(chown_warn));
+    {
+#if defined(HAVE_LINUX_NETWORK)
+      if (chown_warn == EPERM && !have_cap_chown)
+        my_syslog(LOG_INFO, "chown of PID file %s failed: please add capability CAP_CHOWN", daemon->runfile);
+      else
+#endif
+      my_syslog(LOG_WARNING, "chown of PID file %s failed: %s", daemon->runfile, strerror(chown_warn));
+    }
   
 #ifdef HAVE_DBUS
   if (option_bool(OPT_DBUS))

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -786,9 +786,8 @@ struct dyndir {
 #define FREC_DS_QUERY          16
 #define FREC_AD_QUESTION       32
 #define FREC_DO_QUESTION       64
-#define FREC_ADDED_PHEADER    128
-#define FREC_HAS_PHEADER      256
-#define FREC_GONE_TO_TCP      512
+#define FREC_HAS_PHEADER      128
+#define FREC_GONE_TO_TCP      256
 
 struct frec {
   struct frec_src {
@@ -1420,7 +1419,7 @@ void report_addresses(struct dns_header *header, size_t len, u32 mark);
 #endif
 size_t answer_request(struct dns_header *header, char *limit, size_t qlen,  
 		      struct in_addr local_addr, struct in_addr local_netmask, 
-		      time_t now, int ad_reqd, int do_bit, int *stale, int *filtered);
+		      time_t now, int ad_reqd, int do_bit, int no_cache, int *stale, int *filtered);
 int check_for_bogus_wildcard(struct dns_header *header, size_t qlen, char *name, 
 			     time_t now);
 int check_for_ignored_address(struct dns_header *header, size_t qlen);

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -198,6 +198,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
     {
       old_src = 1;
       old_reply = 1;
+      fwd_flags = forward->flags;
     }
   else if (gotname && (forward = lookup_frec(daemon->namebuff, C_IN, (int)rrtype, -1, fwd_flags,
 					     FREC_CHECKING_DISABLED | FREC_AD_QUESTION | FREC_DO_QUESTION |
@@ -537,7 +538,7 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
       if (!(plen = make_local_answer(flags, gotname, plen, header, daemon->namebuff, (char *)(header + replylimit), first, last, ede)))
 	return 0;
       
-      if (forward->flags & FREC_HAS_PHEADER)
+      if (fwd_flags & FREC_HAS_PHEADER)
 	{
 	  u16 swap = htons((u16)ede);
 

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1828,7 +1828,7 @@ void receive_query(struct listener *listen, time_t now)
     if(n == 0)
       return;
 
-    if (have_pseudoheader)
+    if (fwd_flags & FREC_HAS_PHEADER)
     {
       if (ede_len > 0) // Add EDNS0 option EDE if applicable
 	n = add_pseudoheader(header, n, ((unsigned char *) header) + udp_size,

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -174,34 +174,19 @@ static int domain_no_rebind(char *domain)
 static int forward_query(int udpfd, union mysockaddr *udpaddr,
 			 union all_addr *dst_addr, unsigned int dst_iface,
 			 struct dns_header *header, size_t plen,  size_t replylimit, time_t now, 
-			 struct frec *forward, int ad_reqd, int do_bit, int fast_retry)
+			 struct frec *forward, unsigned int fwd_flags, int fast_retry)
 {
   unsigned int flags = 0;
-  unsigned int fwd_flags = 0;
   int is_dnssec = forward && (forward->flags & (FREC_DNSKEY_QUERY | FREC_DS_QUERY));
   struct server *master;
   unsigned int gotname;
   int old_src = 0, old_reply = 0;
   int first, last, start = 0;
-  int cacheable, forwarded = 0;
-  unsigned char *oph;
+  int forwarded = 0;
   int ede = EDE_UNSET;
-  (void)do_bit;
   unsigned short rrtype;
 
   gotname = extract_request(header, plen, daemon->namebuff, &rrtype);
-  oph = find_pseudoheader(header, plen, NULL, NULL, NULL, NULL);
-
-  if (header->hb4 & HB4_CD)
-    fwd_flags |= FREC_CHECKING_DISABLED;
-  if (ad_reqd)
-    fwd_flags |= FREC_AD_QUESTION;
-  if (oph)
-    fwd_flags |= FREC_HAS_PHEADER;
-#ifdef HAVE_DNSSEC
-  if (do_bit)
-    fwd_flags |= FREC_DO_QUESTION;
-#endif
   
   /* Check for retry on existing query.
      FREC_DNSKEY and FREC_DS_QUERY are never set in flags, so the test below 
@@ -332,11 +317,6 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 
       forward->flags = fwd_flags;
 
-      plen = add_edns0_config(header, plen, ((unsigned char *)header) + daemon->edns_pktsz, &forward->frec_src.source, now, &cacheable);
-      
-      if (!cacheable)
-	forward->flags |= FREC_NO_CACHE;
-      
 #ifdef HAVE_DNSSEC
       if (option_bool(OPT_DNSSEC_VALID) && (master->flags & SERV_DO_DNSSEC))
 	{
@@ -349,10 +329,6 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	}
 #endif
       
-      /* If there wasn't a PH before, and there is now, we added it. */
-      if (!oph && find_pseudoheader(header, plen, NULL, NULL, NULL, NULL))
-	forward->flags |= FREC_ADDED_PHEADER;
-	      
       /* Do these before saving query. */
       forward->frec_src.orig_id = ntohs(header->id);
       forward->new_id = get_id();
@@ -376,15 +352,9 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
       forward->forwardall = 0;
       if (domain_no_rebind(daemon->namebuff))
 	forward->flags |= FREC_NOREBIND;
-      if (header->hb4 & HB4_CD)
-	forward->flags |= FREC_CHECKING_DISABLED;
-      if (ad_reqd)
-	forward->flags |= FREC_AD_QUESTION;
 #ifdef HAVE_DNSSEC
       forward->work_counter = daemon->limit[LIMIT_WORK];
       forward->validate_counter = daemon->limit[LIMIT_CRYPTO]; 
-      if (do_bit)
-	forward->flags |= FREC_DO_QUESTION;
 #endif
       
       start = first;
@@ -567,14 +537,14 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
       if (!(plen = make_local_answer(flags, gotname, plen, header, daemon->namebuff, (char *)(header + replylimit), first, last, ede)))
 	return 0;
       
-      if (oph)
+      if (forward->flags & FREC_HAS_PHEADER)
 	{
 	  u16 swap = htons((u16)ede);
 
 	  if (ede != EDE_UNSET)
-	    plen = add_pseudoheader(header, plen, (unsigned char *)(header + replylimit), EDNS0_OPTION_EDE, (unsigned char *)&swap, 2, do_bit, 0);
+	    plen = add_pseudoheader(header, plen, (unsigned char *)(header + replylimit), EDNS0_OPTION_EDE, (unsigned char *)&swap, 2, 0, 0);
 	  else
-	    plen = add_pseudoheader(header, plen, (unsigned char *)(header + replylimit), 0, NULL, 0, do_bit, 0);
+	    plen = add_pseudoheader(header, plen, (unsigned char *)(header + replylimit), 0, NULL, 0, 0, 0);
 	}
       
 #if defined(HAVE_CONNTRACK) && defined(HAVE_UBUS)
@@ -632,8 +602,7 @@ int fast_retry(time_t now)
 		daemon->log_display_id = f->frec_src.log_id;
 		daemon->log_source_addr = NULL;
 		
-		forward_query(-1, NULL, NULL, 0, header, f->stash_len, 0, now, f,
-			      f->flags & FREC_AD_QUESTION, f->flags & FREC_DO_QUESTION, 1);
+		forward_query(-1, NULL, NULL, 0, header, f->stash_len, 0, now, f, 0, 1);
 		
 		to_run = f->forward_delay = 2 * f->forward_delay;
 	      }
@@ -1256,8 +1225,7 @@ void reply_query(int fd, time_t now)
       /* Get the saved query back. */
       blockdata_retrieve(forward->stash, forward->stash_len, (void *)header);
       
-      forward_query(-1, NULL, NULL, 0, header, forward->stash_len, 0, now, forward,
-		    forward->flags & FREC_AD_QUESTION, forward->flags & FREC_DO_QUESTION, 0);
+      forward_query(-1, NULL, NULL, 0, header, forward->stash_len, 0, now, forward, 0, 0);
       return;
     }
 
@@ -1379,7 +1347,7 @@ void return_reply(time_t now, struct frec *forward, struct dns_header *header, s
     header->hb4 |= HB4_CD;
   else
     header->hb4 &= ~HB4_CD;
-  
+
   /* Never cache answers which are contingent on the source or MAC address EDSN0 option,
      since the cache is ignorant of such things. */
   if (forward->flags & FREC_NO_CACHE)
@@ -1387,7 +1355,7 @@ void return_reply(time_t now, struct frec *forward, struct dns_header *header, s
   
   if ((nn = process_reply(header, now, forward->sentto, (size_t)n, check_rebind, no_cache_dnssec, cache_secure, bogusanswer, 
 			  forward->flags & FREC_AD_QUESTION, forward->flags & FREC_DO_QUESTION, 
-			  forward->flags & FREC_ADDED_PHEADER, &forward->frec_src.source,
+			  !(forward->flags & FREC_HAS_PHEADER), &forward->frec_src.source,
 			  ((unsigned char *)header) + daemon->edns_pktsz, ede)))
     {
       struct frec_src *src;
@@ -1523,9 +1491,10 @@ void receive_query(struct listener *listen, time_t now)
   struct in_addr netmask, dst_addr_4;
   size_t m;
   ssize_t n;
-  int if_index = 0, auth_dns = 0, do_bit = 0, have_pseudoheader = 0;
+  int if_index = 0, auth_dns = 0, do_bit = 0;
+  unsigned int fwd_flags = 0;
   int stale = 0, filtered = 0, ede = EDE_UNSET, do_forward = 0;
-  int metric, ad_reqd, fd; 
+  int metric, fd; 
   struct blockdata *saved_question = NULL;
 #ifdef HAVE_CONNTRACK
   unsigned int mark = 0;
@@ -1817,7 +1786,8 @@ void receive_query(struct listener *listen, time_t now)
     { 
       unsigned short flags;
       
-      have_pseudoheader = 1;
+      fwd_flags |= FREC_HAS_PHEADER;
+      
       GETSHORT(udp_size, pheader);
       pheader += 2; /* ext_rcode */
       GETSHORT(flags, pheader);
@@ -1835,10 +1805,15 @@ void receive_query(struct listener *listen, time_t now)
 	udp_size = PACKETSZ; /* Sanity check - can't reduce below default. RFC 6891 6.2.3 */
     }
 
-  ad_reqd = do_bit;
   /* RFC 6840 5.7 */
-  if (header->hb4 & HB4_AD)
-    ad_reqd = 1;
+  if (do_bit || (header->hb4 & HB4_AD))
+    fwd_flags |= FREC_AD_QUESTION;
+
+  if (do_bit)
+    fwd_flags |= FREC_DO_QUESTION;
+
+  if (header->hb4 & HB4_CD)
+    fwd_flags |= FREC_CHECKING_DISABLED;
 
   /************ Pi-hole modification ************/
   if(piholeblocked)
@@ -1902,10 +1877,16 @@ void receive_query(struct listener *listen, time_t now)
 #endif
   else
     {
+      int cacheable;
+
+      n = add_edns0_config(header, n, ((unsigned char *)header) + daemon->edns_pktsz, &source_addr, now, &cacheable);
       saved_question = blockdata_alloc((char *) header, (size_t)n);
-      
+
+      if (!cacheable)
+	fwd_flags |= FREC_NO_CACHE;
+
       m = answer_request(header, ((char *) header) + udp_size, (size_t)n, 
-			 dst_addr_4, netmask, now, ad_reqd, do_bit, &stale, &filtered);
+			 dst_addr_4, netmask, now, fwd_flags & FREC_AD_QUESTION, do_bit, !cacheable, &stale, &filtered);
       
       metric = stale ? METRIC_DNS_STALE_ANSWERED : METRIC_DNS_LOCAL_ANSWERED;
       
@@ -1926,7 +1907,7 @@ void receive_query(struct listener *listen, time_t now)
   
   if (m != 0)
     {
-      if (have_pseudoheader)
+      if (fwd_flags & FREC_HAS_PHEADER)
 	{
 	  if (ede != EDE_UNSET)
 	    {
@@ -1975,9 +1956,9 @@ void receive_query(struct listener *listen, time_t now)
       blockdata_retrieve(saved_question, (size_t)n, (void *)header);
       blockdata_free(saved_question);
       saved_question = NULL;
-      
+
       if (forward_query(fd, &source_addr, &dst_addr, if_index, header, (size_t)n,
-			udp_size, now, NULL, ad_reqd, do_bit, 0))
+			udp_size, now, NULL, fwd_flags, 0))
 	daemon->metrics[METRIC_DNS_QUERIES_FORWARDED]++;
       else
 	daemon->metrics[METRIC_DNS_LOCAL_ANSWERED]++;
@@ -2337,7 +2318,7 @@ unsigned char *tcp_request(int confd, time_t now,
 #ifdef HAVE_AUTH
   int local_auth = 0;
 #endif
-  int checking_disabled, do_bit = 0, ad_reqd = 0, added_pheader = 0, have_pseudoheader = 0;
+  int checking_disabled, do_bit = 0, ad_reqd = 0, have_pseudoheader = 0;
   struct blockdata *saved_question = NULL;
   unsigned short qtype;
   unsigned int gotname = 0;
@@ -2413,7 +2394,7 @@ unsigned char *tcp_request(int confd, time_t now,
 
   while (1)
     {
-      int stale = 0, ede = EDE_UNSET;
+      int cacheable = 1, stale = 0, ede = EDE_UNSET;
       size_t m = 0;
       unsigned int flags = 0;
 #ifdef HAVE_AUTH
@@ -2463,6 +2444,7 @@ unsigned char *tcp_request(int confd, time_t now,
 	      if (saved_question)
 		blockdata_free(saved_question);
 	      
+	      size = add_edns0_config(header, size, ((unsigned char *) header) + 65536, &peer_addr, now, &cacheable);
 	      saved_question = blockdata_alloc((char *)header, (size_t)size);
 	      saved_size = size;
 	      
@@ -2554,7 +2536,7 @@ unsigned char *tcp_request(int confd, time_t now,
 	      /**********************************************/
 	      else
 		m = answer_request(header, ((char *) header) + 65536, (size_t)size, 
-				   dst_addr_4, netmask, now, ad_reqd, do_bit, &stale, &filtered);
+				   dst_addr_4, netmask, now, ad_reqd, do_bit, !cacheable, &stale, &filtered);
 	    }
 	}
       
@@ -2565,7 +2547,7 @@ unsigned char *tcp_request(int confd, time_t now,
 	{
 	  struct server *master;
 	  int start;
-	  int cacheable, no_cache_dnssec = 0, cache_secure = 0, bogusanswer = 0;
+	  int no_cache_dnssec = 0, cache_secure = 0, bogusanswer = 0;
 
 	  blockdata_retrieve(saved_question, (size_t)saved_size, header);
 	  size = saved_size;
@@ -2596,8 +2578,6 @@ unsigned char *tcp_request(int confd, time_t now,
 		  else
 		    start = master->last_server;
 		  
-		  size = add_edns0_config(header, size, ((unsigned char *) header) + 65536, &peer_addr, now, &cacheable);
-		  
 #ifdef HAVE_DNSSEC
 		  if (option_bool(OPT_DNSSEC_VALID) && (master->flags & SERV_DO_DNSSEC))
 		    {
@@ -2609,11 +2589,6 @@ unsigned char *tcp_request(int confd, time_t now,
 			header->hb4 |= HB4_CD;
 		    }
 #endif
-		  
-		  /* Check if we added a pheader on forwarding - may need to
-		     strip it from the reply. */
-		  if (!have_pseudoheader && find_pseudoheader(header, size, NULL, NULL, NULL, NULL))
-		    added_pheader = 1;
 		  
 		  /* Loop round available servers until we succeed in connecting to one. */
 		  if ((m = tcp_talk(first, last, start, packet, size, have_mark, mark, &serv)) == 0)
@@ -2689,7 +2664,7 @@ unsigned char *tcp_request(int confd, time_t now,
 		      
 		      m = process_reply(header, now, serv, (unsigned int)m, 
 					option_bool(OPT_NO_REBIND) && !norebind, no_cache_dnssec, cache_secure, bogusanswer,
-					ad_reqd, do_bit, added_pheader, &peer_addr, ((unsigned char *)header) + 65536, ede);
+					ad_reqd, do_bit, !have_pseudoheader, &peer_addr, ((unsigned char *)header) + 65536, ede);
 
 		      /* process_reply() adds pheader itself */
 		      have_pseudoheader = 0; 

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1458,7 +1458,7 @@ void return_reply(time_t now, struct frec *forward, struct dns_header *header, s
 			  &src->source, &src->dest, src->iface);
 		
 #ifdef HAVE_DUMPFILE
-		dump_packet_udp(DUMP_REPLY, daemon->packet, (size_t)nn, NULL, &src->source, src->fd);
+		dump_packet_udp(DUMP_REPLY, daemon->packet, (size_t)new, NULL, &src->source, src->fd);
 #endif
 		/* Pi-hole modification */
 		FTL_multiple_replies(src->log_id, &first_ID);

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1600,7 +1600,7 @@ static int cache_validated(const struct crec *crecp)
 /* return zero if we can't answer from cache, or packet size if we can */
 size_t answer_request(struct dns_header *header, char *limit, size_t qlen,  
 		      struct in_addr local_addr, struct in_addr local_netmask, 
-		      time_t now, int ad_reqd, int do_bit, int *stale, int *filtered) 
+		      time_t now, int ad_reqd, int do_bit, int no_cache, int *stale, int *filtered) 
 {
   char *name = daemon->namebuff;
   unsigned char *p, *ansp;
@@ -1615,6 +1615,10 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
   size_t len;
   int rd_bit = (header->hb3 & HB3_RD);
   int count = 255; /* catch loops */
+
+  /* Suppress cached answers of no_cache set. */
+  if (no_cache)
+    rd_bit = 0;
   
   if (stale)
     *stale = 0;

--- a/src/dnsmasq/rrfilter.c
+++ b/src/dnsmasq/rrfilter.c
@@ -345,9 +345,6 @@ int expand_workspace(unsigned char ***wkspc, int *szp, int new)
   if (old >= new+1)
     return 1;
 
-  if (new >= 100)
-    return 0;
-
   new += 5;
 
   if (!(p = whine_realloc(*wkspc, new * sizeof(unsigned char *))))

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -774,7 +774,7 @@ int retry_send(ssize_t rc)
    rw = 2 -> write once
    rw = 3 -> read once
 
-   "once" fail if all the data doesn't arrive/go in a single read/write.
+   "once" fails on EAGAIN, as this a timeout.
    This indicates a timeout of a TCP socket.
 */
 int read_write(int fd, unsigned char *packet, int size, int rw)
@@ -783,29 +783,34 @@ int read_write(int fd, unsigned char *packet, int size, int rw)
   
   for (done = 0; done < size; done += n)
     {
-      do { 
-	if (rw & 1)
-	  n = read(fd, &packet[done], (size_t)(size - done));
-	else
-	  n = write(fd, &packet[done], (size_t)(size - done));
-	
-	if (n == 0)
-	  return 0;
-
-	if (n == -1 && errno == EINTR)
-	  continue;
-
-	/* "once" variant */
-	if ((rw & 2) && n != size)
-	  return 0;
-	
-      } while (n == -1 && (errno == EINTR || errno == ENOMEM || errno == ENOBUFS ||
-			   errno == EAGAIN || errno == EWOULDBLOCK));
+      if (rw & 1)
+	n = read(fd, &packet[done], (size_t)(size - done));
+      else
+	n = write(fd, &packet[done], (size_t)(size - done));
       
-      if (n == -1)
+      if (n == 0)
 	return 0;
+
+      if (n == -1)
+	{
+	  n = 0; /* don't mess with counter when we loop. */
+
+	  if (errno == EINTR || errno == ENOMEM || errno == ENOBUFS)
+	    continue;
+
+	  if (errno == EAGAIN || errno == EWOULDBLOCK)
+	    {
+	      /* "once" variant */
+	      if (rw & 2)
+		return 0;
+
+	      continue;
+	    }
+
+	  return 0;
+	}
     }
-     
+          
   return 1;
 }
 

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -771,8 +771,8 @@ int retry_send(ssize_t rc)
 
 /* rw = 0 -> write
    rw = 1 -> read
-   rw = 2 -> read once
-   rw = 3 -> write once
+   rw = 2 -> write once
+   rw = 3 -> read once
 
    "once" fail if all the data doesn't arrive/go in a single read/write.
    This indicates a timeout of a TCP socket.

--- a/test/dnsmasq_warnings
+++ b/test/dnsmasq_warnings
@@ -48,7 +48,7 @@ src/dnsmasq/dhcp-common.c
 src/dnsmasq/dnsmasq.c
 	    my_syslog(LOG_WARNING, _("cache size greater than 10000 may cause performance issues, and is unlikely to be useful."));
 src/dnsmasq/dnsmasq.c
-    my_syslog(LOG_WARNING, "chown of PID file %s failed: %s", daemon->runfile, strerror(chown_warn));
+      my_syslog(LOG_WARNING, "chown of PID file %s failed: %s", daemon->runfile, strerror(chown_warn));
 src/dnsmasq/dnsmasq.c
     my_syslog(LOG_WARNING, _("warning: failed to change owner of %s: %s"), 
 	      daemon->log_file, strerror(log_err));


### PR DESCRIPTION
# What does this implement/fix?

Changelog:

>  Handle queries with EDNS client subnet fields better. If dnsmasq is configured to add an EDNS client subnet to a query, it is careful to suppress use of the cache, since a cached answer may not be valid for a query with a different client subnet. Extend this behaviour to queries which arrive a dnsmasq already carrying an EDNS client subnet.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.