### PR TITLE
dhcp-discover: Fix string processing

### DIFF
--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -437,8 +437,9 @@ static void print_dhcp_offer(struct in_addr source, struct dhcp_packet_data *off
 				// We may need to escape this, buffer size: 4
 				// chars per control character plus room for
 				// possible "(empty)"
-				char *buffer = calloc(4*optlen + 9, sizeof(char));
-				binbuf_to_escaped_C_literal((char*)&offer_packet->options[x], optlen, buffer, sizeof(buffer));
+				size_t bufsiz = 4*optlen + 9;
+				char *buffer = calloc(bufsiz, sizeof(char));
+				binbuf_to_escaped_C_literal((char*)&offer_packet->options[x], optlen, buffer, bufsiz);
 				printf("wpad-server: \"%s\"\n", buffer);
 				free(buffer);
 			}
@@ -634,8 +635,9 @@ static unsigned int get_dhcp_offer(const int sock, const uint32_t xid, const cha
 		if(offer_packet.sname[0] != 0)
 		{
 			size_t len = strlen(offer_packet.sname);
-			char *buffer = calloc(4*len + 9, sizeof(char));
-			binbuf_to_escaped_C_literal(offer_packet.sname, len, buffer, sizeof(buffer));
+			size_t bufsiz = 4*len + 9;
+			char *buffer = calloc(bufsiz, sizeof(char));
+			binbuf_to_escaped_C_literal(offer_packet.sname, len, buffer, bufsiz);
 			printf("%s\n", buffer);
 			free(buffer);
 		}
@@ -646,8 +648,9 @@ static unsigned int get_dhcp_offer(const int sock, const uint32_t xid, const cha
 		if(offer_packet.file[0] != 0)
 		{
 			size_t len = strlen(offer_packet.file);
-			char *buffer = calloc(4*len + 9, sizeof(char));
-			binbuf_to_escaped_C_literal(offer_packet.file, len, buffer, sizeof(buffer));
+			size_t bufsiz = 4*len + 9;
+			char *buffer = calloc(bufsiz, sizeof(char));
+			binbuf_to_escaped_C_literal(offer_packet.file, len, buffer, bufsiz);
 			printf("%s\n", buffer);
 			free(buffer);
 		}


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes the string handling for `pihole-FTL dhcp-discover`

There are several issues with the string output handling of `pihole-FTL discover-dhcp` for wpad, BOOTP server, and BOOTP file.

Text truncates at four characters (if the characters are printable), eg if the dhcp option 252 (wpad host) is "nowpadhere", the output is `wpad-server: "nowa"`. In the case of a string beginning with a low unprintable character (ASCII ≤15), it prints only three characters in the output, as it is only outputting one hex character for the unprintable byte.

Examples :
`sudo Pihole-FTL dhcp-discover` to a server set with `dhcp-option=lan,252,"nowpadhere"` results in:
`wpad-server: "nowp"` rather than `wpad-server: "nowpadhere"`

Similarly to a server set with `dhcp-option=lan,252,05:05:05:05:05:05:05:05:05` results in:
`wpad-server: "0x5"` rather than `wpad-server: "0x050x050x050x050x050x050x050x050x05"`

And to a server set with `dhcp-option=lan,252,50:51:52:fe:53:54:55` results in:
`wpad-server: "PQR0xFE"` rather than `wpad-server: "PQR0xFESTU"`

(These last two examples are not valid wpad domains, but selected to indicate the output issues with unprintable characters).

**How does this PR accomplish the above?:**

The problems were caused by a combination of passing incorrect string length (using sizeof(buffer), which returns the size of the variable buffer, effectively specifying a fixed size of 8, rather than the size of the buffer itself), in combination with errors in the called function.

This patch:

in dhcp-discover.c
sets a variable with the calculated the size of the buffer, using this both for memory allocation and for calling  binbuf_to_escaped_C_literal(), ensuring the buffer's actual size and that reported are identical.

in log.c  binbuf_to_escaped_C_literal():
Moves the test for buffer space to before writing any characters
Writes an escaped backslash to the output in the case of a backslash in the input
Writes any unprintable characters as a full hex byte (eg 0x0F).

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
