### PR TITLE
Fix redirecting when redirecting from /admin/ to /admin/login and back

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -10,8 +10,6 @@
 #ifndef ROUTES_H
 #define ROUTES_H
 
-// struct mg_connection
-#include "webserver/civetweb/civetweb.h"
 // type cJSON
 #include "webserver/cJSON/cJSON.h"
 #include "webserver/http-common.h"

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -20,6 +20,8 @@
 #include "log.h"
 // directory_exists()
 #include "files.h"
+// ftl_http_redirect()
+#include "webserver.h"
 
 static char *login_uri = NULL, *admin_api_uri = NULL;
 void allocate_lua(char *login_uri_in, char *admin_api_uri_in)
@@ -114,8 +116,9 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 			// User is not authenticated, redirect to login page
 			log_web("Authentication required, redirecting to %s%slogin",
 			        config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
-			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %s%slogin\r\n\r\n",
-			          config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
+			ftl_http_redirect(conn, 302, "%s%slogin",
+			                  config.webserver.paths.prefix.v.s,
+			                  config.webserver.paths.webhome.v.s);
 			return 302;
 		}
 	}
@@ -125,11 +128,12 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 		// Check if the user is authenticated
 		if(authorized)
 		{
-			// User is already authenticated, redirect to index page
+			// User is already authenticated, redirecting to index page
 			log_web("User is already authenticated, redirecting to %s%s",
 			        config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
-			mg_printf(conn, "HTTP/1.1 302 Found\r\nLocation: %s%s\r\n\r\n",
-			          config.webserver.paths.prefix.v.s, config.webserver.paths.webhome.v.s);
+			ftl_http_redirect(conn, 302, "%s%s",
+			                  config.webserver.paths.prefix.v.s,
+			                  config.webserver.paths.webhome.v.s);
 			return 302;
 		}
 	}

--- a/src/webserver/webserver.h
+++ b/src/webserver/webserver.h
@@ -11,6 +11,10 @@
 #define WEBSERVER_H
 
 #include <stdbool.h>
+// in_port_t
+#include <netinet/in.h>
+// struct mg_connection
+#include "webserver/civetweb/civetweb.h"
 
 // Hard-coded maximum number of allowed web server threads
 #define MAX_WEBTHREADS 64
@@ -20,6 +24,7 @@
 void http_init(void);
 void http_terminate(void);
 
+int ftl_http_redirect(struct mg_connection *conn, const int code, const char *format, ...) __attribute__((format(printf, 3, 4), nonnull(1, 3)));
 in_port_t get_https_port(void) __attribute__((pure));
 unsigned short get_api_string(char **buf, const bool domain);
 char *get_prefix_webhome(void) __attribute__((pure));


### PR DESCRIPTION
# What does this implement/fix?

User proper redirection functions instead of messing about with HTTP headers ourselves. Yes, simply adding `Content-Length: 0` would have been a equally working fix, but doing it like this is more future-proof.

**Related issue or feature (if applicable):** Fixes #2412 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.