### PR TITLE
Empty DHCP range is valid

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1740,7 +1740,8 @@ bool migrate_config_v6(void)
 
 	// Initialize the TOML config file
 	writeFTLtoml(true);
-	write_dnsmasq_config(&config, false, NULL);
+	char errbuf[ERRBUF_SIZE] = { 0 };
+	write_dnsmasq_config(&config, false, errbuf);
 	write_custom_list();
 
 	return true;
@@ -1768,7 +1769,8 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 			if(rewrite)
 			{
 				writeFTLtoml(true);
-				write_dnsmasq_config(conf, false, NULL);
+				char errbuf[ERRBUF_SIZE] = { 0 };
+				write_dnsmasq_config(conf, false, errbuf);
 				write_custom_list();
 			}
 			return true;
@@ -1800,7 +1802,8 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 
 	// Initialize the TOML config file
 	writeFTLtoml(true);
-	write_dnsmasq_config(conf, false, NULL);
+	char errbuf[ERRBUF_SIZE] = { 0 };
+	write_dnsmasq_config(conf, false, errbuf);
 	write_custom_list();
 
 	return false;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -244,7 +244,7 @@ static void write_config_header(FILE *fp, const char *description)
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "################################################################################");
 }
 
-bool __attribute__((const)) write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE])
+bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE])
 {
 	// Early config checks
 	if(conf->dhcp.active.v.b)

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -296,9 +296,9 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		}
 
 		// Check if the DHCP range is valid (start needs to be smaller than end)
-		if(ntohl(conf->dhcp.start.v.in_addr.s_addr) >= ntohl(conf->dhcp.end.v.in_addr.s_addr))
+		if(ntohl(conf->dhcp.start.v.in_addr.s_addr) > ntohl(conf->dhcp.end.v.in_addr.s_addr))
 		{
-			strncpy(errbuf, "DHCP range start address is larger than or equal to the end address", ERRBUF_SIZE);
+			strncpy(errbuf, "DHCP range start address is larger than the end address", ERRBUF_SIZE);
 			log_err("Unable to update dnsmasq configuration: %s", errbuf);
 			return false;
 		}

--- a/src/config/dnsmasq_config.h
+++ b/src/config/dnsmasq_config.h
@@ -14,7 +14,7 @@
 
 #define ERRBUF_SIZE 1024
 
-bool write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE]);
+bool write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE]) __attribute__((nonnull(1,3)));
 int get_lineno_from_string(const char *string);
 char *get_dnsmasq_line(const unsigned int lineno);
 bool read_legacy_dhcp_static_config(void);


### PR DESCRIPTION
# What does this implement/fix?

Fixes two issues reported on Discourse:

- Always provide `errbuf`, even it was are not going to use it outside of `write_dnsmasq_conf()`. Add `nonnull` attribute that ensures this cannot be forgotten again in the future.
- Make identical DHCP start and end addresses a valid configuration as users may be using `dhcp-host` lines to assign only static addresses which can be outside this range

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/upgrade-to-v6-breaks-installer-and-dns-resolution-on-config-error/77089

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.