### PR TITLE
New/print invalid env

### DIFF
--- a/src/config/env.c
+++ b/src/config/env.c
@@ -23,6 +23,8 @@
 #include <limits.h>
 // openFTLtoml()
 #include "config/toml_helper.h"
+// escape_json()
+#include "webserver/http-common.h"
 struct env_item
 {
 	bool used;
@@ -172,6 +174,25 @@ void freeEnvVars(void)
 		free(env_list);
 		env_list = next;
 	}
+}
+
+/**
+ * @brief Marks an environment item as invalid and logs a warning message.
+ *
+ * @param envvar The value of the environment variable.
+ * @param conf_item A pointer to the configuration item structure.
+ * @param item A pointer to the environment item structure to be marked as invalid.
+ */
+static void invalid_item(const char *envvar, struct conf_item *conf_item, struct env_item *item)
+{
+	item->error = "not an allowed option";
+	item->allowed = conf_item->h;
+	item->valid = false;
+
+	char *escaped_value = escape_json(envvar);
+	log_warn("ENV %s = \"%s\" is %s, allowed options are: %s",
+	         conf_item->e, escaped_value, item->error, item->allowed);
+	free(escaped_value);
 }
 
 bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, struct config *newconf, cJSON *forced_vars, bool *reset)
@@ -386,11 +407,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			}
 			else
 			{
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -405,11 +422,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -424,11 +437,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -443,11 +452,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -462,11 +467,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -481,11 +482,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -500,11 +497,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -519,11 +512,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				item->error = "not an allowed option";
-				item->allowed = conf_item->h;
-				log_warn("ENV %s is %s, allowed options are: %s",
-				         conf_item->e, item->error, item->allowed);
-				item->valid = false;
+				invalid_item(envvar, conf_item, item);
 			}
 			break;
 		}

--- a/src/config/env.c
+++ b/src/config/env.c
@@ -183,16 +183,26 @@ void freeEnvVars(void)
  * @param conf_item A pointer to the configuration item structure.
  * @param item A pointer to the environment item structure to be marked as invalid.
  */
-static void invalid_item(const char *envvar, struct conf_item *conf_item, struct env_item *item)
+static void invalid_enum_item(const char *envvar, struct conf_item *conf_item, struct env_item *item)
 {
 	item->error = "not an allowed option";
 	item->allowed = conf_item->h;
 	item->valid = false;
 
+	cJSON *allowed_items = cJSON_CreateArray();
+	cJSON *it = NULL;
+	cJSON_ArrayForEach(it, conf_item->a)
+	{
+		cJSON *sub_item = cJSON_GetObjectItem(it, "item");
+		cJSON_AddItemToArray(allowed_items, cJSON_Duplicate(sub_item, true));
+	}
+	char *allowed_values = cJSON_PrintUnformatted(allowed_items);
 	char *escaped_value = escape_json(envvar);
-	log_warn("ENV %s = \"%s\" is %s, allowed options are: %s",
-	         conf_item->e, escaped_value, item->error, item->allowed);
+
+	log_warn("ENV %s = %s is %s, allowed options are: %s",
+	         conf_item->e, escaped_value, item->error, allowed_values);
 	free(escaped_value);
+	free(allowed_values);
 }
 
 bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, struct config *newconf, cJSON *forced_vars, bool *reset)
@@ -407,7 +417,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			}
 			else
 			{
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -422,7 +432,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -437,7 +447,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -452,7 +462,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -467,7 +477,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -482,7 +492,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -497,7 +507,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}
@@ -512,7 +522,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			else
 			{
 
-				invalid_item(envvar, conf_item, item);
+				invalid_enum_item(envvar, conf_item, item);
 			}
 			break;
 		}


### PR DESCRIPTION
# What does this implement/fix?

Print values of env vars if invalid, example:
```
ENV FTLCONF_dns_listeningMode = "not_existing"
```
leads to
```
2025-02-24 19:08:11.074 CET [2045070M] WARNING: ENV FTLCONF_dns_listeningMode = "not_existing" is not an allowed option, allowed options are: ["LOCAL","SINGLE","BIND","ALL","NONE"]
```

----

**Related issue or feature (if applicable):** Fixes #2262 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.