### PR TITLE
Rename flushing arp > flushing network

### DIFF
--- a/src/api/action.c
+++ b/src/api/action.c
@@ -162,17 +162,17 @@ int api_action_flush_arp(struct ftl_conn *api)
 	if(!config.webserver.api.allow_destructive.v.b)
 		return send_json_error(api, 403,
 		                       "forbidden",
-		                       "Flushing the ARP tables is not allowed",
+		                       "Flushing the network tables is not allowed",
 		                       "Check setting webserver.api.allow_destructive");
 
-	log_info("Received API request to flush the ARP tables");
+	log_info("Received API request to flush the network tables");
 
-	// Flush the ARP tables
+	// Flush the network tables
 	if(flush_network_table())
 		return send_json_success(api);
 	else
 		return send_json_error(api, 500,
 		                       "server_error",
-		                       "Cannot flush the ARP tables",
+		                       "Cannot flush the network tables",
 		                       NULL);
 }


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We are not flushing the `arp` cache anymore by the action, but only flushing the network table. This should be reflected in the logs.

Discussion: on `core` we are still flushing the `neigh` cache with `pihole arpflush`

https://github.com/pi-hole/pi-hole/blob/ec892ec096cd1adb90b0209d4c0a155953faf813/advanced/Scripts/piholeARPTable.sh#L60-L61

Which way should we go here: FTL also flushing `neigh` or core stop doing so?

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
