### PR TITLE
Allow prefix multiplexing behind reverse proxy

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -432,6 +432,8 @@ components:
                       type: string
                     webhome:
                       type: string
+                    prefix:
+                      type: string
                 interface:
                   type: object
                   properties:
@@ -762,6 +764,7 @@ components:
             paths:
               webroot: "/var/www/html"
               webhome: "/admin/"
+              prefix: ""
             interface:
               boxed: true
               theme: "default-darker"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1064,6 +1064,14 @@ static void initConfig(struct config *conf)
 	conf->webserver.paths.webhome.d.s = (char*)"/admin/";
 	conf->webserver.paths.webhome.c = validate_filepath_two_slash;
 
+	conf->webserver.paths.prefix.k = "webserver.paths.prefix";
+	conf->webserver.paths.prefix.h = "Prefix where the web interface is served\n This is useful when you are using a reverse proxy serving the web interface, e.g., at http://<ip>/pihole/admin/ instead of http://<ip>/admin/. In this example, the prefix would be \"/pihole\". Note that the prefix has to be stripped away by the reverse proxy, e.g., for traefik:\n - traefik.http.routers.pihole.rule=PathPrefix(`/pihole`)\n - traefik.http.middlewares.piholehttp.stripprefix.prefixes=/pihole\n The prefix should start with a slash. If you don't use a prefix, leave this field empty. Setting this field to an incorrect value may result in the web interface not being accessible.\n Don't use this setting if you are not using a reverse proxy!";
+	conf->webserver.paths.prefix.a = cJSON_CreateStringReference("valid URL prefix or empty");
+	conf->webserver.paths.prefix.t = CONF_STRING;
+	conf->webserver.paths.prefix.f = FLAG_RESTART_FTL;
+	conf->webserver.paths.prefix.d.s = (char*)"";
+	conf->webserver.paths.prefix.c = validate_filepath_empty;
+
 	// sub-struct interface
 	conf->webserver.interface.boxed.k = "webserver.interface.boxed";
 	conf->webserver.interface.boxed.h = "Should the web interface use the boxed layout?";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -254,6 +254,7 @@ struct config {
 		struct {
 			struct conf_item webroot;
 			struct conf_item webhome;
+			struct conf_item prefix;
 		} paths;
 		struct {
 			struct conf_item boxed;

--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -23,6 +23,8 @@
 #include "datastructure.h"
 #include "api/api.h"
 #include "scripts/scripts.h"
+// get_prefix_webhome(), get_api_uri()
+#include "webserver/webserver.h"
 
 // prototype for luaopen_pihole()
 #include "lualib.h"
@@ -122,14 +124,24 @@ static void get_abspath(char abs_filename[1024], char rel_filename[1024], const 
 		strncpy(abs_filename, config.webserver.paths.webroot.v.s, abs_filename_len);
 		abs_filename_len -= strlen(config.webserver.paths.webroot.v.s);
 	}
+
+	// Add prefix to rel_filename if applicable
+	if(rel_filename != NULL && config.webserver.paths.prefix.v.s[0] != '\0')
+	{
+		strncpy(rel_filename, config.webserver.paths.prefix.v.s, rel_filename_len);
+		rel_filename_len -= strlen(config.webserver.paths.prefix.v.s);
+	}
+
+	// Add webhome to abs_filename and rel_filename if applicable
 	if(config.webserver.paths.webhome.v.s != NULL)
 	{
 		strncat(abs_filename, config.webserver.paths.webhome.v.s, abs_filename_len);
 		abs_filename_len -= strlen(config.webserver.paths.webhome.v.s);
 
+		// Add webhome to rel_filename
 		if(rel_filename != NULL)
 		{
-			strncpy(rel_filename, config.webserver.paths.webhome.v.s, rel_filename_len);
+			strncat(rel_filename, config.webserver.paths.webhome.v.s, rel_filename_len);
 			rel_filename_len -= strlen(config.webserver.paths.webhome.v.s);
 		}
 	}
@@ -171,6 +183,10 @@ static int pihole_fileversion(lua_State *L) {
 		return 1; // number of results
 	}
 
+	// Cast to long long to avoid warnings on 32-bit systems
+	log_debug(DEBUG_API, "File \"%s\" -> \"%s\" last modified at %lld",
+	          abspath, relpath, (long long)filestat.st_mtime);
+
 	// Return filename + modification time
 	lua_pushfstring(L, "%s?v=%d", relpath, filestat.st_mtime);
 	return 1; // number of results
@@ -205,7 +221,7 @@ static int pihole_webtheme(lua_State *L) {
 // pihole.webhome()
 static int pihole_webhome(lua_State *L) {
 	// Get name of currently set webhome
-	lua_pushstring(L, config.webserver.paths.webhome.v.s);
+	lua_pushstring(L, get_prefix_webhome());
 	return 1; // number of results
 }
 
@@ -240,6 +256,13 @@ static int pihole_needLogin(lua_State *L) {
 	return 1; // number of results
 }
 
+// pihole.api_url()
+static int pihole_api_url(lua_State *L) {
+	// Return API URL
+	lua_pushstring(L, get_api_uri());
+	return 1; // number of results
+}
+
 static const luaL_Reg piholelib[] = {
 	{"ftl_version", pihole_ftl_version},
 	{"hostname", pihole_hostname},
@@ -249,6 +272,7 @@ static const luaL_Reg piholelib[] = {
 	{"include", pihole_include},
 	{"boxedlayout", pihole_boxedlayout},
 	{"needLogin", pihole_needLogin},
+	{"api_url", pihole_api_url},
 	{NULL, NULL}
 };
 

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -18,41 +18,14 @@
 #include "config/config.h"
 // log_web()
 #include "log.h"
-
 // directory_exists()
 #include "files.h"
 
 static char *login_uri = NULL, *admin_api_uri = NULL;
-void allocate_lua(void)
+void allocate_lua(char *login_uri_in, char *admin_api_uri_in)
 {
-	// Build login URI string (webhome + login)
-	// Append "login" to webhome string
-	const size_t login_uri_len = strlen(config.webserver.paths.webhome.v.s);
-	login_uri = calloc(login_uri_len + 6, sizeof(char));
-	memcpy(login_uri, config.webserver.paths.webhome.v.s, login_uri_len);
-	strcpy(login_uri + login_uri_len, "login");
-	login_uri[login_uri_len + 5u] = '\0';
-	log_debug(DEBUG_API, "Login URI: %s", login_uri);
-
-	// Build "wrong" API URI string (webhome + api)
-	// Append "api" to webhome string
-	const size_t admin_api_uri_len = strlen(config.webserver.paths.webhome.v.s);
-	admin_api_uri = calloc(admin_api_uri_len + 4, sizeof(char));
-	memcpy(admin_api_uri, config.webserver.paths.webhome.v.s, admin_api_uri_len);
-	strcpy(admin_api_uri + admin_api_uri_len, "api");
-	admin_api_uri[admin_api_uri_len + 3u] = '\0';
-	log_debug(DEBUG_API, "Admin API URI: %s", admin_api_uri);
-}
-
-void free_lua(void)
-{
-	// Free login_uri
-	if(login_uri != NULL)
-		free(login_uri);
-
-	// Free admin_api_uri
-	if(admin_api_uri != NULL)
-		free(admin_api_uri);
+	login_uri = login_uri_in;
+	admin_api_uri = admin_api_uri_in;
 }
 
 void init_lua(const struct mg_connection *conn, void *L, unsigned context_flags)
@@ -86,7 +59,7 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	api.request = req_info;
 	api.now = double_time();
 
-	// Check if the request is for the API under /admin/api
+	// Check if the request is for the API under <webhome>api
 	// (it is posted at /api)
 	if(strncmp(req_info->local_uri_raw, admin_api_uri, strlen(admin_api_uri)) == 0)
 	{
@@ -127,10 +100,10 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 		if(!authorized)
 		{
 			// User is not authenticated, redirect to login page
-			log_web("Authentication required, redirecting to %slogin",
-			        config.webserver.paths.webhome.v.s);
-			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %slogin\r\n\r\n",
-			          config.webserver.paths.webhome.v.s);
+			log_web("Authentication required, redirecting to %s%slogin",
+			        config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
+			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %s%slogin\r\n\r\n",
+			          config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
 			return 302;
 		}
 	}
@@ -141,8 +114,10 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 		if(authorized)
 		{
 			// User is already authenticated, redirect to index page
-			log_web("User is already authenticated, redirecting to %s", config.webserver.paths.webhome.v.s);
-			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %s\r\n\r\n", config.webserver.paths.webhome.v.s);
+			log_web("User is already authenticated, redirecting to %s%s",
+			        config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
+			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %s%s\r\n\r\n",
+			          config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
 			return 302;
 		}
 	}

--- a/src/webserver/lua_web.h
+++ b/src/webserver/lua_web.h
@@ -13,8 +13,7 @@
 // definition of struct mg_connection
 #include "http-common.h"
 
-void allocate_lua(void);
-void free_lua(void);
+void allocate_lua(char *login_uri_in, char *admin_api_uri_in);
 void init_lua(const struct mg_connection *conn, void *L, unsigned context_flags);
 int request_handler(struct mg_connection *conn, void *cbdata);
 

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -34,9 +34,78 @@
 // Server context handle
 static struct mg_context *ctx = NULL;
 static char *error_pages = NULL;
+static char *prefix_webhome = NULL;
+static char *api_uri = NULL;
+static char *admin_api_uri = NULL;
+static char *login_uri = NULL;
 
 // Private prototypes
 static char *append_to_path(char *path, const char *append);
+
+/**
+ * @brief Constructs various web paths used by the webserver.
+ *
+ * @return true if all paths are successfully constructed and allocated, false otherwise.
+ */
+static bool build_webpaths(void)
+{
+	// Construct error_pages path
+	error_pages = append_to_path(config.webserver.paths.webroot.v.s, config.webserver.paths.webhome.v.s);
+	log_debug(DEBUG_API, "Error pages path: %s", error_pages);
+	if(error_pages == NULL)
+	{
+		log_err("Failed to allocate memory for error_pages path!");
+		return false;
+	}
+
+	// Construct prefix_webhome path
+	prefix_webhome = append_to_path(config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
+	log_debug(DEBUG_API, "Prefix webhome path: %s", prefix_webhome);
+	if(prefix_webhome == NULL)
+	{
+		log_err("Failed to allocate memory for prefix_webhome path!");
+		return false;
+	}
+
+	// Construct api_url path
+	api_uri = append_to_path(config.webserver.paths.prefix.v.s, "/api");
+	log_debug(DEBUG_API, "API URI path: %s", api_uri);
+	if(api_uri == NULL)
+	{
+		log_err("Failed to allocate memory for api_uri path!");
+		return false;
+	}
+
+	// Construct admin_api_uri path
+	admin_api_uri = append_to_path(prefix_webhome, "api");
+	log_debug(DEBUG_API, "Admin API URI path: %s", admin_api_uri);
+	if(admin_api_uri == NULL)
+	{
+		log_err("Failed to allocate memory for admin_api_uri path!");
+		return false;
+	}
+
+	// Construct login_uri path
+	login_uri = append_to_path(config.webserver.paths.webhome.v.s, "login");
+	log_debug(DEBUG_API, "Login URI path: %s", login_uri);
+	if(login_uri == NULL)
+	{
+		log_err("Failed to allocate memory for login_uri path!");
+		return false;
+	}
+
+	return true;
+}
+
+char * __attribute__((pure)) get_prefix_webhome(void)
+{
+	return prefix_webhome;
+}
+
+char * __attribute__((pure)) get_api_uri(void)
+{
+	return api_uri;
+}
 
 static int redirect_root_handler(struct mg_connection *conn, void *input)
 {
@@ -94,13 +163,14 @@ static int redirect_root_handler(struct mg_connection *conn, void *input)
 		if(strcmp(uri, "/") == 0)
 		{
 			log_debug(DEBUG_API, "Redirecting / --308--> %s",
-			          config.webserver.paths.webhome.v.s);
-			mg_send_http_redirect(conn, config.webserver.paths.webhome.v.s, 308);
+			          prefix_webhome);
+			mg_send_http_redirect(conn, prefix_webhome, 308);
 			return 1;
 		}
 	}
 
 	// else: Not redirecting
+	log_debug(DEBUG_API, "Not redirecting %s", uri);
 	return 0;
 }
 
@@ -113,11 +183,11 @@ static int redirect_admin_handler(struct mg_connection *conn, void *input)
 		const char *uri = request->local_uri_raw;
 
 		log_debug(DEBUG_API, "Redirecting %s --308--> %s",
-		          uri, config.webserver.paths.webhome.v.s);
+		          uri, prefix_webhome);
 	}
 
-	// 308 Permanent Redirect from /admin -> /admin/
-	mg_send_http_redirect(conn, config.webserver.paths.webhome.v.s, 308);
+	// 308 Permanent Redirect from [prefix]<webhome without trailing slash> -> [prefix]<webhome>
+	mg_send_http_redirect(conn, prefix_webhome, 308);
 	return 1;
 }
 
