### PR TITLE
Use CODEOWNERS instead of deprecated dependbot/reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @pi-hole/ftl-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: development
-  reviewers:
-    - "pi-hole/ftl-maintainers"
   pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       separator: "-"
@@ -25,8 +23,6 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: development
-  reviewers:
-    - "pi-hole/ftl-maintainers"
   pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       separator: "-"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Dependabot will drop the 'reviewer' option. One should use CODEOWNER file instead.
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
