### PR TITLE
Fix legacy parsing of DEBUG_ALL option

### DIFF
--- a/src/config/legacy_reader.c
+++ b/src/config/legacy_reader.c
@@ -835,13 +835,20 @@ static void readDebugingSettingsLegacy(FILE *fp)
 		opened = true;
 	}
 
-	// DEBUG_ALL
-	// defaults to: false
-	// ~0 is a shortcut for "all bits set"
-	setDebugOption(fp, "DEBUG_ALL", ~(enum debug_flag)0);
-
-	for(enum debug_flag flag = DEBUG_DATABASE; flag < DEBUG_EXTRA; flag <<= 1)
-		setDebugOption(fp, debugstr(flag), flag);
+	bool bit = false;
+	const char *debug_all = parseFTLconf(fp, "DEBUG_ALL");
+	if(debug_all != NULL && parseBool(debug_all, &bit) && bit)
+	{
+		// Set all debug flags if DEBUG_ALL is set to true
+		set_all_debug(&config, true);
+	}
+	else
+	{
+		// Iterate over all debug flags and set them if they are present
+		// in the config file.
+		for(enum debug_flag flag = DEBUG_DATABASE; flag < DEBUG_EXTRA; flag <<= 1)
+			setDebugOption(fp, debugstr(flag), flag);
+	}
 
 	// Parse debug options
 	set_debug_flags(&config);


### PR DESCRIPTION
# What does this implement/fix?

See title and related Discourse discussion (with `backtrace` information)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.