@@ -142,7 +212,7 @@ static int redirect_lp_handler(struct mg_connection *conn, void *input)
 
 	// Copy everything from before the ".lp" to the new URI to effectively
 	// remove it
-	strncpy(new_uri, uri, uri_len - 3);
+	strncat(new_uri, uri, uri_len - 3);
 
 	// Append query string to the new URI if present
 	if(query_len > 0)
@@ -342,9 +412,10 @@ unsigned short get_api_string(char **buf, const bool domain)
 		// We add this at buffer + 1 because the first byte is the
 		// length of the string, which we don't know yet
 		char *api_str = calloc(MAX_URL_LEN, sizeof(char));
-		const ssize_t this_len = snprintf(api_str, MAX_URL_LEN, "http%s://%s:%d/api/",
+		const ssize_t this_len = snprintf(api_str, MAX_URL_LEN, "http%s://%s:%d%s/api/",
 		                                  server_ports[i].is_secure ? "s" : "",
-		                                  addr, server_ports[i].port);
+		                                  addr, server_ports[i].port,
+		                                  config.webserver.paths.prefix.v.s);
 		// Check if snprintf() failed
 		if(this_len < 0)
 		{
@@ -435,16 +506,18 @@ void http_init(void)
 		return;
 	}
 
-	// Construct error_pages path
-	error_pages = append_to_path(config.webserver.paths.webroot.v.s, config.webserver.paths.webhome.v.s);
-	if(error_pages == NULL)
+	if(!build_webpaths())
 	{
-		log_err("Failed to allocate memory for error_pages path!");
+		log_err("Failed to build web paths, web interface will not be available!");
 		return;
 	}
 
 	// Construct additional headers
 	char *webheaders = strdup("");
