### PR TITLE
Add "application/pkix-cert" and "application/pkix-crl" MIME types.

### DIFF
--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -8565,6 +8565,9 @@ static const struct {
      * (http://www.iana.org/assignments/media-types)
      * application types */
     {".bin", 4, "application/octet-stream"},
+    {".cer", 4, "application/pkix-cert"},
+    {".crl", 4, "application/pkix-crl"},
+    {".crt", 4, "application/pkix-cert"},
     {".deb", 4, "application/octet-stream"},
     {".dmg", 4, "application/octet-stream"},
     {".dll", 4, "application/octet-stream"},


### PR DESCRIPTION
### Add registered MIME types for serving certificate and CRL files from FTL.

Currently built-in FTL webserver recognizes only a very limited number of MIME types.
While I'm sure the list may be extended significantly I'd like to contribute the MIME types that are commonly used to serve certificate (.crt, .cer) and CRL files (.crl).

See: [RFC-2585](https://datatracker.ietf.org/doc/html/rfc2585#section-4)
