### PR TITLE
Fix typo in dns option descriptions

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -662,13 +662,13 @@ static void initConfig(struct config *conf)
 
 	// sub-struct dns.special_domains
 	conf->dns.specialDomains.mozillaCanary.k = "dns.specialDomains.mozillaCanary";
-	conf->dns.specialDomains.mozillaCanary.h = "Should Pi-hole always replies with NXDOMAIN to A and AAAA queries of use-application-dns.net to disable Firefox automatic DNS-over-HTTP? This is following the recommendation on https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https";
+	conf->dns.specialDomains.mozillaCanary.h = "Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of use-application-dns.net to disable Firefox automatic DNS-over-HTTP? This is following the recommendation on https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https";
 	conf->dns.specialDomains.mozillaCanary.t = CONF_BOOL;
 	conf->dns.specialDomains.mozillaCanary.d.b = true;
 	conf->dns.specialDomains.mozillaCanary.c = validate_stub; // Only type-based checking
 
 	conf->dns.specialDomains.iCloudPrivateRelay.k = "dns.specialDomains.iCloudPrivateRelay";
-	conf->dns.specialDomains.iCloudPrivateRelay.h = "Should Pi-hole always replies with NXDOMAIN to A and AAAA queries of mask.icloud.com and mask-h2.icloud.com to disable Apple's iCloud Private Relay to prevent Apple devices from bypassing Pi-hole? This is following the recommendation on https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay";
+	conf->dns.specialDomains.iCloudPrivateRelay.h = "Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of mask.icloud.com and mask-h2.icloud.com to disable Apple's iCloud Private Relay to prevent Apple devices from bypassing Pi-hole? This is following the recommendation on https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay";
 	conf->dns.specialDomains.iCloudPrivateRelay.t = CONF_BOOL;
 	conf->dns.specialDomains.iCloudPrivateRelay.d.b = true;
 	conf->dns.specialDomains.iCloudPrivateRelay.c = validate_stub; // Only type-based checking

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -307,13 +307,13 @@
     edns = "TEXT"
 
   [dns.specialDomains]
-    # Should Pi-hole always replies with NXDOMAIN to A and AAAA queries of
+    # Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of
     # use-application-dns.net to disable Firefox automatic DNS-over-HTTP? This is
     # following the recommendation on
     # https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https
     mozillaCanary = true
 
-    # Should Pi-hole always replies with NXDOMAIN to A and AAAA queries of mask.icloud.com
+    # Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of mask.icloud.com
     # and mask-h2.icloud.com to disable Apple's iCloud Private Relay to prevent Apple
     # devices from bypassing Pi-hole? This is following the recommendation on
     # https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix typo in descriptions of dns.specialDomains.mozillaCanary and dns.specialDomains.iCloudPrivateRelay

Reported at [https://discourse.pi-hole.net/t/typos-in-menu-settings/76935](https://discourse.pi-hole.net/t/typos-in-menu-settings/76935)

**How does this PR accomplish the above?:**

Deleting the word replies and substituting reply.

Tests updated to reflect this change.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X ] I have read the above and my PR is ready for review. *Check this box to confirm*
