### PR TITLE
Update embedded CivetWeb

### DIFF
--- a/patch/civetweb/0001-Expose-bound-to-addresses-from-CivetWeb-to-the-front.patch
+++ b/patch/civetweb/0001-Expose-bound-to-addresses-from-CivetWeb-to-the-front.patch
@@ -14,9 +14,9 @@ index fa908e54..66fcab01 100644
 --- a/src/webserver/civetweb/civetweb.c
 +++ b/src/webserver/civetweb/civetweb.c
 @@ -3339,6 +3339,7 @@ mg_get_server_ports(const struct mg_context *ctx,
- 		ports[cnt].is_ssl = ctx->listening_sockets[i].is_ssl;
  		ports[cnt].is_redirect = ctx->listening_sockets[i].ssl_redir;
  		ports[cnt].is_optional = ctx->listening_sockets[i].is_optional;
+ 		ports[cnt].is_bound = ctx->listening_sockets[i].sock != INVALID_SOCKET;
 +		memcpy(&ports[cnt].addr, &ctx->listening_sockets[i].lsa, sizeof(ports[cnt].addr));
  
  		if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET) {
@@ -35,7 +35,7 @@ index eee958b4..6dcfa457 100644
  #define CIVETWEB_VERSION_MAJOR (1)
  #define CIVETWEB_VERSION_MINOR (17)
 @@ -721,6 +723,10 @@ struct mg_server_port {
- 	int _reserved2;
+ 	int is_bound;    /* bound: 0 = no, 1 = yes, relevant for optional ports */
  	int _reserved3;
  	int _reserved4;
 +   union {

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -3339,6 +3339,7 @@ mg_get_server_ports(const struct mg_context *ctx,
 		ports[cnt].is_ssl = ctx->listening_sockets[i].is_ssl;
 		ports[cnt].is_redirect = ctx->listening_sockets[i].ssl_redir;
 		ports[cnt].is_optional = ctx->listening_sockets[i].is_optional;
+		ports[cnt].is_bound = ctx->listening_sockets[i].sock != INVALID_SOCKET;
 		memcpy(&ports[cnt].addr, &ctx->listening_sockets[i].lsa, sizeof(ports[cnt].addr));
 
 		if (ctx->listening_sockets[i].lsa.sa.sa_family == AF_INET) {

--- a/src/webserver/civetweb/civetweb.h
+++ b/src/webserver/civetweb/civetweb.h
@@ -720,7 +720,7 @@ struct mg_server_port {
 	int is_ssl;      /* https port: 0 = no, 1 = yes */
 	int is_redirect; /* redirect all requests: 0 = no, 1 = yes */
 	int is_optional; /* optional: 0 = no, 1 = yes */
-	int _reserved2;
+	int is_bound;    /* bound: 0 = no, 1 = yes, relevant for optional ports */
 	int _reserved3;
 	int _reserved4;
    union {

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -207,6 +207,7 @@ static struct serverports
 	bool is_secure :1;
 	bool is_redirect :1;
 	bool is_optional :1;
+	bool is_bound :1;
 	char addr[INET6_ADDRSTRLEN + 2]; // +2 for square brackets around IPv6 address
 	int port;
 	int protocol; // 1 = IPv4, 3 = IPv6
@@ -253,6 +254,7 @@ static void get_server_ports(void)
 		server_ports[i].is_secure = mgports[i].is_ssl;
 		server_ports[i].is_redirect = mgports[i].is_redirect;
 		server_ports[i].is_optional = mgports[i].is_optional;
+		server_ports[i].is_bound = mgports[i].is_bound;
 		// 1 = IPv4, 3 = IPv6 (can also be a combo-socker serving both),
 		// the documentation in civetweb.h is wrong
 		server_ports[i].protocol = mgports[i].protocol;
@@ -277,13 +279,14 @@ static void get_server_ports(void)
 		// Print port information
 		if(i == 0)
 			log_info("Web server ports:");
-		log_info("  - %s:%d (HTTP%s, IPv%s%s%s)",
+		log_info("  - %s:%d (HTTP%s, IPv%s%s%s, %s)",
 		         server_ports[i].addr,
 		         server_ports[i].port,
 		         server_ports[i].is_secure ? "S" : "",
 		         server_ports[i].protocol == 1 ? "4" : "6",
 		         server_ports[i].is_redirect ? ", redirecting" : "",
-		         server_ports[i].is_optional ? ", optional" : "");
+		         server_ports[i].is_optional ? ", optional" : "",
+		         server_ports[i].is_bound ? "OK" : "NOT bound");
 
 	}
 }


### PR DESCRIPTION
# What does this implement/fix?

Sync embedded CivetWeb to their latest `master` state and implement displaying of the boundness state of ports in the startup log of FTL. The related CivetWeb change has recently been created by us: https://github.com/civetweb/civetweb/pull/1323

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.