### PR TITLE
Reply to address queries in .localhost domain (RFC6171)

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -697,13 +697,17 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	}
 
 	fputs("# RFC 6761: Caching DNS servers SHOULD recognize\n", pihole_conf);
-	fputs("#     test, localhost, invalid\n", pihole_conf);
+	fputs("#     test, & invalid\n", pihole_conf);
 	fputs("# names as special and SHOULD NOT attempt to look up NS records for them, or\n", pihole_conf);
 	fputs("# otherwise query authoritative DNS servers in an attempt to resolve these\n", pihole_conf);
 	fputs("# names.\n", pihole_conf);
 	fputs("server=/test/\n", pihole_conf);
-	fputs("server=/localhost/\n", pihole_conf);
 	fputs("server=/invalid/\n", pihole_conf);
+	fputs("#     localhost\n", pihole_conf);
+	fputs("# Instead, caching DNS servers SHOULD, for all such address queries, generate\n", pihole_conf);
+	fputs("# an immediate positive response giving the IP loopback address\n", pihole_conf);
+	fputs("address=/localhost/127.0.0.1\n", pihole_conf);
+	fputs("address=/localhost/::1\n", pihole_conf);
 	fputs("\n", pihole_conf);
 	fputs("# The same RFC requests something similar for\n", pihole_conf);
 	fputs("#     10.in-addr.arpa.      21.172.in-addr.arpa.  27.172.in-addr.arpa.\n", pihole_conf);


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Respond to any address queries in the localhost domain (eg test.localhost) with the loopback IP address, as per [RFC6171](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3) §6.3.4.

```
;; QUESTION SECTION:
;test.localhost.			IN	A

;; ANSWER SECTION:
test.localhost.		0	IN	A	127.0.0.1
```

```
;; QUESTION SECTION:
;test.localhost.			IN	AAAA

;; ANSWER SECTION:
test.localhost.		0	IN	AAAA	::1
```

Previously these were replied to with NXDOMAIN instead of the loopback IP.
```
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 18250
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;test.localhost.			IN	A
```

**How does this PR accomplish the above?:**

Replaces dnsmasq.conf entry `server=/localhost` with `address=` directives containing the loopback IPs.

**Link documentation PRs if any are needed to support this PR:**

N/A
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
