### PR TITLE
 Change default value of webserver.threads to 50

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1008,10 +1008,10 @@ static void initConfig(struct config *conf)
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.threads.k = "webserver.threads";
-	conf->webserver.threads.h = "Maximum number of worker threads allowed.\n The Pi-hole web server handles each incoming connection in a separate thread. Therefore, the value of this option is effectively the number of concurrent HTTP connections that can be handled. Any other connections are queued until they can be processed by a unoccupied thread.\n The default value of 0 means that the number of threads is automatically determined by the number of online CPU cores minus 1 (e.g., launching up to 8-1 = 7 threads on 8 cores). Any other value specifies the number of threads explicitly. A hard-coded maximum of 64 threads is enforced for this option.\n The total number of threads you see may be lower than the configured value as threads are only created when needed due to incoming connections.";
+	conf->webserver.threads.h = "Maximum number of worker threads allowed.\n The Pi-hole web server handles each incoming connection in a separate thread. Therefore, the value of this option is effectively the number of concurrent HTTP connections that can be handled. Any other connections are queued until they can be processed by a unoccupied thread.\n The total number of threads you see may be lower than the configured value as threads are only created when needed due to incoming connections.\n The value 0 means the number of threads is 50 (as per default settings of CivetWeb) for backwards-compatible behavior.";
 	conf->webserver.threads.t = CONF_UINT;
 	conf->webserver.threads.f = FLAG_RESTART_FTL;
-	conf->webserver.threads.d.ui = 0;
+	conf->webserver.threads.d.ui = 50;
 	conf->webserver.threads.c = validate_stub; // Only type-based checking
 
 	conf->webserver.headers.k = "webserver.headers";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -669,13 +669,11 @@
   # Therefore, the value of this option is effectively the number of concurrent HTTP
   # connections that can be handled. Any other connections are queued until they can be
   # processed by a unoccupied thread.
-  # The default value of 0 means that the number of threads is automatically determined
-  # by the number of online CPU cores minus 1 (e.g., launching up to 8-1 = 7 threads on
-  # 8 cores). Any other value specifies the number of threads explicitly. A hard-coded
-  # maximum of 64 threads is enforced for this option.
   # The total number of threads you see may be lower than the configured value as
   # threads are only created when needed due to incoming connections.
-  threads = 0
+  # The value 0 means the number of threads is 50 (as per default settings of CivetWeb)
+  # for backwards-compatible behavior.
+  threads = 50
 
   # Additional HTTP headers added to the web server responses.
   # The headers are added to all responses, including those for the API.


### PR DESCRIPTION
# What does this implement/fix?

Change default value of `webserver.threads` to 50, make 0 behave as if the user has set 50 (for backwards-compatibility reasons) and remove the upper limit we enforced on the number of threads.

This should improve the webserver/API's performance especially of single- and dual-core machines. 

The word of warning I have for this change can be read here: https://github.com/pi-hole/FTL/issues/2284#issuecomment-2691042248 I guess we still want to do this. We also updated CivetWeb in between (and I will shortly put up another update to their current `master`), so the original issue may really have been fixed.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2284

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.