### PR TITLE
Tests - fix PTR test

### DIFF
--- a/test/hostnames.sh
+++ b/test/hostnames.sh
@@ -14,7 +14,7 @@ getIPs() {
         while IFS= read -r addr ; do
             # Check if Pi-hole can use itself to block a domain
             dig_result=$(dig +tries=1 +time=2 -x "${addr}" @127.0.0.1 +short)
-            if [[ $addr == "127.0.0.1" && $dig_result == "localhost." ]] || [[ $addr == "::1" && [[ $dig_result == "localhost." || $dig_result == "ip6-localhost." ]] ]] || [[ $dig_result == "pi.hole." ]]; then
+            if [[ $addr == "127.0.0.1" && $dig_result == "localhost." ]] || [[ $addr == "::1" && ( $dig_result == "localhost." || $dig_result == "ip6-localhost." ) ]] || [[ $dig_result == "pi.hole." ]]; then
                 echo "${addr} is \"${dig_result}\": OK"
             else
                 # Otherwise, show a failure


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Make the test for PTR lookups run correctly.

Before this the test is not running but fails silently.
The call in test_suite.bats checks for the absence of "ERROR" in the output, but due to the syntax error hostnames.sh was not returning anything at all.

``` bash
$ shellcheck hostnames.sh
 
[Line 17:]
            if [[ $addr == "127.0.0.1" && $dig_result == "localhost." ]] || [[ $addr == "::1" && [[ $dig_result == "localhost." || $dig_result == "ip6-localhost." ]] ]] || [[ $dig_result == "pi.hole." ]]; then
            ^-- [SC1009](https://www.shellcheck.net/wiki/SC1009) (info): The mentioned syntax error was in this if expression.
>>                                                                          ^-- [SC1073](https://www.shellcheck.net/wiki/SC1073) (error): Couldn't parse this test expression. Fix to allow more checks.
>>                                                                                               ^-- [SC1026](https://www.shellcheck.net/wiki/SC1026) (error): If grouping expressions inside [[..]], use ( .. ).
>>                                                                                                  ^-- [SC1072](https://www.shellcheck.net/wiki/SC1072) (error): Expected test to end here (don't wrap commands in []/[[]]). Fix any mentioned problems and try again.
```

**How does this PR accomplish the above?:**

Fixes the syntax error, replacing the nested double square brackets with parentheses)

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
