### PR TITLE
Improve FTL connection error logging

### DIFF
--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -102,9 +102,10 @@ int send_from(int fd, int nowild, char *packet, size_t len,
       /* If interface is still in DAD, EINVAL results - ignore that. */
       if (errno != EINVAL)
 	{
+	  const int errnum = errno;
 	  my_syslog(LOG_ERR, _("failed to send packet: %s"), strerror(errno));
 	  /********** Pi-hole modification **********/
-	  FTL_connection_error("failed to send UDP reply", to);
+	  FTL_connection_error("failed to send UDP reply", to, errnum);
 	  /******************************************/
 	}
 #endif
@@ -516,7 +517,7 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 	    /**** Pi-hole modification ****/
 	    else
 	    {
-	      FTL_connection_error("failed to send UDP request", &srv->addr);
+	      FTL_connection_error("failed to send UDP request", &srv->addr, errno);
 	    }
 	    /******************************/
 	}
@@ -2081,7 +2082,7 @@ static ssize_t tcp_talk(int first, int last, int start, unsigned char *packet,  
 	    fatal = 1;
 	  /**** Pi-hole modification ****/
 	  if (errno != 0)
-	    FTL_connection_error("failed to send TCP(fast-open) packet", &serv->addr);
+	    FTL_connection_error("failed to send TCP(fast-open) packet", &serv->addr, errno);
 	  /******************************/
 #endif
 	  
@@ -2090,7 +2091,7 @@ static ssize_t tcp_talk(int first, int last, int start, unsigned char *packet,  
 	  if (fatal || (!data_sent && connect(serv->tcpfd, &serv->addr.sa, sa_len(&serv->addr)) == -1))
 	    {
 	      /**** Pi-hole modification ****/
-	      FTL_connection_error("failed to send TCP(connect) packet", &serv->addr);
+	      FTL_connection_error("failed to send TCP(connect) packet", &serv->addr, errno);
 	      /******************************/
 	      close(serv->tcpfd);
 	      serv->tcpfd = -1;
@@ -2107,10 +2108,7 @@ static ssize_t tcp_talk(int first, int last, int start, unsigned char *packet,  
 	  !read_write(serv->tcpfd, (unsigned char *)length, sizeof (*length), RW_READ_ONCE) ||
 	  !read_write(serv->tcpfd, payload, (rsize = ntohs(*length)), RW_READ_ONCE))
 	{
-	  /**** Pi-hole modification ****/
-	  FTL_connection_error("failed to send TCP(read_write) packet", &serv->addr);
-	  /******************************/
-
+	  const int errnum = errno;
 	  close(serv->tcpfd);
 	  serv->tcpfd = -1;
 	  /* We get data then EOF, reopen connection to same server,
@@ -2119,7 +2117,12 @@ static ssize_t tcp_talk(int first, int last, int start, unsigned char *packet,  
 	  if (serv->flags & SERV_GOT_TCP)
 	    goto retry;
 	  else
+	  /**** Pi-hole modification ****/
+	  {
+	    FTL_connection_error("failed to send TCP(read_write) packet", &serv->addr, errnum);
 	    continue;
+	  }
+	  /******************************/
 	}
 
       /* If the question section of the reply doesn't match the crc we sent, then

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3737,10 +3737,9 @@ void get_dnsmasq_metrics_obj(cJSON *json)
 		cJSON_AddNumberToObject(json, get_metric_name(i), daemon->metrics[i]);
 }
 
-void FTL_connection_error(const char *reason, const union mysockaddr *addr)
+void FTL_connection_error(const char *reason, const union mysockaddr *addr, const int errnum)
 {
-	// Make a private copy of the error
-	const int errnum = errno;
+	// Get the error message
 	const char *error = strerror(errnum);
 
 	// Set log priority

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -49,7 +49,7 @@ void FTL_TCP_worker_terminating(bool finished);
 
 bool FTL_unlink_DHCP_lease(const char *ipaddr, const char **hint);
 
-void FTL_connection_error(const char *reason, const union mysockaddr *addr);
+void FTL_connection_error(const char *reason, const union mysockaddr *addr, const int errnum);
 
 bool get_dnsmasq_debug(void) __attribute__ ((pure));
 


### PR DESCRIPTION
# What does this implement/fix?

Reducing the number of TCP connection warning by not logging an error on the first retry issued to a server. Only log warnings if the issue persists.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.