### PR TITLE
Fix CLI command for non-local API configuration

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -281,7 +281,7 @@ unsigned short get_api_string(char **buf, const bool domain)
 	size_t len = 0;
 	// First byte has the length of the first string
 	**buf = 0;
-	const char *domain_str = domain ? config.webserver.domain.v.s : "localhost";
+	const char *domain_str = domain ? config.webserver.domain.v.s : "pi.hole";
 	size_t api_str_size = strlen(domain_str) + 20;
 
 	// Check if the string is too long for the TXT record

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1179,7 +1179,7 @@
 @test "API addresses reported correctly by CHAOS TXT local.api.ftl" {
   run bash -c 'dig CHAOS TXT local.api.ftl +short @127.0.0.1'
   printf "dig (full): %s\n" "${lines[@]}"
-  [[ ${lines[0]} == '"http://localhost:80/api/" "https://localhost:443/api/"' ]]
+  [[ ${lines[0]} == '"http://pi.hole:80/api/" "https://pi.hole:443/api/"' ]]
 }
 
 @test "API addresses reported by CHAOS TXT api.ftl identical to domain.api.ftl" {


### PR DESCRIPTION
# What does this implement/fix?

In the corner-case of a user explicitly having configured Pi-hole to NOT listen on lo (because there may be another webserver, etc.), the `pihole` CLI command may be unable to communicate with the API due to the hard-coded path "localhost". Change this to use the special "pi.hole" host name where interface-dependent replying is already implemented

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2192

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.