### PR TITLE
Prevent duplicated entries on successive v5 Teleporter importing

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -841,6 +841,12 @@ bool read_legacy_dhcp_static_config(void)
 		return false;
 	}
 
+	// Clear out config.dhcp.hosts array if it exists
+	if(config.dhcp.hosts.v.json != NULL)
+		cJSON_Delete(config.dhcp.hosts.v.json);
+	config.dhcp.hosts.v.json = cJSON_CreateArray();
+
+	// Read file line by line
 	char *linebuffer = NULL;
 	size_t size = 0u;
 	errno = 0;
@@ -898,6 +904,12 @@ bool read_legacy_cnames_config(void)
 		return false;
 	}
 
+	// Clear out config.dns.cnameRecords array if it exists
+	if(config.dns.cnameRecords.v.json != NULL)
+		cJSON_Delete(config.dns.cnameRecords.v.json);
+	config.dns.cnameRecords.v.json = cJSON_CreateArray();
+
+	// Read file line by line
 	char *linebuffer = NULL;
 	size_t size = 0u;
 	errno = 0;
@@ -955,6 +967,12 @@ bool read_legacy_custom_hosts_config(void)
 		return false;
 	}
 
+	// Clear out config.dns.hosts array if it exists
+	if(config.dns.hosts.v.json != NULL)
+		cJSON_Delete(config.dns.hosts.v.json);
+	config.dns.hosts.v.json = cJSON_CreateArray();
+
+	// Read file line by line
 	char *linebuffer = NULL;
 	size_t size = 0u;
 	errno = 0;


### PR DESCRIPTION
# What does this implement/fix?

Wipe out possibly existing entries in dns.hosts, dns.cnameRecords, and dhcp.hosts when importing from a v5 Teleporter file having the corresponding files

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2257

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.