### PR TITLE
 Fix parsing of envvars with more than one =

### DIFF
--- a/src/config/env.c
+++ b/src/config/env.c
@@ -55,14 +55,21 @@ void getEnvVars(void)
 			// Split key and value using strtok_r
 			char *saveptr = NULL;
 			char *key = strtok_r(env_copy, "=", &saveptr);
-			char *value = strtok_r(NULL, "=", &saveptr);
 
 			// Log warning if value is missing
-			if(value == NULL)
+			char *value;
+			if(strlen(*env) <= strlen(key) + 1)
 			{
 				log_warn("Environment variable %s has no value, substituting with empty string", key);
 				value = (char*)"";
 			}
+			else
+			{
+				// The entire string *after* the key + 1 (for
+				// the '=') is the value
+				value = *env + strlen(key) + 1;
+			}
+			log_debug(DEBUG_CONFIG, "ENV \"%s\" = \"%s\"", key, value);
 
 			// Add to list
 			struct env_item *new_item = calloc(1, sizeof(struct env_item));


### PR DESCRIPTION
# What does this implement/fix?

Ensure we do not split too often at '=' while processing environment variables. This is an issue with multiple `=` being present in environment variables.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.