### PR TITLE
Default-off 0x20 encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ version~
 .vscode/*
 !.vscode/c_cpp_properties.json
 /build/
+.codechecker/
 
 # __pycache__ files (API tests)
 __pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,6 @@ set(CMAKE_C_STANDARD 17)
 
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.91rc5+1)
+set(DNSMASQ_VERSION pi-hole-v2.91rc5+2)
 
 add_subdirectory(src)

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -283,7 +283,8 @@ struct event_desc {
 #define OPT_LOCALHOST_SERVICE  72
 #define OPT_LOG_PROTO      73
 #define OPT_NO_0x20        74
-#define OPT_LAST           75
+#define OPT_DO_0x20        75
+#define OPT_LAST           76
 
 #define OPTION_BITS (sizeof(unsigned int)*8)
 #define OPTION_SIZE ( (OPT_LAST/OPTION_BITS)+((OPT_LAST%OPTION_BITS)!=0) )

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -402,7 +402,7 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
       forward->new_id = get_id();
       header->id = ntohs(forward->new_id);
       
-      forward->frec_src.encode_bitmap = option_bool(OPT_NO_0x20) ? 0 : rand32();
+      forward->frec_src.encode_bitmap = (!option_bool(OPT_NO_0x20) && option_bool(OPT_DO_0x20)) ? rand32() : 0;
       forward->frec_src.encode_bigmap = NULL;
       p = (unsigned char *)(header+1);
       if (!extract_name(header, plen, &p, (char *)&forward->frec_src.encode_bitmap, EXTR_NAME_FLIP, 1))
@@ -3342,12 +3342,12 @@ static struct frec *lookup_frec(char *target, int class, int rrtype, int id, int
   struct dns_header *header;
   int compare_mode = EXTR_NAME_COMPARE;
 
-  /* Only compare case-sensitive when matching frec to a recieved answer,
+  /* Only compare case-sensitive when matching frec to a received answer,
      NOT when looking for a duplicated question. */
   if (flags & FREC_ANSWER)
     {
       flags &= ~FREC_ANSWER;
-      if (!option_bool(OPT_NO_0x20))
+      if (!option_bool(OPT_NO_0x20) && option_bool(OPT_DO_0x20))
 	compare_mode = EXTR_NAME_NOCASE;
     }
   

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -198,6 +198,7 @@ struct myoption {
 #define LOPT_DNSSEC_LIMITS 385
 #define LOPT_PXE_OPT       386
 #define LOPT_NO_ENCODE     387
+#define LOPT_DO_ENCODE     388
 
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -253,6 +254,7 @@ static const struct myoption opts[] =
     { "no-negcache", 0, 0, 'N' },
     { "no-round-robin", 0, 0, LOPT_NORR },
     { "no-0x20-encode", 0, 0, LOPT_NO_ENCODE },
+    { "do-0x20-encode", 0, 0, LOPT_DO_ENCODE },
     { "cache-rr", 1, 0, LOPT_CACHE_RR },
     { "addn-hosts", 1, 0, 'H' },
     { "hostsdir", 1, 0, LOPT_HOST_INOTIFY },
@@ -598,6 +600,7 @@ static struct {
   { LOPT_QUIET_TFTP, OPT_QUIET_TFTP, NULL, gettext_noop("Do not log routine TFTP."), NULL },
   { LOPT_NORR, OPT_NORR, NULL, gettext_noop("Suppress round-robin ordering of DNS records."), NULL },
   { LOPT_NO_ENCODE, OPT_NO_0x20, NULL, gettext_noop("Suppress DNS bit 0x20 encoding."), NULL },
+  { LOPT_DO_ENCODE, OPT_DO_0x20, NULL, gettext_noop("Enable DNS bit 0x20 encoding."), NULL },
   { LOPT_NO_IDENT, OPT_NO_IDENT, NULL, gettext_noop("Do not add CHAOS TXT records."), NULL },
   { LOPT_CACHE_RR, ARG_DUP, "<RR-type>", gettext_noop("Cache this DNS resource record type."), NULL },
   { LOPT_MAX_PROCS, ARG_ONE, "<integer>", gettext_noop("Maximum number of concurrent tcp connections."), NULL },


### PR DESCRIPTION
# What does this implement/fix?

Default-off 0x20 encoding and provide `do-0x20-encode` config option to enable. For now, this causes too many problems to default on.

We keep the `no-0x20-encode` config option as to not break user systems complaining about an unknown/invalid config option. You now have to have `do-0x20-encode` and **not** `no-0x20-encode` for the feature to be active. In case you have `no-0x20-encode`, it always wins and the feature stays off even when `do-0x20-encode` is set. This seems to be the best compromise to ensure backwards compatibility...

---

**Related issue or feature (if applicable):** Many reported issues, most

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.