### PR TITLE
Fix logfile warning port length truncation (bug #2408)

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3885,7 +3885,7 @@ void FTL_connection_error(const char *reason, const union mysockaddr *addr, cons
 		char *server = NULL;
 		if(ip[0] != '\0')
 		{
-			const size_t len = strlen(ip) + 6;
+			const size_t len = strlen(ip) + 7;
 			server = calloc(len, sizeof(char));
 			if(server != NULL)
 			{


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allow the logging of 5 digit port numbers in logfile warning swithout truncation. Bug #2408, as reported on discourse.pi-hole.net

Increases the size of the string that will store the combined server ip & port number.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
