### PR TITLE
Rearrange webserver.port default value

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1004,7 +1004,7 @@ static void initConfig(struct config *conf)
 	conf->webserver.port.a = cJSON_CreateStringReference("comma-separated list of <[ip_address:]port>");
 	conf->webserver.port.f = FLAG_RESTART_FTL;
 	conf->webserver.port.t = CONF_STRING;
-	conf->webserver.port.d.s = (char*)"80o,[::]:80o,443so,[::]:443so";
+	conf->webserver.port.d.s = (char*)"80o,443os,[::]:80o,[::]:443os";
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.threads.k = "webserver.threads";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -657,7 +657,7 @@
   #
   # Possible values are:
   #     comma-separated list of <[ip_address:]port>
-  port = "80o,[::]:80o,443so,[::]:443so"
+  port = "80o,443os,[::]:80o,[::]:443os"
 
   # Maximum number of worker threads allowed.
   # The Pi-hole web server handles each incoming connection in a separate thread.

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -2105,7 +2105,7 @@
   [[ "${lines[0]}" == "[ 1.1.1.1 abc-custom.com def-custom.de, 2.2.2.2 äste.com steä.com ]" ]]
   run bash -c './pihole-FTL --config webserver.port'
   printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "80o,[::]:80o,443so,[::]:443so" ]]
+  [[ "${lines[0]}" == "80o,443os,[::]:80o,[::]:443os" ]]
 }
 
 @test "Create, verify and re-import Teleporter file via CLI" {


### PR DESCRIPTION
# What does this implement/fix?

Change default value of `webserver.port` to comply with auto-generated config string. We do this to avoid the generated string to be flagged as `CHANGED` in `pihole.toml`. No functional change in this PR!

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.