### PR TITLE
Fix typo in dns.showDNSSEC text description

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -430,7 +430,7 @@ static void initConfig(struct config *conf)
 	conf->dns.ignoreLocalhost.c = validate_stub; // Only type-based checking
 
 	conf->dns.showDNSSEC.k = "dns.showDNSSEC";
-	conf->dns.showDNSSEC.h = "Should FTL should analyze and show internally generated DNSSEC queries?";
+	conf->dns.showDNSSEC.h = "Should FTL analyze and show internally generated DNSSEC queries?";
 	conf->dns.showDNSSEC.t = CONF_BOOL;
 	conf->dns.showDNSSEC.d.b = true;
 	conf->dns.showDNSSEC.c = validate_stub; // Only type-based checking

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -40,7 +40,7 @@
   # Should FTL hide queries made by localhost?
   ignoreLocalhost = false
 
-  # Should FTL should analyze and show internally generated DNSSEC queries?
+  # Should FTL analyze and show internally generated DNSSEC queries?
   showDNSSEC = true
 
   # Should FTL analyze *only* A and AAAA queries?


### PR DESCRIPTION
Follow-up on https://github.com/pi-hole/FTL/pull/2209 - all details there.