### PR TITLE
Modify how we use xxd to compile assets into the FTL binary

### DIFF
--- a/src/api/docs/CMakeLists.txt
+++ b/src/api/docs/CMakeLists.txt
@@ -9,37 +9,37 @@
 # Please see LICENSE file for your rights under this license.
 
 set(sources
-        hex/index.html
-        hex/index.css
-        hex/pi-hole.js
-        hex/external/rapidoc-min.js
-        hex/external/rapidoc-min.js.map
-        hex/external/highlight.min.js
-        hex/external/highlight-default.min.css
-        hex/images/logo.svg
-        hex/images/favicon.ico
-        hex/specs/action.yaml
-        hex/specs/auth.yaml
-        hex/specs/clients.yaml
-        hex/specs/config.yaml
-        hex/specs/common.yaml
-        hex/specs/dhcp.yaml
-        hex/specs/dns.yaml
-        hex/specs/docs.yaml
-        hex/specs/domains.yaml
-        hex/specs/endpoints.yaml
-        hex/specs/groups.yaml
-        hex/specs/history.yaml
-        hex/specs/info.yaml
-        hex/specs/lists.yaml
-        hex/specs/logs.yaml
-        hex/specs/main.yaml
-        hex/specs/network.yaml
-        hex/specs/padd.yaml
-        hex/specs/queries.yaml
-        hex/specs/search.yaml
-        hex/specs/stats.yaml
-        hex/specs/teleporter.yaml
+        hex/index_html.h
+        hex/index_css.h
+        hex/pi-hole_js.h
+        hex/external/rapidoc-min_js.h
+        hex/external/rapidoc-min_js_map.h
+        hex/external/highlight_min_js.h
+        hex/external/highlight-default_min_css.h
+        hex/images/logo_svg.h
+        hex/images/favicon_ico.h
+        hex/specs/action_yaml.h
+        hex/specs/auth_yaml.h
+        hex/specs/clients_yaml.h
+        hex/specs/config_yaml.h
+        hex/specs/common_yaml.h
+        hex/specs/dhcp_yaml.h
+        hex/specs/dns_yaml.h
+        hex/specs/docs_yaml.h
+        hex/specs/domains_yaml.h
+        hex/specs/endpoints_yaml.h
+        hex/specs/groups_yaml.h
+        hex/specs/history_yaml.h
+        hex/specs/info_yaml.h
+        hex/specs/lists_yaml.h
+        hex/specs/logs_yaml.h
+        hex/specs/main_yaml.h
+        hex/specs/network_yaml.h
+        hex/specs/padd_yaml.h
+        hex/specs/queries_yaml.h
+        hex/specs/search_yaml.h
+        hex/specs/stats_yaml.h
+        hex/specs/teleporter_yaml.h
         docs.c
         )
 
