### PR TITLE
Fix DHCP_LEASETIME migration

### DIFF
--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -39,10 +39,25 @@ static void get_conf_string_from_setupVars(const char *key, struct conf_item *co
 		return;
 	}
 
+	// If the lease time is a raw value (no unit), we assume it is in hours
+	// as this was the standard convention in the past
+	char *new = strdup(setupVarsValue);
+	if(strcmp(key, "DHCP_LEASETIME") == 0 && strchr(new, 'h') == NULL)
+	{
+		int leaseTimeInHours = atoi(new);
+		free(new);
+		if((new = calloc(10, sizeof(char))) == NULL)
+		{
+			log_warn("get_conf_string_from_setupVars(%s) failed: Could not allocate memory for new", key);
+			return;
+		}
+		snprintf(new, 10, "%dh", leaseTimeInHours);
+	}
+
 	// Free previously allocated memory (if applicable)
 	if(conf_item->t == CONF_STRING_ALLOCATED)
 		free(conf_item->v.s);
-	conf_item->v.s = strdup(setupVarsValue);
+	conf_item->v.s = new;
 	conf_item->t = CONF_STRING_ALLOCATED;
 	conf_item->f |= FLAG_CONF_IMPORTED;
 


### PR DESCRIPTION
# What does this implement/fix?

Assume `DHCP_LEASETIME` is in hours when imported from `setupVars.conf` (e.g., via Teleporter or during v5 -> v6 migration)

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2268

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.