### PR TITLE
Fix typo in json_macros.h for HTTP Status Code body return check

### DIFF
--- a/src/webserver/json_macros.h
+++ b/src/webserver/json_macros.h
@@ -223,7 +223,7 @@
 })
 
 #define JSON_SEND_OBJECT_CODE(object, code)({ \
-	if((code) < 100 || (code) == 204 || (code) == 304) \
+	if((code) < 200 || (code) == 204 || (code) == 304) \
 	{ \
 		/* HTTP codes 1xx, 204 and 304 must not have a body */ \
 		send_http_code(api, NULL, code, ""); \


### PR DESCRIPTION
Check for correct HTTP code range. Codes of 1XX, 204, and 304 should send an empty body. The check was for less than 100 (e.g. 99, 98, ...) instead of less than 200 (e.g. 199, 198, ...)

## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

This pull request fixes a check for HTTP codes when returning an empty body. Codes 1XX, 204, and 304 should return an empty body. However, there was a typo in the check from #2272, causing 1XX codes to be excluded. This PR fixes that.

**How does this PR accomplish the above?:**

By switching the if statement from less than 100, to less than 200, it will now include codes 1XX (e.g. 198, 199, …). Previously, only codes less than 100 would be included (e.g. 99, 98, …)

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
