### PR TITLE
Ensure cache size is sufficient for DNSSEC

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -588,7 +588,7 @@ static void initConfig(struct config *conf)
 		
 	// sub-struct dns.cache
 	conf->dns.cache.size.k = "dns.cache.size";
-	conf->dns.cache.size.h = "Cache size of the DNS server. Note that expiring cache entries naturally make room for new insertions over time. Setting this number too high will have an adverse effect as not only more space is needed, but also lookup speed gets degraded in the 10,000+ range. dnsmasq may issue a warning when you go beyond 10,000+ cache entries.";
+	conf->dns.cache.size.h = "Cache size of the DNS server. Note that expiring cache entries naturally make room for new insertions over time. Setting this number too high will have an adverse effect as not only more space is needed, but also lookup speed gets degraded in the 10,000+ range. dnsmasq may issue a warning when you go beyond 10,000+ cache entries. The minimum cache size is 150 when DNSSEC is enabled as the DNSSEC validation process uses the cache.";
 	conf->dns.cache.size.t = CONF_UINT;
 	conf->dns.cache.size.f = FLAG_RESTART_FTL;
 	conf->dns.cache.size.d.ui = 10000u;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -348,6 +348,12 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	}
 	fputs("# Set the size of dnsmasq's cache. The default is 150 names. Setting the cache\n", pihole_conf);
 	fputs("# size to zero disables caching. Note: huge cache size impacts performance\n", pihole_conf);
+	// Ensure cache is large enough for DNSSEC operation if DNSSEC is enabled
+	if (conf->dns.dnssec.v.b && conf->dns.cache.size.v.ui < 150)
+	{
+		log_warn("Requested cache size insufficient for DNSSEC operation, overriding to 150");
+		conf->dns.cache.size.v.ui = 150;
+	}
 	fprintf(pihole_conf, "cache-size=%u\n", conf->dns.cache.size.v.ui);
 	fputs("\n", pihole_conf);
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -243,6 +243,8 @@
     # for new insertions over time. Setting this number too high will have an adverse
     # effect as not only more space is needed, but also lookup speed gets degraded in the
     # 10,000+ range. dnsmasq may issue a warning when you go beyond 10,000+ cache entries.
+    # The minimum cache size is 150 when DNSSEC is enabled as the DNSSEC validation
+    # process uses the cache.
     size = 10000
 
     # Query cache optimizer: If a DNS name exists in the cache, but its time-to-live has

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1431,6 +1431,16 @@
   [[ ${lines[0]} == "0" ]]
 }
 
+@test "Cache resize in dnsmasq.conf for DNSSEC" {
+  run bash -c 'sed -i s/size\ =\ 10000/size\ =\ 149/g /etc/pihole/pihole.toml'
+  run bash -c 'sed -i s/dnssec\ =\ false/dnssec\ =\ true/g /etc/pihole/pihole.toml'
+  run bash -c 'service pihole-FTL restart'
+  sleep 3
+  run bash -c 'grep "cache-size=150" /etc/pihole/dnsmasq.conf'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == "cache-size=150" ]]
+}
+
 @test "Check dnsmasq warnings in source code" {
   run bash -c "bash test/dnsmasq_warnings.sh"
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Ensures that when DNSSEC is enabled, the cache size is sufficient for DNSSEC to operate correctly.

Dnsmasq has a hardcoded lower cache size of 150 for DNSSEC to operate. Docs mentions the 150 limit but it is currently possible for a user to use the webUI or edit pihole.toml to set it below this size while DNSSEC is enabled, resulting in pihole-FTL being unable to start:

```
2025-06-27 01:09:44.822 CRIT Error in dnsmasq configuration: cannot reduce cache size from default when DNSSEC enabled
```

**How does this PR accomplish the above?:**

Adds a test when writing dnsmasq.conf, so that if dnssec is enabled any cache size below 150 is overridden with the cache is set to 150. This catches changes whether made in the UI or manual edits to pihole.toml.

Logs a note that the change was made.

Does not make any changes to cache size unless DNSSEC is enabled. (So that the cache may still be set to a small size or disabled entirely when the user does not have DNSSEC enabled).

Adds text to the settings page noting the minimum size that applies if DNSSEC is enabled, along with corresponding text in the tests.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
