### PR TITLE
Fix webserver.api.maxHistory usage in API

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -59,11 +59,11 @@
 #define MAXITER 1000
 
 // How many hours do we want to store in FTL's memory? [hours]
-#define MAXLOGAGE 24
+#define MAXLOGAGE 24u
 
 // Interval for overTime data [seconds]
 // Default: 600 (10 minutes)
-#define OVERTIME_INTERVAL 600
+#define OVERTIME_INTERVAL 600u
 
 // How many overTime slots do we need?
 // This is the maximum log age divided by the overtime interval

--- a/src/api/history.c
+++ b/src/api/history.c
@@ -18,14 +18,17 @@
 #include "overTime.h"
 // config struct
 #include "config/config.h"
+// get_max_overtime_slot()
+#include "gc.h"
 
 int api_history(struct ftl_conn *api)
 {
 	lock_shm();
 
-	// Loop over all overTime slots and add them to the array
 	cJSON *history = JSON_NEW_ARRAY();
-	for(unsigned int slot = 0; slot < OVERTIME_SLOTS; slot++)
+	const unsigned int max_slot = get_max_overtime_slot();
+	// Loop over all overTime slots and add them to the array
+	for(unsigned int slot = 0; slot <= max_slot; slot++)
 	{
 		cJSON *item = JSON_NEW_OBJECT();
 		JSON_ADD_NUMBER_TO_OBJECT(item, "timestamp", overTime[slot].timestamp);
@@ -148,7 +151,8 @@ int api_history_clients(struct ftl_conn *api)
 	int others_total = 0;
 
 	cJSON *history = JSON_NEW_ARRAY();
-	for(unsigned int slot = 0; slot < OVERTIME_SLOTS; slot++)
+	const unsigned int max_slot = get_max_overtime_slot();
+	for(unsigned int slot = 0; slot <= max_slot; slot++)
 	{
 		cJSON *item = JSON_NEW_OBJECT();
 		JSON_ADD_NUMBER_TO_OBJECT(item, "timestamp", overTime[slot].timestamp);

--- a/src/database/aliasclients.c
+++ b/src/database/aliasclients.c
@@ -84,7 +84,7 @@ static void recompute_aliasclient(const int aliasclientID)
 		// Add counts of this client to the alias-client
 		aliasclient->count += client->count;
 		aliasclient->blockedcount += client->blockedcount;
-		for(int idx = 0; idx < OVERTIME_SLOTS; idx++)
+		for(unsigned int idx = 0; idx < OVERTIME_SLOTS; idx++)
 			aliasclient->overTime[idx] += client->overTime[idx];
 	}
 }

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -414,7 +414,7 @@ void change_clientcount(clientsData *client, int total, int blocked, int overTim
 {
 		client->count += total;
 		client->blockedcount += blocked;
-		if(overTimeIdx > -1 && overTimeIdx < OVERTIME_SLOTS)
+		if(overTimeIdx > -1 && (unsigned int)overTimeIdx < OVERTIME_SLOTS)
 		{
 			overTime[overTimeIdx].total += overTimeMod;
 			client->overTime[overTimeIdx] += overTimeMod;
@@ -432,7 +432,7 @@ void change_clientcount(clientsData *client, int total, int blocked, int overTim
 			clientsData *aliasclient = getClient(client->aliasclient_id, true);
 			aliasclient->count += total;
 			aliasclient->blockedcount += blocked;
-			if(overTimeIdx > -1 && overTimeIdx < OVERTIME_SLOTS)
+			if(overTimeIdx > -1 && (unsigned int)overTimeIdx < OVERTIME_SLOTS)
 				aliasclient->overTime[overTimeIdx] += overTimeMod;
 		}
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -263,9 +263,9 @@ static void recycle(void)
  *
  * @return The maximum overtime slot as an unsigned integer.
  */
-unsigned int get_max_overtime_slot(void)
+unsigned int __attribute__((pure)) get_max_overtime_slot(void)
 {
-	return min(config.webserver.api.maxHistory.v.ui, MAXLOGAGE * 3600) / OVERTIME_INTERVAL - 1;
+	return min(config.webserver.api.maxHistory.v.ui, MAXLOGAGE * 3600) / OVERTIME_INTERVAL;
 }
 
 // Subtract rate-limitation count from individual client counters

--- a/src/gc.c
+++ b/src/gc.c
@@ -252,6 +252,22 @@ static void recycle(void)
 	}
 }
 
+/**
+ * @brief Computes the maximum overtime slot to send.
+ *
+ * This function calculates the maximum overtime slot based on the
+ * configuration settings for the webserver API's maximum history value.
+ * The calculation involves converting the maximum history value from
+ * hours to seconds, dividing by the overtime interval, and adjusting
+ * the result to get the correct slot number.
+ *
+ * @return The maximum overtime slot as an unsigned integer.
+ */
+unsigned int get_max_overtime_slot(void)
+{
+	return min(config.webserver.api.maxHistory.v.ui, MAXLOGAGE * 3600) / OVERTIME_INTERVAL - 1;
+}
+
 // Subtract rate-limitation count from individual client counters
 // As long as client->rate_limit is still larger than the allowed
 // maximum count, the rate-limitation will just continue

--- a/src/gc.h
+++ b/src/gc.h
@@ -15,7 +15,7 @@
 
 void *GC_thread(void *val);
 void runGC(const time_t now, time_t *lastGCrun, const bool flush);
-unsigned int get_max_overtime_slot(void);
+unsigned int get_max_overtime_slot(void) __attribute__((pure));
 int get_rate_limit_turnaround(const unsigned int rate_limit_count);
 unsigned int set_gc_interval(void);
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -15,6 +15,7 @@
 
 void *GC_thread(void *val);
 void runGC(const time_t now, time_t *lastGCrun, const bool flush);
+unsigned int get_max_overtime_slot(void);
 int get_rate_limit_turnaround(const unsigned int rate_limit_count);
 unsigned int set_gc_interval(void);
 

--- a/src/overTime.c
+++ b/src/overTime.c
@@ -85,12 +85,12 @@ void initOverTime(void)
 		localtime_r(&newest, &tm_n);
 		strftime(first, 20, "%Y-%m-%d %H:%M:%S", &tm_o);
 		strftime(last, 20, "%Y-%m-%d %H:%M:%S", &tm_n);
-		log_debug(DEBUG_OVERTIME, "initOverTime(): Initializing %i slots from %s (%lu) to %s (%lu)",
+		log_debug(DEBUG_OVERTIME, "initOverTime(): Initializing %u slots from %s (%lu) to %s (%lu)",
 		          OVERTIME_SLOTS, first, (unsigned long)oldest, last, (unsigned long)newest);
 	}
 
 	// Iterate over overTime
-	for(int i = 0; i < OVERTIME_SLOTS; i++)
+	for(unsigned int i = 0; i < OVERTIME_SLOTS; i++)
 	{
 		time_t this_slot_ts = oldest + OVERTIME_INTERVAL * i;
 		// Initialize overTime slot
@@ -117,14 +117,14 @@ unsigned int _getOverTimeID(time_t timestamp, const char *file, const int line)
 		// Return first timestamp in case negative timestamp was determined
 		return 0;
 	}
-	else if(id == OVERTIME_SLOTS)
+	else if((unsigned int)id == OVERTIME_SLOTS)
 	{
 		// Possible race-collision (moving of the timeslots is just about to
 		// happen), silently add to the last bin because this is the correct
 		// thing to do
 		return OVERTIME_SLOTS-1;
 	}
-	else if(id > OVERTIME_SLOTS)
+	else if((unsigned int)id > OVERTIME_SLOTS)
 	{
 		// This is definitely wrong. We warn about this (but only once)
 		if(!warned_about_hwclock)


### PR DESCRIPTION
# What does this implement/fix?

Data returned by the API for over-time statistics should not return more than specified in `webserver.api.maxHistory`

### Example: `webserver.api.maxHistory = 3600`

### Before
![Screenshot from 2025-02-24 19-35-16](https://github.com/user-attachments/assets/296ebd96-8795-4b61-903e-ae59cb21c642)


### Now
![Screenshot from 2025-02-24 19-45-16](https://github.com/user-attachments/assets/b30b2c0f-bfd0-44ed-8ccd-cdbec8f54875)


----

**Related issue or feature (if applicable):** https://github.com/pi-hole/web/issues/3255

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.