### PR TITLE
Also validate env variables

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -78,6 +78,7 @@ export FTLCONF_misc_nice="-11"
 export FTLCONF_dns_upstrrr="-11"
 export FTLCONF_debug_api="not_a_bool"
 export FTLCONF_MISC_CHECK_SHMEM=91
+export FTLCONF_files_pcap='*123#./test/pcap'
 
 # Prepare gdb session
 echo "handle SIGHUP nostop SIGPIPE nostop SIGTERM nostop SIG32 nostop SIG33 nostop SIG34 nostop SIG35 nostop SIG41 nostop" > /root/.gdbinit

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -756,7 +756,7 @@
 @test "No ERROR messages in FTL.log (besides known/intended error)" {
   run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log | grep -c -v -E "(index\.html)|(Failed to create shared memory object)|(FTLCONF_debug_api is not a boolean)|(Failed to set|adjust time during NTP sync: Insufficient permissions)"'
+  run bash -c 'grep "ERROR: " /var/log/pihole/FTL.log | grep -c -v -E "(index\.html)|(Failed to create shared memory object)|(FTLCONF_debug_api is not a boolean)|(FTLCONF_files_pcap files.pcap: not a valid file path)|(Failed to set|adjust time during NTP sync: Insufficient permissions)"'
   printf "count: %s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
 }
@@ -1630,24 +1630,40 @@
 }
 
 @test "Correct number of environmental variables is logged" {
-  run bash -c 'grep -q "4 FTLCONF environment variables found (2 used, 1 invalid, 1 ignored)" /var/log/pihole/FTL.log'
+  grep "FTLCONF environment variables" /var/log/pihole/FTL.log
+  printf "%s\n" "${lines[@]}"
+  run bash -c 'grep -q "5 FTLCONF environment variables found (2 used, 2 invalid, 1 ignored)" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
 }
 
 @test "Correct environmental variable is logged" {
+  grep "FTLCONF_misc_nice" /var/log/pihole/FTL.log
+  printf "%s\n" "${lines[@]}"
   run bash -c 'grep -q "FTLCONF_misc_nice is used" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
 }
 
-@test "Invalid environmental variable is logged" {
-  run bash -c 'grep -q "FTLCONF_debug_api is not a boolean" /var/log/pihole/FTL.log'
+@test "Invalid environmental variable is logged (type mismatch)" {
+  grep "FTLCONF_debug_api" /var/log/pihole/FTL.log
+  printf "%s\n" "${lines[@]}"
+  run bash -c 'grep -q "FTLCONF_debug_api is not a boolean, using default instead" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+}
+
+@test "Invalid environmental variable is logged (validation failed)" {
+  grep "FTLCONF_files_pcap" /var/log/pihole/FTL.log
+  printf "%s\n" "${lines[@]}"
+  run bash -c 'grep -q "FTLCONF_files_pcap files.pcap: not a valid file path (\"\*123#./test/pcap\"), using default instead" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
 }
 
 @test "Unknown environmental variable is logged, a useful alternative is suggested" {
+  grep "FTLCONF_dns_upstrrr" /var/log/pihole/FTL.log
+  printf "%s\n" "${lines[@]}"
   run bash -c 'grep -A1 "FTLCONF_dns_upstrrr is unknown" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == *"WARNING: [?] FTLCONF_dns_upstrrr is unknown, did you mean any of these?" ]]


### PR DESCRIPTION
# What does this implement/fix?

Currently, FTL validates config values only if being asked to change them *interactively* either via the API or the CLI where
the validator's feedback reaches the user *immediately*. This PR extends validation of config values also to checking ENVVARS.

In case of invalid ENVVARS, whatever is configured in `pihole.toml` will be used for the value (so it will simply not be overwritten).

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.