### PR TITLE
Check for existing NTP client when starting FTL

### DIFF
--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -41,6 +41,8 @@
 #include "database/message-table.h"
 // check_capability()
 #include "capabilities.h"
+// search_proc()
+#include "procps.h"
 
 // Required accuracy of the NTP sync in seconds in order to start the NTP server
 // thread. If the NTP sync is less accurate than this value, the NTP server
@@ -744,6 +746,13 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 	{
 		log_info("NTP sync is disabled");
 		ntp_server_start();
+		return false;
+	}
+	// Return early if a clock disciplining NTP client is detected
+	// Checks chrony, the ntp family (ntp, ntpsec and openntpd), and ntpd-rs
+	if(search_proc("chronyd") > 0 || search_proc("ntpd") > 0 || search_proc("ntp-daemon") > 0)
+	{
+		log_info("Clock disciplining NTP client detected, not starting embedded NTP client/server");
 		return false;
 	}
 

--- a/src/procps.c
+++ b/src/procps.c
@@ -359,3 +359,59 @@ bool parse_proc_stat(unsigned long *total_sum, unsigned long *idle_sum)
 
 	return true;
 }
+
+/**
+ * @brief Searches for a process by its name in the /proc filesystem.
+ *
+ * This function iterates through the directories in /proc, which represent
+ * process IDs (PIDs), and checks the "comm" file in each directory to find
+ * a process with a matching name.
+ *
+ * @param name The name of the process to search for.
+ *
+ * @return The PID of the process if found, or -1 if no matching process is found
+ *         or if an error occurs (e.g., unable to open /proc or a file).
+ *
+ * @note This function assumes the /proc filesystem is available and accessible.
+ *       It also assumes that the "comm" file in each process directory contains
+ *       the name of the process.
+ */
+pid_t search_proc(const char *name)
+{
+	DIR *dir = opendir("/proc");
+	if(dir == NULL)
+		return -1;
+
+	struct dirent *entry;
+	while((entry = readdir(dir)) != NULL)
+	{
+		// Check if the entry is a directory and contains only digits
+		// We skip ".", "..", "self", and friends
+		if(entry->d_type == DT_DIR && isdigit(entry->d_name[0]))
+		{
+			char filename[64];
+			snprintf(filename, sizeof(filename), "/proc/%s/comm", entry->d_name);
+			FILE *file = fopen(filename, "r");
+			if(file != NULL)
+			{
+				char comm[PROC_PATH_SIZ + 1] = { 0 };
+				// Read the command name from the file
+				if(fscanf(file, "%"xstr(PROC_PATH_SIZ)"s", comm) == 1)
+				{
+					if(strcmp(comm, name) == 0)
+					{
+						// Found a matching process
+						fclose(file);
+						closedir(dir);
+						return atoi(entry->d_name);
+					}
+				}
+				fclose(file);
+			}
+		}
+	}
+
+	// No process found with the given name
+	closedir(dir);
+	return -1;
+}

--- a/src/procps.h
+++ b/src/procps.h
@@ -49,5 +49,6 @@ struct proc_meminfo {
 bool getProcessMemory(struct proc_mem *mem, const unsigned long total_memory);
 bool parse_proc_meminfo(struct proc_meminfo *mem);
 bool parse_proc_stat(unsigned long *total_sum, unsigned long *idle_sum);
+pid_t search_proc(const char *name);
 
 #endif // PROCPS_H


### PR DESCRIPTION
# What does this implement/fix?

> What does this PR aim to accomplish?:
> 
> Prevent Pi-hole's ntp sync from disrupting clock disciplining ntp clients already installed and active.
> 
> Fixes Pi-hole #6139 - https://discourse.pi-hole.net/t/built-in-ntp-server/78404
>
> How does this PR accomplish the above?:
>
> Tests for presence of a daemon process related to chrony, the ntp family (ntp, ntpsec and openntpd), or ntpd-rs.
> If any of these are identified, do not synchronise the time.

This PR is an alternative implementation of #2414 

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.