### PR TITLE
Add `pihole-FTL create-default-config` option and use it to upload `pihole.toml` to `ftl.pi-hole.net`

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -30,4 +30,6 @@ RUN rm -rf cmake && \
     cd / &&\
     cp /app/pihole-FTL . && \
 # Create tarball of API docs
-    tar -C /app/src/api/docs/content/ -czvf /api-docs.tar.gz .
+    tar -C /app/src/api/docs/content/ -czvf /api-docs.tar.gz . && \
+# Generate default config file
+    ./pihole-FTL create-default-config ./pihole.toml

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -32,4 +32,4 @@ RUN rm -rf cmake && \
 # Create tarball of API docs
     tar -C /app/src/api/docs/content/ -czvf /api-docs.tar.gz . && \
 # Generate default config file
-    ./pihole-FTL create-default-config ./pihole.toml
+    ./pihole-FTL create-default-config pihole.toml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
             docker create --platform ${{ matrix.platform }} --name temp-container ftl-builder:local
             docker cp temp-container:/pihole-FTL ./pihole-FTL
             docker cp temp-container:/api-docs.tar.gz ./api-docs.tar.gz
+            docker cp temp-container:/pihole.toml ./pihole.toml
             docker rm temp-container
       -
         name: List files in current directory
@@ -186,6 +187,13 @@ jobs:
           name: pihole-api-docs
           path: 'api-docs.tar.gz'
       -
+        name: Upload pihole.toml artifacts for deployment
+        if: github.event_name != 'pull_request' && matrix.platform == 'linux/amd64' && matrix.build_opts == ''
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: pihole-toml
+          path: 'pihole.toml'
+      -
         name: Get binaries built in previous jobs
         uses: actions/download-artifact@v4.3.0
         id: download
@@ -200,6 +208,13 @@ jobs:
         with:
           path: ftl_builds/
           name: pihole-api-docs
+      -
+        name: Get pihole.toml built in previous job
+        if: matrix.bin_name == 'pihole-FTL-amd64'
+        uses: actions/download-artifact@v4.3.0
+        with:
+          path: ftl_builds/
+          name: pihole-toml
       -
         name: Display structure of downloaded files
         shell: bash

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -861,7 +861,7 @@ static int api_config_patch(struct ftl_conn *api)
 		set_debug_flags(&config);
 
 		// Store changed configuration to disk
-		writeFTLtoml(true);
+		writeFTLtoml(true, NULL);
 
 		// Rewrite HOSTS file if required
 		if(rewrite_hosts)
@@ -1075,7 +1075,7 @@ static int api_config_put_delete(struct ftl_conn *api)
 	set_debug_flags(&config);
 
 	// Store changed configuration to disk
-	writeFTLtoml(true);
+	writeFTLtoml(true, NULL);
 
 	// Rewrite HOSTS file if required
 	if(rewrite_hosts)

--- a/src/args.c
+++ b/src/args.c
@@ -610,6 +610,18 @@ void parse_args(int argc, char *argv[])
 		exit(migrate_config_v6() ? EXIT_SUCCESS : EXIT_FAILURE);
 	}
 
+	// Undocumented option to create an all-default dummy config file
+	if(argc == 3 && strcmp(argv[1], "create-default-config") == 0)
+	{
+		// Enable stdout printing
+		cli_mode = true;
+		log_ctrl(false, true);
+		if(create_default_config(argv[2]))
+			exit(EXIT_SUCCESS);
+		else
+			exit(EXIT_FAILURE);
+	}
+
 	// start from 1, as argv[0] is the executable name
 	for(int i = 1; i < argc; i++)
 	{

--- a/src/args.c
+++ b/src/args.c
@@ -616,6 +616,15 @@ void parse_args(int argc, char *argv[])
 		// Enable stdout printing
 		cli_mode = true;
 		log_ctrl(false, true);
+
+		// Validate the output filename
+		if(strstr(argv[2], "..") || strchr(argv[2], '/') || strchr(argv[2], '\\'))
+		{
+			fprintf(stderr, "Error: Invalid filename. Path traversal or special characters are not allowed.\n");
+			exit(EXIT_FAILURE);
+		}
+
+		// Create the default config file
 		if(create_default_config(argv[2]))
 			exit(EXIT_SUCCESS);
 		else

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -536,7 +536,7 @@ int set_config_from_CLI(const char *key, const char *value)
 	}
 
 	putchar('\n');