+	if (webheaders == NULL) {
+		log_err("Failed to allocate memory for webheaders!");
+		return;
+	}
 	cJSON *header;
 	cJSON_ArrayForEach(header, config.webserver.headers.v.json)
 	{
@@ -580,24 +653,25 @@ void http_init(void)
 	// Get server ports
 	get_server_ports();
 
-	// Register API handler
+	// Register API handler, use "/api" even when a prefix is defined as the
+	// prefix should be stripped away by the reverse proxy
 	mg_set_request_handler(ctx, "/api", api_handler, NULL);
 
-	// Register / -> /admin/ redirect handler
 	mg_set_request_handler(ctx, "/$", redirect_root_handler, NULL);
 
-	// Register /admin -> /admin/ redirect handler
-	if(strlen(config.webserver.paths.webhome.v.s) > 1)
+	// Register [prefix]<webhome without trailing slash> -> [<prefix>]<webhome> redirect handler
+	if(strlen(config.webserver.paths.webhome.v.s) > 1 && config.webserver.paths.webhome.v.s[strlen(config.webserver.paths.webhome.v.s)-1] == '/')
 	{
-		// Construct webhome_matcher path
-		char *webhome_matcher = NULL;
-		webhome_matcher = strdup(config.webserver.paths.webhome.v.s);
-		webhome_matcher[strlen(webhome_matcher)-1] = '$';
+		// Replace trailing slash with end-of-string marker for matcher
+		char *prefix_webhome_matcher = strdup(prefix_webhome);
+		prefix_webhome_matcher[strlen(prefix_webhome_matcher)-1] = '$';
+	
 		log_debug(DEBUG_API, "Redirecting %s --308--> %s",
-		          webhome_matcher, config.webserver.paths.webhome.v.s);
-		// String is internally duplicated during request configuration
-		mg_set_request_handler(ctx, webhome_matcher, redirect_admin_handler, NULL);
-		free(webhome_matcher);
+		          prefix_webhome, config.webserver.paths.webhome.v.s);
+		mg_set_request_handler(ctx, prefix_webhome_matcher, redirect_admin_handler, NULL);
+		// prefix_webhome_matcher is internally duplicated during
+		// request configuration so it can be freed here
+		free(prefix_webhome_matcher);
 	}
 
 	// Register **.lp -> ** redirect handler
