### PR TITLE
Chck for existing clock disciplining NTP client on FTL start

### DIFF
--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -747,6 +747,16 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 		return false;
 	}
 
+	// Return early if a clock disciplining NTP client is detected
+	// Checks chrony, the ntp family (ntp, ntpsec and openntpd), and ntpd-rs
+	if((system ("pidof -x chronyd") == 0) ||
+	   (system ("pidof -x ntpd") == 0) ||
+	   (system ("pidof -x ntp-daemon") == 0))
+	{
+		log_info("Clock disciplining NTP client detected, not starting NTP sync");
+		return false;
+	}
+
 	// Check if we have the ambient capabilities to set the system time.
 	// Without CAP_SYS_TIME, we cannot set the system time and the NTP
 	// client will not be able to synchronize the time so there is no point


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Prevent Pi-hole's ntp sync from disrupting clock disciplining ntp clients already installed and active.

Fixes Pi-hole #6139 - https://discourse.pi-hole.net/t/built-in-ntp-server/78404

**How does this PR accomplish the above?:**

Tests for presence of a daemon process related to chrony, the ntp family (ntp, ntpsec and openntpd), or ntpd-rs.
If any of these are identified, do not synchronise the time.

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
