### PR TITLE
Tweak misc.etc_dnsmasq_d help text and scope - only read *.conf files

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1317,7 +1317,7 @@ static void initConfig(struct config *conf)
 	conf->misc.addr2line.c = validate_stub; // Only type-based checking
 
 	conf->misc.etc_dnsmasq_d.k = "misc.etc_dnsmasq_d";
-	conf->misc.etc_dnsmasq_d.h = "Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?";
+	conf->misc.etc_dnsmasq_d.h = "Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?\n Warning: This is an advanced setting and should only be used with care.\n Incorrectly formatted or config files specifying options which can only be defined once can result in conflicts with the automatic configuration of Pi-hole (see "DNSMASQ_PH_CONFIG") and may stop DNS resolution from working.";
 	conf->misc.etc_dnsmasq_d.t = CONF_BOOL;
 	conf->misc.etc_dnsmasq_d.f = FLAG_RESTART_FTL;
 	conf->misc.etc_dnsmasq_d.d.b = false;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -703,10 +703,11 @@ bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_
 
 	if(directory_exists("/etc/dnsmasq.d") && conf->misc.etc_dnsmasq_d.v.b)
 	{
-		// Load additional user scripts from /etc/dnsmasq.d if the
+		// Load additional user configs from /etc/dnsmasq.d if the
 		// directory exists (it may not, e.g., in a container)
-		fputs("# Load additional user scripts\n", pihole_conf);
-		fputs("conf-dir=/etc/dnsmasq.d\n", pihole_conf);
+		// Load only files ending in .conf
+		fputs("# Load additional user configs\n", pihole_conf);
+		fputs("conf-dir=/etc/dnsmasq.d,*.conf\n", pihole_conf);
 		fputs("\n", pihole_conf);
 	}
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.0.2-18-g392eaa08)
+# Pi-hole configuration file (v6.0.3-14-gbb1ff28a-dirty)
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-02-22 18:05:05 UTC
+# Last updated on 2025-03-03 11:05:52 UTC
 
 [dns]
   # Array of upstream DNS servers used by Pi-hole
@@ -997,6 +997,10 @@
   addr2line = true
 
   # Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?
+  # Warning: This is an advanced setting and should only be used with care.
+  # Incorrectly formatted or config files specifying options which can only be defined
+  # once can result in conflicts with the automatic configuration of Pi-hole (see
+  # /etc/pihole/dnsmasq.conf) and may stop DNS resolution from working.
   etc_dnsmasq_d = true ### CHANGED, default = false
 
   # Additional lines to inject into the generated dnsmasq configuration.


### PR DESCRIPTION
# What does this implement/fix?

- Load only files with suffix `*.conf files` from `/etc/dnsmasq.d` when `misc.etc_dnsmasq_d == true` (not arbitrary files)
- Add warning about the possible causes of conflicting config files in `/etc/dnsmasq.d/` to the help text of `misc.etc_dnsmasq_d`

---

**Related issue or feature (if applicable):** Relates to https://github.com/pi-hole/FTL/issues/2270

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.