@@ -607,7 +681,7 @@ void http_init(void)
 	mg_set_request_handler(ctx, "**", request_handler, NULL);
 
 	// Prepare prerequisites for Lua
-	allocate_lua();
+	allocate_lua(login_uri, admin_api_uri);
 
 	// Restore sessions from database
 	init_api();
@@ -705,16 +779,26 @@ void http_terminate(void)
 	/* Un-initialize the library */
 	mg_exit_library();
 
-	// Free Lua-related resources
-	free_lua();
-
 	// Remove CLI password
 	remove_cli_password();
 
 	// Free error_pages path
 	if(error_pages != NULL)
-	{
 		free(error_pages);
-		error_pages = NULL;
-	}
+
+	// Free webhome_matcher path
+	if(prefix_webhome != NULL)
+		free(prefix_webhome);
+
+	// Free api_uri path
+	if(api_uri != NULL)
+		free(api_uri);
+
+	// Free admin_api_uri path
+	if(admin_api_uri != NULL)
+		free(admin_api_uri);
+	
+	// Free login_uri path
+	if(login_uri != NULL)
+		free(login_uri);
 }

--- a/src/webserver/webserver.h
+++ b/src/webserver/webserver.h
@@ -22,5 +22,7 @@ void http_terminate(void);
 
 in_port_t get_https_port(void) __attribute__((pure));
 unsigned short get_api_string(char **buf, const bool domain);
