### PR TITLE
Speedup build and test by running RISCV on ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,6 @@ jobs:
           - platform: linux/386
             bin_name: pihole-FTL-386
             build_opts: ""
-          - platform: linux/riscv64
-            bin_name: pihole-FTL-riscv64
-            build_opts: ""
     env:
       CI_ARCH: ${{ matrix.platform }}
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
@@ -113,6 +110,8 @@ jobs:
             bin_name: pihole-FTL-armv7
           - platform: linux/arm64/v8
             bin_name: pihole-FTL-arm64
+          - platform: linux/riscv64
+            bin_name: pihole-FTL-riscv64
     env:
       CI_ARCH: ${{ matrix.platform }}
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Should save ~4min compared to running on x64. All successful builds currently take ~22:40 min, on my fork with this PR it only took ~17:30 min

https://github.com/yubiuser/FTL/actions/runs/15500220712

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
