### PR TITLE
Remove surplus SHM unlocking in IPv6 name resolution deceleration code

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -953,7 +953,6 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 			log_debug(DEBUG_RESOLVER, "Postponing resolution of new client %s (IPv6) for at least %.0f more seconds",
 			          getstr(ippos), now - client->firstSeen + DELAY_V6_RESOLUTION);
 
-			unlock_shm();
 			skipped++;
 			continue;
 		}


### PR DESCRIPTION
# What does this implement/fix?

Fixing a glitch reported on Discourse. See link below.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/shm-errors-in-ftl-log-for-v6-development/75131/3?u=dl6er

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.