### PR TITLE
Update embedded dnsmasq to 2.91rc5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,6 @@ set(CMAKE_C_STANDARD 17)
 
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.91rc4)
+set(DNSMASQ_VERSION pi-hole-v2.91rc5)
 
 add_subdirectory(src)

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -301,8 +301,9 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 
 	      if (gobig && !bitvector)
 		{
-		  casediff = (i/BITS_IN_INT) + 1; /* length of array */
-		  if ((bitvector = whine_malloc(casediff)))
+		  casediff = ((i - 1)/BITS_IN_INT) + 1; /* length of array */
+		  /* whine_malloc() zeros memory */
+		  if ((bitvector = whine_malloc(casediff * sizeof(unsigned int))))
 		    goto big_redo;
 		}
 	    }

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1541,13 +1541,13 @@ void return_reply(time_t now, struct frec *forward, struct dns_header *header, s
 	  int first_ID = -1;
 
 	  /* This gets the name back to the state it was in when we started. */
-	  flip_queryname(header, nn, prev, &forward->frec_src);
+	  flip_queryname(header, new, prev, &forward->frec_src);
 	  
 	  for (src = &forward->frec_src, prev = NULL; src; prev = src, src = src->next)
 	    {
 	      /* If you didn't undertand this above, you won't understand it here either. */
 	      if (prev)
-		flip_queryname(header, nn, prev, src);
+		flip_queryname(header, new, prev, src);
 	      
 	      if (src->fd != -1 && nn > src->udp_pkt_size)
 		{


### PR DESCRIPTION
# What does this implement/fix?

`dnsmasq 2.91rc5` has just been tagged. It fixes a few issues around 0x20 encoding so it is rather likely that they can be the cause for the crashes we are seeing.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.