### PR TITLE
Set dns.interface to eth0 by default

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -528,7 +528,7 @@ static void initConfig(struct config *conf)
 	conf->dns.interface.a = cJSON_CreateStringReference("a valid interface name");
 	conf->dns.interface.t = CONF_STRING;
 	conf->dns.interface.f = FLAG_RESTART_FTL;
-	conf->dns.interface.d.s = (char*)"";
+	conf->dns.interface.d.s = (char*)"eth0";
 	conf->dns.interface.c = validate_stub; // Type-based checking + dnsmasq syntax checking
 
 	conf->dns.hostRecord.k = "dns.hostRecord";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -150,7 +150,7 @@
   #
   # Possible values are:
   #     a valid interface name
-  interface = ""
+  interface = "eth0"
 
   # Add A, AAAA and PTR records to the DNS. This adds one or more names to the DNS with
   # associated IPv4 (A) and IPv6 (AAAA) records


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Set `dns.interface` to `eth0?` by default. We already use `eth0` if no interface is set, but this PR makes this more obvious to the users.

https://github.com/pi-hole/FTL/blob/e0f96fee53413ce32cc0c95878d14de85cddda38/src/config/dnsmasq_config.c#L445-L448

Accompanies: https://github.com/pi-hole/pi-hole/pull/6216 and https://github.com/pi-hole/web/pull/3436

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
