### PR TITLE
api/network Avoid NULL string comparison logspam

### DIFF
--- a/src/api/network.c
+++ b/src/api/network.c
@@ -75,7 +75,7 @@ int get_gateway(struct ftl_conn *api, cJSON * json, const bool detailed)
 			cJSON_ArrayForEach(iface, interfaces)
 			{
 				const char *ifname = cJSON_GetStringValue(cJSON_GetObjectItem(iface, "name"));
-				if(ifname != NULL && strcmp(ifname, iface_name) == 0)
+				if(ifname != NULL && iface_name != NULL && strcmp(ifname, iface_name) == 0)
 				{
 					cJSON *addr = NULL;
 					cJSON *addrs = cJSON_GetObjectItem(iface, "addresses");


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Avoids the logspam noted on discourse and #2525 on some static routes.

**How does this PR accomplish the above?:**

Adds an additional check against NULL string before the string comparison.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
