### PR TITLE
Add new special permitted upstream filter for Query Log

### DIFF
--- a/src/api/docs/content/specs/queries.yaml
+++ b/src/api/docs/content/specs/queries.yaml
@@ -19,7 +19,7 @@ components:
 
           - Only show queries *from* a given timestamp on: Use parameter `from`
           - Only show queries *until* a given timestamp: Use parameter `until`
-          - Only show queries sent to a specific upstream destination (may also be `cache` or `blocklist`): Use parameter `upstream`
+          - Only show queries sent to a specific upstream destination (may also be `cache`, `blocklist`, or `permitted`): Use parameter `upstream`
           - Only show queries for specific domains: Use parameter `domain`
           - Only show queries for specific clients: Use parameter `client`
 

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -157,6 +157,10 @@ int api_queries_suggestions(struct ftl_conn *api)
 		JSON_REF_STR_IN_ARRAY(dnssec, string);
 	}
 
+	// Add special "permitted" upstream which is the sum of forwarded and
+	// cached queries
+	JSON_REF_STR_IN_ARRAY(upstream, "permitted");
+
 	cJSON *suggestions = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(suggestions, "domain", domain);
 	JSON_ADD_ITEM_TO_OBJECT(suggestions, "client_ip", client_ip);
@@ -345,6 +349,12 @@ int api_queries(struct ftl_conn *api)
 			{
 				// Pseudo-upstream for cached queries
 				add_querystr_string(api, querystr, "q.status IN ", get_cached_statuslist(), &where);
+				filtering = true;
+			}
+			else if(strcmp(upstreamname, "permitted") == 0)
+			{
+				// Pseudo-upstream for permitted queries
+				add_querystr_string(api, querystr, "q.status IN ", get_permitted_statuslist(), &where);
 				filtering = true;
 			}
 			else

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -1013,6 +1013,29 @@ const char * __attribute__ ((pure)) get_cached_statuslist(void)
 	return cached_list;
 }
 
+static char permitted_list[32] = { 0 };
+const char * __attribute__ ((pure)) get_permitted_statuslist(void)
+{
+	if(permitted_list[0] != '\0')
+		return permitted_list;
+
+	// Build a list of permitted query statuses
+	unsigned int first = 0;
+	// Open parenthesis
+	permitted_list[0] = '(';
+	for(enum query_status status = 0; status < QUERY_STATUS_MAX; status++)
+		if(!is_blocked(status))
+			snprintf(permitted_list + strlen(permitted_list),
+			         sizeof(permitted_list) - strlen(permitted_list),
+			         "%s%d", first++ < 1 ? "" : ",", status);
+
+	// Close parenthesis
+	const size_t len = strlen(permitted_list);
+	permitted_list[len] = ')';
+	permitted_list[len + 1] = '\0';
+	return permitted_list;
+}
+
 unsigned int __attribute__ ((pure)) get_blocked_count(void)
 {
 	int blocked = 0;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -148,6 +148,7 @@ bool is_blocked(const enum query_status status) __attribute__ ((const));
 bool is_cached(const enum query_status status) __attribute__ ((const));
 const char *get_blocked_statuslist(void) __attribute__ ((pure));
 const char *get_cached_statuslist(void) __attribute__ ((pure));
+const char * get_permitted_statuslist(void) __attribute__ ((pure));
 unsigned int get_blocked_count(void) __attribute__ ((pure));
 unsigned int get_forwarded_count(void) __attribute__ ((pure));
 unsigned int get_cached_count(void) __attribute__ ((pure));


### PR DESCRIPTION
# What does this implement/fix?

Add new special `?upstream=permitted` filter for Query Log much like the already existing "blocklist" and "cache" options.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.