### PR TITLE
Increase niceness of CivetWeb threads

### DIFF
--- a/patch/civetweb.sh
+++ b/patch/civetweb.sh
@@ -23,4 +23,7 @@ patch -p1 < patch/civetweb/0001-Log-debug-messages-to-webserver.log-when-debug.w
 echo "Applying patch 0001-Expose-bound-to-addresses-from-CivetWeb-to-the-front.patch"
 patch -p1 < patch/civetweb/0001-Expose-bound-to-addresses-from-CivetWeb-to-the-front.patch
 
+echo "Applying patch 0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch"
+patch -p1 < patch/civetweb/0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch
+
 echo "ALL PATCHES APPLIED OKAY"

--- a/patch/civetweb/0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch
+++ b/patch/civetweb/0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch
@@ -1,0 +1,36 @@
+From ed07ef026f1ba4ad26b8740e6280263f808aeb44 Mon Sep 17 00:00:00 2001
+From: DL6ER <dl6er@dl6er.de>
+Date: Mon, 3 Mar 2025 17:03:19 +0100
+Subject: [PATCH] Increase niceness of all civetweb threads as DNS operation is
+ more important than the API and dashboard
+
+Signed-off-by: DL6ER <dl6er@dl6er.de>
+---
+ src/webserver/civetweb/civetweb.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/webserver/civetweb/civetweb.c b/src/webserver/civetweb/civetweb.c
+index da254bb4..b1e5b9a6 100644
+--- a/src/webserver/civetweb/civetweb.c
++++ b/src/webserver/civetweb/civetweb.c
+@@ -244,6 +244,7 @@ static void DEBUG_TRACE_FUNC(const char *func,
+ 
+ #else
+ #include "log.h"
++#include <sys/resource.h>
+ #define DEBUG_TRACE(fmt, ...)                                                  \
+ 	if(debug_flags[DEBUG_WEBSERVER]) {\
+ 		log_web("DEBUG: " fmt " (%s:%d)", ##__VA_ARGS__, short_path(__FILE__), __LINE__); }
+@@ -2890,6 +2891,9 @@ mg_set_thread_name(const char *name)
+ 	 */
+ 	(void)prctl(PR_SET_NAME, threadName, 0, 0, 0);
+ #endif
++
++	// Pi-hole modification: Increase niceness of threads
++	setpriority(PRIO_PROCESS, gettid(), 5);
+ }
+ #else /* !defined(NO_THREAD_NAME) */
+ static void
+-- 
+2.43.0
+

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -244,6 +244,7 @@ static void DEBUG_TRACE_FUNC(const char *func,
 
 #else
 #include "log.h"
+#include <sys/resource.h>
 #define DEBUG_TRACE(fmt, ...)                                                  \
 	if(debug_flags[DEBUG_WEBSERVER]) {\
 		log_web("DEBUG: " fmt " (%s:%d)", ##__VA_ARGS__, short_path(__FILE__), __LINE__); }
@@ -2890,6 +2891,9 @@ mg_set_thread_name(const char *name)
 	 */
 	(void)prctl(PR_SET_NAME, threadName, 0, 0, 0);
 #endif
+
+	// Pi-hole modification: Increase niceness of threads
+	setpriority(PRIO_PROCESS, gettid(), 5);
 }
 #else /* !defined(NO_THREAD_NAME) */
 static void


### PR DESCRIPTION
# What does this implement/fix?

Increase niceness of all CivetWeb threads as DNS operation is more important than the API and dashboard. This is a follow-up on #2305 to ensure the webserver workers cannot take over the system on heavy load.

![image](https://github.com/user-attachments/assets/2f80b947-7391-4f18-9a61-bd640482208c)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.