### PR TITLE
Do not update webserver.threads in-place

### DIFF
--- a/src/config/toml_reader.c
+++ b/src/config/toml_reader.c
@@ -197,7 +197,10 @@ bool readFTLtoml(struct config *oldconf, struct config *newconf,
 		{
 			log_debug(DEBUG_CONFIG, "%s CHANGED", new_conf_item->k);
 			if(new_conf_item->f & FLAG_RESTART_FTL && restart != NULL)
+			{
+				log_info("Restarting FTL due to change of %s", new_conf_item->k);
 				*restart = true;
+			}
 
 			// Check if this item changed the password, if so, we need to
 			// invalidate all currently active sessions
@@ -208,7 +211,10 @@ bool readFTLtoml(struct config *oldconf, struct config *newconf,
 
 	// Migrate config from old to new
 	if(migrate_config(toml, newconf) && restart != NULL)
+	{
+		log_info("Restarting FTL due to migration of configuration");
 		*restart = true;
+	}
 
 	// Report debug config if enabled
 	set_debug_flags(newconf);

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -418,16 +418,19 @@ void http_init(void)
 
 	// Get maximum number of threads for webserver
 	char num_threads[16] = { 0 };
-	if(config.webserver.threads.v.ui == 0)
+	unsigned int threads = config.webserver.threads.v.ui;
+	if(threads == 0)
 	{
 		// For compatibility with older versions, set the number of
 		// threads to the default value (50) if it was 0. Before Pi-hole
 		// FTL v6.0.4, the number of threads was computed in dependence
 		// of the number of CPUs available. This is no longer the case.
-		config.webserver.threads.v.ui = 50;
+		threads = 50;
 	}
 
-	snprintf(num_threads, sizeof(num_threads), "%u", config.webserver.threads.v.ui);
+	snprintf(num_threads, sizeof(num_threads), "%u", threads);
+
+	// Ensure null termination for safety
 	num_threads[sizeof(num_threads) - 1] = '\0';
 
 	/* Initialize the library */


### PR DESCRIPTION
# What does this implement/fix?

This fixes FTL restarting for every (!) config change when webserver.threads = 0 and *any* other config setting is changed, e.g., any of the debug flags out of which none should be triggering a full restart of FTL.

This bug is part of v6.0.4. It is a regression of https://github.com/pi-hole/FTL/commit/2aeccfbe126c29f94bb1dc7e3ea261bd38a20b3f. I'm not aware of any reports out in the wild. I furthermore added logging for the particular reason a restart was necessary.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.