### PR TITLE
Increase restrictions on POST /api/teleporter

### DIFF
--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -219,6 +219,16 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 
 static int api_teleporter_POST(struct ftl_conn *api)
 {
+	// Check if this is an app session and reject the request if app sudo
+	// mode is disabled
+	if(api->session != NULL && api->session->app && !config.webserver.api.app_sudo.v.b)
+	{
+		return send_json_error(api, 403,
+		                       "forbidden",
+		                       "Unable to change configuration (read-only)",
+		                       "The current app session is not allowed to modify Pi-hole config settings (webserver.api.app_sudo is false)");
+	}
+
 	struct upload_data data;
 	memset(&data, 0, sizeof(struct upload_data));
 	const struct mg_request_info *req_info = mg_get_request_info(api->conn);


### PR DESCRIPTION
# What does this implement/fix?

`POST /api/teleporter` should be rejected when app password is used but `webserver.api.app_sudo == false`.

---

**Related issue or feature (if applicable):** Fixes #2347 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.