### PR TITLE
request_info.is_authenticated needs to be initialized explicitly with…

### DIFF
--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -18202,6 +18202,7 @@ reset_per_request_attributes(struct mg_connection *conn)
 
 	/* Pi-hole addition */
 	memset(conn->request_info.csrf_token, 0, sizeof(conn->request_info.csrf_token));
+	memset(&conn->request_info.is_authenticated, 0, sizeof(conn->request_info.is_authenticated));
 
 #if defined(USE_SERVER_STATS)
 	conn->processing_time = 0;


### PR DESCRIPTION
# What does this implement/fix?

`request_info.is_authenticated` needs to be initialized explicitly with zero to avoid random values in it all being evaluated to `true`

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2532

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.