### PR TITLE
[RFC] Prevent .internal queries from being upstreamed. Draft draft-davies-internal-tld-03

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -476,6 +476,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	// Add upstream DNS servers for reverse lookups
 	bool domain_revServer = false;
 	bool domain_homearpa = false;
+	bool domain_internal = false;
 	const unsigned int revServers = cJSON_GetArraySize(conf->dns.revServers.v.json);
 	for(unsigned int i = 0; i < revServers; i++)
 	{
@@ -530,6 +531,10 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 			// Flag if configured a server for queries for home.arpa domains
 			if(strcmp(domain, "home.arpa") == 0)
 				domain_homearpa = true;
+			
+			// Flag if configured a server for queries for .internal domains
+			if(strcmp(domain, "internal") == 0)
+				domain_internal = true;
 		}
 
 		// Forward unqualified names to the target only when the "never forward
@@ -558,6 +563,14 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	{
 		fputs("# Do not forward home.arpa domains to upstream servers\n",pihole_conf);
 		fputs("local=/home.arpa/\n\n",pihole_conf);
+	}
+
+	// Ensure that .internal domains (Internet-Draft draft-davies-internal-tld-03) are not
+	// sent upstream, unless configured by user as local domain, with server setting applied above
+	if (!domain_internal)
+	{
+		fputs("# Do not forward .internal domains to upstream servers\n",pihole_conf);
+		fputs("local=/internal/\n\n",pihole_conf);
 	}
 
 	// Add domain to DNS server. It will also be used for DHCP if the DHCP


### PR DESCRIPTION
Hi :wave:,

after seeing https://github.com/pi-hole/FTL/pull/2405 in the latest release notes, I figured I hand this change in for RFC.

The draft [draft-davies-internal-tld-03](https://datatracker.ietf.org/doc/html/draft-davies-internal-tld-03) defines  `.internal` as  special use domain for local DNS in a home network.
These are not globally resolvable and should not be sent upstream.

Unsure, if you want to upstream this right now as it is still in draft and no RFC published yet. Let me know what you think about this.

I also held back on refactoring the two similar cases. First, because of the rule of three and second because of the RFC character of this PR.

**What does this PR aim to accomplish?:**

Prevent queries for .internal domains being sent to upstream services.

**How does this PR accomplish the above?:**

Checks if the user has specified .internal as a reverse server domain. In that case, we will forward the query to this server.

Otherwise, blocks queries to this domain.

**Link documentation PRs if any are needed to support this PR:**
n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
