### PR TITLE
Remove remaining traces of ARP flush

### DIFF
--- a/src/api/action.c
+++ b/src/api/action.c
@@ -157,7 +157,7 @@ int api_action_flush_logs(struct ftl_conn *api)
 		                       NULL);
 }
 
-int api_action_flush_arp(struct ftl_conn *api)
+int api_action_flush_network(struct ftl_conn *api)
 {
 	if(!config.webserver.api.allow_destructive.v.b)
 		return send_json_error(api, 403,

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -101,6 +101,7 @@ static struct {
 	{ "/api/action/gravity",                    "",                           api_action_gravity,                    { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/restartdns",                 "",                           api_action_restartDNS,                 { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/flush/logs",                 "",                           api_action_flush_logs,                 { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
+	{ "/api/action/flush/arp",                  "",                           api_action_flush_network,              { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/flush/network",              "",                           api_action_flush_network,              { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/padd",                              "",                           api_padd,                              { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/docs",                              "",                           api_docs,                              { API_PARSE_JSON, 0                         }, false, HTTP_GET },

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -101,7 +101,7 @@ static struct {
 	{ "/api/action/gravity",                    "",                           api_action_gravity,                    { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/restartdns",                 "",                           api_action_restartDNS,                 { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/flush/logs",                 "",                           api_action_flush_logs,                 { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
-	{ "/api/action/flush/arp",                  "",                           api_action_flush_arp,                  { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
+	{ "/api/action/flush/network",              "",                           api_action_flush_network,              { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/padd",                              "",                           api_padd,                              { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/docs",                              "",                           api_docs,                              { API_PARSE_JSON, 0                         }, false, HTTP_GET },
 };

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -130,7 +130,7 @@ int api_teleporter(struct ftl_conn *api);
 int api_action_gravity(struct ftl_conn *api);
 int api_action_restartDNS(struct ftl_conn *api);
 int api_action_flush_logs(struct ftl_conn *api);
-int api_action_flush_arp(struct ftl_conn *api);
+int api_action_flush_network(struct ftl_conn *api);
 
 // Search methods
 int api_search(struct ftl_conn *api);

--- a/src/api/docs/content/specs/action.yaml
+++ b/src/api/docs/content/specs/action.yaml
@@ -113,14 +113,14 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
-    flush_arp:
+    flush_network:
       post:
         summary: Flush the network table
         tags:
           - Actions
-        operationId: "action_flusharp"
+        operationId: "action_flushnetwork"
         description: |
-          Flushes the network table. This includes emptying the ARP table and removing both all known devices and their associated addresses.
+          Flushes the network table. This includes removing both all known devices and their associated addresses.
         responses:
           '200':
             description: OK

--- a/src/api/docs/content/specs/action.yaml
+++ b/src/api/docs/content/specs/action.yaml
@@ -113,6 +113,40 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
+    flush_arp:
+      post:
+        summary: Flush the network table
+        tags:
+          - Actions
+        operationId: "action_flusharp"
+        deprecated: true
+        description: |
+          Deprecated! Use '/action/flush/network' instead.
+          Flushes the network table. This includes removing both all known devices and their associated addresses.
+        responses:
+          '200':
+            description: OK
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'common.yaml#/components/schemas/success'
+                    - $ref: 'common.yaml#/components/schemas/took'
+          '401':
+            description: Unauthorized
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'common.yaml#/components/errors/unauthorized'
+                    - $ref: 'common.yaml#/components/schemas/took'
+          '403':
+            description: Forbidden
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'action.yaml#/components/errors/forbidden'
     flush_network:
       post:
         summary: Flush the network table

--- a/src/api/docs/content/specs/main.yaml
+++ b/src/api/docs/content/specs/main.yaml
@@ -261,6 +261,9 @@ paths:
   /action/flush/logs:
     $ref: 'action.yaml#/components/paths/flush_logs'
 
+  /action/flush/arp:
+    $ref: 'action.yaml#/components/paths/flush_arp'
+
   /action/flush/network:
     $ref: 'action.yaml#/components/paths/flush_network'
 

--- a/src/api/docs/content/specs/main.yaml
+++ b/src/api/docs/content/specs/main.yaml
@@ -261,8 +261,8 @@ paths:
   /action/flush/logs:
     $ref: 'action.yaml#/components/paths/flush_logs'
 
-  /action/flush/arp:
-    $ref: 'action.yaml#/components/paths/flush_arp'
+  /action/flush/network:
+    $ref: 'action.yaml#/components/paths/flush_network'
 
   /dhcp/leases:
     $ref: 'dhcp.yaml#/components/paths/leases'


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes some remaining hints to ARP flush that were forgotten in https://github.com/pi-hole/FTL/pull/2541

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
