### PR TITLE
Fix docs for lists batchDelete

### DIFF
--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -194,7 +194,24 @@ components:
           content:
             application/json:
               schema:
-                $ref: 'lists.yaml#/components/schemas/lists/post'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    item:
+                      type: string
+                      description: group name
+                    type:
+                      type: string
+                      enum:
+                        - "allow"
+                        - "block"
+                      description: Type of list
+                example:
+                  - item: "https://hosts-file.net/ad_servers.txt"
+                    type: "block"
+                  - item: "https://hosts-file.net/ad_servers2.txt"
+                    type: "block"
         responses:
           '204':
             description: Items deleted


### PR DESCRIPTION
# What does this implement/fix?

Fix documentation for the lists `batchDelete` endpoint. It was incorrectly referring to the `POST /lists` semantics.

---

**Related issue or feature (if applicable):** Fixes #2377 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.