### PR TITLE
Use arm64 machines provided by GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
           [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
         shell: bash
 
-  gha:
-    runs-on: ubuntu-latest
+  gha-x86:
+    runs-on: ubuntu-24.04
     needs: smoke-tests
     strategy:
       fail-fast: false
@@ -100,8 +100,8 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
 
-  self-hosted-arm64:
-    runs-on: ARM64
+  gha-arm64:
+    runs-on: ubuntu-24.04-arm
     needs: smoke-tests
     strategy:
       fail-fast: false


### PR DESCRIPTION
# What does this implement/fix?

The GHA provided machines have 4 cores assigned each and are, accordingly almost 2x as fast as our own runners (featuring two cores, each).

Related Github blog post: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview

Comparison:

### OLD
![old](https://github.com/user-attachments/assets/a71c465d-1bea-40ef-b7de-deb9cfc235a3)


### NEW
![new](https://github.com/user-attachments/assets/882d978b-adb2-4d34-a312-4fd376eef879)


---


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.