### PR TITLE
We should not send any content for HTTP codes 1xx, 204 and 304

### DIFF
--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -401,7 +401,7 @@ static int send_api_auth_status(struct ftl_conn *api, const int user_id, const t
 			const int code = delete_session(user_id) ? 204 : 404;
 
 			// Send empty reply with appropriate HTTP status code
-			send_http_code(api, "application/json; charset=utf-8", code, "");
+			send_http_code(api, NULL, code, "");
 			return code;
 		}
 		else

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -974,16 +974,9 @@ static int api_info_messages_DELETE(struct ftl_conn *api)
 		char *endptr = NULL;
 		long int idval = strtol(token, &endptr, 10);
 		if(errno != 0 || endptr == token || *endptr != '\0' || idval < 0)
-		{
-			// Send error reply
-			free(id);
-			return send_json_error(api, 400, // 400 Bad Request
-			                       "uri_error",
-			                       "Invalid ID in path",
-			                       api->action_path);
-		}
-
-		cJSON_AddNumberToObject(ids, "id", idval);
+			log_warn("API: URI error - skipping invalid ID in path (%s): %s", api->action_path, token);
+		else
+			cJSON_AddNumberToArray(ids, idval);
 
 		// Get next token
 		token = strtok_r(NULL, ",", &saveptr);

--- a/src/webserver/json_macros.h
+++ b/src/webserver/json_macros.h
@@ -223,10 +223,14 @@
 })
 
 #define JSON_SEND_OBJECT_CODE(object, code)({ \
-	if((code) != 204) \
+	if((code) < 100 || (code) == 204 || (code) == 304) \
 	{ \
-		cJSON_AddNumberToObject(object, "took", double_time() - api->now); \
+		/* HTTP codes 1xx, 204 and 304 must not have a body */ \
+		send_http_code(api, NULL, code, ""); \
+		cJSON_Delete(object); \
+		return code; \
 	} \
+	cJSON_AddNumberToObject(object, "took", double_time() - api->now); \
 	char *json_string = json_formatter(object); \
 	if(json_string == NULL) \
 	{ \


### PR DESCRIPTION
# What does this implement/fix?

See title and the referenced issue ticket for further context.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2266

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.