### PR TITLE
 Fix blocked upstream (IP) handling

### DIFF
--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -529,9 +529,10 @@
   before="$(grep -c ^ /var/log/pihole/FTL.log)"
 
   # Run test
-  run bash -c "dig A umbrella.ftl @127.0.0.1"
+  run bash -c "dig A umbrella.ftl +short @127.0.0.1"
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[@]} == *"EDE: 15 (Blocked): (upstream IP)"* ]]
+  [[ ${lines[0]} == "146.112.61.104" ]]
+  [[ ${lines[1]} == "" ]]
 
   # Get number of lines in the log after the test
   after="$(grep -c ^ /var/log/pihole/FTL.log)"
@@ -548,7 +549,6 @@
   [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded umbrella.ftl to 127.0.0.1#5555"* ]]
   [[ ${lines[@]} == *"DEBUG_QUERIES: blocked upstream with known address (IPv4)"* ]]
   [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella.ftl -> EXTERNAL_BLOCKED_IP"* ]]
-  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl A 0.0.0.0\""* ]]
 }
 
 @test "Upstream blocked domain: IP is recognized (cached)" {
@@ -556,9 +556,10 @@
   before="$(grep -c ^ /var/log/pihole/FTL.log)"
 
   # Run test
-  run bash -c "dig A umbrella.ftl @127.0.0.1"
+  run bash -c "dig A umbrella.ftl +short @127.0.0.1"
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[@]} == *"EDE: 15 (Blocked): (upstream IP)"* ]]
+  [[ ${lines[0]} == "146.112.61.104" ]]
+  [[ ${lines[1]} == "" ]]
 
   # Get number of lines in the log after the test
   after="$(grep -c ^ /var/log/pihole/FTL.log)"
@@ -572,8 +573,10 @@
   done <<< "${log}"
   printf "%s\n" "${lines[@]}"
   [[ ${lines[@]} == *"DEBUG_QUERIES: umbrella.ftl is known as blocked upstream with known address (expires in"* ]]
+  # Test for NOT forwarded ...
   [[ ${lines[@]} != *"DEBUG_QUERIES: **** forwarded umbrella.ftl to 127.0.0.1#5555"* ]]
-  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl A 0.0.0.0\""* ]]
+  # ... but cached
+  [[ ${lines[@]} == *"DEBUG_QUERIES: **** got cache reply: umbrella.ftl is 146.112.61.104"* ]]
 }
 
 @test "Upstream blocked domain: IP is recognized (IPv6)" {
@@ -581,8 +584,10 @@
   before="$(grep -c ^ /var/log/pihole/FTL.log)"
 
   # Run test
-  run bash -c "dig AAAA umbrella.ftl @127.0.0.1"
+  run bash -c "dig AAAA umbrella.ftl +short @127.0.0.1"
   printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "::ffff:146.112.61.104" ]]
+  [[ ${lines[1]} == "" ]]
 
   # Get number of lines in the log after the test
   after="$(grep -c ^ /var/log/pihole/FTL.log)"
@@ -599,7 +604,6 @@
   [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded umbrella.ftl to 127.0.0.1#5555"* ]]
   [[ ${lines[@]} == *"DEBUG_QUERIES: blocked upstream with known address (IPv6)"* ]]
   [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: AAAA/127.0.0.1/umbrella.ftl -> EXTERNAL_BLOCKED_IP"* ]]
-  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella.ftl AAAA ::\""* ]]
 }
 
 @test "Upstream blocked domain: IP is recognized (multi)" {
@@ -607,8 +611,11 @@
   before="$(grep -c ^ /var/log/pihole/FTL.log)"
 
   # Run test
-  run bash -c "dig A umbrella-multi.ftl @127.0.0.1"
+  run bash -c "dig A umbrella-multi.ftl +short @127.0.0.1"
   printf "%s\n" "${lines[@]}"
+  [[ "${lines[@]}" == *"146.112.61.104"* ]]
+  [[ "${lines[@]}" == *"8.8.8.8"* ]]
+  [[ "${lines[@]}" == *"1.2.3.4"* ]]
 
   # Get number of lines in the log after the test
   after="$(grep -c ^ /var/log/pihole/FTL.log)"
@@ -624,7 +631,6 @@
   [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella-multi.ftl is not blocked (domainlist ID: -1)"* ]]
   [[ ${lines[@]} == *"DEBUG_QUERIES: **** forwarded umbrella-multi.ftl to 127.0.0.1#5555"* ]]
   [[ ${lines[@]} == *"DEBUG_QUERIES: DNS cache: A/127.0.0.1/umbrella-multi.ftl -> EXTERNAL_BLOCKED_IP"* ]]
-  [[ ${lines[@]} == *"DEBUG_QUERIES:   Adding RR: \"umbrella-multi.ftl A 0.0.0.0\""* ]]
 }
 
 @test "Upstream blocked domain: EDE 15 is recognized" {


### PR DESCRIPTION
# What does this implement/fix?

Queries blocked upstream with a known blocking page IP should not be short-circuited locally as this will cause FTL to reply with the locally defined blocking mode instead of the IP address of the upstream DNS server's blocking page

The tests have been adjusted to test for the new behavior. The now succeeding tests verify it is working as expected. Local testing is possible by specifying the Cisco Umbrella `208.67.222.123, 208.67.220.123` servers as upstream servers and then testing a blocked domain (which is not on your gravity!), e.g., http://www.internetbadguys.com/.

**Related issue or feature (if applicable):** This is a regression of https://github.com/pi-hole/FTL/pull/2030 and fixes https://github.com/pi-hole/FTL/issues/2175

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.