### PR TITLE
ntp : ignore client version, always return a v4 packet

### DIFF
--- a/src/ntp/server.c
+++ b/src/ntp/server.c
@@ -82,12 +82,11 @@ static bool ntp_reply(const int socket_fd, const struct sockaddr *saddr_p, const
 	if ((recv_buf[0] & 0x07) != 0x3) {
 		log_warn("Received invalid NTP request: not from an NTP client, ignoring");
 		return false;
-	// Check if the request is NTP version 4
 	}
-	if (((recv_buf[0] >> 3) & 0x07) != 0x4) {
-		log_warn("Received NTP request has unsupported version, ignoring");
-		return false;
-	}
+        // Check NTP version, log if it is an old unsupported version (< v4)
+        if (((recv_buf[0] >> 3) & 0x07) != 0x4) {
+                log_debug(DEBUG_NTP, "Received request has unsupported version");
+        }
 
 	// set LI = 0 (no warning about leap seconds), set version-number to
 	// 4 and set mode = 4 ("server")


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Send an ntp response to any client, no matter the version the client is identifying as.

Some clients (such as win32tm shipping with Microsoft Windows 11, and apparently some IOT devices described in #2504) send their client packet with an unspecified version number, or set to version 1. 

I have confirmed that in the case of Microsoft Windows, it is able to accept and correctly interpret a valid ntp v4 packet in response. 

The RFCs for the earlier versions are from 1992 (v3), 1989 (v2) and 1985 (v1), so it seems unlikely that these clients are actually expecting data to be returned in any of these older formats, but this PR does return the onus of correct interpretation to the clients.

**How does this PR accomplish the above?:**

Delete the version check for incoming client packets.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
