### PR TITLE
Display invalid character and offset correctly in hostname diagnosis

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1147,7 +1147,7 @@ bool format_messages(cJSON *array)
 			{
 				const char *ip = (const char*)sqlite3_column_text(stmt, 3);
 				const char *name = (const char*)sqlite3_column_text(stmt, 4);
-				const int pos = sqlite3_column_int(stmt, 6);
+				const int pos = sqlite3_column_int(stmt, 5);
 
 				format_hostname_message(plain, sizeof(plain), html, sizeof(html),
 				                        ip, name, pos);


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix the display of invalid hostname information in Pi-hole diagnosis.

The issue is noted in # 2452 , and has been mentioned on discourse.

Example:

Upon encountering an invalid host name (eg `in$valid.host.name`)
The correct offset is written to FTL.log 

```
2025-06-03 08:52:01.364 AEST [209227/T209230] WARNING: Host name of client "192.168.1.130" => "in$valid.host.name" contains (at least) one invalid character (hex 24) at position 2
```

And records it correctly to Pihole-FTL.db
![image](https://github.com/user-attachments/assets/6a4062cd-4be1-4008-8660-214ea7dc6d11)

However when the same incident is viewed in Pi-hole diagnosis, it lists an incorrect offset, and the character present at that offset rather than identifying the actual problem.:

```
2025-06-02 22:52:01 HOSTNAME Host name of client 192.168.1.130 => "in$valid.host.name" contains (at least) one invalid character (hex 69) at position 0
```

**How does this PR accomplish the above?:**

Gets the position of the invalid character from the correct location in the table

**Link documentation PRs if any are needed to support this PR:**

N/a
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