@@ -54,10 +54,12 @@ find_program(RESOURCE_COMPILER xxd)
 file(GLOB_RECURSE COMPILED_RESOURCES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/content" "content/*")
 foreach(INPUT_FILE ${COMPILED_RESOURCES})
     set(IN ${CMAKE_CURRENT_SOURCE_DIR}/content/${INPUT_FILE})
-    set(OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/hex/${INPUT_FILE})
+    string(REPLACE "." "_" INPUT_FILE_MODIFIED ${INPUT_FILE})
+    string(REPLACE "/" "_" VARIABLE_NAME ${INPUT_FILE})
+    set(OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/hex/${INPUT_FILE_MODIFIED}.h)
     add_custom_command(
-        OUTPUT hex/${INPUT_FILE}
-        COMMAND ${RESOURCE_COMPILER} -i < ${IN} > ${OUTPUT_FILE}
+        OUTPUT hex/${INPUT_FILE_MODIFIED}.h
+        COMMAND ${RESOURCE_COMPILER} -iC -n ${VARIABLE_NAME} - < ${IN} | sed "s/unsigned /static const unsigned /" > ${OUTPUT_FILE}
         COMMENT "Compiling ${INPUT_FILE}"
         VERBATIM)
     list(APPEND COMPILED_RESOURCES ${OUTPUT_FILE})

--- a/src/api/docs/docs.h
+++ b/src/api/docs/docs.h
@@ -16,130 +16,37 @@
 #include "webserver/json_macros.h"
 #include "api/api.h"
 
-static const unsigned char index_html[] = {
-#include "hex/index.html"
-};
-
-static const unsigned char index_css[] = {
-#include "hex/index.css"
-};
-
-static const unsigned char pi_hole_js[] = {
-#include "hex/pi-hole.js"
-};
-
-static const unsigned char rapidoc_min_js[] = {
-#include "hex/external/rapidoc-min.js"
-};
-
-static const unsigned char rapidoc_min_js_map[] = {
-#include "hex/external/rapidoc-min.js.map"
-};
-
-static const unsigned char highlight_default_min_css[] = {
-#include "hex/external/highlight-default.min.css"
-};
-
-static const unsigned char highlight_min_js[] = {
-#include "hex/external/highlight.min.js"
-};
-
-static const unsigned char images_logo_svg[] = {
-#include "hex/images/logo.svg"
-};
-
-static const unsigned char images_favicon_ico[] = {
-#include "hex/images/favicon.ico"
-};
-
-static const unsigned char specs_auth_yaml[] = {
-#include "hex/specs/auth.yaml"
-};
-
-static const unsigned char specs_clients_yaml[] = {
-#include "hex/specs/clients.yaml"
-};
-
-static const unsigned char specs_common_yaml[] = {
-#include "hex/specs/common.yaml"
-};
-
-static const unsigned char specs_dhcp_yaml[] = {
-#include "hex/specs/dhcp.yaml"
-};
-
-static const unsigned char specs_dns_yaml[] = {
-#include "hex/specs/dns.yaml"
-};
-
-static const unsigned char specs_docs_yaml[] = {
-#include "hex/specs/docs.yaml"
-};
-
-static const unsigned char specs_domains_yaml[] = {
-#include "hex/specs/domains.yaml"
-};
-
-static const unsigned char specs_info_yaml[] = {
-#include "hex/specs/info.yaml"
-};
-
-static const unsigned char specs_groups_yaml[] = {
-#include "hex/specs/groups.yaml"
-};
-
-static const unsigned char specs_history_yaml[] = {
-#include "hex/specs/history.yaml"
-};
-
-static const unsigned char specs_lists_yaml[] = {
-#include "hex/specs/lists.yaml"
-};
-
-static const unsigned char specs_main_yaml[] = {
-#include "hex/specs/main.yaml"
-};
-
-static const unsigned char specs_queries_yaml[] = {
-#include "hex/specs/queries.yaml"
-};
-
-static const unsigned char specs_stats_yaml[] = {
-#include "hex/specs/stats.yaml"
-};
-
-static const unsigned char specs_config_yaml[] = {
-#include "hex/specs/config.yaml"
-};
-
-static const unsigned char specs_network_yaml[] = {
-#include "hex/specs/network.yaml"
-};
-
-static const unsigned char specs_logs_yaml[] = {
-#include "hex/specs/logs.yaml"
-};
-
-static const unsigned char specs_endpoints_yaml[] = {
-#include "hex/specs/endpoints.yaml"
-};
-
-static const unsigned char specs_teleporter_yaml[] = {
-#include "hex/specs/teleporter.yaml"
-};
-
-static const unsigned char specs_search_yaml[] = {
-#include "hex/specs/search.yaml"
-};
-
-static const unsigned char specs_action_yaml[] = {
-#include "hex/specs/action.yaml"
-};
-
-static const unsigned char specs_padd_yaml[] = {
-#include "hex/specs/padd.yaml"
-};
-
+#include "hex/index_html.h"
+#include "hex/index_css.h"
+#include "hex/pi-hole_js.h"
+#include "hex/external/rapidoc-min_js.h"
+#include "hex/external/rapidoc-min_js_map.h"
+#include "hex/external/highlight-default_min_css.h"
+#include "hex/external/highlight_min_js.h"
+#include "hex/images/logo_svg.h"
+#include "hex/images/favicon_ico.h"
+#include "hex/specs/auth_yaml.h"
+#include "hex/specs/clients_yaml.h"
+#include "hex/specs/common_yaml.h"
+#include "hex/specs/dhcp_yaml.h"
+#include "hex/specs/dns_yaml.h"
+#include "hex/specs/docs_yaml.h"
+#include "hex/specs/domains_yaml.h"
+#include "hex/specs/info_yaml.h"
+#include "hex/specs/groups_yaml.h"
+#include "hex/specs/history_yaml.h"
+#include "hex/specs/lists_yaml.h"
+#include "hex/specs/main_yaml.h"
+#include "hex/specs/queries_yaml.h"
+#include "hex/specs/stats_yaml.h"
+#include "hex/specs/config_yaml.h"
+#include "hex/specs/network_yaml.h"
+#include "hex/specs/logs_yaml.h"
+#include "hex/specs/endpoints_yaml.h"
+#include "hex/specs/teleporter_yaml.h"
+#include "hex/specs/search_yaml.h"
+#include "hex/specs/action_yaml.h"
+#include "hex/specs/padd_yaml.h"
 struct {
     const char *path;
     const char *mime_type;
@@ -147,37 +54,37 @@ struct {
     const size_t content_size;
 } docs_files[] =
 {
-    {"index.html", "text/html", (const char*)index_html, sizeof(index_html)},
-    {"index.css", "text/css", (const char*)index_css, sizeof(index_css)},
-    {"pi-hole.js", "application/javascript", (const char*)pi_hole_js, sizeof(pi_hole_js)},
-    {"external/rapidoc-min.js", "application/javascript", (const char*)rapidoc_min_js, sizeof(rapidoc_min_js)},
-    {"external/rapidoc-min.js.map", "text/plain", (const char*)rapidoc_min_js_map, sizeof(rapidoc_min_js_map)},
-    {"external/highlight-default.min.css", "text/css", (const char*)highlight_default_min_css, sizeof(highlight_default_min_css)},
-    {"external/highlight.min.js", "application/javascript", (const char*)highlight_min_js, sizeof(highlight_min_js)},
-    {"images/logo.svg", "image/svg+xml", (const char*)images_logo_svg, sizeof(images_logo_svg)},
-    {"images/favicon.ico", "image/ico", (const char*)images_favicon_ico, sizeof(images_favicon_ico)},
-    {"specs/auth.yaml", "text/plain", (const char*)specs_auth_yaml, sizeof(specs_auth_yaml)},
-    {"specs/clients.yaml", "text/plain", (const char*)specs_clients_yaml, sizeof(specs_clients_yaml)},
-    {"specs/config.yaml", "text/plain", (const char*)specs_config_yaml, sizeof(specs_config_yaml)},
-    {"specs/common.yaml", "text/plain", (const char*)specs_common_yaml, sizeof(specs_common_yaml)},
-    {"specs/dhcp.yaml", "text/plain", (const char*)specs_dhcp_yaml, sizeof(specs_dhcp_yaml)},
-    {"specs/dns.yaml", "text/plain", (const char*)specs_dns_yaml, sizeof(specs_dns_yaml)},
-    {"specs/domains.yaml", "text/plain", (const char*)specs_domains_yaml, sizeof(specs_domains_yaml)},
-    {"specs/docs.yaml", "text/plain", (const char*)specs_docs_yaml, sizeof(specs_docs_yaml)},
-    {"specs/endpoints.yaml", "text/plain", (const char*)specs_endpoints_yaml, sizeof(specs_endpoints_yaml)},
-    {"specs/groups.yaml", "text/plain", (const char*)specs_groups_yaml, sizeof(specs_groups_yaml)},
-    {"specs/history.yaml", "text/plain", (const char*)specs_history_yaml, sizeof(specs_history_yaml)},
-    {"specs/info.yaml", "text/plain", (const char*)specs_info_yaml, sizeof(specs_info_yaml)},
-    {"specs/lists.yaml", "text/plain", (const char*)specs_lists_yaml, sizeof(specs_lists_yaml)},
-    {"specs/logs.yaml", "text/plain", (const char*)specs_logs_yaml, sizeof(specs_logs_yaml)},
-    {"specs/main.yaml", "text/plain", (const char*)specs_main_yaml, sizeof(specs_main_yaml)},
-    {"specs/network.yaml", "text/plain", (const char*)specs_network_yaml, sizeof(specs_network_yaml)},
-    {"specs/queries.yaml", "text/plain", (const char*)specs_queries_yaml, sizeof(specs_queries_yaml)},
-    {"specs/search.yaml", "text/plain", (const char*)specs_search_yaml, sizeof(specs_search_yaml)},
-    {"specs/stats.yaml", "text/plain", (const char*)specs_stats_yaml, sizeof(specs_stats_yaml)},
-    {"specs/teleporter.yaml", "text/plain", (const char*)specs_teleporter_yaml, sizeof(specs_teleporter_yaml)},
-    {"specs/action.yaml", "text/plain", (const char*)specs_action_yaml, sizeof(specs_action_yaml)},
-    {"specs/padd.yaml", "text/plain", (const char*)specs_padd_yaml, sizeof(specs_padd_yaml)},
+    {"index.html", "text/html", (const char*)index_html, index_html_len},
+    {"index.css", "text/css", (const char*)index_css, index_css_len},
+    {"pi-hole.js", "application/javascript", (const char*)pi_hole_js, pi_hole_js_len},
+    {"external/rapidoc-min.js", "application/javascript", (const char*)external_rapidoc_min_js, external_rapidoc_min_js_len},
+    {"external/rapidoc-min.js.map", "text/plain", (const char*)external_rapidoc_min_js_map, external_rapidoc_min_js_map_len},
+    {"external/highlight-default.min.css", "text/css", (const char*)external_highlight_default_min_css, external_highlight_default_min_css_len},
+    {"external/highlight.min.js", "application/javascript", (const char*)external_highlight_min_js, external_highlight_min_js_len},
+    {"images/logo.svg", "image/svg+xml", (const char*)images_logo_svg, images_logo_svg_len},
+    {"images/favicon.ico", "image/ico", (const char*)images_favicon_ico, images_favicon_ico_len},
+    {"specs/auth.yaml", "text/plain", (const char*)specs_auth_yaml, specs_auth_yaml_len},
+    {"specs/clients.yaml", "text/plain", (const char*)specs_clients_yaml, specs_clients_yaml_len},
+    {"specs/config.yaml", "text/plain", (const char*)specs_config_yaml, specs_config_yaml_len},
+    {"specs/common.yaml", "text/plain", (const char*)specs_common_yaml, specs_common_yaml_len},
+    {"specs/dhcp.yaml", "text/plain", (const char*)specs_dhcp_yaml, specs_dhcp_yaml_len},
+    {"specs/dns.yaml", "text/plain", (const char*)specs_dns_yaml, specs_dns_yaml_len},
+    {"specs/domains.yaml", "text/plain", (const char*)specs_domains_yaml, specs_domains_yaml_len},
+    {"specs/docs.yaml", "text/plain", (const char*)specs_docs_yaml, specs_docs_yaml_len},
+    {"specs/endpoints.yaml", "text/plain", (const char*)specs_endpoints_yaml, specs_endpoints_yaml_len},
+    {"specs/groups.yaml", "text/plain", (const char*)specs_groups_yaml, specs_groups_yaml_len},
+    {"specs/history.yaml", "text/plain", (const char*)specs_history_yaml, specs_history_yaml_len},
+    {"specs/info.yaml", "text/plain", (const char*)specs_info_yaml, specs_info_yaml_len},
+    {"specs/lists.yaml", "text/plain", (const char*)specs_lists_yaml, specs_lists_yaml_len},
+    {"specs/logs.yaml", "text/plain", (const char*)specs_logs_yaml, specs_logs_yaml_len},
+    {"specs/main.yaml", "text/plain", (const char*)specs_main_yaml, specs_main_yaml_len},
+    {"specs/network.yaml", "text/plain", (const char*)specs_network_yaml, specs_network_yaml_len},
+    {"specs/queries.yaml", "text/plain", (const char*)specs_queries_yaml, specs_queries_yaml_len},
+    {"specs/search.yaml", "text/plain", (const char*)specs_search_yaml, specs_search_yaml_len},
+    {"specs/stats.yaml", "text/plain", (const char*)specs_stats_yaml, specs_stats_yaml_len},
+    {"specs/teleporter.yaml", "text/plain", (const char*)specs_teleporter_yaml, specs_teleporter_yaml_len},
+    {"specs/action.yaml", "text/plain", (const char*)specs_action_yaml, specs_action_yaml_len},
+    {"specs/padd.yaml", "text/plain", (const char*)specs_padd_yaml, specs_padd_yaml_len},
 };
 
 #endif // API_DOCS_H


### PR DESCRIPTION
# What does this implement/fix?

Modify how we use `xxd` to compile assets into the FTL binary. This addresses the CodeQL concern that only valid header files should be included using `#include` pre-processor directives. In the end, it doesn't really matter but - as the same complaint is coming up on each addition/change of related files - we can modify the `xxd` compilation step to generate "proper" header files

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/pull/2445#discussion_r2075906032

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.