### PR TITLE
Use keep-alive

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -475,6 +475,8 @@ void http_init(void)
 		"authentication_domain", config.webserver.domain.v.s,
 		"additional_header", webheaders,
 		"index_files", "index.html,index.htm,index.lp",
+		"enable_keep_alive", "yes",
+		"keep_alive_timeout_ms", "5000",
 		NULL, NULL,
 		NULL, NULL, // Leave slots for access control list (ACL) and TLS configuration at the end
 		NULL


### PR DESCRIPTION
# What does this implement/fix?

Use HTTP/1.1 keep-alive to allows clients to reuse TCP connection for subsequent HTTP requests, which **can improve performance dramatically** as no further TLS handshakes and connection opening/closing are required. This reduces pressure especially on low-end hardware lacking hardware-crypto for TLS.

This is disabled by default in CivetWeb as it puts additional compliance constraints on the request handlers. However, Pi-hole's API already fully complies with these additional constraints so no other changes than enabling this are needed.

We set a default timeout of 5 seconds after which the server closes the ready-to-be-used-again connections to free them for other requests. We intentionally keep such a long timeout so that requests being fired on the background (e.g. the regular update of `GET /api/summary`) can benefit here as well without needing additional handshakes.

Note that, while this reduces the overhead for opening and closing connections when loading several resources from one server, it also blocks one port and one thread at the server during the lifetime of this connection. Unfortunately, most browsers do not seem to close the keep-alive connection after loading all resources required to show a website. The server closes a keep-alive connection, if there is no additional request from the client during this timeout. If there are really many clients using the webserver at the same time, this may require you to increase `webserver.threads` when you see timeouts.

> [!NOTE]
> Don't get me wrong here. This does *not* reduce the number of TLS handshakes from, say, 35 to 1. It just allows already established connections to be reused. If the web interface makes five requests *exactly* parallel, there will be five handshakes. 
> However, if requests happens sequentially, the total number of handshakes is drastically reduced (see TL;DR below). Even on my fairly fast `x86_64` microserver running Pi-hole the speed enhancement was noticeable.
>
> TL;DR: On `development`, we see roughly 70 individual TLS handshakes but **only six** on this branch.

## Before this PR
Each connection needed a connection-establishment incl. a TLS handshake *on its own*.

![Screenshot from 2025-03-08 09-51-30](https://github.com/user-attachments/assets/be0edbf4-1104-4497-b368-103b12afdeea)
![Screenshot from 2025-03-08 09-50-59](https://github.com/user-attachments/assets/c9ac7f16-e15b-4951-86f6-107df0f0b516)

## After this PR
Only the first connection needs the full handshake, following connections can reuse the existing connection *without* having to do any additional handshaking *on their own*.

![Screenshot from 2025-03-08 09-52-09](https://github.com/user-attachments/assets/a8a20ddd-a909-4e47-a75e-6e96d40e0c98)
![Screenshot from 2025-03-08 09-51-27](https://github.com/user-attachments/assets/d83c7f93-1472-4765-a078-9a0d8add8d82)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.