### PR TITLE
Allow forcing color in CLI output

### DIFF
--- a/src/api/action.c
+++ b/src/api/action.c
@@ -71,6 +71,7 @@ static int run_and_stream_command(struct ftl_conn *api, const char *path, const 
 		// Read readirected STDOUT/STDERR until EOF
 		// We are only interested in the last pipe line
 		char errbuf[1024] = "";
+		FILE *f = fopen("/tmp/gravity.tmp", "w");
 		while(read(pipefd[0], errbuf, sizeof(errbuf)) > 0)
 		{
 			// Send chunked data
@@ -79,10 +80,13 @@ static int run_and_stream_command(struct ftl_conn *api, const char *path, const 
 			// followed by a chunk of data (the string itself) of the specified
 			// size
 			mg_printf(api->conn, "%zX\r\n%s\r\n", strlen(errbuf), errbuf);
+			fputs(errbuf, f);
 
 			// Reset buffer
 			memset(errbuf, 0, sizeof(errbuf));
 		}
+
+		fclose(f);
 
 		// Wait until child has exited to get its return code
 		int status;

--- a/src/args.c
+++ b/src/args.c
@@ -113,8 +113,9 @@ const char** argv_dnsmasq = NULL;
 
 static bool __attribute__ ((pure)) is_term(void)
 {
-	// test whether STDOUT refers to a terminal
-	return isatty(fileno(stdout)) == 1;
+	// test whether STDOUT refers to a terminal or if env variable
+	// FORCE_COLOR is set
+	return getenv("FORCE_COLOR") != NULL || isatty(fileno(stdout)) == 1;
 }
 
 // Returns green [✓]


### PR DESCRIPTION
# What does this implement/fix?

Show color in CLI output of FTL when `FORCE_COLOR` env var is set and set this env var when running the gravity streaming action via the API.

For reference, see https://github.com/pi-hole/web/pull/3530


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.