### PR TITLE
Improve gravity parseLists on low-RAM systems

### DIFF
--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -219,6 +219,16 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 		return EXIT_FAILURE;
 	}
 
+	// Use temp_store = FILE to avoid memory exhaustion for a very large number of lists
+	// This pragma tells SQLite to store temporary tables and indices in a file instead of in memory
+	if(!checkOnly && sqlite3_exec(db, "PRAGMA temp_store = FILE;", NULL, NULL, NULL) != SQLITE_OK)
+	{
+		printf("%s  %s Unable to set temp_store to FILE in database file %s\n", over, cross, outfile);
+		fclose(fpin);
+		sqlite3_close(db);
+		return EXIT_FAILURE;
+	}
+
 	// Get size of input file
 	fseek(fpin, 0L, SEEK_END);
 	const size_t fsize = ftell(fpin);


### PR DESCRIPTION
# What does this implement/fix?

Use `temp_store = FILE` to avoid memory exhaustion for a very large number of lists in `gravity parseLists`. This is nothing else than extending the already merged https://github.com/pi-hole/pi-hole/pull/5977 also to the `parseList` feature. I did not expect this to be affected, too, however, if single lists already have multi-million domains on them, then this is a problem is your Pi-hole is having only 512 MB total RAM (or even less...).

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2194

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.