### PR TITLE
Do not try to migrate setupVars.conf if it does not exist.

### DIFF
--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -13,6 +13,8 @@
 #include "config/config.h"
 #include "config/setupVars.h"
 #include "datastructure.h"
+// file_exists()
+#include "files.h"
 
 unsigned int setupVarsElements = 0;
 char ** setupVarsArray = NULL;
@@ -514,6 +516,14 @@ static void get_conf_listeningMode_from_setupVars(void)
 
 void importsetupVarsConf(void)
 {
+	// Check if the file exists. If not, there is nothing to do and we
+	// return early
+	if(!file_exists(config.files.setupVars.v.s))
+	{
+		log_info("setupVars.conf does not exist, skipping migration");
+		return;
+	}
+
 	log_info("Migrating config from %s", config.files.setupVars.v.s);
 
 	// Try to obtain password hash from setupVars.conf


### PR DESCRIPTION
# What does this implement/fix?

Return early if no setupVars.conf is found, currently this is producing unnecessarily verbose output during installation, cfm. https://github.com/pi-hole/FTL/issues/2217

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2217

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.