### PR TITLE
Add new dns.domainLocal config option

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -210,6 +210,8 @@ components:
                     type: string
                 domainNeeded:
                   type: boolean
+                domainLocal:
+                  type: boolean
                 expandHosts:
                   type: boolean
                 domain:
@@ -666,6 +668,7 @@ components:
             hosts:
               - "192.168.2.123 mymusicbox"
             domainNeeded: true
+            domainLocal: true
             expandHosts: true
             domain: "lan"
             bogusPriv: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -494,6 +494,13 @@ static void initConfig(struct config *conf)
 	conf->dns.domainNeeded.d.b = false;
 	conf->dns.domainNeeded.c = validate_stub; // Only type-based checking
 
+	conf->dns.domainLocal.k = "dns.domainLocal";
+	conf->dns.domainLocal.h = "If set, the domain is considered local and queries for this domain are never forwarded upstream unless a dns.revServer is configured for this domain.\n If unset, queries for this domain are forwarded upstream to (possibly public) server which is probably not what you want *unless* you have added extra configuration for this domain *or* your upstream servers are able to handle local domains (e.g., router).";
+	conf->dns.domainLocal.t = CONF_BOOL;
+	conf->dns.domainLocal.f = FLAG_RESTART_FTL;
+	conf->dns.domainLocal.d.b = true;
+	conf->dns.domainLocal.c = validate_stub; // Only type-based checking
+
 	conf->dns.expandHosts.k = "dns.expandHosts";
 	conf->dns.expandHosts.h = "If set, the domain is added to simple names (without a period) in /etc/hosts in the same way as for DHCP-derived names";
 	conf->dns.expandHosts.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -141,6 +141,7 @@ struct config {
 		struct conf_item blockTTL;
 		struct conf_item hosts;
 		struct conf_item domainNeeded;
+		struct conf_item domainLocal;
 		struct conf_item expandHosts;
 		struct conf_item domain;
 		struct conf_item bogusPriv;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -534,7 +534,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 			// Flag if configured a server for queries for home.arpa domains
 			if(strcmp(domain, "home.arpa") == 0)
 				domain_homearpa = true;
-			
+
 			// Flag if configured a server for queries for .internal domains
 			if(strcmp(domain, "internal") == 0)
 				domain_internal = true;
@@ -581,19 +581,30 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	if(strlen(conf->dns.domain.v.s) > 0)
 	{
 		fputs("# DNS domain for both the DNS and DHCP server\n", pihole_conf);
-		if(!domain_revServer)
+		if(domain_revServer || !config.dns.domainLocal.v.b)
+		{
+			if(domain_revServer)
+			{
+				fputs("# This DNS domain is also used for reverse lookups\n", pihole_conf);
+				fputs("# It is forwarded to the upstream servers configured above\n", pihole_conf);
+			}
+			else if(!config.dns.domainLocal.v.b)
+			{
+				fputs("# This domain is explicitly configured to *not* be local. Ensure\n", pihole_conf);
+				fputs("# that you have configured at least one upstream server for this\n", pihole_conf);
+				fputs("# domain elsewhere to prevent it from being forwarded to the general\n", pihole_conf);
+				fputs("# (probably public) upstream servers\n", pihole_conf);
+			}
+			fputs("# (see server=/<domain>/target above)\n", pihole_conf);
+			fprintf(pihole_conf, "domain=%s\n\n", conf->dns.domain.v.s);
+		}
+		else
 		{
 			fputs("# This DNS domain is purely local. FTL may answer queries from\n", pihole_conf);
 			fputs("# /etc/hosts or DHCP but should never forward queries on that\n", pihole_conf);
 			fputs("# domain to any upstream servers\n", pihole_conf);
 			fprintf(pihole_conf, "domain=%s\n", conf->dns.domain.v.s);
 			fprintf(pihole_conf, "local=/%s/\n\n", conf->dns.domain.v.s);
-		}
-		else
-		{
-			fputs("# This DNS domain is also used for reverse lookups\n", pihole_conf);
-			fputs("# (see server=/<domain>/target above)\n", pihole_conf);
-			fprintf(pihole_conf, "domain=%s\n\n", conf->dns.domain.v.s);
 		}
 	}
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.0.4-75-gc53cf00b)
+# Pi-hole configuration file (v6.2.3-16-g7eb5c0bb-dirty)
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-03-27 11:04:20 UTC
+# Last updated on 2025-06-19 18:31:11 UTC
 
 [dns]
   # Array of upstream DNS servers used by Pi-hole
@@ -107,6 +107,14 @@
   # If set, A and AAAA queries for plain names, without dots or domain parts, are never
   # forwarded to upstream nameservers
   domainNeeded = false
+
+  # If set, the domain is considered local and queries for this domain are never
+  # forwarded upstream unless a dns.revServer is configured for this domain.
+  # If unset, queries for this domain are forwarded upstream to (possibly public) server
+  # which is probably not what you want *unless* you have added extra configuration for
+  # this domain *or* your upstream servers are able to handle local domains (e.g.,
+  # router).
+  domainLocal = true
 
   # If set, the domain is added to simple names (without a period) in /etc/hosts in the
   # same way as for DHCP-derived names
@@ -1206,7 +1214,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 156 total entries out of which 99 entries are default
+# 157 total entries out of which 100 entries are default
 # --> 57 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

Add new dns.domainLocal` config option defaulting to true.

If set, the domain is considered local and queries for this domain are never forwarded upstream unless a `dns.revServer` is configured for this domain.\n If unset, queries for this domain are forwarded upstream to (possibly public) server which is probably not what you want *unless* you have added extra configuration for this domain *or* your upstream servers are able to handle local domains (e.g., router).

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2497

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.