### PR TITLE
Avoid endless spinning in UDP->TCP path

### DIFF
--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -2195,6 +2195,9 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
 	  /* See comment above re: netlink socket. */
 	  close(daemon->netlinkfd);
 	  read_write(pipefd[1], &a, 1, RW_WRITE);
+
+    // Pi-hole modification
+    daemon->netlinkfd = -1;
 #endif		  
 	  close(pipefd[0]); /* close read end in child. */
 	  daemon->pipe_to_parent = pipefd[1];	  

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -953,7 +953,10 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	}
 
 	// Try to obtain MAC address from dnsmasq's cache (also asks the kernel)
-	if(client->hwlen < 1)
+	// Don't do this for internally generated queries (e.g., DNSSEC), if the
+	// MAC address is already known or if the netlink socket is not available
+	// (e.g., when retrying a query using TCP after UDP truncation)
+	if(!internal_query && client->hwlen < 1 && daemon->netlinkfd > 0)
 	{
 		client->hwlen = find_mac(addr, client->hwaddr, 1, time(NULL));
 		if(config.debug.arp.v.b)


### PR DESCRIPTION
# What does this implement/fix?

Do not try to use `find_mac()` if `netlink` socket is closed.

Fix #2154 

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.