### PR TITLE
Simplify CI build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,7 @@ jobs:
           [[ $FAIL == 1 ]] && exit 1 || echo "Branch name depth check passed."
         shell: bash
 
-  gha-x86:
-    runs-on: ubuntu-24.04
+  build-and-test:
     needs: smoke-tests
     strategy:
       fail-fast: false
@@ -64,13 +63,33 @@ jobs:
         include:
           - platform: linux/amd64
             bin_name: pihole-FTL-amd64
+            runner: ubuntu-24.04
             build_opts: ""
           - platform: linux/amd64
             bin_name: pihole-FTL-amd64-clang
+            runner: ubuntu-24.04
             build_opts: clang
           - platform: linux/386
             bin_name: pihole-FTL-386
+            runner: ubuntu-24.04
             build_opts: ""
+          - platform: linux/arm/v6
+            bin_name: pihole-FTL-armv6
+            runner: ubuntu-24.04-arm
+            build_opts: ""
+          - platform: linux/arm/v7
+            bin_name: pihole-FTL-armv7
+            runner: ubuntu-24.04-arm
+            build_opts: ""
+          - platform: linux/arm64/v8
+            bin_name: pihole-FTL-arm64
+            runner: ubuntu-24.04-arm
+            build_opts: ""
+          - platform: linux/riscv64
+            bin_name: pihole-FTL-riscv64
+            runner: ubuntu-24.04-arm
+            build_opts: ""
+    runs-on: ${{ matrix.runner }}
     env:
       CI_ARCH: ${{ matrix.platform }}
       GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
@@ -80,52 +99,12 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.7
       -
-        name: Build and test and deploy FTL
+        name: Build, test and deploy FTL
         uses: ./.github/actions/build-and-test
         with:
           platform: ${{ matrix.platform }}
           bin_name: ${{ matrix.bin_name }}
           build_opts: ${{ matrix.build_opts }}
-          artifact_name: ${{ matrix.bin_name }}-binary
-          target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
-          git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
-          git_tag: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-          event_name: ${{ github.event_name }}
-          actor: ${{ github.actor }}
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-
-  gha-arm64:
-    runs-on: ubuntu-24.04-arm
-    needs: smoke-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/arm/v6
-            bin_name: pihole-FTL-armv6
-          - platform: linux/arm/v7
-            bin_name: pihole-FTL-armv7
-          - platform: linux/arm64/v8
-            bin_name: pihole-FTL-arm64
-          - platform: linux/riscv64
-            bin_name: pihole-FTL-riscv64
-    env:
-      CI_ARCH: ${{ matrix.platform }}
-      GIT_BRANCH: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}
-      GIT_TAG: ${{ needs.smoke-tests.outputs.GIT_TAG }}
-    steps:
-      -
-        name: Checkout code
-        uses: actions/checkout@v4.1.7
-      -
-        name: Build and test and deploy FTL
-        uses: ./.github/actions/build-and-test
-        with:
-          platform: ${{ matrix.platform }}
-          bin_name: ${{ matrix.bin_name }}
           artifact_name: ${{ matrix.bin_name }}-binary
           target_dir: ${{ needs.smoke-tests.outputs.OUTPUT_DIR }}
           git_branch: ${{ needs.smoke-tests.outputs.GIT_BRANCH }}


### PR DESCRIPTION
# What does this implement/fix?

Merge the `build-and-test` workflows into one to largely reduce code duplication. Before this, we had two identical workflows with the only difference being the `runner` string. However, the `runner` can be part of the matrix, simplifying the entire process and reducing any unnecessary code duplication.

## Before
![image](https://github.com/user-attachments/assets/240d4444-427a-4a28-81fa-93adcbb41fad)

##Now
![image](https://github.com/user-attachments/assets/7fa797e8-c38e-44da-90b9-487dd1b74bc2)

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/pull/2501#issuecomment-2953657938

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.