+char *get_prefix_webhome(void) __attribute__((pure));
+char *get_api_uri(void) __attribute__((pure));
 
 #endif // WEBSERVER_H

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.0.2-18-g392eaa08)
+# Pi-hole configuration file (v6.0.3-12-gd154623c-dirty)
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-02-22 18:05:05 UTC
+# Last updated on 2025-03-02 19:01:39 UTC
 
 [dns]
   # Array of upstream DNS servers used by Pi-hole
@@ -751,6 +751,22 @@
     #     <valid subpath>, both slashes are needed!
     webhome = "/admin/"
 
+    # Prefix where the web interface is served
+    # This is useful when you are using a reverse proxy serving the web interface, e.g.,
+    # at http://<ip>/pihole/admin/ instead of http://<ip>/admin/. In this example, the
+    # prefix would be "/pihole". Note that the prefix has to be stripped away by the
+    # reverse proxy, e.g., for traefik:
+    # - traefik.http.routers.pihole.rule=PathPrefix(`/pihole`)
+    # - traefik.http.middlewares.piholehttp.stripprefix.prefixes=/pihole
+    # The prefix should start with a slash. If you don't use a prefix, leave this field
+    # empty. Setting this field to an incorrect value may result in the web interface not
+    # being accessible.
+    # Don't use this setting if you are not using a reverse proxy!
+    #
+    # Possible values are:
+    #     valid URL prefix or empty
+    prefix = ""
+
   [webserver.interface]
     # Should the web interface use the boxed layout?
     boxed = true
@@ -1176,7 +1192,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 153 total entries out of which 96 entries are default
+# 154 total entries out of which 97 entries are default
 # --> 57 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1199,7 +1199,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 154 total entries out of which 97 entries are default
+# 155 total entries out of which 98 entries are default
 # --> 57 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

Add new config option `webserver.paths.prefix` allowing Pi-hole's dashboard and API to be used behind a reverse proxy with path prefix multiplexing. This was already possible in Pi-hole v5.0 without having been added intentionally at any point. It is debatable whether this is a new feature or a bug (because it used to work like this pre-v6.0).

A self-contained `docker-compose.yml` suitable for testing this can be found in #2298 

> [!NOTE]
> You will need the related web branch `new/web_prefix` for this to work as expected.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2298

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.