### PR TITLE
Allow escaping special single-character wildcard "_" when doing partial matching

### DIFF
--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -517,21 +517,6 @@ int api_queries(struct ftl_conn *api)
 						search[j][0] = '%';
 					}
 
-					// Escape any possible underscore in the
-					// search string to ensure it is not
-					// interpreted as a wildcard by SQLite3
-					for(unsigned int i = 0; i < searchlen; i++)
-					{
-						if(search[j][i] == '_')
-						{
-							// Escape underscore
-							memmove(search[j] + i + 1, search[j] + i, searchlen - i + 1);
-							search[j][i] = '\\';
-							searchlen++;
-							i++;
-						}
-					}
-
 					// Apply the search string to the query if this is an allowed column
 					if(j == 0 && strcasecmp(search_col_id_str, "domain") == 0)
 					{

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2098,7 +2098,9 @@ bool gravityDB_readTable(const enum gravity_list_type listtype,
 	if(!exact && item != NULL && item[0] != '\0')
 	{
 		// Build LIKE string (% + item + %)
-		const size_t maxlen = 2*strlen(item)+  3;
+		// 2 for '%' at start and end, 1 for null terminator
+		const size_t LIKE_PATTERN_EXTRA_CHARS = 3;
+		const size_t maxlen = 2*strlen(item) + LIKE_PATTERN_EXTRA_CHARS;
 		like_name = calloc(maxlen, sizeof(char));
 		if(like_name == NULL)
 		{
@@ -2106,30 +2108,7 @@ bool gravityDB_readTable(const enum gravity_list_type listtype,
 			*message = "Failed to allocate memory for like_name";
 			return false;
 		}
-		// Iterate through item and escape any possible underscore (if
-		// present)
-		if(strchr(item, '_') != NULL)
-		{
-			// Add initial percent sign
-			like_name[0] = '%';
-
-			// Iterate through item
-			char *p = like_name + 1;
-			for(const char *c = item; *c != '\0'; c++)
-			{
-				// Add escape character when needed
-				if(*c == '_') *p++ = '\\';
-				*p++ = *c;
-			}
-			// Ensure the string is nul-terminated
-			*p = '\0';
-
-			// Add final percent sign
-			strncat(like_name, "%", maxlen - strlen(like_name) - 1);
-		}
-		else
-			// No escaping needed, just add percent signs
-			snprintf(like_name, maxlen, "%%%s%%", item);
+		snprintf(like_name, maxlen, "%%%s%%", item);
 	}
 	const char *filter = "";
 	if(listtype == GRAVITY_GROUPS)


### PR DESCRIPTION
# What does this implement/fix?

~~See title. Discussion ongoing in that issue ticket, hence, opening in draft mode here~~

If user use `_` when matching domains or clients, this will not match a literal underscore but act as the SQLite3 default single-character wildcard. This PR allows users to **escape** underscores in domains/clients by escaping their underscore like `\_`. This was not possible before.

---

**Related issue or feature (if applicable):** Fixes #2549 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.