### PR TITLE
Add Discovery of Designated Resolvers special zone blocking

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -261,6 +261,8 @@ components:
                       type: boolean
                     iCloudPrivateRelay:
                       type: boolean
+                    designatedResolver:
+                      type: boolean
                 reply:
                   type: object
                   properties:
@@ -685,6 +687,7 @@ components:
             specialDomains:
               mozillaCanary: true
               iCloudPrivateRelay: true
+              designatedResolver: true
             reply:
               host:
                 force4: false

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -673,6 +673,12 @@ static void initConfig(struct config *conf)
 	conf->dns.specialDomains.iCloudPrivateRelay.d.b = true;
 	conf->dns.specialDomains.iCloudPrivateRelay.c = validate_stub; // Only type-based checking
 
+	conf->dns.specialDomains.designatedResolver.k = "dns.specialDomains.designatedResolver";
+	conf->dns.specialDomains.designatedResolver.h = "Should Pi-hole always reply with NODATA to all queries to zone resolver.arpa to prevent devices from bypassing Pi-hole using Discovery of Designated Resolvers? This is based on recommendations at the end of RFC 9462, section 4.";
+	conf->dns.specialDomains.designatedResolver.t = CONF_BOOL;
+	conf->dns.specialDomains.designatedResolver.d.b = true;
+	conf->dns.specialDomains.designatedResolver.c = validate_stub; // Only type-based checking
+
 	// sub-struct dns.reply_addr
 	conf->dns.reply.host.force4.k = "dns.reply.host.force4";
 	conf->dns.reply.host.force4.h = "Use a specific IPv4 address for the Pi-hole host? By default, FTL determines the address of the interface a query arrived on and uses this address for replying to A queries with the most suitable address for the requesting client. This setting can be used to use a fixed, rather than the dynamically obtained, address when Pi-hole responds to the following names: [ \"pi.hole\", \"<the device's hostname>\", \"pi.hole.<local domain>\", \"<the device's hostname>.<local domain>\" ]";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -162,6 +162,7 @@ struct config {
 		struct {
 			struct conf_item mozillaCanary;
 			struct conf_item iCloudPrivateRelay;
+			struct conf_item designatedResolver;
 		} specialDomains;
 		struct {
 			struct {

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.0.2-18-g392eaa08)
+# Pi-hole configuration file (v6.0.3-12-gd154623c-dirty)
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-02-22 18:05:05 UTC
+# Last updated on 2025-03-01 11:59:17 UTC
 
 [dns]
   # Array of upstream DNS servers used by Pi-hole
@@ -318,6 +318,11 @@
     # devices from bypassing Pi-hole? This is following the recommendation on
     # https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay
     iCloudPrivateRelay = true
+
+    # Should Pi-hole always reply with NODATA to all queries to zone resolver.arpa to
+    # prevent devices from bypassing Pi-hole using Discovery of Designated Resolvers? This
+    # is based on recommendations at the end of RFC 9462, section 4.
+    designatedResolver = true
 
     [dns.reply.host]
       # Use a specific IPv4 address for the Pi-hole host? By default, FTL determines the
@@ -1176,7 +1181,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 153 total entries out of which 96 entries are default
+# 154 total entries out of which 97 entries are default
 # --> 57 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

Add Discovery of Designated Resolvers special zone blocking to prevent a possible way to bypass Pi-hole depending on the configured upstream.

For instance, if you are using Google DNS (`8.8.8.8`) a client locally querying
```
SVCB _dns.resolver.arpa
```
would get the reply
```
_dns.resolver.arpa.     86400   IN      SVCB    1 dns.google. alpn="dot"
_dns.resolver.arpa.     86400   IN      SVCB    2 dns.google. alpn="h2,h3" key7="/dns-query{?dns}"
```
giving them a valid path to try to evade Pi-hole's blocking. This PR adds blocking for the new special zone `resolver.arpa` described in [RFC 9462](https://datatracker.ietf.org/doc/rfc9462/) and provides `NODATA` whenever this is enabled (default on). This behavior is recommended at the end of section 4:
>    If the recursive resolver that receives this query has no Designated
>   Resolvers, it SHOULD return NODATA for queries to the "resolver.arpa"
>   zone, to provide a consistent and accurate signal to clients that it
>   does not have a Designated Resolver.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/are-svcb-queries-sent-through-pi-hole-of-blocking-concern/59983

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.