### PR TITLE
Change default file serving behavior **possibly breaking**

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -413,6 +413,8 @@ components:
                   type: array
                   items:
                     type: string
+                serve_all:
+                  type: boolean
                 session:
                   type: object
                   properties:
@@ -754,6 +756,7 @@ components:
               - "X-XSS-Protection: 0"
               - "X-Content-Type-Options: nosniff"
               - "Referrer-Policy: strict-origin-when-cross-origin"
+            serve_all: false
             session:
               timeout: 300
               restore: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1027,6 +1027,12 @@ static void initConfig(struct config *conf)
 	cJSON_AddItemReferenceToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("Referrer-Policy: strict-origin-when-cross-origin"));
 	conf->webserver.headers.c = validate_stub; // Only type-based checking
 
+	conf->webserver.serve_all.k = "webserver.serve_all";
+	conf->webserver.serve_all.h = "Should the web server serve all files in webserver.paths.webroot directory? If disabled, only files within the path defined through webserver.paths.webhome and /api will be served.";
+	conf->webserver.serve_all.t = CONF_BOOL;
+	conf->webserver.serve_all.d.b = false;
+	conf->webserver.serve_all.c = validate_stub;
+
 	conf->webserver.tls.cert.k = "webserver.tls.cert";
 	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. All directories along the path must be readable and accessible by the user running FTL (typically 'pihole'). This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
 	conf->webserver.tls.cert.a = cJSON_CreateStringReference("<valid TLS certificate file (*.pem)>");

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -244,6 +244,7 @@ struct config {
 		struct conf_item port;
 		struct conf_item threads;
 		struct conf_item headers;
+		struct conf_item serve_all;
 		struct {
 			struct conf_item timeout;
 			struct conf_item restore;

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -87,7 +87,7 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	if(!config.webserver.serve_all.v.b &&
 	   strncmp(req_info->local_uri_raw, config.webserver.paths.webhome.v.s, strlen(config.webserver.paths.webhome.v.s)) != 0)
 	{
-		log_debug(DEBUG_API, "Not serving %s, returning 404", req_info->local_uri_raw);
+		log_debug(DEBUG_WEBSERVER, "Not serving %s, returning 404", req_info->local_uri_raw);
 		mg_send_http_error(conn, 404, "Not Found");
 		return 404;
 	}

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -80,6 +80,18 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 		return 0;
 	}
 
+	// Check if we are allowed to serve this directory by checking the
+	// configuration setting webserver.serve_all and the requested URI to
+	// start with something else than config.webserver.paths.webhome. If so,
+	// send error 404
+	if(!config.webserver.serve_all.v.b &&
+	   strncmp(req_info->local_uri_raw, config.webserver.paths.webhome.v.s, strlen(config.webserver.paths.webhome.v.s)) != 0)
+	{
+		log_debug(DEBUG_API, "Not serving %s, returning 404", req_info->local_uri_raw);
+		mg_send_http_error(conn, 404, "Not Found");
+		return 404;
+	}
+
 	// Build minimal api struct to check authentication
 	struct ftl_conn api = { 0 };
 	api.conn = conn;

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -135,7 +135,7 @@ static int redirect_lp_handler(struct mg_connection *conn, void *input)
 	if(!config.webserver.serve_all.v.b &&
 	   strncmp(uri, config.webserver.paths.webhome.v.s, strlen(config.webserver.paths.webhome.v.s)) != 0)
 	{
-		log_debug(DEBUG_API, "Not serving %s, returning 404", uri);
+		log_debug(DEBUG_WEBSERVER, "Not serving %s, returning 404", uri);
 		mg_send_http_error(conn, 404, "Not Found");
 		return 404;
 	}

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.0.3-14-gbb1ff28a-dirty)
+# Pi-hole configuration file (v6.0.4-20-g70547d28-dirty)
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-03-03 11:05:52 UTC
+# Last updated on 2025-03-07 18:48:00 UTC
 
 [dns]
   # Array of upstream DNS servers used by Pi-hole
@@ -706,6 +706,11 @@
     "Referrer-Policy: strict-origin-when-cross-origin"
   ]
 
+  # Should the web server serve all files in webserver.paths.webroot directory? If
+  # disabled, only files within the path defined through webserver.paths.webhome and
+  # /api will be served.
+  serve_all = false
+
   [webserver.session]
     # Session timeout in seconds. If a session is inactive for more than this time, it will
     # be terminated. Sessions are continuously refreshed by the web interface, preventing
@@ -1178,7 +1183,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 153 total entries out of which 96 entries are default
+# 154 total entries out of which 97 entries are default
 # --> 57 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1771,8 +1771,19 @@
   [[ ${lines[0]} == "0" ]]
 }
 
-# This test should run before a password it set
+@test "Lua server page outside /admin is not served by default" {
+  run bash -c 'curl -sI 127.0.0.1/broken_lua'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "HTTP/1.1 404 Not Found"* ]]
+}
+
+# This test should run before a password is set
 @test "Lua server page is generating proper backtrace" {
+  # Enable serving of Lua pages outside /admin
+  run bash -c './pihole-FTL --config webserver.serve_all true'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == 'true' ]]
+  run bash -c 'sleep 1'
   # Run a page with a syntax error
   run bash -c 'curl -s 127.0.0.1/broken_lua'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
# What does this implement/fix?

Add new `webserver.serve_all` option defaulting to `false`, controlling if we should serve any content outside `/admin` and `/api`.

---

**Related issue or feature (if applicable):** Fixes #2349 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.