-	writeFTLtoml(false);
+	writeFTLtoml(false, NULL);
 	return OKAY;
 }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -366,7 +366,7 @@ void set_debug_flags(struct config *conf);
 void set_all_debug(struct config *conf, const bool status);
 bool migrate_config_v6(void);
 bool readFTLconf(struct config *conf, const bool rewrite);
-bool getLogFilePath(void);
+bool getLogFilePath(bool try_read);
 struct conf_item *get_conf_item(struct config *conf, const unsigned int n);
 struct conf_item *get_debug_item(struct config *conf, const enum debug_flag debug);
 unsigned int config_path_depth(char **paths) __attribute__ ((pure));
@@ -380,6 +380,7 @@ const char *get_conf_type_str(const enum conf_type type) __attribute__ ((const))
 void replace_config(struct config *newconf);
 void reread_config(void);
 bool create_migration_target_v6(void);
+bool create_default_config(const char *filename);
 
 // Defined in toml_reader.c
 bool readDebugSettings(void);

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -496,7 +496,7 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 					free(config.webserver.api.pwhash.v.s);
 				config.webserver.api.pwhash.v.s = new_hash;
 				config.webserver.api.pwhash.t = CONF_STRING_ALLOCATED;
-				writeFTLtoml(true);
+				writeFTLtoml(true, NULL);
 			}
 
 			// Successful logins do not count against rate-limiting

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -21,6 +21,8 @@
 #include "config/inotify.h"
 // files_different()
 #include "files.h"
+// git_branch()
+#include "version.h"
 
 // defined in config/config.c
 extern uint8_t last_checksum[SHA256_DIGEST_SIZE];
@@ -53,8 +55,10 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 	}
 
 	// Write header
-	fprintf(fp, "# Pi-hole configuration file (%s)\n", get_FTL_version());
-	fputs("# Encoding: UTF-8\n", fp);
+	fprintf(fp, "# Pi-hole configuration file (%s)", get_FTL_version());
+	if(strcmp(git_branch(), "master") != 0)
+		fprintf(fp, " on branch %s", git_branch());
+	fputs("\n# Encoding: UTF-8\n", fp);
 	fputs("# This file is managed by pihole-FTL\n", fp);
 	char timestring[TIMESTR_SIZE];
 	get_timestr(timestring, time(NULL), false, false);

--- a/src/config/toml_writer.h
+++ b/src/config/toml_writer.h
@@ -10,6 +10,6 @@
 #ifndef TOML_WRITER_H
 #define TOML_WRITER_H
 
-bool writeFTLtoml(const bool verbose);
+bool writeFTLtoml(const bool verbose, FILE *fp);
 
 #endif //TOML_WRITER_H

--- a/src/main.c
+++ b/src/main.c
@@ -49,7 +49,7 @@ int main (int argc, char *argv[])
 	username = getUserName();
 
 	// Obtain log file location
-	getLogFilePath();
+	getLogFilePath(true);
 
 	// Parse arguments
 	// We run this also for no direct arguments

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -335,7 +335,7 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 	// Write new pihole.toml to disk, the dnsmaq config was already written above
 	// Also write the custom list to disk
 	rotate_files(GLOBALTOMLPATH, NULL);
-	writeFTLtoml(true);
+	writeFTLtoml(true, NULL);
 	write_custom_list();
 
 	return NULL;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Add new undocumented flag `pihole-FTL create-default-config <file.toml>` which will generate a default config file without starting FTL. This `pihole.toml` is then uploaded during the build process to ftl.pi-hole.net for later use (e.g. in https://github.com/pi-hole/docs/pull/1215)

Supersedes https://github.com/pi-hole/FTL/pull/2537 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
