### PR TITLE
Fix duplicate web port information output in FTL startup

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -666,9 +666,6 @@ void http_init(void)
 		return;
 	}
 
-	// Get server ports
-	get_server_ports();
-
 	// Register API handler, use "/api" even when a prefix is defined as the
 	// prefix should be stripped away by the reverse proxy
 	mg_set_request_handler(ctx, "/api", api_handler, NULL);


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Stops this from happening:

```
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO: Web server ports:
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - 0.0.0.0:80 (HTTP, IPv4, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - 0.0.0.0:443 (HTTPS, IPv4, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - [::]:80 (HTTP, IPv6, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - [::]:443 (HTTPS, IPv6, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO: Web server ports:
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - 0.0.0.0:80 (HTTP, IPv4, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - 0.0.0.0:443 (HTTPS, IPv4, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - [::]:80 (HTTP, IPv6, optional, OK)
pihole  | 2025-04-02 17:27:37.400 BST [52M] INFO:   - [::]:443 (HTTPS, IPv6, optional, OK)
```

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_