### PR TITLE
Webserver: Allow webhome to be root

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -725,7 +725,7 @@ void http_init(void)
 	if(strcmp(config.webserver.paths.webhome.v.s, "/") == 0 &&
 	   config.dns.blocking.mode.v.blocking_mode == MODE_IP)
 	{
-		log_warn("Webhome is set to root (/) and IP blocking is enabled!");
+		log_warn("Webhome is set to root (/) and IP blocking is enabled. This may result in the Pi-hole web interface to display in places where otherwise ads would show up");
 	}
 
 	// Register [prefix]<webhome without trailing slash> -> [<prefix>]<webhome> redirect handler


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allow users to set webhome to root "/", to serve the admin interface on the bare domain.

Prevents the redirect loop noted by @averyvigolo in #2518.

**How does this PR accomplish the above?:**

Tests if webhome is root and if so does not redirect from root.

Logs a warning if the blockingmode is IP and webhome is root on webserver startup.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
