### PR TITLE
Fix unlocking warning in /api/history/clients

### DIFF
--- a/src/api/history.c
+++ b/src/api/history.c
@@ -102,7 +102,7 @@ int api_history_clients(struct ftl_conn *api)
 		JSON_ADD_ITEM_TO_OBJECT(json, "history", history);
 		cJSON *clients = JSON_NEW_ARRAY();
 		JSON_ADD_ITEM_TO_OBJECT(json, "clients", clients);
-		JSON_SEND_OBJECT_UNLOCK(json);
+		JSON_SEND_OBJECT(json);
 	}
 
 	// Get number of clients to return


### PR DESCRIPTION
# What does this implement/fix?

Do not try to unlock when there is no lock. Only affects `/api/history/clients` when the user has `misc.privacylevel >= 2`.

I checked similar code regions depending where similar `misc.privacylevel` code exists but this seems to have been the only place where this was done wrong.

---

**Related issue or feature (if applicable):** Fixes #2350 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.