### PR TITLE
Restore static DHCP leases from v5 tar.gz Teleporter archives

### DIFF
--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -753,6 +753,9 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 			.archive_name = "setupVars.conf",
 			.destination = config.files.setupVars.v.s
 		},{
+			.archive_name = "dnsmasq.d/04-pihole-static-dhcp.conf",
+			.destination = DNSMASQ_STATIC_LEASES
+		},{
 			.archive_name = "dnsmasq.d/05-pihole-custom-cname.conf",
 			.destination = DNSMASQ_CNAMES
 		}


### PR DESCRIPTION
# What does this implement/fix?

Add restoring of static DHCP leases from pre-v6 `tar.gz` Teleporter archives

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.