### PR TITLE
Add new Lua function pihole.format_path()

### DIFF
--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -240,6 +240,34 @@ static int pihole_needLogin(lua_State *L) {
 	return 1; // number of results
 }
 
+// pihole.format_path()
+static int pihole_format_path(lua_State *L) {
+	// Get current page (first argument to LUA function)
+	const char *page = luaL_checkstring(L, 1);
+
+	// Strip leading webhome from page (if it exists)
+	if (config.webserver.paths.webhome.v.s != NULL)
+	{
+		const size_t webhome_len = strlen(config.webserver.paths.webhome.v.s);
+		if (strncmp(page, config.webserver.paths.webhome.v.s, webhome_len) == 0)
+			page += webhome_len;
+	}
+
+	// Convert all / to -
+	for (char *p = (char *)page; *p != '\0'; p++)
+		if (*p == '/')
+			*p = '-';
+
+	// Substitute "index" for empty string (dashboard landing page)
+	if (page[0] == '\0')
+		page = "index";
+
+	// Return the formatted page string
+	lua_pushstring(L, page);
+
+	return 1; // number of results
+}
+
 static const luaL_Reg piholelib[] = {
 	{"ftl_version", pihole_ftl_version},
 	{"hostname", pihole_hostname},
@@ -249,6 +277,7 @@ static const luaL_Reg piholelib[] = {
 	{"include", pihole_include},
 	{"boxedlayout", pihole_boxedlayout},
 	{"needLogin", pihole_needLogin},
+	{"format_path", pihole_format_path},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Add new Lua function pihole.format_path() which may be used to translate local URIs (like "/admin/settings/dns") to a more usable string (like "settings-dns").

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.