### PR TITLE
Add new `GET /api/config/_properties` endpoint

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -88,6 +88,7 @@ static struct {
 	{ "/api/stats/database/summary",            "",                           api_stats_database_summary,            { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/stats/database/query_types",        "",                           api_stats_database_query_types,        { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/stats/database/upstreams",          "",                           api_stats_database_upstreams,          { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
+	{ "/api/config/_properties",                "",                           api_config_properties,                 { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/config",                            "",                           api_config,                            { API_PARSE_JSON, 0                         }, true,  HTTP_GET | HTTP_PATCH },
 	{ "/api/config",                            "/{element}",                 api_config,                            { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/config",                            "/{element}/{value}",         api_config,                            { API_PARSE_JSON, 0                         }, true,  HTTP_DELETE | HTTP_PUT },

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -79,6 +79,7 @@ int get_version_obj(struct ftl_conn *api, cJSON *version);
 
 // Config methods
 int api_config(struct ftl_conn *api);
+int api_config_properties(struct ftl_conn *api);
 int get_json_config(struct ftl_conn *api, cJSON *json, const bool detailed);
 cJSON *addJSONConfValue(const enum conf_type conf_type, union conf_value *val);
 

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -1152,6 +1152,11 @@ int api_config_properties(struct ftl_conn *api)
 			reason = "env_var";
 			description = "Set via environment variable";
 		}
+		else if(config.misc.readOnly.v.b)
+		{
+			reason = "read_only";
+			description = "Config is in read-only mode";
+		}
 		else if(conf_item->f & FLAG_READ_ONLY)
 		{
 			reason = "read_only";

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -1134,3 +1134,44 @@ int api_config(struct ftl_conn *api)
 
 	return 0;
 }
+
+int api_config_properties(struct ftl_conn *api)
+{
+	cJSON *read_only = JSON_NEW_ARRAY();
+
+	// Iterate over all known config elements
+	for(unsigned int i = 0; i < CONFIG_ELEMENTS; i++)
+	{
+		// Get pointer to memory location of this conf_item
+		struct conf_item *conf_item = get_conf_item(&config, i);
+
+		const char *reason = NULL;
+		const char *description = NULL;
+		if(conf_item->f & FLAG_ENV_VAR)
+		{
+			reason = "env_var";
+			description = "Set via environment variable";
+		}
+		else if(conf_item->f & FLAG_READ_ONLY)
+		{
+			reason = "read_only";
+			description = "Variable can only be set in pihole.toml, not via API";
+		}
+		else
+			continue;
+
+		cJSON *obj = JSON_NEW_OBJECT();
+		JSON_REF_STR_IN_OBJECT(obj, "key", conf_item->k);
+		JSON_REF_STR_IN_OBJECT(obj, "reason", reason);
+		JSON_REF_STR_IN_OBJECT(obj, "description", description);
+		JSON_ADD_ITEM_TO_ARRAY(read_only, obj);
+	}
+
+	// Build and return JSON response
+	cJSON *configj = JSON_NEW_OBJECT();
+	JSON_ADD_ITEM_TO_OBJECT(configj, "read_only", read_only);
+	cJSON *json = JSON_NEW_OBJECT();
+	JSON_ADD_ITEM_TO_OBJECT(json, "config", configj);
+	JSON_SEND_OBJECT(json);
+	return 0;
+}

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -175,6 +175,34 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
+    props:
+      get:
+        summary: Get special properties of your Pi-hole configuration
+        tags:
+          - "Pi-hole Configuration"
+        operationId: "get_config_props"
+        description: |
+          This API hook returns a list of special properties in your Pi-hole configuration.
+        responses:
+          '200':
+            description: OK
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'config.yaml#/components/schemas/props'
+                    - $ref: 'common.yaml#/components/schemas/took'
+                examples:
+                  props:
+                    $ref: 'config.yaml#/components/examples/props'
+          '401':
+            description: Unauthorized
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'common.yaml#/components/errors/unauthorized'
+                    - $ref: 'common.yaml#/components/schemas/took'
 
   schemas:
     config:
@@ -677,6 +705,26 @@ components:
                 description: Array of IPv6 addresses (if any)
                 items:
                   type: string
+    props:
+      type: object
+      properties:
+        config:
+          type: object
+          properties:
+            read_only:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The name of the read-only property
+                  reason:
+                    type: string
+                    description: The reason why this property is read-only (machine-readable)
+                  description:
+                    type: string
+                    description: A human-readable description of the read-only reason
 
   examples:
     config:
@@ -929,6 +977,17 @@ components:
           - name: OpenDNS (ECS, DNSSEC)
             v4: ["208.67.222.222", "208.67.220.220"]
             v6: ["2620:119:35::35","2620:119:53::53"]
+    props:
+      summary: All read-only properties
+      value:
+        config:
+          read_only:
+            - key: "misc.readOnly"
+              reason: "read_only"
+              description: "Variable can only be set in pihole.toml, not via API"
+            - key: "webserver.api.pwhash"
+              reason: "env_var"
+              description: "Set via environment variable"
     errors:
       bad_request:
         invalid_path_depth:

--- a/src/api/docs/content/specs/main.yaml
+++ b/src/api/docs/content/specs/main.yaml
@@ -234,6 +234,9 @@ paths:
   /config:
     $ref: 'config.yaml#/components/paths/config'
 
+  /config/_properties:
+    $ref: 'config.yaml#/components/paths/props'
+
   /config/{element}:
     $ref: 'config.yaml#/components/paths/config_elem'
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1895,7 +1895,7 @@ setup() {
   [[ ${lines[24]} == "" ]]
 }
 
-# This test should run before a password it set
+# This test should run before a password is set
 @test "Lua server page is generating proper backtrace" {
   # Enable serving of Lua pages outside /admin
   logsize_before=$(stat -c%s /var/log/pihole/FTL.log)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1865,6 +1865,37 @@ setup() {
 }
 
 # This test should run before a password is set
+@test "API: Config properties return as expected" {
+  run bash -c 'curl -s 127.0.0.1/api/config/_properties | jq .config'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "{" ]]
+  [[ ${lines[1]} == "  \"read_only\": [" ]]
+  [[ ${lines[2]} == "    {" ]]
+  [[ ${lines[3]} == "      \"key\": \"misc.nice\"," ]]
+  [[ ${lines[4]} == "      \"reason\": \"env_var\"," ]]
+  [[ ${lines[5]} == "      \"description\": \"Set via environment variable\"" ]]
+  [[ ${lines[6]} == "    }," ]]
+  [[ ${lines[7]} == "    {" ]]
+  [[ ${lines[8]} == "      \"key\": \"misc.readOnly\"," ]]
+  [[ ${lines[9]} == "      \"reason\": \"read_only\"," ]]
+  [[ ${lines[10]} == "      \"description\": \"Variable can only be set in pihole.toml, not via API\"" ]]
+  [[ ${lines[11]} == "    }," ]]
+  [[ ${lines[12]} == "    {" ]]
+  [[ ${lines[13]} == "      \"key\": \"misc.check.shmem\"," ]]
+  [[ ${lines[14]} == "      \"reason\": \"env_var\"," ]]
+  [[ ${lines[15]} == "      \"description\": \"Set via environment variable\"" ]]
+  [[ ${lines[16]} == "    }," ]]
+  [[ ${lines[17]} == "    {" ]]
+  [[ ${lines[18]} == "      \"key\": \"debug.api\"," ]]
+  [[ ${lines[19]} == "      \"reason\": \"env_var\"," ]]
+  [[ ${lines[20]} == "      \"description\": \"Set via environment variable\"" ]]
+  [[ ${lines[21]} == "    }" ]]
+  [[ ${lines[22]} == "  ]" ]]
+  [[ ${lines[23]} == "}" ]]
+  [[ ${lines[24]} == "" ]]
+}
+
+# This test should run before a password it set
 @test "Lua server page is generating proper backtrace" {
   # Enable serving of Lua pages outside /admin
   logsize_before=$(stat -c%s /var/log/pihole/FTL.log)


### PR DESCRIPTION
# What does this implement/fix?

Add new `GET /api/config/_properties` endpoint listing read-only config items. It may be extended to more things later. See #2348 

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.