### PR TITLE
Allow default GH token to write content in the build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build, Test, Deploy
 
 permissions:
   id-token: write
-  contents: read
+  contents: write # needed for softprops/action-gh-release
   attestations: write
 
 on:


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We use https://github.com/softprops/action-gh-release to attach files to the release. They always needed `content: write` [permission](https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions). So far this was not an issue, but the scope of the default GH token seems to have changed (https://github.com/softprops/action-gh-release/issues/572#issuecomment-2586651697).
This PR grants the necessary permissions.

See a failing action trigged by a release tag here: https://github.com/pi-hole/FTL/actions/runs/13396405826

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
