### PR TITLE
Allow newlines in env vars as separator

### DIFF
--- a/src/config/env.c
+++ b/src/config/env.c
@@ -580,8 +580,8 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			cJSON_Delete(conf_item->v.json);
 			conf_item->v.json = cJSON_CreateArray();
 			// Parse envvar array and generate a JSON array (env var
-			// arrays are ;-delimited)
-			const char delim[] =";";
+			// arrays are ; or \n-delimited)
+			const char delim[] =";\n";
 			const char *elem = strtok(envvar_copy, delim);
 			while(elem != NULL)
 			{


### PR DESCRIPTION
# What does this implement/fix?

Add newline as additionally allowed separator (next to ";") for string arrays defined through env vars

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2339

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.