### PR TITLE
Report RFC6598 shared address space as "Carrier-Grade NAT"

### DIFF
--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -421,6 +421,8 @@ static int nlparsemsg_address(struct ifaddrmsg *ifa, void *buf, size_t len, cJSO
 						cJSON_AddStringToObject(addr, type_str, "multicast");
 					else if(private_net(*in, false))
 						cJSON_AddStringToObject(addr, type_str, "private");
+					else if((in->s_addr & htonl(0xffc00000)) == htonl(0x64400000))
+						cJSON_AddStringToObject(addr, type_str, "shared");
 					else
 						cJSON_AddStringToObject(addr, type_str, "public");
 				}

--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -422,7 +422,8 @@ static int nlparsemsg_address(struct ifaddrmsg *ifa, void *buf, size_t len, cJSO
 					else if(private_net(*in, false))
 						cJSON_AddStringToObject(addr, type_str, "private");
 					else if((in->s_addr & htonl(0xffc00000)) == htonl(0x64400000))
-						cJSON_AddStringToObject(addr, type_str, "shared");
+						// RFC 6598: Carrier-Grade NAT (CGN) 100.64.0.0/10
+						cJSON_AddStringToObject(addr, type_str, "Carrier-Grade NAT");
 					else
 						cJSON_AddStringToObject(addr, type_str, "public");
 				}


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Report addresses within the RFC6598 shared address space as Carrier-Grade NAT

Issue raised in #2422 of these addresses being misidentified as "public"

**How does this PR accomplish the above?:**

Adds detection for addresses falling within 100.64.0.0/8 to the address type logic, instead of them falling through to the "public" catch-all.

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
