### PR TITLE
The domain pi.hole should be fully local

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -568,6 +568,15 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		}
 	}
 
+	// The domain "pi.hole" is purely local, never forward it to upstream servers
+	fputs("# Local domain for Pi-hole\n", pihole_conf);
+	fputs("# This domain is purely local and should never be forwarded to any\n", pihole_conf);
+	fputs("# upstream servers. We add a false A-record to this domain to prevent\n", pihole_conf);
+	fputs("# NXDOMAIN responses for queries on this domain. The actual response\n", pihole_conf);
+	fputs("# is handled by FTL at runtime\n", pihole_conf);
+	fputs("local=/pi.hole/\n", pihole_conf);
+	fputs("host-record=pi.hole,0.0.0.0\n", pihole_conf);
+
 	if(conf->dhcp.active.v.b)
 	{
 		fputs("# DHCP server setting\n", pihole_conf);


### PR DESCRIPTION
# What does this implement/fix?

The domain `pi.hole` should be fully local. Queries (of whatever type) should never be forwarded upstream.

---

**Related issue or feature (if applicable):** Fixes #2330 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.