### PR TITLE
Make <domain> in revServer *really* optional

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -500,9 +500,9 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 			continue;
 		}
 
-		if(active == NULL || cidr == NULL || target == NULL || domain == NULL)
+		if(active == NULL || cidr == NULL || target == NULL)
 		{
-			log_err("Skipped invalid dns.revServers[%u]: %s", i, revServer->valuestring);
+			log_err("Skipped invalid dns.revServers[%u]: %s (not fully defined)", i, revServer->valuestring);
 			free(copy);
 			continue;
 		}
@@ -513,7 +513,7 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 
 		// If we have a reverse domain, we forward all queries to this domain to
 		// the same destination
-		if(strlen(domain) > 0)
+		if(domain != NULL && strlen(domain) > 0)
 		{
 			fprintf(pihole_conf, "server=/%s/%s\n", domain, target);
 


### PR DESCRIPTION
# What does this implement/fix?

Some time ago (in https://github.com/pi-hole/FTL/pull/2116), we fixed the config validator to accept `revServer` lines without `<domain>`, however, there was another check at the point where this configuration is written into `dnsmasq.conf` as users may have edited `pihole.toml` directly without going through the API (so, effectively, bypassing the validators). This last check still enforced `<domain>` which is relaxed herein.

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2216

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.