### PR TITLE
Add python script to convert parse pihole.toml and produce a markdown…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,3 +269,25 @@ jobs:
         with:
           files: |
             ftl_builds/*
+      -
+        name: Pull docs repository to update configuation page from pihole.toml        
+        #if: env.GIT_BRANCH == 'master' && env.DO_DEPLOY == 'true' && matrix.bin_name == 'pihole-FTL-amd64'
+        if: env.DO_DEPLOY == 'true' && matrix.bin_name == 'pihole-FTL-amd64'
+        run: |
+          git clone https://github.com/pi-hole/docs.git docs-repo
+          python3 tools/pihole_toml_to_markdown.py ftl_builds/pihole.toml docs-repo/docs/ftldns/configfile.md          
+      -
+        name: Create Pull Request to pi-hole/docs
+        #if: env.GIT_BRANCH == 'master' && env.DO_DEPLOY == 'true' && matrix.bin_name == 'pihole-FTL-amd64'
+        if: env.DO_DEPLOY == 'true' && matrix.bin_name == 'pihole-FTL-amd64'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PRALOR_PULL_REQUESTS }}
+          commit-message: "docs: update pihole.toml documentation"
+          title: "Update pihole.toml documentation"
+          body: "Automated PR to update pihole.toml documentation from FTL build."
+          branch: update-pihole-toml-docs
+          base: master
+          path: docs-repo
+          add-paths: |
+            docs/ftldns/configfile.md

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -398,8 +398,8 @@ static void initConfig(struct config *conf)
 
 	// struct dns
 	conf->dns.upstreams.k = "dns.upstreams";
-	conf->dns.upstreams.h = "Array of upstream DNS servers used by Pi-hole\n Example: [ \"8.8.8.8\", \"127.0.0.1#5335\", \"docker-resolver\" ]";
-	conf->dns.upstreams.a = cJSON_CreateStringReference("array of IP addresses and/or hostnames, optionally with a port (#...)");
+	conf->dns.upstreams.h = "Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not resolve any non-local queries.\n\n Example: [ \"8.8.8.8\", \"127.0.0.1#5335\", \"docker-resolver\" ]";
+	conf->dns.upstreams.a = cJSON_CreateStringReference("Array of IP addresses and/or hostnames, optionally with a port (#...)");
 	conf->dns.upstreams.t = CONF_JSON_STRING_ARRAY;
 	conf->dns.upstreams.d.json = cJSON_CreateArray();
 	conf->dns.upstreams.f = FLAG_RESTART_FTL;
@@ -407,36 +407,42 @@ static void initConfig(struct config *conf)
 
 	conf->dns.CNAMEdeepInspect.k = "dns.CNAMEdeepInspect";
 	conf->dns.CNAMEdeepInspect.h = "Use this option to control deep CNAME inspection. Disabling it might be beneficial for very low-end devices";
+	conf->dns.CNAMEdeepInspect.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.CNAMEdeepInspect.t = CONF_BOOL;
 	conf->dns.CNAMEdeepInspect.d.b = true;
 	conf->dns.CNAMEdeepInspect.c = validate_stub; // Only type-based checking
 
 	conf->dns.blockESNI.k = "dns.blockESNI";
-	conf->dns.blockESNI.h = "Should _esni. subdomains be blocked by default? Encrypted Server Name Indication (ESNI) is certainly a good step into the right direction to enhance privacy on the web. It prevents on-path observers, including ISPs, coffee shop owners and firewalls, from intercepting the TLS Server Name Indication (SNI) extension by encrypting it. This prevents the SNI from being used to determine which websites users are visiting.\n ESNI will obviously cause issues for pixelserv-tls which will be unable to generate matching certificates on-the-fly when it cannot read the SNI. Cloudflare and Firefox are already enabling ESNI. According to the IEFT draft (link above), we can easily restore piselserv-tls's operation by replying NXDOMAIN to _esni. subdomains of blocked domains as this mimics a \"not configured for this domain\" behavior.";
+	conf->dns.blockESNI.h = "Should _esni. subdomains be blocked by default? Encrypted Server Name Indication (ESNI) is certainly a good step into the right direction to enhance privacy on the web. It prevents on-path observers, including ISPs, coffee shop owners and firewalls, from intercepting the TLS Server Name Indication (SNI) extension by encrypting it. This prevents the SNI from being used to determine which websites users are visiting.\n\n ESNI will obviously cause issues for pixelserv-tls which will be unable to generate matching certificates on-the-fly when it cannot read the SNI. Cloudflare and Firefox are already enabling ESNI. According to the IEFT draft (link above), we can easily restore piselserv-tls's operation by replying NXDOMAIN to _esni. subdomains of blocked domains as this mimics a \"not configured for this domain\" behavior.";
+	conf->dns.blockESNI.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.blockESNI.t = CONF_BOOL;
 	conf->dns.blockESNI.d.b = true;
 	conf->dns.blockESNI.c = validate_stub; // Only type-based checking
 
 	conf->dns.EDNS0ECS.k = "dns.EDNS0ECS";
 	conf->dns.EDNS0ECS.h = "Should we overwrite the query source when client information is provided through EDNS0 client subnet (ECS) information? This allows Pi-hole to obtain client IPs even if they are hidden behind the NAT of a router. This feature has been requested and discussed on Discourse where further information how to use it can be found: https://discourse.pi-hole.net/t/support-for-add-subnet-option-from-dnsmasq-ecs-edns0-client-subnet/35940";
+	conf->dns.EDNS0ECS.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.EDNS0ECS.t = CONF_BOOL;
 	conf->dns.EDNS0ECS.d.b = true;
 	conf->dns.EDNS0ECS.c = validate_stub; // Only type-based checking
 
 	conf->dns.ignoreLocalhost.k = "dns.ignoreLocalhost";
 	conf->dns.ignoreLocalhost.h = "Should FTL hide queries made by localhost?";
+	conf->dns.ignoreLocalhost.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.ignoreLocalhost.t = CONF_BOOL;
 	conf->dns.ignoreLocalhost.d.b = false;
 	conf->dns.ignoreLocalhost.c = validate_stub; // Only type-based checking
 
 	conf->dns.showDNSSEC.k = "dns.showDNSSEC";
 	conf->dns.showDNSSEC.h = "Should FTL analyze and show internally generated DNSSEC queries?";
+	conf->dns.showDNSSEC.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.showDNSSEC.t = CONF_BOOL;
 	conf->dns.showDNSSEC.d.b = true;
 	conf->dns.showDNSSEC.c = validate_stub; // Only type-based checking
 
 	conf->dns.analyzeOnlyAandAAAA.k = "dns.analyzeOnlyAandAAAA";
 	conf->dns.analyzeOnlyAandAAAA.h = "Should FTL analyze *only* A and AAAA queries?";
+	conf->dns.analyzeOnlyAandAAAA.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.analyzeOnlyAandAAAA.t = CONF_BOOL;
 	conf->dns.analyzeOnlyAandAAAA.d.b = false;
 	conf->dns.analyzeOnlyAandAAAA.c = validate_stub; // Only type-based checking
@@ -475,13 +481,14 @@ static void initConfig(struct config *conf)
 	conf->dns.replyWhenBusy.c = validate_stub; // Only type-based checking
 
 	conf->dns.blockTTL.k = "dns.blockTTL";
-	conf->dns.blockTTL.h = "FTL's internal TTL to be handed out for blocked queries in seconds. This settings allows users to select a value different from the dnsmasq config option local-ttl. This is useful in context of locally used hostnames that are known to stay constant over long times (printers, etc.).\n Note that large values may render whitelisting ineffective due to client-side caching of blocked queries.";
+	conf->dns.blockTTL.h = "FTL's internal TTL to be handed out for blocked queries in seconds. This settings allows users to select a value different from the dnsmasq config option local-ttl. This is useful in context of locally used hostnames that are known to stay constant over long times (printers, etc.).\n\n Note that large values may render whitelisting ineffective due to client-side caching of blocked queries.";
+	conf->dns.blockTTL.a = cJSON_CreateStringReference("A positive integer value in seconds");
 	conf->dns.blockTTL.t = CONF_UINT;
 	conf->dns.blockTTL.d.ui = 2;
 	conf->dns.blockTTL.c = validate_stub; // Only type-based checking
 
 	conf->dns.hosts.k = "dns.hosts";
-	conf->dns.hosts.h = "Array of custom DNS records\n Example: hosts = [ \"127.0.0.1 mylocal\", \"192.168.0.1 therouter\" ]";
+	conf->dns.hosts.h = "Array of custom DNS records\n\n Example: [ \"127.0.0.1 mylocal\", \"192.168.0.1 therouter\" ]";
 	conf->dns.hosts.a = cJSON_CreateStringReference("Array of custom DNS records each one in HOSTS form: \"IP HOSTNAME\"");
 	conf->dns.hosts.t = CONF_JSON_STRING_ARRAY;
 	conf->dns.hosts.d.json = cJSON_CreateArray();
@@ -489,6 +496,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.domainNeeded.k = "dns.domainNeeded";
 	conf->dns.domainNeeded.h = "If set, A and AAAA queries for plain names, without dots or domain parts, are never forwarded to upstream nameservers";
+	conf->dns.domainNeeded.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.domainNeeded.t = CONF_BOOL;
 	conf->dns.domainNeeded.f = FLAG_RESTART_FTL;
 	conf->dns.domainNeeded.d.b = false;
@@ -496,6 +504,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.expandHosts.k = "dns.expandHosts";
 	conf->dns.expandHosts.h = "If set, the domain is added to simple names (without a period) in /etc/hosts in the same way as for DHCP-derived names";
+	conf->dns.expandHosts.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.expandHosts.t = CONF_BOOL;
 	conf->dns.expandHosts.f = FLAG_RESTART_FTL;
 	conf->dns.expandHosts.d.b = false;
@@ -503,7 +512,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.domain.k = "dns.domain";
 	conf->dns.domain.h = "The DNS domain used by your Pi-hole.\n\n This DNS domain is purely local. FTL may answer queries from its local cache and configuration but *never* forwards any requests upstream *unless* you have configured a dns.revServer exactly for this domain. In the latter case, all queries for this domain are sent exclusively to this server (including reverse lookups).\n\n For DHCP, this has two effects; firstly it causes the DHCP server to return the domain to any hosts which request it, and secondly it sets the domain which it is legal for DHCP-configured hosts to claim. The intention is to constrain hostnames so that an untrusted host on the LAN cannot advertise its name via DHCP as e.g. \"google.com\" and capture traffic not meant for it. If no domain suffix is specified, then any DHCP hostname with a domain part (ie with a period) will be disallowed and logged. If a domain is specified, then hostnames with a domain part are allowed, provided the domain part matches the suffix. In addition, when a suffix is set then hostnames without a domain part have the suffix added as an optional domain part. For instance, we can set domain=mylab.com and have a machine whose DHCP hostname is \"laptop\". The IP address for that machine is available both as \"laptop\" and \"laptop.mylab.com\".\n\n You can disable setting a domain by setting this option to an empty string.";
-	conf->dns.domain.a = cJSON_CreateStringReference("<any valid domain>");
+	conf->dns.domain.a = cJSON_CreateStringReference("Any valid domain");
 	conf->dns.domain.t = CONF_STRING;
 	conf->dns.domain.f = FLAG_RESTART_FTL;
 	conf->dns.domain.d.s = (char*)"lan";
@@ -511,6 +520,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.bogusPriv.k = "dns.bogusPriv";
 	conf->dns.bogusPriv.h = "Should all reverse lookups for private IP ranges (i.e., 192.168.x.y, etc) which are not found in /etc/hosts or the DHCP leases file be answered with \"no such domain\" rather than being forwarded upstream?";
+	conf->dns.bogusPriv.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.bogusPriv.t = CONF_BOOL;
 	conf->dns.bogusPriv.f = FLAG_RESTART_FTL;
 	conf->dns.bogusPriv.d.b = true;
@@ -518,6 +528,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.dnssec.k = "dns.dnssec";
 	conf->dns.dnssec.h = "Validate DNS replies using DNSSEC?";
+	conf->dns.dnssec.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.dnssec.t = CONF_BOOL;
 	conf->dns.dnssec.f = FLAG_RESTART_FTL;
 	conf->dns.dnssec.c = validate_stub; // Only type-based checking
@@ -530,10 +541,10 @@ static void initConfig(struct config *conf)
 	conf->dns.interface.f = FLAG_RESTART_FTL;
 	conf->dns.interface.d.s = (char*)"eth0";
 	conf->dns.interface.c = validate_stub; // Type-based checking + dnsmasq syntax checking
-
+	
 	conf->dns.hostRecord.k = "dns.hostRecord";
-	conf->dns.hostRecord.h = "Add A, AAAA and PTR records to the DNS. This adds one or more names to the DNS with associated IPv4 (A) and IPv6 (AAAA) records";
-	conf->dns.hostRecord.a = cJSON_CreateStringReference("<name>[,<name>....],[<IPv4-address>],[<IPv6-address>][,<TTL>]");
+	conf->dns.hostRecord.h = "Add an A, AAAA and PTR record to the DNS. This adds a singular name to the DNS with associated IPv4 (A) and IPv6 (AAAA) records\n\n Example: \"laptop,laptop.lan,192.168.0.1,1234::100\"";
+	conf->dns.hostRecord.a = cJSON_CreateStringReference("A string in the format \"<name>[,<name>....],[<IPv4-address>],[<IPv6-address>][,<TTL>]\"");
 	conf->dns.hostRecord.t = CONF_STRING;
 	conf->dns.hostRecord.f = FLAG_RESTART_FTL;
 	conf->dns.hostRecord.d.s = (char*)"";
@@ -559,6 +570,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.queryLogging.k = "dns.queryLogging";
 	conf->dns.queryLogging.h = "Log DNS queries and replies to pihole.log";
+	conf->dns.queryLogging.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.queryLogging.t = CONF_BOOL;
 	conf->dns.queryLogging.f = FLAG_RESTART_FTL;
 	conf->dns.queryLogging.d.b = true;
@@ -566,7 +578,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.cnameRecords.k = "dns.cnameRecords";
 	conf->dns.cnameRecords.h = "List of CNAME records which indicate that <cname> is really <target>. If the <TTL> is given, it overwrites the value of local-ttl";
-	conf->dns.cnameRecords.a = cJSON_CreateStringReference("Array of CNAMEs each on in one of the following forms: \"<cname>,<target>[,<TTL>]\"");
+	conf->dns.cnameRecords.a = cJSON_CreateStringReference("Array of CNAMEs, each one in the following form: \"<cname>,<target>[,<TTL>]\"");
 	conf->dns.cnameRecords.t = CONF_JSON_STRING_ARRAY;
 	conf->dns.cnameRecords.f = FLAG_RESTART_FTL;
 	conf->dns.cnameRecords.d.json = cJSON_CreateArray();
@@ -574,6 +586,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.port.k = "dns.port";
 	conf->dns.port.h = "Port used by the DNS server";
+	conf->dns.port.a = cJSON_CreateStringReference("Any available valid (1 - 65535) port number");
 	conf->dns.port.t = CONF_UINT16;
 	conf->dns.port.f = FLAG_RESTART_FTL;
 	conf->dns.port.d.u16 = 53u;
@@ -581,21 +594,32 @@ static void initConfig(struct config *conf)
 
 	conf->dns.localise.k = "dns.localise";
 	conf->dns.localise.h = "Enable/Disable the localise-queries option of dnsmasq. When this setting is disabled dnsmasq will return all possible values for local DNS Records. Enabled by default";
+	conf->dns.localise.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.localise.t = CONF_BOOL;
 	conf->dns.localise.f = FLAG_RESTART_FTL;
 	conf->dns.localise.d.b = true;
 	conf->dns.localise.c = validate_stub; // Only type-based checking
 
+	conf->dns.revServers.k = "dns.revServers";
+	conf->dns.revServers.h = "Reverse server (formerly called \"conditional forwarding\")\n\n If not configured as your DHCP server, Pi-hole typically won't be able to determine the names of devices on your local network. As a result, tables such as Top Clients will only show IP addresses.\n\n One solution for this is to configure Pi-hole to forward these requests to your DHCP server (most likely your router), but only for devices on your home network. To configure this we will need to know the IP address of your DHCP server and which addresses belong to your local network.\n\n Example: [ \"true,192.168.0.0/24,192.168.0.1,fritz.box\" ]";
+	conf->dns.revServers.a = cJSON_CreateStringReference("Array of reverse servers each one in the following form:\n\n \"<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>]\"\n\nExplanation of individual components:\n\n - \"<enabled>\": either \"true\" or \"false\"\n\n - \"<ip-address>[/<prefix-len>]\": Address range for the reverse server feature in CIDR notation. If the prefix length is omitted, either 32 (IPv4) or 128 (IPv6) are substituted (exact address match). This is almost certainly not what you want here.\n Example: \"192.168.0.0/24\" for the range 192.168.0.1 - 192.168.0.255\n\n - \"<server>[#<port>]\": Target server to be used for the reverse server feature\n Example: \"192.168.0.1#53\"\n\n - \"<domain>\": Domain used for the reverse server feature (e.g., \"fritz.box\")\n Example: \"fritz.box\"");
+	conf->dns.revServers.t = CONF_JSON_STRING_ARRAY;
+	conf->dns.revServers.d.json = cJSON_CreateArray();
+	conf->dns.revServers.c = validate_dns_revServers;
+	conf->dns.revServers.f = FLAG_RESTART_FTL;
+
 	// sub-struct dns.cache
 	conf->dns.cache.size.k = "dns.cache.size";
-	conf->dns.cache.size.h = "Cache size of the DNS server. Note that expiring cache entries naturally make room for new insertions over time. Setting this number too high will have an adverse effect as not only more space is needed, but also lookup speed gets degraded in the 10,000+ range. dnsmasq may issue a warning when you go beyond 10,000+ cache entries.";
+	conf->dns.cache.size.h = "Cache size of the DNS server. Note that expiring cache entries naturally make room for new insertions over time.\n\nSetting this number too high will have an adverse effect as not only more space is needed, but also lookup speed gets degraded in the 10,000+ range. dnsmasq may issue a warning when you go beyond 10,000+ cache entries.";
+	conf->dns.cache.size.a = cJSON_CreateStringReference("A positive integer value");
 	conf->dns.cache.size.t = CONF_UINT;
 	conf->dns.cache.size.f = FLAG_RESTART_FTL;
 	conf->dns.cache.size.d.ui = 10000u;
 	conf->dns.cache.size.c = validate_stub; // Only type-based checking
 
 	conf->dns.cache.optimizer.k = "dns.cache.optimizer";
-	conf->dns.cache.optimizer.h = "Query cache optimizer: If a DNS name exists in the cache, but its time-to-live has expired only recently, the data will be used anyway (a refreshing from upstream is triggered). This can improve DNS query delays especially over unreliable Internet connections. This feature comes at the expense of possibly sometimes returning out-of-date data and less efficient cache utilization, since old data cannot be flushed when its TTL expires, so the cache becomes mostly least-recently-used. To mitigate issues caused by massively outdated DNS replies, the maximum overaging of cached records is limited. We strongly recommend staying below 86400 (1 day) with this option.\n Setting the TTL excess time to zero will serve stale cache data regardless how long it has expired. This is not recommended as it may lead to stale data being served for a long time. Setting this option to any negative value will disable this feature altogether.";
+	conf->dns.cache.optimizer.h = "Query cache optimizer: If a DNS name exists in the cache, but its time-to-live has expired only recently, the data will be used anyway (a refreshing from upstream is triggered). This can improve DNS query delays especially over unreliable Internet connections. This feature comes at the expense of possibly sometimes returning out-of-date data and less efficient cache utilization, since old data cannot be flushed when its TTL expires, so the cache becomes mostly least-recently-used. To mitigate issues caused by massively outdated DNS replies, the maximum overaging of cached records is limited. We strongly recommend staying below 86400 (1 day) with this option.\n\n Setting the TTL excess time to zero will serve stale cache data regardless how long it has expired. This is not recommended as it may lead to stale data being served for a long time. Setting this option to any negative value will disable this feature altogether.";
+	conf->dns.cache.optimizer.a = cJSON_CreateStringReference("A positive integer value in seconds, or any negative to disable this feature");
 	conf->dns.cache.optimizer.t = CONF_INT;
 	conf->dns.cache.optimizer.f = FLAG_RESTART_FTL;
 	conf->dns.cache.optimizer.d.i = 3600u;
@@ -603,6 +627,7 @@ static void initConfig(struct config *conf)
 
 	conf->dns.cache.upstreamBlockedTTL.k = "dns.cache.upstreamBlockedTTL";
 	conf->dns.cache.upstreamBlockedTTL.h = "This setting allows you to specify the TTL used for queries blocked upstream. Once the TTL expires, the query will be forwarded to the upstream server again to check if the block is still valid. Defaults to caching for one day (86400 seconds). Setting this value to zero disables caching of queries blocked upstream.";
+	conf->dns.cache.upstreamBlockedTTL.a = cJSON_CreateStringReference("A positive integer value in seconds, or zero to disable caching of upstream blocked queries");
 	conf->dns.cache.upstreamBlockedTTL.t = CONF_UINT;
 	conf->dns.cache.upstreamBlockedTTL.d.ui = 86400;
 	conf->dns.cache.upstreamBlockedTTL.c = validate_stub; // Only type-based checking
@@ -610,6 +635,7 @@ static void initConfig(struct config *conf)
 	// sub-struct dns.blocking
 	conf->dns.blocking.active.k = "dns.blocking.active";
 	conf->dns.blocking.active.h = "Should FTL block queries?";
+	conf->dns.blocking.active.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.blocking.active.t = CONF_BOOL;
 	conf->dns.blocking.active.d.b = true;
 	conf->dns.blocking.active.c = validate_stub; // Only type-based checking
@@ -646,134 +672,137 @@ static void initConfig(struct config *conf)
 	conf->dns.blocking.edns.d.edns_mode = EDNS_MODE_TEXT;
 	conf->dns.blocking.edns.c = validate_stub; // Only type-based checking
 
-	conf->dns.revServers.k = "dns.revServers";
-	conf->dns.revServers.h = "Reverse server (former also called \"conditional forwarding\") feature\n Array of reverse servers each one in one of the following forms: \"<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>]\"\n\n Individual components:\n\n <enabled>: either \"true\" or \"false\"\n\n <ip-address>[/<prefix-len>]: Address range for the reverse server feature in CIDR notation. If the prefix length is omitted, either 32 (IPv4) or 128 (IPv6) are substituted (exact address match). This is almost certainly not what you want here.\n Example: \"192.168.0.0/24\" for the range 192.168.0.1 - 192.168.0.255\n\n <server>[#<port>]: Target server to be used for the reverse server feature\n Example: \"192.168.0.1#53\"\n\n <domain>: Domain used for the reverse server feature (e.g., \"fritz.box\")\n Example: \"fritz.box\"";
-	conf->dns.revServers.a = cJSON_CreateStringReference("array of reverse servers each one in one of the following forms: \"<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>]\", e.g., \"true,192.168.0.0/24,192.168.0.1,fritz.box\"");
-	conf->dns.revServers.t = CONF_JSON_STRING_ARRAY;
-	conf->dns.revServers.d.json = cJSON_CreateArray();
-	conf->dns.revServers.c = validate_dns_revServers;
-	conf->dns.revServers.f = FLAG_RESTART_FTL;
-
-	// sub-struct dns.rate_limit
-	conf->dns.rateLimit.count.k = "dns.rateLimit.count";
-	conf->dns.rateLimit.count.h = "Rate-limited queries are answered with a REFUSED reply and not further processed by FTL.\n The default settings for FTL's rate-limiting are to permit no more than 1000 queries in 60 seconds. Both numbers can be customized independently. It is important to note that rate-limiting is happening on a per-client basis. Other clients can continue to use FTL while rate-limited clients are short-circuited at the same time.\n For this setting, both numbers, the maximum number of queries within a given time, and the length of the time interval (seconds) have to be specified. For instance, if you want to set a rate limit of 1 query per hour, the option should look like dns.rateLimit.count=1 and dns.rateLimit.interval=3600. The time interval is relative to when FTL has finished starting (start of the daemon + possible delay by DELAY_STARTUP) then it will advance in steps of the rate-limiting interval. If a client reaches the maximum number of queries it will be blocked until the end of the current interval. This will be logged to /var/log/pihole/FTL.log, e.g. Rate-limiting 10.0.1.39 for at least 44 seconds. If the client continues to send queries while being blocked already and this number of queries during the blocking exceeds the limit the client will continue to be blocked until the end of the next interval (FTL.log will contain lines like Still rate-limiting 10.0.1.39 as it made additional 5007 queries). As soon as the client requests less than the set limit, it will be unblocked (Ending rate-limitation of 10.0.1.39).\n Rate-limiting may be disabled altogether by setting both values to zero (this results in the same behavior as before FTL v5.7).\n How many queries are permitted...";
-	conf->dns.rateLimit.count.t = CONF_UINT;
-	conf->dns.rateLimit.count.d.ui = 1000;
-	conf->dns.rateLimit.count.c = validate_stub; // Only type-based checking
-
-	conf->dns.rateLimit.interval.k = "dns.rateLimit.interval";
-	conf->dns.rateLimit.interval.h = "... in the set interval before rate-limiting?";
-	conf->dns.rateLimit.interval.t = CONF_UINT;
-	conf->dns.rateLimit.interval.d.ui = 60;
-	conf->dns.rateLimit.interval.c = validate_stub; // Only type-based checking
-
 	// sub-struct dns.special_domains
 	conf->dns.specialDomains.mozillaCanary.k = "dns.specialDomains.mozillaCanary";
-	conf->dns.specialDomains.mozillaCanary.h = "Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of use-application-dns.net to disable Firefox automatic DNS-over-HTTP? This is following the recommendation on https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https";
+	conf->dns.specialDomains.mozillaCanary.h = "Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of use-application-dns.net to disable Firefox automatic DNS-over-HTTP?\n\n This follows the recommendation on https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https";
+	conf->dns.specialDomains.mozillaCanary.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.specialDomains.mozillaCanary.t = CONF_BOOL;
 	conf->dns.specialDomains.mozillaCanary.d.b = true;
 	conf->dns.specialDomains.mozillaCanary.c = validate_stub; // Only type-based checking
 
 	conf->dns.specialDomains.iCloudPrivateRelay.k = "dns.specialDomains.iCloudPrivateRelay";
-	conf->dns.specialDomains.iCloudPrivateRelay.h = "Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of mask.icloud.com and mask-h2.icloud.com to disable Apple's iCloud Private Relay to prevent Apple devices from bypassing Pi-hole? This is following the recommendation on https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay";
+	conf->dns.specialDomains.iCloudPrivateRelay.h = "Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of mask.icloud.com and mask-h2.icloud.com to disable Apple's iCloud Private Relay to prevent Apple devices from bypassing Pi-hole?\n\n This follows the recommendation on https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay";
+	conf->dns.specialDomains.iCloudPrivateRelay.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.specialDomains.iCloudPrivateRelay.t = CONF_BOOL;
 	conf->dns.specialDomains.iCloudPrivateRelay.d.b = true;
 	conf->dns.specialDomains.iCloudPrivateRelay.c = validate_stub; // Only type-based checking
 
 	conf->dns.specialDomains.designatedResolver.k = "dns.specialDomains.designatedResolver";
-	conf->dns.specialDomains.designatedResolver.h = "Should Pi-hole always reply with NODATA to all queries to zone resolver.arpa to prevent devices from bypassing Pi-hole using Discovery of Designated Resolvers? This is based on recommendations at the end of RFC 9462, section 4.";
+	conf->dns.specialDomains.designatedResolver.h = "Should Pi-hole always reply with NODATA to all queries to zone resolver.arpa to prevent devices from bypassing Pi-hole using Discovery of Designated Resolvers?\n\n This is based on recommendations at the end of RFC 9462, section 4.";
+	conf->dns.specialDomains.designatedResolver.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.specialDomains.designatedResolver.t = CONF_BOOL;
 	conf->dns.specialDomains.designatedResolver.d.b = true;
 	conf->dns.specialDomains.designatedResolver.c = validate_stub; // Only type-based checking
 
 	// sub-struct dns.reply_addr
 	conf->dns.reply.host.force4.k = "dns.reply.host.force4";
-	conf->dns.reply.host.force4.h = "Use a specific IPv4 address for the Pi-hole host? By default, FTL determines the address of the interface a query arrived on and uses this address for replying to A queries with the most suitable address for the requesting client. This setting can be used to use a fixed, rather than the dynamically obtained, address when Pi-hole responds to the following names: [ \"pi.hole\", \"<the device's hostname>\", \"pi.hole.<local domain>\", \"<the device's hostname>.<local domain>\" ]";
+	conf->dns.reply.host.force4.h = "Use a specific IPv4 address for the Pi-hole host? By default, FTL determines the address of the interface a query arrived on and uses this address for replying to A queries with the most suitable address for the requesting client.\n\n This setting can be used to use a fixed, rather than the dynamically obtained, address when Pi-hole responds to the following names:\n - \"pi.hole\"\n - \"<the device's hostname>\"\n - \"pi.hole.<local domain>\"\n - \"<the device's hostname>.<local domain>\"";
+	conf->dns.reply.host.force4.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.reply.host.force4.t = CONF_BOOL;
 	conf->dns.reply.host.force4.d.b = false;
 	conf->dns.reply.host.force4.c = validate_stub; // Only type-based checking
 
 	conf->dns.reply.host.v4.k = "dns.reply.host.IPv4";
 	conf->dns.reply.host.v4.h = "Custom IPv4 address for the Pi-hole host";
-	conf->dns.reply.host.v4.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\")");
+	conf->dns.reply.host.v4.a = cJSON_CreateStringReference("A valid IPv4 address or empty string (\"\")");	
 	conf->dns.reply.host.v4.t = CONF_STRUCT_IN_ADDR;
 	memset(&conf->dns.reply.host.v4.d.in_addr, 0, sizeof(struct in_addr));
 	conf->dns.reply.host.v4.c = validate_stub; // Only type-based checking
 
 	conf->dns.reply.host.force6.k = "dns.reply.host.force6";
 	conf->dns.reply.host.force6.h = "Use a specific IPv6 address for the Pi-hole host? See description for the IPv4 variant above for further details.";
+	conf->dns.reply.host.force6.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.reply.host.force6.t = CONF_BOOL;
 	conf->dns.reply.host.force6.d.b = false;
 	conf->dns.reply.host.force6.c = validate_stub; // Only type-based checking
 
 	conf->dns.reply.host.v6.k = "dns.reply.host.IPv6";
 	conf->dns.reply.host.v6.h = "Custom IPv6 address for the Pi-hole host";
-	conf->dns.reply.host.v6.a = cJSON_CreateStringReference("<valid IPv6 address> or empty string (\"\")");
+	conf->dns.reply.host.v6.a = cJSON_CreateStringReference("A valid IPv6 address or empty string (\"\")");
 	conf->dns.reply.host.v6.t = CONF_STRUCT_IN6_ADDR;
 	memset(&conf->dns.reply.host.v6.d.in6_addr, 0, sizeof(struct in6_addr));
 	conf->dns.reply.host.v6.c = validate_stub; // Only type-based checking
 
+	// sub-struct dns.reply.blocking
 	conf->dns.reply.blocking.force4.k = "dns.reply.blocking.force4";
-	conf->dns.reply.blocking.force4.h = "Use a specific IPv4 address in IP blocking mode? By default, FTL determines the address of the interface a query arrived on and uses this address for replying to A queries with the most suitable address for the requesting client. This setting can be used to use a fixed, rather than the dynamically obtained, address when Pi-hole responds in the following cases: IP blocking mode is used and this query is to be blocked, regular expressions with the ;reply=IP regex extension.";
+	conf->dns.reply.blocking.force4.h = "Use a specific IPv4 address in IP blocking mode? By default, FTL determines the address of the interface a query arrived on and uses this address for replying to A queries with the most suitable address for the requesting client.\n\n This setting can be used to use a fixed, rather than the dynamically obtained, address when Pi-hole responds in the following cases:\n - IP blocking mode is used and this query is to be blocked\n - regular expressions with the ;reply=IP regex extension.";
+	conf->dns.reply.blocking.force4.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.reply.blocking.force4.t = CONF_BOOL;
 	conf->dns.reply.blocking.force4.d.b = false;
 	conf->dns.reply.blocking.force4.c = validate_stub; // Only type-based checking
 
 	conf->dns.reply.blocking.v4.k = "dns.reply.blocking.IPv4";
 	conf->dns.reply.blocking.v4.h = "Custom IPv4 address for IP blocking mode";
-	conf->dns.reply.blocking.v4.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\")");
+	conf->dns.reply.blocking.v4.a = cJSON_CreateStringReference("A valid IPv4 address or empty string (\"\")");
 	conf->dns.reply.blocking.v4.t = CONF_STRUCT_IN_ADDR;
 	memset(&conf->dns.reply.blocking.v4.d.in_addr, 0, sizeof(struct in_addr));
 	conf->dns.reply.blocking.v4.c = validate_stub; // Only type-based checking
 
 	conf->dns.reply.blocking.force6.k = "dns.reply.blocking.force6";
 	conf->dns.reply.blocking.force6.h = "Use a specific IPv6 address in IP blocking mode? See description for the IPv4 variant above for further details.";
+	conf->dns.reply.blocking.force6.a = cJSON_CreateStringReference("<true|false>");
 	conf->dns.reply.blocking.force6.t = CONF_BOOL;
 	conf->dns.reply.blocking.force6.d.b = false;
 	conf->dns.reply.blocking.force6.c = validate_stub; // Only type-based checking
 
 	conf->dns.reply.blocking.v6.k = "dns.reply.blocking.IPv6";
 	conf->dns.reply.blocking.v6.h = "Custom IPv6 address for IP blocking mode";
-	conf->dns.reply.blocking.v6.a = cJSON_CreateStringReference("<valid IPv6 address> or empty string (\"\")");
+	conf->dns.reply.blocking.v6.a = cJSON_CreateStringReference("Avalid IPv6 address or empty string (\"\")");
 	conf->dns.reply.blocking.v6.t = CONF_STRUCT_IN6_ADDR;
 	memset(&conf->dns.reply.blocking.v6.d.in6_addr, 0, sizeof(struct in6_addr));
 	conf->dns.reply.blocking.v6.c = validate_stub; // Only type-based checking
 
+	// sub-struct dns.rate_limit
+	conf->dns.rateLimit.count.k = "dns.rateLimit.count";
+	conf->dns.rateLimit.count.h = "Rate-limited queries are answered with a REFUSED reply and not further processed by FTL.\n\n The default settings for FTL's rate-limiting are to permit no more than 1000 queries in 60 seconds. Both numbers can be customized independently. It is important to note that rate-limiting is happening on a per-client basis. Other clients can continue to use FTL while rate-limited clients are short-circuited at the same time.\n\n For this setting, both numbers, the maximum number of queries within a given time, and the length of the time interval (seconds) have to be specified. For instance, if you want to set a rate limit of 1 query per hour, the option should look like dns.rateLimit.count=1 and dns.rateLimit.interval=3600. The time interval is relative to when FTL has finished starting (start of the daemon + possible delay by DELAY_STARTUP) then it will advance in steps of the rate-limiting interval. If a client reaches the maximum number of queries it will be blocked until the end of the current interval. This will be logged to /var/log/pihole/FTL.log, e.g. Rate-limiting 10.0.1.39 for at least 44 seconds. If the client continues to send queries while being blocked already and this number of queries during the blocking exceeds the limit the client will continue to be blocked until the end of the next interval (FTL.log will contain lines like Still rate-limiting 10.0.1.39 as it made additional 5007 queries). As soon as the client requests less than the set limit, it will be unblocked (Ending rate-limitation of 10.0.1.39).\n\n Rate-limiting may be disabled altogether by setting both values to zero (this results in the same behavior as before FTL v5.7).\n\n How many queries are permitted...";
+	conf->dns.rateLimit.count.a = cJSON_CreateStringReference("A positive integer value");
+	conf->dns.rateLimit.count.t = CONF_UINT;
+	conf->dns.rateLimit.count.d.ui = 1000;
+	conf->dns.rateLimit.count.c = validate_stub; // Only type-based checking
+
+	conf->dns.rateLimit.interval.k = "dns.rateLimit.interval";
+	conf->dns.rateLimit.interval.h = "... in the set interval before rate-limiting?";
+	conf->dns.rateLimit.interval.a = cJSON_CreateStringReference("A positive integer value in seconds");
+	conf->dns.rateLimit.interval.t = CONF_UINT;
+	conf->dns.rateLimit.interval.d.ui = 60;
+	conf->dns.rateLimit.interval.c = validate_stub; // Only type-based checking
+
 	// sub-struct dhcp
 	conf->dhcp.active.k = "dhcp.active";
 	conf->dhcp.active.h = "Is the embedded DHCP server enabled?";
+	conf->dhcp.active.a = cJSON_CreateStringReference("<true|false>");
 	conf->dhcp.active.t = CONF_BOOL;
 	conf->dhcp.active.f = FLAG_RESTART_FTL;
 	conf->dhcp.active.d.b = false;
 	conf->dhcp.active.c = validate_stub; // Only type-based checking
 
 	conf->dhcp.start.k = "dhcp.start";
-	conf->dhcp.start.h = "Start address of the DHCP address pool";
-	conf->dhcp.start.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\"), e.g., \"192.168.0.10\"");
+	conf->dhcp.start.h = "Start address of the DHCP address pool\n\n Example: \"192.168.0.10\"";
+	conf->dhcp.start.a = cJSON_CreateStringReference("A valid IPv4 address, or empty string (\"\")");
 	conf->dhcp.start.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.start.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.start.d.in_addr, 0, sizeof(struct in_addr));
 	conf->dhcp.start.c = validate_stub; // Only type-based checking
 
 	conf->dhcp.end.k = "dhcp.end";
-	conf->dhcp.end.h = "End address of the DHCP address pool";
-	conf->dhcp.end.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\"), e.g., \"192.168.0.250\"");
+	conf->dhcp.end.h = "End address of the DHCP address pool\n\n Example: \"192.168.0.250\"";
+	conf->dhcp.end.a = cJSON_CreateStringReference("A valid IPv4 address, or empty string (\"\")");
 	conf->dhcp.end.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.end.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.end.d.in_addr, 0, sizeof(struct in_addr));
 	conf->dhcp.end.c = validate_stub; // Only type-based checking
 
 	conf->dhcp.router.k = "dhcp.router";
-	conf->dhcp.router.h = "Address of the gateway to be used (typically the address of your router in a home installation)";
-	conf->dhcp.router.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\"), e.g., \"192.168.0.1\"");
+	conf->dhcp.router.h = "Address of the gateway to be used (typically the address of your router in a home installation)\n\n Example: \"192.168.0.1\"";
+	conf->dhcp.router.a = cJSON_CreateStringReference("A valid IPv4 address, or empty string (\"\")");
 	conf->dhcp.router.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.router.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.router.d.in_addr, 0, sizeof(struct in_addr));
 	conf->dhcp.router.c = validate_stub; // Only type-based checking
 
 	conf->dhcp.netmask.k = "dhcp.netmask";
-	conf->dhcp.netmask.h = "The netmask used by your Pi-hole. For directly connected networks (i.e., networks on which the machine running Pi-hole has an interface) the netmask is optional and may be set to an empty string (\"\"): it will then be determined from the interface configuration itself. For networks which receive DHCP service via a relay agent, we cannot determine the netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses based on the class (A, B or C) of the network address.";
-	conf->dhcp.netmask.a = cJSON_CreateStringReference("<any valid netmask> (e.g., \"255.255.255.0\") or empty string (\"\") for auto-discovery");
+	conf->dhcp.netmask.h = "The netmask used by your Pi-hole. For directly connected networks (i.e., networks on which the machine running Pi-hole has an interface) the netmask is optional and may be set to an empty string (\"\"): it will then be determined from the interface configuration itself.\n\n For networks which receive DHCP service via a relay agent, we cannot determine the netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses based on the class (A, B or C) of the network address.\n\n Example: \"255.255.255.0\"";
+	conf->dhcp.netmask.a = cJSON_CreateStringReference("Any valid netmask, or an empty string (\"\") for auto-discovery");
 	conf->dhcp.netmask.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.netmask.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.netmask.d.in_addr, 0, sizeof(struct in_addr));
@@ -789,6 +818,7 @@ static void initConfig(struct config *conf)
 
 	conf->dhcp.ipv6.k = "dhcp.ipv6";
 	conf->dhcp.ipv6.h = "Should Pi-hole make an attempt to also satisfy IPv6 address requests (be aware that IPv6 works a whole lot different than IPv4)";
+	conf->dhcp.ipv6.a = cJSON_CreateStringReference("<true|false>");
 	conf->dhcp.ipv6.t = CONF_BOOL;
 	conf->dhcp.ipv6.f = FLAG_RESTART_FTL;
 	conf->dhcp.ipv6.d.b = false;
@@ -796,6 +826,7 @@ static void initConfig(struct config *conf)
 
 	conf->dhcp.multiDNS.k = "dhcp.multiDNS";
 	conf->dhcp.multiDNS.h = "Advertise DNS server multiple times to clients. Some devices will add their own proprietary DNS servers to the list of DNS servers, which can cause issues with Pi-hole. This option will advertise the Pi-hole DNS server multiple times to clients, which should prevent this from happening.";
+	conf->dhcp.multiDNS.a = cJSON_CreateStringReference("<true|false>");
 	conf->dhcp.multiDNS.t = CONF_BOOL;
 	conf->dhcp.multiDNS.f = FLAG_RESTART_FTL;
 	conf->dhcp.multiDNS.d.b = false;
@@ -803,6 +834,7 @@ static void initConfig(struct config *conf)
 
 	conf->dhcp.rapidCommit.k = "dhcp.rapidCommit";
 	conf->dhcp.rapidCommit.h = "Enable DHCPv4 Rapid Commit Option specified in RFC 4039. Should only be enabled if either the server is the only server for the subnet to avoid conflicts";
+	conf->dhcp.rapidCommit.a = cJSON_CreateStringReference("<true|false>");
 	conf->dhcp.rapidCommit.t = CONF_BOOL;
 	conf->dhcp.rapidCommit.f = FLAG_RESTART_FTL;
 	conf->dhcp.rapidCommit.d.b = false;
@@ -810,21 +842,23 @@ static void initConfig(struct config *conf)
 
 	conf->dhcp.logging.k = "dhcp.logging";
 	conf->dhcp.logging.h = "Enable logging for DHCP. This will log all relevant DHCP-related activity, including, e.g., all the options sent to DHCP clients and the tags used to determine them (if any). This can be useful for debugging DHCP issues. The generated output is saved to the file specified by files.log.dnsmasq below.";
+	conf->dhcp.logging.a = cJSON_CreateStringReference("<true|false>");
 	conf->dhcp.logging.t = CONF_BOOL;
 	conf->dhcp.logging.f = FLAG_RESTART_FTL;
 	conf->dhcp.logging.d.b = false;
 	conf->dhcp.logging.c = validate_stub; // Only type-based checking
 
 	conf->dhcp.ignoreUnknownClients.k = "dhcp.ignoreUnknownClients";
-	conf->dhcp.ignoreUnknownClients.h = "Ignore unknown DHCP clients.\n If this option is set, Pi-hole ignores all clients which are not explicitly configured through dhcp.hosts. This can be useful to prevent unauthorized clients from getting an IP address from the DHCP server.\n It should be noted that this option is not a security feature, as clients can still assign themselves an IP address and use the network. It is merely a convenience feature to prevent unknown clients from getting a valid IP configuration assigned automatically.\n Note that you will need to configure new clients manually in dhcp.hosts before they can use the network when this feature is enabled.";
+	conf->dhcp.ignoreUnknownClients.h = "Ignore unknown DHCP clients.\n If this option is set, Pi-hole ignores all clients which are not explicitly configured through dhcp.hosts. This can be useful to prevent unauthorized clients from getting an IP address from the DHCP server.\n\n It should be noted that this option is not a security feature, as clients can still assign themselves an IP address and use the network. It is merely a convenience feature to prevent unknown clients from getting a valid IP configuration assigned automatically.\n\n Note that you will need to configure new clients manually in dhcp.hosts before they can use the network when this feature is enabled.";
+	conf->dhcp.ignoreUnknownClients.a = cJSON_CreateStringReference("<true|false>");
 	conf->dhcp.ignoreUnknownClients.t = CONF_BOOL;
 	conf->dhcp.ignoreUnknownClients.f = FLAG_RESTART_FTL;
 	conf->dhcp.ignoreUnknownClients.d.b = false;
 	conf->dhcp.ignoreUnknownClients.c = validate_stub; // Only type-based checking
 
 	conf->dhcp.hosts.k = "dhcp.hosts";
-	conf->dhcp.hosts.h = "Per host parameters for the DHCP server. This allows a machine with a particular hardware address to be always allocated the same hostname, IP address and lease time or to specify static DHCP leases";
-	conf->dhcp.hosts.a = cJSON_CreateStringReference("Array of static leases each on in one of the following forms: \"[<hwaddr>][,id:<client_id>|*][,set:<tag>][,tag:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]\"");
+	conf->dhcp.hosts.h = "Per host parameters for the DHCP server. This allows a machine with a particular hardware address to be always allocated the same hostname, IP address and lease time or to specify static DHCP leases\n\n Example: [ \"00:20:e0:3b:13:af,192.168.0.123,laptop,24h\", \"00:20:e0:ab:cd:ef,192.168.0.124,desktop,24h\"]";
+	conf->dhcp.hosts.a = cJSON_CreateStringReference("Array of static leases each one in the following form: \"[<hwaddr>][,id:<client_id>|*][,set:<tag>][,tag:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]\"");
 	conf->dhcp.hosts.t = CONF_JSON_STRING_ARRAY;
 	conf->dhcp.hosts.f = FLAG_RESTART_FTL;
 	conf->dhcp.hosts.d.json = cJSON_CreateArray();
@@ -834,6 +868,7 @@ static void initConfig(struct config *conf)
 	// struct ntp
 	conf->ntp.ipv4.active.k = "ntp.ipv4.active";
 	conf->ntp.ipv4.active.h = "Should FTL act as network time protocol (NTP) server (IPv4)?";
+	conf->ntp.ipv4.active.a = cJSON_CreateStringReference("<true|false>");
 	conf->ntp.ipv4.active.t = CONF_BOOL;
 	conf->ntp.ipv4.active.f = FLAG_RESTART_FTL;
 	conf->ntp.ipv4.active.d.b = true;
@@ -841,7 +876,7 @@ static void initConfig(struct config *conf)
 
 	conf->ntp.ipv4.address.k = "ntp.ipv4.address";
 	conf->ntp.ipv4.address.h = "IPv4 address to listen on for NTP requests";
-	conf->ntp.ipv4.address.a = cJSON_CreateStringReference("<valid IPv4 address> or empty string (\"\") for wildcard (0.0.0.0)");
+	conf->ntp.ipv4.address.a = cJSON_CreateStringReference("A valid IPv4 address, or empty string (\"\"). For wildcard (0.0.0.0)");
 	conf->ntp.ipv4.address.t = CONF_STRUCT_IN_ADDR;
 	conf->ntp.ipv4.address.f = FLAG_RESTART_FTL;
 	memset(&conf->ntp.ipv4.address.d.in_addr, 0, sizeof(struct in_addr));
@@ -849,6 +884,7 @@ static void initConfig(struct config *conf)
 
 	conf->ntp.ipv6.active.k = "ntp.ipv6.active";
 	conf->ntp.ipv6.active.h = "Should FTL act as network time protocol (NTP) server (IPv6)?";
+	conf->ntp.ipv6.active.a = cJSON_CreateStringReference("<true|false>");
 	conf->ntp.ipv6.active.t = CONF_BOOL;
 	conf->ntp.ipv6.active.f = FLAG_RESTART_FTL;
 	conf->ntp.ipv6.active.d.b = true;
@@ -856,7 +892,7 @@ static void initConfig(struct config *conf)
 
 	conf->ntp.ipv6.address.k = "ntp.ipv6.address";
 	conf->ntp.ipv6.address.h = "IPv6 address to listen on for NTP requests";
-	conf->ntp.ipv6.address.a = cJSON_CreateStringReference("<valid IPv6 address> or empty string (\"\") for wildcard (::)");
+	conf->ntp.ipv6.address.a = cJSON_CreateStringReference("A valid IPv6 address, or empty string (\"\"). For wildcard (::)");
 	conf->ntp.ipv6.address.t = CONF_STRUCT_IN6_ADDR;
 	conf->ntp.ipv6.address.f = FLAG_RESTART_FTL;
 	memset(&conf->ntp.ipv6.address.d.in6_addr, 0, sizeof(struct in6_addr));
@@ -864,6 +900,7 @@ static void initConfig(struct config *conf)
 
 	conf->ntp.sync.active.k = "ntp.sync.active";
 	conf->ntp.sync.active.h = "Should FTL try to synchronize the system time with an upstream NTP server?";
+	conf->ntp.sync.active.a = cJSON_CreateStringReference("<true|false>");
 	conf->ntp.sync.active.t = CONF_BOOL;
 	conf->ntp.sync.active.f = FLAG_RESTART_FTL;
 	conf->ntp.sync.active.d.b = true;
@@ -871,38 +908,42 @@ static void initConfig(struct config *conf)
 
 	conf->ntp.sync.server.k = "ntp.sync.server";
 	conf->ntp.sync.server.h = "NTP upstream server to sync with, e.g., \"pool.ntp.org\". Note that the NTP server should be located as close as possible to you in order to minimize the time offset possibly introduced by different routing paths.";
-	conf->ntp.sync.server.a = cJSON_CreateStringReference("valid NTP upstream server");
+	conf->ntp.sync.server.a = cJSON_CreateStringReference("A valid NTP upstream server");
 	conf->ntp.sync.server.t = CONF_STRING;
 	conf->ntp.sync.server.d.s = (char*)"pool.ntp.org";
 	conf->ntp.sync.server.c = validate_stub; // Only type-based checking
 
 	conf->ntp.sync.interval.k = "ntp.sync.interval";
 	conf->ntp.sync.interval.h = "Interval in seconds between successive synchronization attempts with the NTP server";
+	conf->ntp.sync.interval.a = cJSON_CreateStringReference("A positive integer value in seconds");
 	conf->ntp.sync.interval.t = CONF_UINT;
 	conf->ntp.sync.interval.d.ui = 3600;
 	conf->ntp.sync.interval.c = validate_stub; // Only type-based checking
 
 	conf->ntp.sync.count.k = "ntp.sync.count";
 	conf->ntp.sync.count.h = "Number of NTP syncs to perform and average before updating the system time";
+	conf->ntp.sync.count.a = cJSON_CreateStringReference("A positive integer value");
 	conf->ntp.sync.count.t = CONF_UINT;
 	conf->ntp.sync.count.d.ui = 8;
 	conf->ntp.sync.count.c = validate_stub; // Only type-based checking
 
 	conf->ntp.sync.rtc.set.k = "ntp.sync.rtc.set";
 	conf->ntp.sync.rtc.set.h = "Should FTL update a real-time clock (RTC) if available?";
+	conf->ntp.sync.rtc.set.a = cJSON_CreateStringReference("<true|false>");
 	conf->ntp.sync.rtc.set.t = CONF_BOOL;
 	conf->ntp.sync.rtc.set.d.b = false;
 	conf->ntp.sync.rtc.set.c = validate_stub; // Only type-based checking
 
 	conf->ntp.sync.rtc.device.k = "ntp.sync.rtc.device";
-	conf->ntp.sync.rtc.device.h = "Path to the RTC device to update. Leave empty for auto-discovery";
-	conf->ntp.sync.rtc.device.a = cJSON_CreateStringReference("Path to the RTC device, e.g., \"/dev/rtc0\"");
+	conf->ntp.sync.rtc.device.h = "Path to the RTC device to update.\n\n Example: \"/dev/rtc0\"";
+	conf->ntp.sync.rtc.device.a = cJSON_CreateStringReference("A valid RTC device path, or empty string (\"\") for auto-discovery");
 	conf->ntp.sync.rtc.device.t = CONF_STRING;
 	conf->ntp.sync.rtc.device.d.s = (char*)"";
 	conf->ntp.sync.rtc.device.c = validate_stub; // Only type-based checking
 
 	conf->ntp.sync.rtc.utc.k = "ntp.sync.rtc.utc";
 	conf->ntp.sync.rtc.utc.h = "Should the RTC be set to UTC?";
+	conf->ntp.sync.rtc.utc.a = cJSON_CreateStringReference("<true|false>");
 	conf->ntp.sync.rtc.utc.t = CONF_BOOL;
 	conf->ntp.sync.rtc.utc.d.b = true;
 	conf->ntp.sync.rtc.utc.c = validate_stub; // Only type-based checking
@@ -911,18 +952,21 @@ static void initConfig(struct config *conf)
 	// struct resolver
 	conf->resolver.resolveIPv6.k = "resolver.resolveIPv6";
 	conf->resolver.resolveIPv6.h = "Should FTL try to resolve IPv6 addresses to hostnames?";
+	conf->resolver.resolveIPv6.a = cJSON_CreateStringReference("<true|false>");
 	conf->resolver.resolveIPv6.t = CONF_BOOL;
 	conf->resolver.resolveIPv6.d.b = true;
 	conf->resolver.resolveIPv6.c = validate_stub; // Only type-based checking
 
 	conf->resolver.resolveIPv4.k = "resolver.resolveIPv4";
 	conf->resolver.resolveIPv4.h = "Should FTL try to resolve IPv4 addresses to hostnames?";
+	conf->resolver.resolveIPv4.a = cJSON_CreateStringReference("<true|false>");
 	conf->resolver.resolveIPv4.t = CONF_BOOL;
 	conf->resolver.resolveIPv4.d.b = true;
 	conf->resolver.resolveIPv4.c = validate_stub; // Only type-based checking
 
 	conf->resolver.networkNames.k = "resolver.networkNames";
-	conf->resolver.networkNames.h = "Control whether FTL should use the fallback option to try to obtain client names from checking the network table. This behavior can be disabled with this option.\n Assume an IPv6 client without a host names. However, the network table knows - though the client's MAC address - that this is the same device where we have a host name for another IP address (e.g., a DHCP server managed IPv4 address). In this case, we use the host name associated to the other address as this is the same device.";
+	conf->resolver.networkNames.h = "Control whether FTL should use the fallback option to try to obtain client names from checking the network table. This behavior can be disabled with this option.\n\n Assume an IPv6 client without a host names. However, the network table knows - though the client's MAC address - that this is the same device where we have a host name for another IP address (e.g., a DHCP server managed IPv4 address). In this case, we use the host name associated to the other address as this is the same device.";
+	conf->resolver.networkNames.a = cJSON_CreateStringReference("<true|false>");
 	conf->resolver.networkNames.t = CONF_BOOL;
 	conf->resolver.networkNames.d.b = true;
 	conf->resolver.networkNames.c = validate_stub; // Only type-based checking
@@ -947,24 +991,28 @@ static void initConfig(struct config *conf)
 	// struct database
 	conf->database.DBimport.k = "database.DBimport";
 	conf->database.DBimport.h = "Should FTL load information from the database on startup to be aware of the most recent history?";
+	conf->database.DBimport.a = cJSON_CreateStringReference("<true|false>");
 	conf->database.DBimport.t = CONF_BOOL;
 	conf->database.DBimport.d.b = true;
 	conf->database.DBimport.c = validate_stub; // Only type-based checking
 
 	conf->database.maxDBdays.k = "database.maxDBdays";
-	conf->database.maxDBdays.h = "How long should queries be stored in the database [days]?\n Setting this value to 0 will disable the database.";
+	conf->database.maxDBdays.h = "How long should queries be stored in the database [days]?";
+	conf->database.maxDBdays.a = cJSON_CreateStringReference("A positive integer value in days, or 0 to disable the database");
 	conf->database.maxDBdays.t = CONF_INT;
 	conf->database.maxDBdays.d.i = (365/4);
 	conf->database.maxDBdays.c = validate_stub; // Only type-based checking
 
 	conf->database.DBinterval.k = "database.DBinterval";
 	conf->database.DBinterval.h = "How often do we store queries in FTL's database [seconds]?";
+	conf->database.DBinterval.a = cJSON_CreateStringReference("A positive integer value in seconds");
 	conf->database.DBinterval.t = CONF_UINT;
 	conf->database.DBinterval.d.ui = 60;
 	conf->database.DBinterval.c = validate_stub; // Only type-based checking
 
 	conf->database.useWAL.k = "database.useWAL";
-	conf->database.useWAL.h = "Should FTL enable Write-Ahead Log (WAL) mode for the on-disk query database (configured via files.database)?\n It is recommended to leave this setting enabled for performance reasons. About the only reason to disable WAL mode is if you are experiencing specific issues with it, e.g., when using a database that is accessed from multiple hosts via a network share. When this setting is disabled, FTL will use SQLite3's default journal mode (rollback journal in DELETE mode).";
+	conf->database.useWAL.h = "Should FTL enable Write-Ahead Log (WAL) mode for the on-disk query database (configured via files.database)?\n\n It is recommended to leave this setting enabled for performance reasons. About the only reason to disable WAL mode is if you are experiencing specific issues with it, e.g., when using a database that is accessed from multiple hosts via a network share. When this setting is disabled, FTL will use SQLite3's default journal mode (rollback journal in DELETE mode).";
+	conf->database.useWAL.a = cJSON_CreateStringReference("<true|false>");
 	conf->database.useWAL.t = CONF_BOOL;
 	// Note: We would not necessarily need to restart FTL when this setting
 	// is changed, but we do it anyway as this ensures the database is
@@ -984,44 +1032,47 @@ static void initConfig(struct config *conf)
 	// sub-struct database.network
 	conf->database.network.parseARPcache.k = "database.network.parseARPcache";
 	conf->database.network.parseARPcache.h = "Should FTL analyze the local ARP cache? When disabled, client identification and the network table will stop working reliably.";
+	conf->database.network.parseARPcache.a = cJSON_CreateStringReference("<true|false>");
 	conf->database.network.parseARPcache.t = CONF_BOOL;
 	conf->database.network.parseARPcache.d.b = true;
 	conf->database.network.parseARPcache.c = validate_stub; // Only type-based checking
 
 	conf->database.network.expire.k = "database.network.expire";
 	conf->database.network.expire.h = "How long should IP addresses be kept in the network_addresses table [days]? IP addresses (and associated host names) older than the specified number of days are removed to avoid dead entries in the network overview table.";
+	conf->database.network.expire.a = cJSON_CreateStringReference("A positive integer value in days");
 	conf->database.network.expire.t = CONF_UINT;
 	conf->database.network.expire.d.ui = conf->database.maxDBdays.d.ui;
 	conf->database.network.expire.c = validate_stub; // Only type-based checking
 
 
-	// struct http
+	// struct webserver
 	conf->webserver.domain.k = "webserver.domain";
 	conf->webserver.domain.h = "On which domain is the web interface served?";
-	conf->webserver.domain.a = cJSON_CreateStringReference("<valid domain>");
+	conf->webserver.domain.a = cJSON_CreateStringReference("A valid domain");
 	conf->webserver.domain.t = CONF_STRING;
 	conf->webserver.domain.f = FLAG_RESTART_FTL;
 	conf->webserver.domain.d.s = (char*)"pi.hole";
 	conf->webserver.domain.c = validate_domain;
 
 	conf->webserver.acl.k = "webserver.acl";
-	conf->webserver.acl.h = "Webserver access control list (ACL) allowing for restrictions to be put on the list of IP addresses which have access to the web server. The ACL is a comma separated list of IP subnets, where each subnet is prepended by either a - or a + sign. A plus sign means allow, where a minus sign means deny. If a subnet mask is omitted, such as -1.2.3.4, this means to deny only that single IP address. If this value is not set (empty string), all accesses are allowed. Otherwise, the default setting is to deny all accesses. On each request the full list is traversed, and the last (!) match wins. IPv6 addresses may be specified in CIDR-form [a:b::c]/64.\n\n Example 1: acl = \"+127.0.0.1,+[::1]\"\n ---> deny all access, except from 127.0.0.1 and ::1,\n Example 2: acl = \"+192.168.0.0/16\"\n ---> deny all accesses, except from the 192.168.0.0/16 subnet,\n Example 3: acl = \"+[::]/0\" ---> allow only IPv6 access.";
-	conf->webserver.acl.a = cJSON_CreateStringReference("<valid ACL>");
+	conf->webserver.acl.h = "Webserver access control list (ACL) allowing for restrictions to be put on the list of IP addresses which have access to the web server. The ACL is a comma separated list of IP subnets, where each subnet is prepended by either a - or a + sign. A plus sign means allow, where a minus sign means deny.\n\n If a subnet mask is omitted, such as -1.2.3.4, this means to deny only that single IP address. If this value is not set (empty string), all accesses are allowed. Otherwise, the default setting is to deny all accesses. On each request the full list is traversed, and the last (!) match wins. IPv6 addresses may be specified in CIDR-form [a:b::c]/64.\n\n Example 1: \"+127.0.0.1,+[::1]\" ---> deny all access, except from 127.0.0.1 and ::1\n\n Example 2: \"+192.168.0.0/16\" ---> deny all accesses, except from the 192.168.0.0/16 subnet\n\n Example 3: \"+[::]/0\" ---> allow only IPv6 access.";
+	conf->webserver.acl.a = cJSON_CreateStringReference("A valid ACL");
 	conf->webserver.acl.f = FLAG_RESTART_FTL;
 	conf->webserver.acl.t = CONF_STRING;
 	conf->webserver.acl.d.s = (char*)"";
 	conf->webserver.acl.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.port.k = "webserver.port";
-	conf->webserver.port.h = "Ports to be used by the webserver.\n Comma-separated list of ports to listen on. It is possible to specify an IP address to bind to. In this case, an IP address and a colon must be prepended to the port number. For example, to bind to the loopback interface on port 80 (IPv4) and to all interfaces port 8080 (IPv4), use \"127.0.0.1:80,8080\". \"[::]:80\" can be used to listen to IPv6 connections to port 80. IPv6 addresses of network interfaces can be specified as well, e.g. \"[::1]:80\" for the IPv6 loopback interface. [::]:80 will bind to port 80 IPv6 only.\n In order to use port 80 for all interfaces, both IPv4 and IPv6, use either the configuration \"80,[::]:80\" (create one socket for IPv4 and one for IPv6 only), or \"+80\" (create one socket for both, IPv4 and IPv6). The '+' notation to use IPv4 and IPv6 will only work if no network interface is specified. Depending on your operating system version and IPv6 network environment, some configurations might not work as expected, so you have to test to find the configuration most suitable for your needs. In case \"+80\" does not work for your environment, you need to use \"80,[::]:80\".\n If the port is TLS/SSL, a letter 's' (secure) must be appended, for example, \"80,443s\" will open port 80 and port 443, and connections on port 443 will be encrypted. For non-encrypted ports, it is allowed to append letter 'r' (as in redirect). Redirected ports will redirect all their traffic to the first configured SSL port. For example, if webserver.port is \"80r,443s\", then all HTTP traffic coming at port 80 will be redirected to HTTPS port 443.\n When specifying 'o' (optional) behind a port, inability to use this port is not considered an error. For instance, specifying \"80o,8080o\" will allow the webserver to listen on either 80, 8080, both or even none of the two ports. This flag may be combined with 'r' and 's' like \"80or,443os,8080,4443s\" (80 redirecting to SSL if available, 443 encrypted if available, 8080 mandatory and unencrypted, 4443 mandatory and encrypted).\n If this value is not set (empty string), the web server will not be started and, hence, the API will not be available.";
-	conf->webserver.port.a = cJSON_CreateStringReference("comma-separated list of <[ip_address:]port>");
+	conf->webserver.port.h = "Ports to be used by the webserver.\n\n Comma-separated list of ports to listen on. It is possible to specify an IP address to bind to. In this case, an IP address and a colon must be prepended to the port number. For example, to bind to the loopback interface on port 80 (IPv4) and to all interfaces port 8080 (IPv4), use \"127.0.0.1:80,8080\". \"[::]:80\" can be used to listen to IPv6 connections to port 80. IPv6 addresses of network interfaces can be specified as well, e.g. \"[::1]:80\" for the IPv6 loopback interface. \"[::]:80\" will bind to port 80 IPv6 only.\n\n In order to use port 80 for all interfaces, both IPv4 and IPv6, use either the configuration \"80,[::]:80\" (create one socket for IPv4 and one for IPv6 only), or \"+80\" (create one socket for both, IPv4 and IPv6). The '+' notation to use IPv4 and IPv6 will only work if no network interface is specified. Depending on your operating system version and IPv6 network environment, some configurations might not work as expected, so you have to test to find the configuration most suitable for your needs. In case \"+80\" does not work for your environment, you need to use \"80,[::]:80\".\n\n If the port is TLS/SSL, a letter 's' (secure) must be appended, for example, \"80,443s\" will open port 80 and port 443, and connections on port 443 will be encrypted. For non-encrypted ports, it is allowed to append letter 'r' (as in redirect). Redirected ports will redirect all their traffic to the first configured SSL port. For example, if webserver.port is \"80r,443s\", then all HTTP traffic coming at port 80 will be redirected to HTTPS port 443.\n\n When specifying 'o' (optional) behind a port, inability to use this port is not considered an error. For instance, specifying \"80o,8080o\" will allow the webserver to listen on either 80, 8080, both or even none of the two ports. This flag may be combined with 'r' and 's' like \"80or,443os,8080,4443s\" (80 redirecting to SSL if available, 443 encrypted if available, 8080 mandatory and unencrypted, 4443 mandatory and encrypted).\n\n If this value is not set (empty string), the web server will not be started and, hence, the API will not be available.";
+	conf->webserver.port.a = cJSON_CreateStringReference("A comma-separated list of <[ip_address:]port>");
 	conf->webserver.port.f = FLAG_RESTART_FTL;
 	conf->webserver.port.t = CONF_STRING;
 	conf->webserver.port.d.s = (char*)"80o,443os,[::]:80o,[::]:443os";
 	conf->webserver.port.c = validate_stub; // Type-based checking + civetweb syntax checking
 
 	conf->webserver.threads.k = "webserver.threads";
-	conf->webserver.threads.h = "Maximum number of worker threads allowed.\n The Pi-hole web server handles each incoming connection in a separate thread. Therefore, the value of this option is effectively the number of concurrent HTTP connections that can be handled. Any other connections are queued until they can be processed by a unoccupied thread.\n The total number of threads you see may be lower than the configured value as threads are only created when needed due to incoming connections.\n The value 0 means the number of threads is 50 (as per default settings of CivetWeb) for backwards-compatible behavior.";
+	conf->webserver.threads.h = "Maximum number of worker threads allowed.\n\n The Pi-hole web server handles each incoming connection in a separate thread. Therefore, the value of this option is effectively the number of concurrent HTTP connections that can be handled. Any other connections are queued until they can be processed by a unoccupied thread.\n\n The total number of threads you see may be lower than the configured value as threads are only created when needed due to incoming connections.\n\n The value 0 means the number of threads is 50 (as per default settings of CivetWeb) for backwards-compatible behavior.";
+	conf->webserver.threads.a = cJSON_CreateStringReference("A positive integer value, or 0 for default (50)");
 	conf->webserver.threads.t = CONF_UINT;
 	conf->webserver.threads.f = FLAG_RESTART_FTL;
 	conf->webserver.threads.d.ui = 50;
@@ -1029,7 +1080,7 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.headers.k = "webserver.headers";
 	conf->webserver.headers.h = "Additional HTTP headers added to the web server responses.\n The headers are added to all responses, including those for the API.\n Note about the default additional headers:\n - X-DNS-Prefetch-Control: off: Usually browsers proactively perform domain name resolution on links that the user may choose to follow. We disable DNS prefetching here.\n - Content-Security-Policy: [...] 'unsafe-inline' is both required by Chart.js styling some elements directly, and index.html containing some inlined Javascript code.\n - X-Frame-Options: DENY: The page can not be displayed in a frame, regardless of the site attempting to do so.\n - X-Xss-Protection: 0: Disables XSS filtering in browsers that support it. This header is usually enabled by default in browsers, and is not recommended as it can hurt the security of the site. (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).\n - X-Content-Type-Options: nosniff: Marker used by the server to indicate that the MIME types advertised in the  Content-Type headers should not be changed and be followed. This allows to opt-out of MIME type sniffing, or, in other words, it is a way to say that the webmasters knew what they were doing. Site security testers usually expect this header to be set.\n - Referrer-Policy: strict-origin-when-cross-origin: A referrer will be sent for same-site origins, but cross-origin requests will send no referrer information.\n The latter four headers are set as expected by https://securityheaders.io";
-	conf->webserver.headers.a = cJSON_CreateStringReference("array of HTTP headers");
+	conf->webserver.headers.a = cJSON_CreateStringReference("An array of HTTP headers");
 	conf->webserver.headers.t = CONF_JSON_STRING_ARRAY;
 	conf->webserver.headers.f = FLAG_RESTART_FTL;
 	conf->webserver.headers.d.json = cJSON_CreateArray();
@@ -1043,34 +1094,38 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.serve_all.k = "webserver.serve_all";
 	conf->webserver.serve_all.h = "Should the web server serve all files in webserver.paths.webroot directory? If disabled, only files within the path defined through webserver.paths.webhome and /api will be served.";
+	conf->webserver.serve_all.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.serve_all.t = CONF_BOOL;
 	conf->webserver.serve_all.d.b = false;
 	conf->webserver.serve_all.c = validate_stub;
 
-	conf->webserver.tls.cert.k = "webserver.tls.cert";
-	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. All directories along the path must be readable and accessible by the user running FTL (typically 'pihole'). This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n The *.pem file can be created using\n     cp server.crt server.pem\n     cat server.key >> server.pem\n if you have these files instead";
-	conf->webserver.tls.cert.a = cJSON_CreateStringReference("<valid TLS certificate file (*.pem)>");
-	conf->webserver.tls.cert.f = FLAG_RESTART_FTL;
-	conf->webserver.tls.cert.t = CONF_STRING;
-	conf->webserver.tls.cert.d.s = (char*)"/etc/pihole/tls.pem";
-	conf->webserver.tls.cert.c = validate_filepath;
-
+	// sub-struct session
 	conf->webserver.session.timeout.k = "webserver.session.timeout";
-	conf->webserver.session.timeout.h = "Session timeout in seconds. If a session is inactive for more than this time, it will be terminated. Sessions are continuously refreshed by the web interface, preventing sessions from timing out while the web interface is open.\n This option may also be used to make logins persistent for long times, e.g. 86400 seconds (24 hours), 604800 seconds (7 days) or 2592000 seconds (30 days). Note that the total number of concurrent sessions is limited so setting this value too high may result in users being rejected and unable to log in if there are already too many sessions active.";
+	conf->webserver.session.timeout.h = "Session timeout in seconds. If a session is inactive for more than this time, it will be terminated. Sessions are continuously refreshed by the web interface, preventing sessions from timing out while the web interface is open.\n\n This option may also be used to make logins persistent for long times, e.g. 86400 seconds (24 hours), 604800 seconds (7 days) or 2592000 seconds (30 days). Note that the total number of concurrent sessions is limited so setting this value too high may result in users being rejected and unable to log in if there are already too many sessions active.";
+	conf->webserver.session.timeout.a = cJSON_CreateStringReference("A positive integer value in seconds");
 	conf->webserver.session.timeout.t = CONF_UINT;
 	conf->webserver.session.timeout.d.ui = 1800u;
 	conf->webserver.session.timeout.c = validate_stub; // Only type-based checking
 
 	conf->webserver.session.restore.k = "webserver.session.restore";
 	conf->webserver.session.restore.h = "Should Pi-hole backup and restore sessions from the database? This is useful if you want to keep your sessions after a restart of the web interface.";
+	conf->webserver.session.restore.a = cJSON_CreateStringReference("<true|false>");	
 	conf->webserver.session.restore.t = CONF_BOOL;
 	conf->webserver.session.restore.d.b = true;
 	conf->webserver.session.restore.c = validate_stub; // Only type-based checking
 
+	conf->webserver.tls.cert.k = "webserver.tls.cert";
+	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file. All directories along the path must be readable and accessible by the user running FTL (typically 'pihole'). This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n\n The *.pem file can be created using `cp server.crt server.pem && cat server.key >> server.pem` if you have these files instead";
+	conf->webserver.tls.cert.a = cJSON_CreateStringReference("A valid TLS certificate file (*.pem)");
+	conf->webserver.tls.cert.f = FLAG_RESTART_FTL;
+	conf->webserver.tls.cert.t = CONF_STRING;
+	conf->webserver.tls.cert.d.s = (char*)"/etc/pihole/tls.pem";
+	conf->webserver.tls.cert.c = validate_filepath;
+
 	// sub-struct paths
 	conf->webserver.paths.webroot.k = "webserver.paths.webroot";
 	conf->webserver.paths.webroot.h = "Server root on the host";
-	conf->webserver.paths.webroot.a = cJSON_CreateStringReference("<valid path>");
+	conf->webserver.paths.webroot.a = cJSON_CreateStringReference("A valid path");
 	conf->webserver.paths.webroot.t = CONF_STRING;
 	conf->webserver.paths.webroot.f = FLAG_RESTART_FTL;
 	conf->webserver.paths.webroot.d.s = (char*)"/var/www/html";
@@ -1078,15 +1133,15 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.paths.webhome.k = "webserver.paths.webhome";
 	conf->webserver.paths.webhome.h = "Sub-directory of the root containing the web interface";
-	conf->webserver.paths.webhome.a = cJSON_CreateStringReference("<valid subpath>, both slashes are needed!");
+	conf->webserver.paths.webhome.a = cJSON_CreateStringReference("A valid subpath, both slashes are needed!");
 	conf->webserver.paths.webhome.t = CONF_STRING;
 	conf->webserver.paths.webhome.f = FLAG_RESTART_FTL;
 	conf->webserver.paths.webhome.d.s = (char*)"/admin/";
 	conf->webserver.paths.webhome.c = validate_filepath_two_slash;
 
 	conf->webserver.paths.prefix.k = "webserver.paths.prefix";
-	conf->webserver.paths.prefix.h = "Prefix where the web interface is served\n This is useful when you are using a reverse proxy serving the web interface, e.g., at http://<ip>/pihole/admin/ instead of http://<ip>/admin/. In this example, the prefix would be \"/pihole\". Note that the prefix has to be stripped away by the reverse proxy, e.g., for traefik:\n - traefik.http.routers.pihole.rule=PathPrefix(`/pihole`)\n - traefik.http.middlewares.piholehttp.stripprefix.prefixes=/pihole\n The prefix should start with a slash. If you don't use a prefix, leave this field empty. Setting this field to an incorrect value may result in the web interface not being accessible.\n Don't use this setting if you are not using a reverse proxy!";
-	conf->webserver.paths.prefix.a = cJSON_CreateStringReference("valid URL prefix or empty");
+	conf->webserver.paths.prefix.h = "Prefix where the web interface is served\n\n This is useful when you are using a reverse proxy serving the web interface, e.g., at http://<ip>/pihole/admin/ instead of http://<ip>/admin/. In this example, the prefix would be \"/pihole\". Note that the prefix has to be stripped away by the reverse proxy, e.g., for traefik:\n - traefik.http.routers.pihole.rule=PathPrefix(`/pihole`)\n - traefik.http.middlewares.piholehttp.stripprefix.prefixes=/pihole\n The prefix should start with a slash. If you don't use a prefix, leave this field empty. Setting this field to an incorrect value may result in the web interface not being accessible.\n Don't use this setting if you are not using a reverse proxy!";
+	conf->webserver.paths.prefix.a = cJSON_CreateStringReference("A valid URL prefix or empty");
 	conf->webserver.paths.prefix.t = CONF_STRING;
 	conf->webserver.paths.prefix.f = FLAG_RESTART_FTL;
 	conf->webserver.paths.prefix.d.s = (char*)"";
@@ -1095,6 +1150,7 @@ static void initConfig(struct config *conf)
 	// sub-struct interface
 	conf->webserver.interface.boxed.k = "webserver.interface.boxed";
 	conf->webserver.interface.boxed.h = "Should the web interface use the boxed layout?";
+	conf->webserver.interface.boxed.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.interface.boxed.t = CONF_BOOL;
 	conf->webserver.interface.boxed.d.b = true;
 	conf->webserver.interface.boxed.c = validate_stub; // Only type-based checking
@@ -1116,7 +1172,8 @@ static void initConfig(struct config *conf)
 
 	// sub-struct api
 	conf->webserver.api.max_sessions.k = "webserver.api.max_sessions";
-	conf->webserver.api.max_sessions.h = "Number of concurrent sessions allowed for the API. If the number of sessions exceeds this value, no new sessions will be allowed until the number of sessions drops due to session expiration or logout. Note that the number of concurrent sessions is irrelevant if authentication is disabled as no sessions are used in this case.";
+	conf->webserver.api.max_sessions.h = "Number of concurrent sessions allowed for the API. If the number of sessions exceeds this value, no new sessions will be allowed until the number of sessions drops due to session expiration or logout.\n\n Note that the number of concurrent sessions is irrelevant if authentication is disabled as no sessions are used in this case.";
+	conf->webserver.api.max_sessions.a = cJSON_CreateStringReference("A positive integer value");
 	conf->webserver.api.max_sessions.t = CONF_UINT16;
 	conf->webserver.api.max_sessions.d.u16 = 16;
 	conf->webserver.api.max_sessions.f = FLAG_RESTART_FTL;
@@ -1124,13 +1181,14 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.api.prettyJSON.k = "webserver.api.prettyJSON";
 	conf->webserver.api.prettyJSON.h = "Should FTL prettify the API output (add extra spaces, newlines and indentation)?";
+	conf->webserver.api.prettyJSON.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.api.prettyJSON.t = CONF_BOOL;
 	conf->webserver.api.prettyJSON.d.b = false;
 	conf->webserver.api.prettyJSON.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.pwhash.k = "webserver.api.pwhash";
 	conf->webserver.api.pwhash.h = "API password hash";
-	conf->webserver.api.pwhash.a = cJSON_CreateStringReference("<valid Pi-hole password hash>");
+	conf->webserver.api.pwhash.a = cJSON_CreateStringReference("A valid Pi-hole password hash");
 	conf->webserver.api.pwhash.t = CONF_STRING;
 	conf->webserver.api.pwhash.f = FLAG_INVALIDATE_SESSIONS;
 	conf->webserver.api.pwhash.d.s = (char*)"";
@@ -1138,7 +1196,7 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.api.password.k = "webserver.api.password";
 	conf->webserver.api.password.h = "Pi-hole web interface and API password. When set to something different than \""PASSWORD_VALUE"\", this property will compute the corresponding password hash to set webserver.api.pwhash";
-	conf->webserver.api.password.a = cJSON_CreateStringReference("<valid Pi-hole password>");
+	conf->webserver.api.password.a = cJSON_CreateStringReference("Avalid Pi-hole password");
 	conf->webserver.api.password.t = CONF_PASSWORD;
 	conf->webserver.api.password.f = FLAG_PSEUDO_ITEM | FLAG_INVALIDATE_SESSIONS;
 	conf->webserver.api.password.d.s = (char*)"";
@@ -1146,28 +1204,30 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.api.totp_secret.k = "webserver.api.totp_secret";
 	conf->webserver.api.totp_secret.h = "Pi-hole 2FA TOTP secret. When set to something different than \"""\", 2FA authentication will be enforced for the API and the web interface. This setting is write-only, you can not read the secret back.";
-	conf->webserver.api.totp_secret.a = cJSON_CreateStringReference("<valid TOTP secret (20 Bytes in Base32 encoding)>");
+	conf->webserver.api.totp_secret.a = cJSON_CreateStringReference("A valid TOTP secret (20 Bytes in Base32 encoding)");
 	conf->webserver.api.totp_secret.t = CONF_STRING;
 	conf->webserver.api.totp_secret.f = FLAG_WRITE_ONLY | FLAG_INVALIDATE_SESSIONS;
 	conf->webserver.api.totp_secret.d.s = (char*)"";
 	conf->webserver.api.totp_secret.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.app_pwhash.k = "webserver.api.app_pwhash";
-	conf->webserver.api.app_pwhash.h = "Pi-hole application password.\n After you turn on two-factor (2FA) verification and set up an Authenticator app, you may run into issues if you use apps or other services that don't support two-step verification. In this case, you can create and use an app password to sign in. An app password is a long, randomly generated password that can be used instead of your regular password + TOTP token when signing in to the API. The app password can be generated through the API and will be shown only once. You can revoke the app password at any time. If you revoke the app password, be sure to generate a new one and update your app with the new password.";
-	conf->webserver.api.app_pwhash.a = cJSON_CreateStringReference("<valid Pi-hole password hash>");
+	conf->webserver.api.app_pwhash.h = "Pi-hole application password.\n\n After you turn on two-factor (2FA) verification and set up an Authenticator app, you may run into issues if you use apps or other services that don't support two-step verification. In this case, you can create and use an app password to sign in.\n\n An app password is a long, randomly generated password that can be used instead of your regular password + TOTP token when signing in to the API. The app password can be generated through the API and will be shown only once.\n\n You can revoke the app password at any time. If you revoke the app password, be sure to generate a new one and update your app with the new password.";
+	conf->webserver.api.app_pwhash.a = cJSON_CreateStringReference("A valid Pi-hole password hash");
 	conf->webserver.api.app_pwhash.t = CONF_STRING;
 	conf->webserver.api.app_pwhash.f = FLAG_INVALIDATE_SESSIONS;
 	conf->webserver.api.app_pwhash.d.s = (char*)"";
 	conf->webserver.api.app_pwhash.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.app_sudo.k = "webserver.api.app_sudo";
-	conf->webserver.api.app_sudo.h = "Should application password API sessions be allowed to modify config settings?\n Setting this to true allows third-party applications using the application password to modify settings, e.g., the upstream DNS servers, DHCP server settings, or changing passwords. This setting should only be enabled if really needed and only if you trust the applications using the application password.";
+	conf->webserver.api.app_sudo.h = "Should application password API sessions be allowed to modify config settings?\n\n Setting this to true allows third-party applications using the application password to modify settings, e.g., the upstream DNS servers, DHCP server settings, or changing passwords. This setting should only be enabled if really needed and only if you trust the applications using the application password.";
+	conf->webserver.api.app_sudo.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.api.app_sudo.t = CONF_BOOL;
 	conf->webserver.api.app_sudo.d.b = false;
 	conf->webserver.api.app_sudo.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.cli_pw.k = "webserver.api.cli_pw";
-	conf->webserver.api.cli_pw.h = "Should FTL create a temporary CLI password? This password is stored in clear in /etc/pihole and can be used by the CLI (pihole ...  commands) to authenticate against the API. Note that the password is only valid for the current session and regenerated on each FTL restart. Sessions initiated with this password cannot modify the Pi-hole configuration (change passwords, etc.) for security reasons but can still use the API to query data and manage lists.";
+	conf->webserver.api.cli_pw.h = "Should FTL create a temporary CLI password?\n\n This password is stored in clear in /etc/pihole and can be used by the CLI (pihole ...  commands) to authenticate against the API. Note that the password is only valid for the current session and regenerated on each FTL restart. Sessions initiated with this password cannot modify the Pi-hole configuration (change passwords, etc.) for security reasons but can still use the API to query data and manage lists.";
+	conf->webserver.api.cli_pw.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.api.cli_pw.t = CONF_BOOL;
 	conf->webserver.api.cli_pw.f = FLAG_RESTART_FTL;
 	conf->webserver.api.cli_pw.d.b = true;
@@ -1175,39 +1235,43 @@ static void initConfig(struct config *conf)
 
 	conf->webserver.api.excludeClients.k = "webserver.api.excludeClients";
 	conf->webserver.api.excludeClients.h = "Array of clients to be excluded from certain API responses (regex):\n - Query Log (/api/queries)\n - Top Clients (/api/stats/top_clients)\n This setting accepts both IP addresses (IPv4 and IPv6) as well as hostnames.\n Note that backslashes \"\\\" need to be escaped, i.e. \"\\\\\" in this setting\n\n Example: [ \"^192\\\\.168\\\\.2\\\\.56$\", \"^fe80::341:[0-9a-f]*$\", \"^localhost$\" ]";
-	conf->webserver.api.excludeClients.a = cJSON_CreateStringReference("array of regular expressions describing clients");
+	conf->webserver.api.excludeClients.a = cJSON_CreateStringReference("An array of regular expressions describing clients");
 	conf->webserver.api.excludeClients.t = CONF_JSON_STRING_ARRAY;
 	conf->webserver.api.excludeClients.d.json = cJSON_CreateArray();
 	conf->webserver.api.excludeClients.c = validate_regex_array;
 
 	conf->webserver.api.excludeDomains.k = "webserver.api.excludeDomains";
 	conf->webserver.api.excludeDomains.h = "Array of domains to be excluded from certain API responses (regex):\n - Query Log (/api/queries)\n - Top Clients (/api/stats/top_domains)\n Note that backslashes \"\\\" need to be escaped, i.e. \"\\\\\" in this setting\n\n Example: [ \"(^|\\\\.)\\\\.google\\\\.de$\", \"\\\\.pi-hole\\\\.net$\" ]";
-	conf->webserver.api.excludeDomains.a = cJSON_CreateStringReference("array of regular expressions describing domains");
+	conf->webserver.api.excludeDomains.a = cJSON_CreateStringReference("An array of regular expressions describing domains");
 	conf->webserver.api.excludeDomains.t = CONF_JSON_STRING_ARRAY;
 	conf->webserver.api.excludeDomains.d.json = cJSON_CreateArray();
 	conf->webserver.api.excludeDomains.c = validate_regex_array;
 
 	conf->webserver.api.maxHistory.k = "webserver.api.maxHistory";
-	conf->webserver.api.maxHistory.h = "How much history should be imported from the database and returned by the API [seconds]? (max 24*60*60 = 86400)";
+	conf->webserver.api.maxHistory.h = "How much history should be imported from the database and returned by the API [seconds]? (max 24hrs = 86400)";
+	conf->webserver.api.maxHistory.a = cJSON_CreateStringReference("A positive integer value in seconds up to 86400");
 	conf->webserver.api.maxHistory.t = CONF_UINT;
 	conf->webserver.api.maxHistory.f = FLAG_RESTART_FTL; // Restart FTL to import more data in case of enlarging of this value
 	conf->webserver.api.maxHistory.d.ui = MAXLOGAGE*3600;
 	conf->webserver.api.maxHistory.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.maxClients.k = "webserver.api.maxClients";
-	conf->webserver.api.maxClients.h = "Up to how many clients should be returned in the activity graph endpoint (/api/history/clients)?\n This setting can be overwritten at run-time using the parameter N. Setting this to 0 will always send all clients. Be aware that this may be challenging for the GUI if you have many (think > 1.000 clients) in your network";
+	conf->webserver.api.maxClients.h = "Up to how many clients should be returned in the activity graph endpoint (/api/history/clients)?\n\n This setting can be overwritten at run-time using the parameter N. Setting this to 0 will always send all clients. Be aware that this may be challenging for the GUI if you have many (think > 1.000 clients) in your network";
+	conf->webserver.api.maxClients.a = cJSON_CreateStringReference("A positive integer value");
 	conf->webserver.api.maxClients.t = CONF_UINT16;
 	conf->webserver.api.maxClients.d.u16 = 10;
 	conf->webserver.api.maxClients.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.client_history_global_max.k = "webserver.api.client_history_global_max";
 	conf->webserver.api.client_history_global_max.h = "How should the API compute the most active clients? If set to true, the API will return the clients with the most queries globally (within 24 hours). If set to false, the API will return the clients with the most queries per time slot individually.";
+	conf->webserver.api.client_history_global_max.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.api.client_history_global_max.t = CONF_BOOL;
 	conf->webserver.api.client_history_global_max.d.b = true;
 	conf->webserver.api.client_history_global_max.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.allow_destructive.k = "webserver.api.allow_destructive";
 	conf->webserver.api.allow_destructive.h = "Allow destructive API calls (e.g. restart DNS server, flush logs, ...)";
+	conf->webserver.api.allow_destructive.a = cJSON_CreateStringReference("<true|false>");
 	conf->webserver.api.allow_destructive.t = CONF_BOOL;
 	conf->webserver.api.allow_destructive.d.b = true;
 	conf->webserver.api.allow_destructive.c = validate_stub; // Only type-based checking
@@ -1215,6 +1279,7 @@ static void initConfig(struct config *conf)
 	// sub-struct webserver.api.temp
 	conf->webserver.api.temp.limit.k = "webserver.api.temp.limit";
 	conf->webserver.api.temp.limit.h = "Which upper temperature limit should be used by Pi-hole? Temperatures above this limit will be shown as \"hot\". The number specified here is in the unit defined below";
+	conf->webserver.api.temp.limit.a = cJSON_CreateStringReference("A positive floating point value in the unit defined below");
 	conf->webserver.api.temp.limit.t = CONF_DOUBLE;
 	conf->webserver.api.temp.limit.d.d = 60.0; // °C
 	conf->webserver.api.temp.limit.c = validate_stub; // Only type-based checking
@@ -1237,7 +1302,7 @@ static void initConfig(struct config *conf)
 	// struct files
 	conf->files.pid.k = "files.pid";
 	conf->files.pid.h = "The file which contains the PID of FTL's main process.";
-	conf->files.pid.a = cJSON_CreateStringReference("<any writable file>");
+	conf->files.pid.a = cJSON_CreateStringReference("Any writable file");
 	conf->files.pid.t = CONF_STRING;
 	conf->files.pid.f = FLAG_RESTART_FTL;
 	conf->files.pid.d.s = (char*)"/run/pihole-FTL.pid";
@@ -1245,14 +1310,14 @@ static void initConfig(struct config *conf)
 
 	conf->files.database.k = "files.database";
 	conf->files.database.h = "The location of FTL's long-term database";
-	conf->files.database.a = cJSON_CreateStringReference("<any FTL database>");
+	conf->files.database.a = cJSON_CreateStringReference("Any FTL database");
 	conf->files.database.t = CONF_STRING;
 	conf->files.database.d.s = (char*)"/etc/pihole/pihole-FTL.db";
 	conf->files.database.c = validate_filepath;
 
 	conf->files.gravity.k = "files.gravity";
 	conf->files.gravity.h = "The location of Pi-hole's gravity database";
-	conf->files.gravity.a = cJSON_CreateStringReference("<any Pi-hole gravity database>");
+	conf->files.gravity.a = cJSON_CreateStringReference("Any Pi-hole gravity database");
 	conf->files.gravity.t = CONF_STRING;
 	conf->files.gravity.f = FLAG_RESTART_FTL;
 	conf->files.gravity.d.s = (char*)"/etc/pihole/gravity.db";
@@ -1260,7 +1325,7 @@ static void initConfig(struct config *conf)
 
 	conf->files.gravity_tmp.k = "files.gravity_tmp";
 	conf->files.gravity_tmp.h = "A temporary directory where Pi-hole can store files during gravity updates. This directory must be writable by the user running gravity (typically pihole).";
-	conf->files.gravity_tmp.a = cJSON_CreateStringReference("<any existing world-writable writable directory>");
+	conf->files.gravity_tmp.a = cJSON_CreateStringReference("Any existing world-writable writable directory");
 	conf->files.gravity_tmp.t = CONF_STRING;
 	conf->files.gravity_tmp.f = FLAG_RESTART_FTL;
 	conf->files.gravity_tmp.d.s = (char*)"/tmp";
@@ -1268,38 +1333,37 @@ static void initConfig(struct config *conf)
 
 	conf->files.macvendor.k = "files.macvendor";
 	conf->files.macvendor.h = "The database containing MAC -> Vendor information for the network table";
-	conf->files.macvendor.a = cJSON_CreateStringReference("<any Pi-hole macvendor database>");
+	conf->files.macvendor.a = cJSON_CreateStringReference("Any Pi-hole macvendor database");
 	conf->files.macvendor.t = CONF_STRING;
 	conf->files.macvendor.d.s = (char*)"/etc/pihole/macvendor.db";
 	conf->files.macvendor.c = validate_filepath;
 
 	conf->files.pcap.k = "files.pcap";
-	conf->files.pcap.h = "An optional file containing a pcap capture of the network traffic. This file is used for debugging purposes only. If you don't know what this is, you don't need it.\n Setting this to an empty string disables pcap recording. The file must be writable by the user running FTL (typically pihole). Failure to write to this file will prevent the DNS resolver from starting. The file is appended to if it already exists.";
-	conf->files.pcap.a = cJSON_CreateStringReference("<any writable pcap file>");
+	conf->files.pcap.h = "An optional file containing a pcap capture of the network traffic. This file is used for debugging purposes only. If you don't know what this is, you don't need it.\n\n Setting this to an empty string disables pcap recording. The file must be writable by the user running FTL (typically pihole). Failure to write to this file will prevent the DNS resolver from starting. The file is appended to if it already exists.";
+	conf->files.pcap.a = cJSON_CreateStringReference("Any writable pcap file");
 	conf->files.pcap.t = CONF_STRING;
 	conf->files.pcap.f = FLAG_RESTART_FTL;
 	conf->files.pcap.d.s = (char*)"";
 	conf->files.pcap.c = validate_filepath_empty;
 
 	// sub-struct files.log
-	// conf->files.log.ftl is set in a separate function
-
-	conf->files.log.webserver.k = "files.log.webserver";
-	conf->files.log.webserver.h = "The log file used by the webserver";
-	conf->files.log.webserver.a = cJSON_CreateStringReference("<any writable file>");
-	conf->files.log.webserver.t = CONF_STRING;
-	conf->files.log.webserver.f = FLAG_RESTART_FTL;
-	conf->files.log.webserver.d.s = (char*)"/var/log/pihole/webserver.log";
-	conf->files.log.webserver.c = validate_filepath;
+	// conf->files.log.ftl is set in a separate function (getLogFilePath)
 
 	conf->files.log.dnsmasq.k = "files.log.dnsmasq";
 	conf->files.log.dnsmasq.h = "The log file used by the embedded dnsmasq DNS server";
-	conf->files.log.dnsmasq.a = cJSON_CreateStringReference("<any writable file>");
+	conf->files.log.dnsmasq.a = cJSON_CreateStringReference("Any writable file");
 	conf->files.log.dnsmasq.t = CONF_STRING;
 	conf->files.log.dnsmasq.f = FLAG_RESTART_FTL;
 	conf->files.log.dnsmasq.d.s = (char*)"/var/log/pihole/pihole.log";
 	conf->files.log.dnsmasq.c = validate_filepath_dash;
 
+	conf->files.log.webserver.k = "files.log.webserver";
+	conf->files.log.webserver.h = "The log file used by the webserver";
+	conf->files.log.webserver.a = cJSON_CreateStringReference("Any writable file");
+	conf->files.log.webserver.t = CONF_STRING;
+	conf->files.log.webserver.f = FLAG_RESTART_FTL;
+	conf->files.log.webserver.d.s = (char*)"/var/log/pihole/webserver.log";
+	conf->files.log.webserver.c = validate_filepath;
 
 	// struct misc
 	conf->misc.privacylevel.k = "misc.privacylevel";
@@ -1319,41 +1383,46 @@ static void initConfig(struct config *conf)
 	conf->misc.privacylevel.c = validate_stub; // Only type-based checking
 
 	conf->misc.delay_startup.k = "misc.delay_startup";
-	conf->misc.delay_startup.h = "During startup, in some configurations, network interfaces appear only late during system startup and are not ready when FTL tries to bind to them. Therefore, you may want FTL to wait a given amount of time before trying to start the DNS revolver. This setting takes any integer value between 0 and 300 seconds. To prevent delayed startup while the system is already running and FTL is restarted, the delay only takes place within the first 180 seconds (hard-coded) after booting.";
+	conf->misc.delay_startup.h = "During startup, in some configurations, network interfaces appear only late during system startup and are not ready when FTL tries to bind to them. Therefore, you may want FTL to wait a given amount of time before trying to start the DNS revolver.\n\n This setting takes any integer value between 0 and 300 seconds. To prevent delayed startup while the system is already running and FTL is restarted, the delay only takes place within the first 180 seconds (hard-coded) after booting.";
+	conf->misc.delay_startup.a = cJSON_CreateStringReference("A positive integer value between 0 and 300");
 	conf->misc.delay_startup.t = CONF_UINT;
 	conf->misc.delay_startup.d.ui = 0;
 	conf->misc.delay_startup.c = validate_stub; // Only type-based checking
 
 	conf->misc.nice.k = "misc.nice";
-	conf->misc.nice.h = "Set niceness of pihole-FTL. Defaults to -10 and can be disabled altogether by setting a value of -999. The nice value is an attribute that can be used to influence the CPU scheduler to favor or disfavor a process in scheduling decisions. The range of the nice value varies across UNIX systems. On modern Linux, the range is -20 (high priority = not very nice to other processes) to +19 (low priority).";
+	conf->misc.nice.h = "Set niceness of pihole-FTL. Defaults to -10 and can be disabled altogether by setting a value of -999. The nice value is an attribute that can be used to influence the CPU scheduler to favor or disfavor a process in scheduling decisions.\n\n The range of the nice value varies across UNIX systems. On modern Linux, the range is -20 (high priority = not very nice to other processes) to +19 (low priority).";
+	conf->misc.nice.a = cJSON_CreateStringReference("A signed integer value between -20 and 19, or -999 to disable niceness");
 	conf->misc.nice.t = CONF_INT;
 	conf->misc.nice.f = FLAG_RESTART_FTL;
 	conf->misc.nice.d.i = -10;
 	conf->misc.nice.c = validate_stub; // Only type-based checking
 
 	conf->misc.addr2line.k = "misc.addr2line";
-	conf->misc.addr2line.h = "Should FTL translate its own stack addresses into code lines during the bug backtrace? This improves the analysis of crashed significantly. It is recommended to leave the option enabled. This option should only be disabled when addr2line is known to not be working correctly on the machine because, in this case, the malfunctioning addr2line can prevent from generating any backtrace at all.";
+	conf->misc.addr2line.h = "Should FTL translate its own stack addresses into code lines during the bug backtrace? This improves the analysis of crashed significantly. It is recommended to leave the option enabled.\n\n This option should only be disabled when addr2line is known to not be working correctly on the machine because, in this case, the malfunctioning addr2line can prevent from generating any backtrace at all.";
+	conf->misc.addr2line.a = cJSON_CreateStringReference("<true|false>");
 	conf->misc.addr2line.t = CONF_BOOL;
 	conf->misc.addr2line.d.b = true;
 	conf->misc.addr2line.c = validate_stub; // Only type-based checking
 
 	conf->misc.etc_dnsmasq_d.k = "misc.etc_dnsmasq_d";
-	conf->misc.etc_dnsmasq_d.h = "Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?\n Warning: This is an advanced setting and should only be used with care.\n Incorrectly formatted or config files specifying options which can only be defined once can result in conflicts with the automatic configuration of Pi-hole (see "DNSMASQ_PH_CONFIG") and may stop DNS resolution from working.";
+	conf->misc.etc_dnsmasq_d.h = "Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?\n\n Warning: This is an advanced setting and should only be used with care.\n Incorrectly formatted or config files specifying options which can only be defined once can result in conflicts with the automatic configuration of Pi-hole (see "DNSMASQ_PH_CONFIG") and may stop DNS resolution from working.";
+	conf->misc.etc_dnsmasq_d.a = cJSON_CreateStringReference("<true|false>");
 	conf->misc.etc_dnsmasq_d.t = CONF_BOOL;
 	conf->misc.etc_dnsmasq_d.f = FLAG_RESTART_FTL;
 	conf->misc.etc_dnsmasq_d.d.b = false;
 	conf->misc.etc_dnsmasq_d.c = validate_stub; // Only type-based checking
 
 	conf->misc.dnsmasq_lines.k = "misc.dnsmasq_lines";
-	conf->misc.dnsmasq_lines.h = "Additional lines to inject into the generated dnsmasq configuration.\n Warning: This is an advanced setting and should only be used with care. Incorrectly formatted or duplicated lines as well as lines conflicting with the automatic configuration of Pi-hole can break the embedded dnsmasq and will stop DNS resolution from working.\n Use this option with extra care.";
-	conf->misc.dnsmasq_lines.a = cJSON_CreateStringReference("array of valid dnsmasq config line options");
+	conf->misc.dnsmasq_lines.h = "Additional lines to inject into the generated dnsmasq configuration.\n Warning: This is an advanced setting and should only be used with care. Incorrectly formatted or duplicated lines as well as lines conflicting with the automatic configuration of Pi-hole can break the embedded dnsmasq and will stop DNS resolution from working.\n\n Use this option with extra care.";
+	conf->misc.dnsmasq_lines.a = cJSON_CreateStringReference("Array of valid dnsmasq config line options");
 	conf->misc.dnsmasq_lines.t = CONF_JSON_STRING_ARRAY;
 	conf->misc.dnsmasq_lines.f = FLAG_RESTART_FTL;
 	conf->misc.dnsmasq_lines.d.json = cJSON_CreateArray();
 	conf->misc.dnsmasq_lines.c = validate_stub; // Type-based checking + dnsmasq syntax checking
 
 	conf->misc.extraLogging.k = "misc.extraLogging";
-	conf->misc.extraLogging.h = "Log additional information about queries and replies to pihole.log\n When this setting is enabled, the log has extra information at the start of each line. This consists of a serial number which ties together the log lines associated with an individual query, and the IP address of the requestor. This setting is only effective if dns.queryLogging is enabled, too. This option is only useful for debugging and is not recommended for normal use.";
+	conf->misc.extraLogging.h = "Log additional information about queries and replies to pihole.log\n\n When this setting is enabled, the log has extra information at the start of each line. This consists of a serial number which ties together the log lines associated with an individual query, and the IP address of the requestor. This setting is only effective if dns.queryLogging is enabled, too. This option is only useful for debugging and is not recommended for normal use.";
+	conf->misc.extraLogging.a = cJSON_CreateStringReference("<true|false>");
 	conf->misc.extraLogging.t = CONF_BOOL;
 	conf->misc.extraLogging.f = FLAG_RESTART_FTL;
 	conf->misc.extraLogging.d.b = false;
@@ -1361,6 +1430,7 @@ static void initConfig(struct config *conf)
 
 	conf->misc.readOnly.k = "misc.readOnly";
 	conf->misc.readOnly.h = "Put configuration into read-only mode. This will prevent any changes to the configuration file via the API or CLI. This setting useful when a configuration is to be forced/modified by some third-party application (like infrastructure-as-code providers) and should not be changed by any means.";
+	conf->misc.readOnly.a = cJSON_CreateStringReference("<true|false>");
 	conf->misc.readOnly.t = CONF_BOOL;
 	conf->misc.readOnly.f = FLAG_READ_ONLY;
 	conf->misc.readOnly.d.b = false;
@@ -1368,19 +1438,22 @@ static void initConfig(struct config *conf)
 
 	// sub-struct misc.check
 	conf->misc.check.load.k = "misc.check.load";
-	conf->misc.check.load.h = "Pi-hole is very lightweight on resources. Nevertheless, this does not mean that you should run Pi-hole on a server that is otherwise extremely busy as queuing on the system can lead to unnecessary delays in DNS operation as the system becomes less and less usable as the system load increases because all resources are permanently in use. To account for this, FTL regularly checks the system load. To bring this to your attention, FTL warns about excessive load when the 15 minute system load average exceeds the number of cores.\n This check can be disabled with this setting.";
+	conf->misc.check.load.h = "Pi-hole is very lightweight on resources. Nevertheless, this does not mean that you should run Pi-hole on a server that is otherwise extremely busy as queuing on the system can lead to unnecessary delays in DNS operation as the system becomes less and less usable as the system load increases because all resources are permanently in use. To account for this, FTL regularly checks the system load. To bring this to your attention, FTL warns about excessive load when the 15 minute system load average exceeds the number of cores.\n\n This check can be disabled with this setting.";
+	conf->misc.check.load.a = cJSON_CreateStringReference("<true|false>");
 	conf->misc.check.load.t = CONF_BOOL;
 	conf->misc.check.load.d.b = true;
 	conf->misc.check.load.c = validate_stub; // Only type-based checking
 
 	conf->misc.check.disk.k = "misc.check.disk";
 	conf->misc.check.disk.h = "FTL stores its long-term history in a database file on disk. Furthermore, FTL stores log files. By default, FTL warns if usage of the disk holding any crucial file exceeds 90%. You can set any integer limit between 0 to 100 (interpreted as percentages) where 0 means that checking of disk usage is disabled.";
+	conf->misc.check.disk.a = cJSON_CreateStringReference("A positive integer value between 0 and 100");
 	conf->misc.check.disk.t = CONF_UINT;
 	conf->misc.check.disk.d.ui = 90;
 	conf->misc.check.disk.c = validate_stub; // Only type-based checking
 
 	conf->misc.check.shmem.k = "misc.check.shmem";
 	conf->misc.check.shmem.h = "FTL stores history in shared memory to allow inter-process communication with forked dedicated TCP workers. If FTL runs out of memory, it cannot continue to work as queries cannot be analyzed any further. Hence, FTL checks if enough shared memory is available on your system and warns you if this is not the case.\n By default, FTL warns if the shared-memory usage exceeds 90%. You can set any integer limit between 0 to 100 (interpreted as percentages) where 0 means that checking of shared-memory usage is disabled.";
+	conf->misc.check.shmem.a = cJSON_CreateStringReference("A positive integer value between 0 and 100");
 	conf->misc.check.shmem.t = CONF_UINT;
 	conf->misc.check.shmem.d.ui = 90;
 	conf->misc.check.shmem.c = validate_stub; // Only type-based checking
@@ -1389,180 +1462,210 @@ static void initConfig(struct config *conf)
 	// struct debug
 	conf->debug.database.k = "debug.database";
 	conf->debug.database.h = "Print debugging information about database actions. This prints performed SQL statements as well as some general information such as the time it took to store the queries and how many have been saved to the database.";
+	conf->debug.database.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.database.t = CONF_BOOL;
 	conf->debug.database.d.b = false;
 	conf->debug.database.c = validate_stub; // Only type-based checking
 
 	conf->debug.networking.k = "debug.networking";
 	conf->debug.networking.h = "Prints a list of the detected interfaces on the startup of pihole-FTL. Also, prints whether these interfaces are IPv4 or IPv6 interfaces.";
+	conf->debug.networking.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.networking.t = CONF_BOOL;
 	conf->debug.networking.d.b = false;
 	conf->debug.networking.c = validate_stub; // Only type-based checking
 
 	conf->debug.locks.k = "debug.locks";
 	conf->debug.locks.h = "Print information about shared memory locks. Messages will be generated when waiting, obtaining, and releasing a lock.";
+	conf->debug.locks.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.locks.t = CONF_BOOL;
 	conf->debug.locks.d.b = false;
 	conf->debug.locks.c = validate_stub; // Only type-based checking
 
 	conf->debug.queries.k = "debug.queries";
 	conf->debug.queries.h = "Print extensive query information (domains, types, replies, etc.). This has always been part of the legacy debug mode of pihole-FTL.";
+	conf->debug.queries.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.queries.t = CONF_BOOL;
 	conf->debug.queries.d.b = false;
 	conf->debug.queries.c = validate_stub; // Only type-based checking
 
 	conf->debug.flags.k = "debug.flags";
 	conf->debug.flags.h = "Print flags of queries received by the DNS hooks. Only effective when DEBUG_QUERIES is enabled as well.";
+	conf->debug.flags.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.flags.t = CONF_BOOL;
 	conf->debug.flags.d.b = false;
 	conf->debug.flags.c = validate_stub; // Only type-based checking
 
 	conf->debug.shmem.k = "debug.shmem";
 	conf->debug.shmem.h = "Print information about shared memory buffers. Messages are either about creating or enlarging shmem objects or string injections.";
+	conf->debug.shmem.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.shmem.t = CONF_BOOL;
 	conf->debug.shmem.d.b = false;
 	conf->debug.shmem.c = validate_stub; // Only type-based checking
 
 	conf->debug.gc.k = "debug.gc";
 	conf->debug.gc.h = "Print information about garbage collection (GC): What is to be removed, how many have been removed and how long did GC take.";
+	conf->debug.gc.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.gc.t = CONF_BOOL;
 	conf->debug.gc.d.b = false;
 	conf->debug.gc.c = validate_stub; // Only type-based checking
 
 	conf->debug.arp.k = "debug.arp";
 	conf->debug.arp.h = "Print information about ARP table processing: How long did parsing take, whether read MAC addresses are valid, and if the macvendor.db file exists.";
+	conf->debug.arp.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.arp.t = CONF_BOOL;
 	conf->debug.arp.d.b = false;
 	conf->debug.arp.c = validate_stub; // Only type-based checking
 
 	conf->debug.regex.k = "debug.regex";
 	conf->debug.regex.h = "Controls if FTLDNS should print extended details about regex matching into FTL.log.";
+	conf->debug.regex.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.regex.t = CONF_BOOL;
 	conf->debug.regex.d.b = false;
 	conf->debug.regex.c = validate_stub; // Only type-based checking
 
 	conf->debug.api.k = "debug.api";
 	conf->debug.api.h = "Print extra debugging information concerning API calls. This includes the request, the request parameters, and the internal details about how the algorithms decide which data to present and in what form. This very verbose output should only be used when debugging specific API issues and can be helpful, e.g., when a client cannot connect due to an obscure API error. Furthermore, this setting enables logging of all API requests (auth log) and details about user authentication attempts.";
+	conf->debug.api.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.api.t = CONF_BOOL;
 	conf->debug.api.d.b = false;
 	conf->debug.api.c = validate_stub; // Only type-based checking
 
 	conf->debug.tls.k = "debug.tls";
 	conf->debug.tls.h = "Print extra debugging information about TLS connections. This includes the TLS version, the cipher suite, the certificate chain and much more. This very verbose output should only be used when debugging specific TLS issues and can be helpful, e.g., when a client cannot connect due to an obscure TLS error as modern browsers do not provide much information about the underlying TLS connection and most often give only very generic error messages without much/any underlying technical information.";
+	conf->debug.tls.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.tls.t = CONF_BOOL;
 	conf->debug.tls.d.b = false;
 	conf->debug.tls.c = validate_stub; // Only type-based checking
 
 	conf->debug.overtime.k = "debug.overtime";
 	conf->debug.overtime.h = "Print information about overTime memory operations, such as initializing or moving overTime slots.";
+	conf->debug.overtime.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.overtime.t = CONF_BOOL;
 	conf->debug.overtime.d.b = false;
 	conf->debug.overtime.c = validate_stub; // Only type-based checking
 
 	conf->debug.status.k = "debug.status";
 	conf->debug.status.h = "Print information about status changes for individual queries. This can be useful to identify unexpected unknown queries.";
+	conf->debug.status.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.status.t = CONF_BOOL;
 	conf->debug.status.d.b = false;
 	conf->debug.status.c = validate_stub; // Only type-based checking
 
 	conf->debug.caps.k = "debug.caps";
 	conf->debug.caps.h = "Print information about capabilities granted to the pihole-FTL process. The current capabilities are printed on receipt of SIGHUP, i.e., the current set of capabilities can be queried without restarting pihole-FTL (by setting DEBUG_CAPS=true and thereafter sending killall -HUP pihole-FTL).";
+	conf->debug.caps.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.caps.t = CONF_BOOL;
 	conf->debug.caps.d.b = false;
 	conf->debug.caps.c = validate_stub; // Only type-based checking
 
 	conf->debug.dnssec.k = "debug.dnssec";
 	conf->debug.dnssec.h = "Print information about DNSSEC activity";
+	conf->debug.dnssec.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.dnssec.t = CONF_BOOL;
 	conf->debug.dnssec.d.b = false;
 	conf->debug.dnssec.c = validate_stub; // Only type-based checking
 
 	conf->debug.vectors.k = "debug.vectors";
 	conf->debug.vectors.h = "FTL uses dynamically allocated vectors for various tasks. This config option enables extensive debugging information such as information about allocation, referencing, deletion, and appending.";
+	conf->debug.vectors.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.vectors.t = CONF_BOOL;
 	conf->debug.vectors.d.b = false;
 	conf->debug.vectors.c = validate_stub; // Only type-based checking
 
 	conf->debug.resolver.k = "debug.resolver";
 	conf->debug.resolver.h = "Extensive information about hostname resolution like which DNS servers are used in the first and second hostname resolving tries (only affecting internally generated PTR queries).";
+	conf->debug.resolver.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.resolver.t = CONF_BOOL;
 	conf->debug.resolver.d.b = false;
 	conf->debug.resolver.c = validate_stub; // Only type-based checking
 
 	conf->debug.edns0.k = "debug.edns0";
 	conf->debug.edns0.h = "Print debugging information about received EDNS(0) data.";
+	conf->debug.edns0.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.edns0.t = CONF_BOOL;
 	conf->debug.edns0.d.b = false;
 	conf->debug.edns0.c = validate_stub; // Only type-based checking
 
 	conf->debug.clients.k = "debug.clients";
 	conf->debug.clients.h = "Log various important client events such as change of interface (e.g., client switching from WiFi to wired or VPN connection), as well as extensive reporting about how clients were assigned to its groups.";
+	conf->debug.clients.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.clients.t = CONF_BOOL;
 	conf->debug.clients.d.b = false;
 	conf->debug.clients.c = validate_stub; // Only type-based checking
 
 	conf->debug.aliasclients.k = "debug.aliasclients";
 	conf->debug.aliasclients.h = "Log information related to alias-client processing.";
+	conf->debug.aliasclients.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.aliasclients.t = CONF_BOOL;
 	conf->debug.aliasclients.d.b = false;
 	conf->debug.aliasclients.c = validate_stub; // Only type-based checking
 
 	conf->debug.events.k = "debug.events";
 	conf->debug.events.h = "Log information regarding FTL's embedded event handling queue.";
+	conf->debug.events.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.events.t = CONF_BOOL;
 	conf->debug.events.d.b = false;
 	conf->debug.events.c = validate_stub; // Only type-based checking
 
 	conf->debug.helper.k = "debug.helper";
 	conf->debug.helper.h = "Log information about script helpers, e.g., due to dhcp-script.";
+	conf->debug.helper.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.helper.t = CONF_BOOL;
 	conf->debug.helper.d.b = false;
 	conf->debug.helper.c = validate_stub; // Only type-based checking
 
 	conf->debug.config.k = "debug.config";
 	conf->debug.config.h = "Print config parsing details";
+	conf->debug.config.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.config.t = CONF_BOOL;
 	conf->debug.config.d.b = false;
 	conf->debug.config.c = validate_stub; // Only type-based checking
 
 	conf->debug.inotify.k = "debug.inotify";
 	conf->debug.inotify.h = "Debug monitoring of /etc/pihole filesystem events";
+	conf->debug.inotify.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.inotify.t = CONF_BOOL;
 	conf->debug.inotify.d.b = false;
 	conf->debug.inotify.c = validate_stub; // Only type-based checking
 
 	conf->debug.webserver.k = "debug.webserver";
 	conf->debug.webserver.h = "Debug monitoring of the webserver (CivetWeb) events";
+	conf->debug.webserver.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.webserver.t = CONF_BOOL;
 	conf->debug.webserver.d.b = false;
 	conf->debug.webserver.c = validate_stub; // Only type-based checking
 
 	conf->debug.extra.k = "debug.extra";
 	conf->debug.extra.h = "Temporary flag that may print additional information. This debug flag is meant to be used whenever needed for temporary investigations. The logged content may change without further notice at any time.";
+	conf->debug.extra.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.extra.t = CONF_BOOL;
 	conf->debug.extra.d.b = false;
 	conf->debug.extra.c = validate_stub; // Only type-based checking
 
 	conf->debug.reserved.k = "debug.reserved";
 	conf->debug.reserved.h = "Reserved debug flag";
+	conf->debug.reserved.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.reserved.t = CONF_BOOL;
 	conf->debug.reserved.d.b = false;
 	conf->debug.reserved.c = validate_stub; // Only type-based checking
 
 	conf->debug.ntp.k = "debug.ntp";
 	conf->debug.ntp.h = "Print information about NTP synchronization";
+	conf->debug.ntp.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.ntp.t = CONF_BOOL;
 	conf->debug.ntp.d.b = false;
 	conf->debug.ntp.c = validate_stub; // Only type-based checking
 
 	conf->debug.netlink.k = "debug.netlink";
 	conf->debug.netlink.h = "Print information about netlink communication and parsing";
+	conf->debug.netlink.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.netlink.t = CONF_BOOL;
 	conf->debug.netlink.d.b = false;
 	conf->debug.netlink.c = validate_stub; // Only type-based checking
 
 	conf->debug.all.k = "debug.all";
 	conf->debug.all.h = "Set all debug flags at once. This is a convenience option to enable all debug flags at once. Note that this option is not persistent, setting it to true will enable all *remaining* debug flags but unsetting it will disable *all* debug flags.";
+	conf->debug.all.a = cJSON_CreateStringReference("<true|false>");
 	conf->debug.all.t = CONF_ALL_DEBUG_BOOL;
 	conf->debug.all.d.b = false;
 	conf->debug.all.c = validate_stub; // Only type-based checking
@@ -1839,7 +1942,7 @@ bool getLogFilePath(bool try_read)
 	// Initialize the config file path
 	config.files.log.ftl.k = "files.log.ftl";
 	config.files.log.ftl.h = "The location of FTL's log file";
-	config.files.log.ftl.a = cJSON_CreateStringReference("<any writable file>");
+	config.files.log.ftl.a = cJSON_CreateStringReference("any writable file");
 	config.files.log.ftl.t = CONF_STRING;
 	config.files.log.ftl.d.s = (char*)"/var/log/pihole/FTL.log";
 	config.files.log.ftl.v.s = config.files.log.ftl.d.s;

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -253,7 +253,7 @@ void print_comment(FILE *fp, const char *str, const char *intro, const unsigned 
 void print_toml_allowed_values(cJSON *allowed_values, FILE *fp, const unsigned int width, const unsigned int indent)
 {
 	print_comment(fp, "", "", 85, indent);
-	print_comment(fp, "", "Possible values are:", 85, indent);
+	print_comment(fp, "", "Allowed values are:", 85, indent);
 	if(cJSON_IsArray(allowed_values))
 	{
 		// Loop over array items

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,20 +1,25 @@
-# Pi-hole configuration file (v6.0.4-75-gc53cf00b)
+# Pi-hole configuration file (v6.2.3-47-gd26afc12-dirty) on branch new/docs_config_pr
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-03-27 11:04:20 UTC
+# Last updated on 2025-07-06 22:38:03 UTC
 
 [dns]
-  # Array of upstream DNS servers used by Pi-hole
+  # Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not
+  # resolve any non-local queries.
+  #
   # Example: [ "8.8.8.8", "127.0.0.1#5335", "docker-resolver" ]
   #
-  # Possible values are:
-  #     array of IP addresses and/or hostnames, optionally with a port (#...)
+  # Allowed values are:
+  #     Array of IP addresses and/or hostnames, optionally with a port (#...)
   upstreams = [
     "127.0.0.1#5555"
   ] ### CHANGED, default = []
 
   # Use this option to control deep CNAME inspection. Disabling it might be beneficial
   # for very low-end devices
+  #
+  # Allowed values are:
+  #     <true|false>
   CNAMEdeepInspect = true
 
   # Should _esni. subdomains be blocked by default? Encrypted Server Name Indication
@@ -23,11 +28,15 @@
   # firewalls, from intercepting the TLS Server Name Indication (SNI) extension by
   # encrypting it. This prevents the SNI from being used to determine which websites
   # users are visiting.
+  #
   # ESNI will obviously cause issues for pixelserv-tls which will be unable to generate
   # matching certificates on-the-fly when it cannot read the SNI. Cloudflare and Firefox
   # are already enabling ESNI. According to the IEFT draft (link above), we can easily
   # restore piselserv-tls's operation by replying NXDOMAIN to _esni. subdomains of
   # blocked domains as this mimics a "not configured for this domain" behavior.
+  #
+  # Allowed values are:
+  #     <true|false>
   blockESNI = true
 
   # Should we overwrite the query source when client information is provided through
@@ -35,21 +44,33 @@
   # if they are hidden behind the NAT of a router. This feature has been requested and
   # discussed on Discourse where further information how to use it can be found:
   # https://discourse.pi-hole.net/t/support-for-add-subnet-option-from-dnsmasq-ecs-edns0-client-subnet/35940
+  #
+  # Allowed values are:
+  #     <true|false>
   EDNS0ECS = true
 
   # Should FTL hide queries made by localhost?
+  #
+  # Allowed values are:
+  #     <true|false>
   ignoreLocalhost = false
 
   # Should FTL analyze and show internally generated DNSSEC queries?
+  #
+  # Allowed values are:
+  #     <true|false>
   showDNSSEC = true
 
   # Should FTL analyze *only* A and AAAA queries?
+  #
+  # Allowed values are:
+  #     <true|false>
   analyzeOnlyAandAAAA = false
 
   # Controls whether and how FTL will reply with for address for which a local interface
   # exists. Changing this setting causes FTL to restart.
   #
-  # Possible values are:
+  # Allowed values are:
   #   - "NONE"
   #       Pi-hole will not respond automatically on PTR requests to local interface
   #       addresses. Ensure pi.hole and/or hostname records exist elsewhere.
@@ -72,7 +93,7 @@
 
   # How should FTL handle queries when the gravity database is not available?
   #
-  # Possible values are:
+  # Allowed values are:
   #   - "BLOCK"
   #       Block all queries when the database is busy.
   #   - "ALLOW"
@@ -90,14 +111,19 @@
   # allows users to select a value different from the dnsmasq config option local-ttl.
   # This is useful in context of locally used hostnames that are known to stay constant
   # over long times (printers, etc.).
+  #
   # Note that large values may render whitelisting ineffective due to client-side
   # caching of blocked queries.
+  #
+  # Allowed values are:
+  #     A positive integer value in seconds
   blockTTL = 2
 
   # Array of custom DNS records
-  # Example: hosts = [ "127.0.0.1 mylocal", "192.168.0.1 therouter" ]
   #
-  # Possible values are:
+  # Example: [ "127.0.0.1 mylocal", "192.168.0.1 therouter" ]
+  #
+  # Allowed values are:
   #     Array of custom DNS records each one in HOSTS form: "IP HOSTNAME"
   hosts = [
     "1.1.1.1 abc-custom.com def-custom.de",
@@ -106,10 +132,16 @@
 
   # If set, A and AAAA queries for plain names, without dots or domain parts, are never
   # forwarded to upstream nameservers
+  #
+  # Allowed values are:
+  #     <true|false>
   domainNeeded = false
 
   # If set, the domain is added to simple names (without a period) in /etc/hosts in the
   # same way as for DHCP-derived names
+  #
+  # Allowed values are:
+  #     <true|false>
   expandHosts = false
 
   # The DNS domain used by your Pi-hole.
@@ -134,34 +166,43 @@
   #
   # You can disable setting a domain by setting this option to an empty string.
   #
-  # Possible values are:
-  #     <any valid domain>
+  # Allowed values are:
+  #     Any valid domain
   domain = "lan"
 
   # Should all reverse lookups for private IP ranges (i.e., 192.168.x.y, etc) which are
   # not found in /etc/hosts or the DHCP leases file be answered with "no such domain"
   # rather than being forwarded upstream?
+  #
+  # Allowed values are:
+  #     <true|false>
   bogusPriv = true
 
   # Validate DNS replies using DNSSEC?
+  #
+  # Allowed values are:
+  #     <true|false>
   dnssec = true ### CHANGED, default = false
 
   # Interface to use for DNS (see also dnsmasq.listening.mode) and DHCP (if enabled)
   #
-  # Possible values are:
+  # Allowed values are:
   #     a valid interface name
   interface = "eth0"
 
-  # Add A, AAAA and PTR records to the DNS. This adds one or more names to the DNS with
+  # Add an A, AAAA and PTR record to the DNS. This adds a singular name to the DNS with
   # associated IPv4 (A) and IPv6 (AAAA) records
   #
-  # Possible values are:
-  #     <name>[,<name>....],[<IPv4-address>],[<IPv6-address>][,<TTL>]
+  # Example: "laptop,laptop.lan,192.168.0.1,1234::100"
+  #
+  # Allowed values are:
+  #     A string in the format
+  #     "<name>[,<name>....],[<IPv4-address>],[<IPv6-address>][,<TTL>]"
   hostRecord = ""
 
   # Pi-hole interface listening modes
   #
-  # Possible values are:
+  # Allowed values are:
   #   - "LOCAL"
   #       Allow only local requests. This setting accepts DNS queries only from hosts
   #       whose address is on a local subnet, i.e., a subnet for which an interface
@@ -195,54 +236,78 @@
   listeningMode = "LOCAL"
 
   # Log DNS queries and replies to pihole.log
+  #
+  # Allowed values are:
+  #     <true|false>
   queryLogging = true
 
   # List of CNAME records which indicate that <cname> is really <target>. If the <TTL> is
   # given, it overwrites the value of local-ttl
   #
-  # Possible values are:
-  #     Array of CNAMEs each on in one of the following forms: "<cname>,<target>[,<TTL>]"
+  # Allowed values are:
+  #     Array of CNAMEs, each one in the following form: "<cname>,<target>[,<TTL>]"
   cnameRecords = [
     "brücke.com,äste.com,2"
   ] ### CHANGED, default = []
 
   # Port used by the DNS server
+  #
+  # Allowed values are:
+  #     Any available valid (1 - 65535) port number
   port = 53
 
   # Enable/Disable the localise-queries option of dnsmasq. When this setting is disabled
   # dnsmasq will return all possible values for local DNS Records. Enabled by default
+  #
+  # Allowed values are:
+  #     <true|false>
   localise = true
 
-  # Reverse server (former also called "conditional forwarding") feature
-  # Array of reverse servers each one in one of the following forms:
-  # "<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>]"
+  # Reverse server (formerly called "conditional forwarding")
   #
-  # Individual components:
+  # If not configured as your DHCP server, Pi-hole typically won't be able to determine
+  # the names of devices on your local network. As a result, tables such as Top Clients
+  # will only show IP addresses.
   #
-  # <enabled>: either "true" or "false"
+  # One solution for this is to configure Pi-hole to forward these requests to your DHCP
+  # server (most likely your router), but only for devices on your home network. To
+  # configure this we will need to know the IP address of your DHCP server and which
+  # addresses belong to your local network.
   #
-  # <ip-address>[/<prefix-len>]: Address range for the reverse server feature in CIDR
-  # notation. If the prefix length is omitted, either 32 (IPv4) or 128 (IPv6) are
-  # substituted (exact address match). This is almost certainly not what you want here.
-  # Example: "192.168.0.0/24" for the range 192.168.0.1 - 192.168.0.255
+  # Example: [ "true,192.168.0.0/24,192.168.0.1,fritz.box" ]
   #
-  # <server>[#<port>]: Target server to be used for the reverse server feature
-  # Example: "192.168.0.1#53"
-  #
-  # <domain>: Domain used for the reverse server feature (e.g., "fritz.box")
-  # Example: "fritz.box"
-  #
-  # Possible values are:
-  #     array of reverse servers each one in one of the following forms:
-  #     "<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>]", e.g.,
-  #     "true,192.168.0.0/24,192.168.0.1,fritz.box"
+  # Allowed values are:
+  #     Array of reverse servers each one in the following form:
+  #    
+  #     "<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>]"
+  #    
+  #    Explanation of individual components:
+  #    
+  #     - "<enabled>": either "true" or "false"
+  #    
+  #     - "<ip-address>[/<prefix-len>]": Address range for the reverse server feature in
+  #     CIDR notation. If the prefix length is omitted, either 32 (IPv4) or 128 (IPv6)
+  #     are substituted (exact address match). This is almost certainly not what you
+  #     want here.
+  #     Example: "192.168.0.0/24" for the range 192.168.0.1 - 192.168.0.255
+  #    
+  #     - "<server>[#<port>]": Target server to be used for the reverse server feature
+  #     Example: "192.168.0.1#53"
+  #    
+  #     - "<domain>": Domain used for the reverse server feature (e.g., "fritz.box")
+  #     Example: "fritz.box"
   revServers = []
 
   [dns.cache]
     # Cache size of the DNS server. Note that expiring cache entries naturally make room
-    # for new insertions over time. Setting this number too high will have an adverse
-    # effect as not only more space is needed, but also lookup speed gets degraded in the
-    # 10,000+ range. dnsmasq may issue a warning when you go beyond 10,000+ cache entries.
+    # for new insertions over time.
+    #
+    #Setting this number too high will have an adverse effect as not only more space is
+    # needed, but also lookup speed gets degraded in the 10,000+ range. dnsmasq may issue
+    # a warning when you go beyond 10,000+ cache entries.
+    #
+    # Allowed values are:
+    #     A positive integer value
     size = 10000
 
     # Query cache optimizer: If a DNS name exists in the cache, but its time-to-live has
@@ -254,25 +319,36 @@
     # mitigate issues caused by massively outdated DNS replies, the maximum overaging of
     # cached records is limited. We strongly recommend staying below 86400 (1 day) with
     # this option.
+    #
     # Setting the TTL excess time to zero will serve stale cache data regardless how long
     # it has expired. This is not recommended as it may lead to stale data being served
     # for a long time. Setting this option to any negative value will disable this feature
     # altogether.
+    #
+    # Allowed values are:
+    #     A positive integer value in seconds, or any negative to disable this feature
     optimizer = 3600
 
     # This setting allows you to specify the TTL used for queries blocked upstream. Once
     # the TTL expires, the query will be forwarded to the upstream server again to check
     # if the block is still valid. Defaults to caching for one day (86400 seconds).
     # Setting this value to zero disables caching of queries blocked upstream.
+    #
+    # Allowed values are:
+    #     A positive integer value in seconds, or zero to disable caching of upstream
+    #     blocked queries
     upstreamBlockedTTL = 86400
 
   [dns.blocking]
     # Should FTL block queries?
+    #
+    # Allowed values are:
+    #     <true|false>
     active = true
 
     # How should FTL reply to blocked queries?
     #
-    # Possible values are:
+    # Allowed values are:
     #   - "NULL"
     #       In NULL mode, which is both the default and recommended mode for Pi-hole
     #       FTLDNS, blocked queries will be answered with the "unspecified address"
@@ -300,7 +376,7 @@
 
     # Should FTL enrich blocked replies with EDNS0 information?
     #
-    # Possible values are:
+    # Allowed values are:
     #   - "NONE"
     #       In NONE mode, no additional EDNS information is added to blocked queries
     #   - "CODE"
@@ -312,79 +388,112 @@
 
   [dns.specialDomains]
     # Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of
-    # use-application-dns.net to disable Firefox automatic DNS-over-HTTP? This is
-    # following the recommendation on
+    # use-application-dns.net to disable Firefox automatic DNS-over-HTTP?
+    #
+    # This follows the recommendation on
     # https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https
+    #
+    # Allowed values are:
+    #     <true|false>
     mozillaCanary = true
 
     # Should Pi-hole always reply with NXDOMAIN to A and AAAA queries of mask.icloud.com
     # and mask-h2.icloud.com to disable Apple's iCloud Private Relay to prevent Apple
-    # devices from bypassing Pi-hole? This is following the recommendation on
+    # devices from bypassing Pi-hole?
+    #
+    # This follows the recommendation on
     # https://developer.apple.com/support/prepare-your-network-for-icloud-private-relay
+    #
+    # Allowed values are:
+    #     <true|false>
     iCloudPrivateRelay = true
 
     # Should Pi-hole always reply with NODATA to all queries to zone resolver.arpa to
-    # prevent devices from bypassing Pi-hole using Discovery of Designated Resolvers? This
-    # is based on recommendations at the end of RFC 9462, section 4.
+    # prevent devices from bypassing Pi-hole using Discovery of Designated Resolvers?
+    #
+    # This is based on recommendations at the end of RFC 9462, section 4.
+    #
+    # Allowed values are:
+    #     <true|false>
     designatedResolver = true
 
     [dns.reply.host]
       # Use a specific IPv4 address for the Pi-hole host? By default, FTL determines the
       # address of the interface a query arrived on and uses this address for replying to A
-      # queries with the most suitable address for the requesting client. This setting can
-      # be used to use a fixed, rather than the dynamically obtained, address when Pi-hole
-      # responds to the following names: [ "pi.hole", "<the device's hostname>",
-      # "pi.hole.<local domain>", "<the device's hostname>.<local domain>" ]
+      # queries with the most suitable address for the requesting client.
+      #
+      # This setting can be used to use a fixed, rather than the dynamically obtained,
+      # address when Pi-hole responds to the following names:
+      # - "pi.hole"
+      # - "<the device's hostname>"
+      # - "pi.hole.<local domain>"
+      # - "<the device's hostname>.<local domain>"
+      #
+      # Allowed values are:
+      #     <true|false>
       force4 = true ### CHANGED, default = false
 
       # Custom IPv4 address for the Pi-hole host
       #
-      # Possible values are:
-      #     <valid IPv4 address> or empty string ("")
+      # Allowed values are:
+      #     A valid IPv4 address or empty string ("")
       IPv4 = "10.100.0.10" ### CHANGED, default = ""
 
       # Use a specific IPv6 address for the Pi-hole host? See description for the IPv4
       # variant above for further details.
+      #
+      # Allowed values are:
+      #     <true|false>
       force6 = true ### CHANGED, default = false
 
       # Custom IPv6 address for the Pi-hole host
       #
-      # Possible values are:
-      #     <valid IPv6 address> or empty string ("")
+      # Allowed values are:
+      #     A valid IPv6 address or empty string ("")
       IPv6 = "fe80::10" ### CHANGED, default = ""
 
     [dns.reply.blocking]
       # Use a specific IPv4 address in IP blocking mode? By default, FTL determines the
       # address of the interface a query arrived on and uses this address for replying to A
-      # queries with the most suitable address for the requesting client. This setting can
-      # be used to use a fixed, rather than the dynamically obtained, address when Pi-hole
-      # responds in the following cases: IP blocking mode is used and this query is to be
-      # blocked, regular expressions with the ;reply=IP regex extension.
+      # queries with the most suitable address for the requesting client.
+      #
+      # This setting can be used to use a fixed, rather than the dynamically obtained,
+      # address when Pi-hole responds in the following cases:
+      # - IP blocking mode is used and this query is to be blocked
+      # - regular expressions with the ;reply=IP regex extension.
+      #
+      # Allowed values are:
+      #     <true|false>
       force4 = true ### CHANGED, default = false
 
       # Custom IPv4 address for IP blocking mode
       #
-      # Possible values are:
-      #     <valid IPv4 address> or empty string ("")
+      # Allowed values are:
+      #     A valid IPv4 address or empty string ("")
       IPv4 = "10.100.0.11" ### CHANGED, default = ""
 
       # Use a specific IPv6 address in IP blocking mode? See description for the IPv4 variant
       # above for further details.
+      #
+      # Allowed values are:
+      #     <true|false>
       force6 = true ### CHANGED, default = false
 
       # Custom IPv6 address for IP blocking mode
       #
-      # Possible values are:
-      #     <valid IPv6 address> or empty string ("")
+      # Allowed values are:
+      #     Avalid IPv6 address or empty string ("")
       IPv6 = "fe80::11" ### CHANGED, default = ""
 
   [dns.rateLimit]
     # Rate-limited queries are answered with a REFUSED reply and not further processed by
     # FTL.
+    #
     # The default settings for FTL's rate-limiting are to permit no more than 1000 queries
     # in 60 seconds. Both numbers can be customized independently. It is important to note
     # that rate-limiting is happening on a per-client basis. Other clients can continue to
     # use FTL while rate-limited clients are short-circuited at the same time.
+    #
     # For this setting, both numbers, the maximum number of queries within a given time,
     # and the length of the time interval (seconds) have to be specified. For instance, if
     # you want to set a rate limit of 1 query per hour, the option should look like
@@ -399,53 +508,73 @@
     # (FTL.log will contain lines like Still rate-limiting 10.0.1.39 as it made additional
     # 5007 queries). As soon as the client requests less than the set limit, it will be
     # unblocked (Ending rate-limitation of 10.0.1.39).
+    #
     # Rate-limiting may be disabled altogether by setting both values to zero (this
     # results in the same behavior as before FTL v5.7).
+    #
     # How many queries are permitted...
+    #
+    # Allowed values are:
+    #     A positive integer value
     count = 0 ### CHANGED, default = 1000
 
     # ... in the set interval before rate-limiting?
+    #
+    # Allowed values are:
+    #     A positive integer value in seconds
     interval = 0 ### CHANGED, default = 60
 
 [dhcp]
   # Is the embedded DHCP server enabled?
+  #
+  # Allowed values are:
+  #     <true|false>
   active = false
 
   # Start address of the DHCP address pool
   #
-  # Possible values are:
-  #     <valid IPv4 address> or empty string (""), e.g., "192.168.0.10"
+  # Example: "192.168.0.10"
+  #
+  # Allowed values are:
+  #     A valid IPv4 address, or empty string ("")
   start = ""
 
   # End address of the DHCP address pool
   #
-  # Possible values are:
-  #     <valid IPv4 address> or empty string (""), e.g., "192.168.0.250"
+  # Example: "192.168.0.250"
+  #
+  # Allowed values are:
+  #     A valid IPv4 address, or empty string ("")
   end = ""
 
   # Address of the gateway to be used (typically the address of your router in a home
   # installation)
   #
-  # Possible values are:
-  #     <valid IPv4 address> or empty string (""), e.g., "192.168.0.1"
+  # Example: "192.168.0.1"
+  #
+  # Allowed values are:
+  #     A valid IPv4 address, or empty string ("")
   router = ""
 
   # The netmask used by your Pi-hole. For directly connected networks (i.e., networks on
   # which the machine running Pi-hole has an interface) the netmask is optional and may
   # be set to an empty string (""): it will then be determined from the interface
-  # configuration itself. For networks which receive DHCP service via a relay agent, we
-  # cannot determine the netmask itself, so it should explicitly be specified, otherwise
-  # Pi-hole guesses based on the class (A, B or C) of the network address.
+  # configuration itself.
   #
-  # Possible values are:
-  #     <any valid netmask> (e.g., "255.255.255.0") or empty string ("") for
-  #     auto-discovery
+  # For networks which receive DHCP service via a relay agent, we cannot determine the
+  # netmask itself, so it should explicitly be specified, otherwise Pi-hole guesses
+  # based on the class (A, B or C) of the network address.
+  #
+  # Example: "255.255.255.0"
+  #
+  # Allowed values are:
+  #     Any valid netmask, or an empty string ("") for auto-discovery
   netmask = ""
 
   # If the lease time is given, then leases will be given for that length of time. If not
   # given, the default lease time is one hour for IPv4 and one day for IPv6.
   #
-  # Possible values are:
+  # Allowed values are:
   #     The lease time can be in seconds, or minutes (e.g., "45m") or hours (e.g., "1h")
   #     or days (like "2d") or even weeks ("1w"). You may also use "infinite" as string
   #     but be aware of the drawbacks
@@ -453,116 +582,169 @@
 
   # Should Pi-hole make an attempt to also satisfy IPv6 address requests (be aware that
   # IPv6 works a whole lot different than IPv4)
+  #
+  # Allowed values are:
+  #     <true|false>
   ipv6 = false
 
   # Enable DHCPv4 Rapid Commit Option specified in RFC 4039. Should only be enabled if
   # either the server is the only server for the subnet to avoid conflicts
+  #
+  # Allowed values are:
+  #     <true|false>
   rapidCommit = false
 
   # Advertise DNS server multiple times to clients. Some devices will add their own
   # proprietary DNS servers to the list of DNS servers, which can cause issues with
   # Pi-hole. This option will advertise the Pi-hole DNS server multiple times to
   # clients, which should prevent this from happening.
+  #
+  # Allowed values are:
+  #     <true|false>
   multiDNS = false
 
   # Enable logging for DHCP. This will log all relevant DHCP-related activity, including,
   # e.g., all the options sent to DHCP clients and the tags used to determine them (if
   # any). This can be useful for debugging DHCP issues. The generated output is saved to
   # the file specified by files.log.dnsmasq below.
+  #
+  # Allowed values are:
+  #     <true|false>
   logging = false
 
   # Ignore unknown DHCP clients.
   # If this option is set, Pi-hole ignores all clients which are not explicitly
   # configured through dhcp.hosts. This can be useful to prevent unauthorized clients
   # from getting an IP address from the DHCP server.
+  #
   # It should be noted that this option is not a security feature, as clients can still
   # assign themselves an IP address and use the network. It is merely a convenience
   # feature to prevent unknown clients from getting a valid IP configuration assigned
   # automatically.
+  #
   # Note that you will need to configure new clients manually in dhcp.hosts before they
   # can use the network when this feature is enabled.
+  #
+  # Allowed values are:
+  #     <true|false>
   ignoreUnknownClients = false
 
   # Per host parameters for the DHCP server. This allows a machine with a particular
   # hardware address to be always allocated the same hostname, IP address and lease time
   # or to specify static DHCP leases
   #
-  # Possible values are:
-  #     Array of static leases each on in one of the following forms:
+  # Example: [ "00:20:e0:3b:13:af,192.168.0.123,laptop,24h",
+  # "00:20:e0:ab:cd:ef,192.168.0.124,desktop,24h"]
+  #
+  # Allowed values are:
+  #     Array of static leases each one in the following form:
   #     "[<hwaddr>][,id:<client_id>|*][,set:<tag>][,tag:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]"
   hosts = []
 
   [ntp.ipv4]
     # Should FTL act as network time protocol (NTP) server (IPv4)?
+    #
+    # Allowed values are:
+    #     <true|false>
     active = true
 
     # IPv4 address to listen on for NTP requests
     #
-    # Possible values are:
-    #     <valid IPv4 address> or empty string ("") for wildcard (0.0.0.0)
+    # Allowed values are:
+    #     A valid IPv4 address, or empty string (""). For wildcard (0.0.0.0)
     address = ""
 
   [ntp.ipv6]
     # Should FTL act as network time protocol (NTP) server (IPv6)?
+    #
+    # Allowed values are:
+    #     <true|false>
     active = true
 
     # IPv6 address to listen on for NTP requests
     #
-    # Possible values are:
-    #     <valid IPv6 address> or empty string ("") for wildcard (::)
+    # Allowed values are:
+    #     A valid IPv6 address, or empty string (""). For wildcard (::)
     address = ""
 
   [ntp.sync]
     # Should FTL try to synchronize the system time with an upstream NTP server?
+    #
+    # Allowed values are:
+    #     <true|false>
     active = true
 
     # NTP upstream server to sync with, e.g., "pool.ntp.org". Note that the NTP server
     # should be located as close as possible to you in order to minimize the time offset
     # possibly introduced by different routing paths.
     #
-    # Possible values are:
-    #     valid NTP upstream server
+    # Allowed values are:
+    #     A valid NTP upstream server
     server = "pool.ntp.org"
 
     # Interval in seconds between successive synchronization attempts with the NTP server
+    #
+    # Allowed values are:
+    #     A positive integer value in seconds
     interval = 3600
 
     # Number of NTP syncs to perform and average before updating the system time
+    #
+    # Allowed values are:
+    #     A positive integer value
     count = 8
 
     [ntp.sync.rtc]
       # Should FTL update a real-time clock (RTC) if available?
+      #
+      # Allowed values are:
+      #     <true|false>
       set = false
 
-      # Path to the RTC device to update. Leave empty for auto-discovery
+      # Path to the RTC device to update.
       #
-      # Possible values are:
-      #     Path to the RTC device, e.g., "/dev/rtc0"
+      # Example: "/dev/rtc0"
+      #
+      # Allowed values are:
+      #     A valid RTC device path, or empty string ("") for auto-discovery
       device = ""
 
       # Should the RTC be set to UTC?
+      #
+      # Allowed values are:
+      #     <true|false>
       utc = true
 
 [resolver]
   # Should FTL try to resolve IPv4 addresses to hostnames?
+  #
+  # Allowed values are:
+  #     <true|false>
   resolveIPv4 = false ### CHANGED, default = true
 
   # Should FTL try to resolve IPv6 addresses to hostnames?
+  #
+  # Allowed values are:
+  #     <true|false>
   resolveIPv6 = false ### CHANGED, default = true
 
   # Control whether FTL should use the fallback option to try to obtain client names from
   # checking the network table. This behavior can be disabled with this option.
+  #
   # Assume an IPv6 client without a host names. However, the network table knows -
   # though the client's MAC address - that this is the same device where we have a host
   # name for another IP address (e.g., a DHCP server managed IPv4 address). In this
   # case, we use the host name associated to the other address as this is the same
   # device.
+  #
+  # Allowed values are:
+  #     <true|false>
   networkNames = false ### CHANGED, default = true
 
   # With this option, you can change how (and if) hourly PTR requests are made to check
   # for changes in client and upstream server hostnames.
   #
-  # Possible values are:
+  # Allowed values are:
   #   - "IPV4_ONLY"
   #       Do hourly PTR lookups only for IPv4 addresses. This is the new default since
   #       Pi-hole FTL v5.3.2. It should resolve issues with more and more very
@@ -584,68 +766,91 @@
 [database]
   # Should FTL load information from the database on startup to be aware of the most
   # recent history?
+  #
+  # Allowed values are:
+  #     <true|false>
   DBimport = true
 
   # How long should queries be stored in the database [days]?
-  # Setting this value to 0 will disable the database.
+  #
+  # Allowed values are:
+  #     A positive integer value in days, or 0 to disable the database
   maxDBdays = 91
 
   # How often do we store queries in FTL's database [seconds]?
+  #
+  # Allowed values are:
+  #     A positive integer value in seconds
   DBinterval = 60
 
   # Should FTL enable Write-Ahead Log (WAL) mode for the on-disk query database
   # (configured via files.database)?
+  #
   # It is recommended to leave this setting enabled for performance reasons. About the
   # only reason to disable WAL mode is if you are experiencing specific issues with it,
   # e.g., when using a database that is accessed from multiple hosts via a network
   # share. When this setting is disabled, FTL will use SQLite3's default journal mode
   # (rollback journal in DELETE mode).
+  #
+  # Allowed values are:
+  #     <true|false>
   useWAL = true
 
   [database.network]
     # Should FTL analyze the local ARP cache? When disabled, client identification and the
     # network table will stop working reliably.
+    #
+    # Allowed values are:
+    #     <true|false>
     parseARPcache = true
 
     # How long should IP addresses be kept in the network_addresses table [days]? IP
     # addresses (and associated host names) older than the specified number of days are
     # removed to avoid dead entries in the network overview table.
+    #
+    # Allowed values are:
+    #     A positive integer value in days
     expire = 91
 
 [webserver]
   # On which domain is the web interface served?
   #
-  # Possible values are:
-  #     <valid domain>
+  # Allowed values are:
+  #     A valid domain
   domain = "pi.hole"
 
   # Webserver access control list (ACL) allowing for restrictions to be put on the list
   # of IP addresses which have access to the web server. The ACL is a comma separated
   # list of IP subnets, where each subnet is prepended by either a - or a + sign. A plus
-  # sign means allow, where a minus sign means deny. If a subnet mask is omitted, such
-  # as -1.2.3.4, this means to deny only that single IP address. If this value is not
-  # set (empty string), all accesses are allowed. Otherwise, the default setting is to
-  # deny all accesses. On each request the full list is traversed, and the last (!)
-  # match wins. IPv6 addresses may be specified in CIDR-form [a:b::c]/64.
+  # sign means allow, where a minus sign means deny.
   #
-  # Example 1: acl = "+127.0.0.1,+[::1]"
-  # ---> deny all access, except from 127.0.0.1 and ::1,
-  # Example 2: acl = "+192.168.0.0/16"
-  # ---> deny all accesses, except from the 192.168.0.0/16 subnet,
-  # Example 3: acl = "+[::]/0" ---> allow only IPv6 access.
+  # If a subnet mask is omitted, such as -1.2.3.4, this means to deny only that single
+  # IP address. If this value is not set (empty string), all accesses are allowed.
+  # Otherwise, the default setting is to deny all accesses. On each request the full
+  # list is traversed, and the last (!) match wins. IPv6 addresses may be specified in
+  # CIDR-form [a:b::c]/64.
   #
-  # Possible values are:
-  #     <valid ACL>
+  # Example 1: "+127.0.0.1,+[::1]" ---> deny all access, except from 127.0.0.1 and ::1
+  #
+  # Example 2: "+192.168.0.0/16" ---> deny all accesses, except from the 192.168.0.0/16
+  # subnet
+  #
+  # Example 3: "+[::]/0" ---> allow only IPv6 access.
+  #
+  # Allowed values are:
+  #     A valid ACL
   acl = ""
 
   # Ports to be used by the webserver.
+  #
   # Comma-separated list of ports to listen on. It is possible to specify an IP address
   # to bind to. In this case, an IP address and a colon must be prepended to the port
   # number. For example, to bind to the loopback interface on port 80 (IPv4) and to all
   # interfaces port 8080 (IPv4), use "127.0.0.1:80,8080". "[::]:80" can be used to
   # listen to IPv6 connections to port 80. IPv6 addresses of network interfaces can be
-  # specified as well, e.g. "[::1]:80" for the IPv6 loopback interface. [::]:80 will
+  # specified as well, e.g. "[::1]:80" for the IPv6 loopback interface. "[::]:80" will
   # bind to port 80 IPv6 only.
+  #
   # In order to use port 80 for all interfaces, both IPv4 and IPv6, use either the
   # configuration "80,[::]:80" (create one socket for IPv4 and one for IPv6 only), or
   # "+80" (create one socket for both, IPv4 and IPv6). The '+' notation to use IPv4 and
@@ -654,34 +859,43 @@
   # work as expected, so you have to test to find the configuration most suitable for
   # your needs. In case "+80" does not work for your environment, you need to use
   # "80,[::]:80".
+  #
   # If the port is TLS/SSL, a letter 's' (secure) must be appended, for example,
   # "80,443s" will open port 80 and port 443, and connections on port 443 will be
   # encrypted. For non-encrypted ports, it is allowed to append letter 'r' (as in
   # redirect). Redirected ports will redirect all their traffic to the first configured
   # SSL port. For example, if webserver.port is "80r,443s", then all HTTP traffic coming
   # at port 80 will be redirected to HTTPS port 443.
+  #
   # When specifying 'o' (optional) behind a port, inability to use this port is not
   # considered an error. For instance, specifying "80o,8080o" will allow the webserver
   # to listen on either 80, 8080, both or even none of the two ports. This flag may be
   # combined with 'r' and 's' like "80or,443os,8080,4443s" (80 redirecting to SSL if
   # available, 443 encrypted if available, 8080 mandatory and unencrypted, 4443
   # mandatory and encrypted).
+  #
   # If this value is not set (empty string), the web server will not be started and,
   # hence, the API will not be available.
   #
-  # Possible values are:
-  #     comma-separated list of <[ip_address:]port>
+  # Allowed values are:
+  #     A comma-separated list of <[ip_address:]port>
   port = "80o,443os,[::]:80o,[::]:443os"
 
   # Maximum number of worker threads allowed.
+  #
   # The Pi-hole web server handles each incoming connection in a separate thread.
   # Therefore, the value of this option is effectively the number of concurrent HTTP
   # connections that can be handled. Any other connections are queued until they can be
   # processed by a unoccupied thread.
+  #
   # The total number of threads you see may be lower than the configured value as
   # threads are only created when needed due to incoming connections.
+  #
   # The value 0 means the number of threads is 50 (as per default settings of CivetWeb)
   # for backwards-compatible behavior.
+  #
+  # Allowed values are:
+  #     A positive integer value, or 0 for default (50)
   threads = 50
 
   # Additional HTTP headers added to the web server responses.
@@ -708,8 +922,8 @@
   # same-site origins, but cross-origin requests will send no referrer information.
   # The latter four headers are set as expected by https://securityheaders.io
   #
-  # Possible values are:
-  #     array of HTTP headers
+  # Allowed values are:
+  #     An array of HTTP headers
   headers = [
     "X-DNS-Prefetch-Control: off",
     "Content-Security-Policy: default-src 'self' 'unsafe-inline';",
@@ -722,21 +936,31 @@
   # Should the web server serve all files in webserver.paths.webroot directory? If
   # disabled, only files within the path defined through webserver.paths.webhome and
   # /api will be served.
+  #
+  # Allowed values are:
+  #     <true|false>
   serve_all = false
 
   [webserver.session]
     # Session timeout in seconds. If a session is inactive for more than this time, it will
     # be terminated. Sessions are continuously refreshed by the web interface, preventing
     # sessions from timing out while the web interface is open.
+    #
     # This option may also be used to make logins persistent for long times, e.g. 86400
     # seconds (24 hours), 604800 seconds (7 days) or 2592000 seconds (30 days). Note that
     # the total number of concurrent sessions is limited so setting this value too high
     # may result in users being rejected and unable to log in if there are already too
     # many sessions active.
+    #
+    # Allowed values are:
+    #     A positive integer value in seconds
     timeout = 300 ### CHANGED, default = 1800
 
     # Should Pi-hole backup and restore sessions from the database? This is useful if you
     # want to keep your sessions after a restart of the web interface.
+    #
+    # Allowed values are:
+    #     <true|false>
     restore = true
 
   [webserver.tls]
@@ -745,29 +969,29 @@
     # only required when at least one of webserver.port is TLS. The file must be in PEM
     # format, and it must have both, private key and certificate (the *.pem file created
     # must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).
-    # The *.pem file can be created using
-    #     cp server.crt server.pem
-    #     cat server.key >> server.pem
-    # if you have these files instead
     #
-    # Possible values are:
-    #     <valid TLS certificate file (*.pem)>
+    # The *.pem file can be created using `cp server.crt server.pem && cat server.key >>
+    # server.pem` if you have these files instead
+    #
+    # Allowed values are:
+    #     A valid TLS certificate file (*.pem)
     cert = "/etc/pihole/test.pem" ### CHANGED, default = "/etc/pihole/tls.pem"
 
   [webserver.paths]
     # Server root on the host
     #
-    # Possible values are:
-    #     <valid path>
+    # Allowed values are:
+    #     A valid path
     webroot = "/var/www/html"
 
     # Sub-directory of the root containing the web interface
     #
-    # Possible values are:
-    #     <valid subpath>, both slashes are needed!
+    # Allowed values are:
+    #     A valid subpath, both slashes are needed!
     webhome = "/admin/"
 
     # Prefix where the web interface is served
+    #
     # This is useful when you are using a reverse proxy serving the web interface, e.g.,
     # at http://<ip>/pihole/admin/ instead of http://<ip>/admin/. In this example, the
     # prefix would be "/pihole". Note that the prefix has to be stripped away by the
@@ -779,17 +1003,20 @@
     # being accessible.
     # Don't use this setting if you are not using a reverse proxy!
     #
-    # Possible values are:
-    #     valid URL prefix or empty
+    # Allowed values are:
+    #     A valid URL prefix or empty
     prefix = ""
 
   [webserver.interface]
     # Should the web interface use the boxed layout?
+    #
+    # Allowed values are:
+    #     <true|false>
     boxed = true
 
     # Theme used by the Pi-hole web interface
     #
-    # Possible values are:
+    # Allowed values are:
     #   - "default-auto"
     #       Pi-hole auto
     #   - "default-light"
@@ -809,54 +1036,73 @@
   [webserver.api]
     # Number of concurrent sessions allowed for the API. If the number of sessions exceeds
     # this value, no new sessions will be allowed until the number of sessions drops due
-    # to session expiration or logout. Note that the number of concurrent sessions is
-    # irrelevant if authentication is disabled as no sessions are used in this case.
+    # to session expiration or logout.
+    #
+    # Note that the number of concurrent sessions is irrelevant if authentication is
+    # disabled as no sessions are used in this case.
+    #
+    # Allowed values are:
+    #     A positive integer value
     max_sessions = 16
 
     # Should FTL prettify the API output (add extra spaces, newlines and indentation)?
+    #
+    # Allowed values are:
+    #     <true|false>
     prettyJSON = false
 
     # API password hash
     #
-    # Possible values are:
-    #     <valid Pi-hole password hash>
+    # Allowed values are:
+    #     A valid Pi-hole password hash
     pwhash = ""
 
     # Pi-hole 2FA TOTP secret. When set to something different than "", 2FA authentication
     # will be enforced for the API and the web interface. This setting is write-only, you
     # can not read the secret back.
     #
-    # Possible values are:
-    #     <valid TOTP secret (20 Bytes in Base32 encoding)>
+    # Allowed values are:
+    #     A valid TOTP secret (20 Bytes in Base32 encoding)
     totp_secret = ""
 
     # Pi-hole application password.
+    #
     # After you turn on two-factor (2FA) verification and set up an Authenticator app, you
     # may run into issues if you use apps or other services that don't support two-step
-    # verification. In this case, you can create and use an app password to sign in. An
-    # app password is a long, randomly generated password that can be used instead of your
-    # regular password + TOTP token when signing in to the API. The app password can be
-    # generated through the API and will be shown only once. You can revoke the app
-    # password at any time. If you revoke the app password, be sure to generate a new one
-    # and update your app with the new password.
+    # verification. In this case, you can create and use an app password to sign in.
     #
-    # Possible values are:
-    #     <valid Pi-hole password hash>
+    # An app password is a long, randomly generated password that can be used instead of
+    # your regular password + TOTP token when signing in to the API. The app password can
+    # be generated through the API and will be shown only once.
+    #
+    # You can revoke the app password at any time. If you revoke the app password, be sure
+    # to generate a new one and update your app with the new password.
+    #
+    # Allowed values are:
+    #     A valid Pi-hole password hash
     app_pwhash = ""
 
     # Should application password API sessions be allowed to modify config settings?
+    #
     # Setting this to true allows third-party applications using the application password
     # to modify settings, e.g., the upstream DNS servers, DHCP server settings, or
     # changing passwords. This setting should only be enabled if really needed and only if
     # you trust the applications using the application password.
+    #
+    # Allowed values are:
+    #     <true|false>
     app_sudo = false
 
-    # Should FTL create a temporary CLI password? This password is stored in clear in
-    # /etc/pihole and can be used by the CLI (pihole ...  commands) to authenticate
-    # against the API. Note that the password is only valid for the current session and
-    # regenerated on each FTL restart. Sessions initiated with this password cannot modify
-    # the Pi-hole configuration (change passwords, etc.) for security reasons but can
-    # still use the API to query data and manage lists.
+    # Should FTL create a temporary CLI password?
+    #
+    # This password is stored in clear in /etc/pihole and can be used by the CLI (pihole
+    # ...  commands) to authenticate against the API. Note that the password is only valid
+    # for the current session and regenerated on each FTL restart. Sessions initiated with
+    # this password cannot modify the Pi-hole configuration (change passwords, etc.) for
+    # security reasons but can still use the API to query data and manage lists.
+    #
+    # Allowed values are:
+    #     <true|false>
     cli_pw = true
 
     # Array of clients to be excluded from certain API responses (regex):
@@ -867,8 +1113,8 @@
     #
     # Example: [ "^192\\.168\\.2\\.56$", "^fe80::341:[0-9a-f]*$", "^localhost$" ]
     #
-    # Possible values are:
-    #     array of regular expressions describing clients
+    # Allowed values are:
+    #     An array of regular expressions describing clients
     excludeClients = [
       "^1\\.2\\.3\\.4$"
     ] ### CHANGED, default = []
@@ -880,38 +1126,54 @@
     #
     # Example: [ "(^|\\.)\\.google\\.de$", "\\.pi-hole\\.net$" ]
     #
-    # Possible values are:
-    #     array of regular expressions describing domains
+    # Allowed values are:
+    #     An array of regular expressions describing domains
     excludeDomains = []
 
     # How much history should be imported from the database and returned by the API
-    # [seconds]? (max 24*60*60 = 86400)
+    # [seconds]? (max 24hrs = 86400)
+    #
+    # Allowed values are:
+    #     A positive integer value in seconds up to 86400
     maxHistory = 86400
 
     # Up to how many clients should be returned in the activity graph endpoint
     # (/api/history/clients)?
+    #
     # This setting can be overwritten at run-time using the parameter N. Setting this to 0
     # will always send all clients. Be aware that this may be challenging for the GUI if
     # you have many (think > 1.000 clients) in your network
+    #
+    # Allowed values are:
+    #     A positive integer value
     maxClients = 10
 
     # How should the API compute the most active clients? If set to true, the API will
     # return the clients with the most queries globally (within 24 hours). If set to
     # false, the API will return the clients with the most queries per time slot
     # individually.
+    #
+    # Allowed values are:
+    #     <true|false>
     client_history_global_max = true
 
     # Allow destructive API calls (e.g. restart DNS server, flush logs, ...)
+    #
+    # Allowed values are:
+    #     <true|false>
     allow_destructive = true
 
     [webserver.api.temp]
       # Which upper temperature limit should be used by Pi-hole? Temperatures above this
       # limit will be shown as "hot". The number specified here is in the unit defined below
+      #
+      # Allowed values are:
+      #     A positive floating point value in the unit defined below
       limit = 60.000000
 
       # Which temperature unit should be used for temperatures processed by FTL?
       #
-      # Possible values are:
+      # Allowed values are:
       #   - "C"
       #       Celsius
       #   - "F"
@@ -923,70 +1185,71 @@
 [files]
   # The file which contains the PID of FTL's main process.
   #
-  # Possible values are:
-  #     <any writable file>
+  # Allowed values are:
+  #     Any writable file
   pid = "/run/pihole-FTL.pid"
 
   # The location of FTL's long-term database
   #
-  # Possible values are:
-  #     <any FTL database>
+  # Allowed values are:
+  #     Any FTL database
   database = "/etc/pihole/pihole-FTL.db"
 
   # The location of Pi-hole's gravity database
   #
-  # Possible values are:
-  #     <any Pi-hole gravity database>
+  # Allowed values are:
+  #     Any Pi-hole gravity database
   gravity = "/etc/pihole/gravity.db"
 
   # A temporary directory where Pi-hole can store files during gravity updates. This
   # directory must be writable by the user running gravity (typically pihole).
   #
-  # Possible values are:
-  #     <any existing world-writable writable directory>
+  # Allowed values are:
+  #     Any existing world-writable writable directory
   gravity_tmp = "/tmp"
 
   # The database containing MAC -> Vendor information for the network table
   #
-  # Possible values are:
-  #     <any Pi-hole macvendor database>
+  # Allowed values are:
+  #     Any Pi-hole macvendor database
   macvendor = "/etc/pihole/macvendor.db"
 
   # An optional file containing a pcap capture of the network traffic. This file is used
   # for debugging purposes only. If you don't know what this is, you don't need it.
+  #
   # Setting this to an empty string disables pcap recording. The file must be writable
   # by the user running FTL (typically pihole). Failure to write to this file will
   # prevent the DNS resolver from starting. The file is appended to if it already
   # exists.
   #
-  # Possible values are:
-  #     <any writable pcap file>
+  # Allowed values are:
+  #     Any writable pcap file
   pcap = ""
 
   [files.log]
     # The location of FTL's log file
     #
-    # Possible values are:
-    #     <any writable file>
+    # Allowed values are:
+    #     any writable file
     ftl = "/var/log/pihole/FTL.log"
 
     # The log file used by the embedded dnsmasq DNS server
     #
-    # Possible values are:
-    #     <any writable file>
+    # Allowed values are:
+    #     Any writable file
     dnsmasq = "/var/log/pihole/pihole.log"
 
     # The log file used by the webserver
     #
-    # Possible values are:
-    #     <any writable file>
+    # Allowed values are:
+    #     Any writable file
     webserver = "/var/log/pihole/webserver.log"
 
 [misc]
   # Using privacy levels you can specify which level of detail you want to see in your
   # Pi-hole statistics. Changing this setting will trigger a restart of FTL
   #
-  # Possible values are:
+  # Allowed values are:
   #   - 0
   #       Don't hide anything, all statistics are available.
   #   - 1
@@ -1003,30 +1266,47 @@
   # During startup, in some configurations, network interfaces appear only late during
   # system startup and are not ready when FTL tries to bind to them. Therefore, you may
   # want FTL to wait a given amount of time before trying to start the DNS revolver.
+  #
   # This setting takes any integer value between 0 and 300 seconds. To prevent delayed
   # startup while the system is already running and FTL is restarted, the delay only
   # takes place within the first 180 seconds (hard-coded) after booting.
+  #
+  # Allowed values are:
+  #     A positive integer value between 0 and 300
   delay_startup = 0
 
   # Set niceness of pihole-FTL. Defaults to -10 and can be disabled altogether by setting
   # a value of -999. The nice value is an attribute that can be used to influence the
-  # CPU scheduler to favor or disfavor a process in scheduling decisions. The range of
-  # the nice value varies across UNIX systems. On modern Linux, the range is -20 (high
-  # priority = not very nice to other processes) to +19 (low priority).
+  # CPU scheduler to favor or disfavor a process in scheduling decisions.
+  #
+  # The range of the nice value varies across UNIX systems. On modern Linux, the range
+  # is -20 (high priority = not very nice to other processes) to +19 (low priority).
+  #
+  # Allowed values are:
+  #     A signed integer value between -20 and 19, or -999 to disable niceness
   nice = -11 ### CHANGED (env), default = -10
 
   # Should FTL translate its own stack addresses into code lines during the bug
   # backtrace? This improves the analysis of crashed significantly. It is recommended to
-  # leave the option enabled. This option should only be disabled when addr2line is
-  # known to not be working correctly on the machine because, in this case, the
-  # malfunctioning addr2line can prevent from generating any backtrace at all.
+  # leave the option enabled.
+  #
+  # This option should only be disabled when addr2line is known to not be working
+  # correctly on the machine because, in this case, the malfunctioning addr2line can
+  # prevent from generating any backtrace at all.
+  #
+  # Allowed values are:
+  #     <true|false>
   addr2line = true
 
   # Should FTL load additional dnsmasq configuration files from /etc/dnsmasq.d/?
+  #
   # Warning: This is an advanced setting and should only be used with care.
   # Incorrectly formatted or config files specifying options which can only be defined
   # once can result in conflicts with the automatic configuration of Pi-hole (see
   # /etc/pihole/dnsmasq.conf) and may stop DNS resolution from working.
+  #
+  # Allowed values are:
+  #     <true|false>
   etc_dnsmasq_d = true ### CHANGED, default = false
 
   # Additional lines to inject into the generated dnsmasq configuration.
@@ -1034,24 +1314,32 @@
   # formatted or duplicated lines as well as lines conflicting with the automatic
   # configuration of Pi-hole can break the embedded dnsmasq and will stop DNS resolution
   # from working.
+  #
   # Use this option with extra care.
   #
-  # Possible values are:
-  #     array of valid dnsmasq config line options
+  # Allowed values are:
+  #     Array of valid dnsmasq config line options
   dnsmasq_lines = []
 
   # Log additional information about queries and replies to pihole.log
+  #
   # When this setting is enabled, the log has extra information at the start of each
   # line. This consists of a serial number which ties together the log lines associated
   # with an individual query, and the IP address of the requestor. This setting is only
   # effective if dns.queryLogging is enabled, too. This option is only useful for
   # debugging and is not recommended for normal use.
+  #
+  # Allowed values are:
+  #     <true|false>
   extraLogging = true ### CHANGED, default = false
 
   # Put configuration into read-only mode. This will prevent any changes to the
   # configuration file via the API or CLI. This setting useful when a configuration is
   # to be forced/modified by some third-party application (like infrastructure-as-code
   # providers) and should not be changed by any means.
+  #
+  # Allowed values are:
+  #     <true|false>
   readOnly = false
 
   [misc.check]
@@ -1062,7 +1350,11 @@
     # in use. To account for this, FTL regularly checks the system load. To bring this to
     # your attention, FTL warns about excessive load when the 15 minute system load
     # average exceeds the number of cores.
+    #
     # This check can be disabled with this setting.
+    #
+    # Allowed values are:
+    #     <true|false>
     load = false ### CHANGED, default = true
 
     # FTL stores history in shared memory to allow inter-process communication with forked
@@ -1072,49 +1364,82 @@
     # By default, FTL warns if the shared-memory usage exceeds 90%. You can set any
     # integer limit between 0 to 100 (interpreted as percentages) where 0 means that
     # checking of shared-memory usage is disabled.
+    #
+    # Allowed values are:
+    #     A positive integer value between 0 and 100
     shmem = 91 ### CHANGED (env), default = 90
 
     # FTL stores its long-term history in a database file on disk. Furthermore, FTL stores
     # log files. By default, FTL warns if usage of the disk holding any crucial file
     # exceeds 90%. You can set any integer limit between 0 to 100 (interpreted as
     # percentages) where 0 means that checking of disk usage is disabled.
+    #
+    # Allowed values are:
+    #     A positive integer value between 0 and 100
     disk = 0 ### CHANGED, default = 90
 
 [debug]
   # Print debugging information about database actions. This prints performed SQL
   # statements as well as some general information such as the time it took to store the
   # queries and how many have been saved to the database.
+  #
+  # Allowed values are:
+  #     <true|false>
   database = true ### CHANGED, default = false
 
   # Prints a list of the detected interfaces on the startup of pihole-FTL. Also, prints
   # whether these interfaces are IPv4 or IPv6 interfaces.
+  #
+  # Allowed values are:
+  #     <true|false>
   networking = true ### CHANGED, default = false
 
   # Print information about shared memory locks. Messages will be generated when waiting,
   # obtaining, and releasing a lock.
+  #
+  # Allowed values are:
+  #     <true|false>
   locks = true ### CHANGED, default = false
 
   # Print extensive query information (domains, types, replies, etc.). This has always
   # been part of the legacy debug mode of pihole-FTL.
+  #
+  # Allowed values are:
+  #     <true|false>
   queries = true ### CHANGED, default = false
 
   # Print flags of queries received by the DNS hooks. Only effective when DEBUG_QUERIES
   # is enabled as well.
+  #
+  # Allowed values are:
+  #     <true|false>
   flags = true ### CHANGED, default = false
 
   # Print information about shared memory buffers. Messages are either about creating or
   # enlarging shmem objects or string injections.
+  #
+  # Allowed values are:
+  #     <true|false>
   shmem = true ### CHANGED, default = false
 
   # Print information about garbage collection (GC): What is to be removed, how many have
   # been removed and how long did GC take.
+  #
+  # Allowed values are:
+  #     <true|false>
   gc = true ### CHANGED, default = false
 
   # Print information about ARP table processing: How long did parsing take, whether read
   # MAC addresses are valid, and if the macvendor.db file exists.
+  #
+  # Allowed values are:
+  #     <true|false>
   arp = true ### CHANGED, default = false
 
   # Controls if FTLDNS should print extended details about regex matching into FTL.log.
+  #
+  # Allowed values are:
+  #     <true|false>
   regex = true ### CHANGED, default = false
 
   # Print extra debugging information concerning API calls. This includes the request,
@@ -1123,6 +1448,9 @@
   # when debugging specific API issues and can be helpful, e.g., when a client cannot
   # connect due to an obscure API error. Furthermore, this setting enables logging of
   # all API requests (auth log) and details about user authentication attempts.
+  #
+  # Allowed values are:
+  #     <true|false>
   api = true ### CHANGED (env), default = false
 
   # Print extra debugging information about TLS connections. This includes the TLS
@@ -1131,78 +1459,138 @@
   # e.g., when a client cannot connect due to an obscure TLS error as modern browsers do
   # not provide much information about the underlying TLS connection and most often give
   # only very generic error messages without much/any underlying technical information.
+  #
+  # Allowed values are:
+  #     <true|false>
   tls = true ### CHANGED, default = false
 
   # Print information about overTime memory operations, such as initializing or moving
   # overTime slots.
+  #
+  # Allowed values are:
+  #     <true|false>
   overtime = true ### CHANGED, default = false
 
   # Print information about status changes for individual queries. This can be useful to
   # identify unexpected unknown queries.
+  #
+  # Allowed values are:
+  #     <true|false>
   status = true ### CHANGED, default = false
 
   # Print information about capabilities granted to the pihole-FTL process. The current
   # capabilities are printed on receipt of SIGHUP, i.e., the current set of capabilities
   # can be queried without restarting pihole-FTL (by setting DEBUG_CAPS=true and
   # thereafter sending killall -HUP pihole-FTL).
+  #
+  # Allowed values are:
+  #     <true|false>
   caps = true ### CHANGED, default = false
 
   # Print information about DNSSEC activity
+  #
+  # Allowed values are:
+  #     <true|false>
   dnssec = true ### CHANGED, default = false
 
   # FTL uses dynamically allocated vectors for various tasks. This config option enables
   # extensive debugging information such as information about allocation, referencing,
   # deletion, and appending.
+  #
+  # Allowed values are:
+  #     <true|false>
   vectors = true ### CHANGED, default = false
 
   # Extensive information about hostname resolution like which DNS servers are used in
   # the first and second hostname resolving tries (only affecting internally generated
   # PTR queries).
+  #
+  # Allowed values are:
+  #     <true|false>
   resolver = true ### CHANGED, default = false
 
   # Print debugging information about received EDNS(0) data.
+  #
+  # Allowed values are:
+  #     <true|false>
   edns0 = true ### CHANGED, default = false
 
   # Log various important client events such as change of interface (e.g., client
   # switching from WiFi to wired or VPN connection), as well as extensive reporting
   # about how clients were assigned to its groups.
+  #
+  # Allowed values are:
+  #     <true|false>
   clients = true ### CHANGED, default = false
 
   # Log information related to alias-client processing.
+  #
+  # Allowed values are:
+  #     <true|false>
   aliasclients = true ### CHANGED, default = false
 
   # Log information regarding FTL's embedded event handling queue.
+  #
+  # Allowed values are:
+  #     <true|false>
   events = true ### CHANGED, default = false
 
   # Log information about script helpers, e.g., due to dhcp-script.
+  #
+  # Allowed values are:
+  #     <true|false>
   helper = true ### CHANGED, default = false
 
   # Print config parsing details
+  #
+  # Allowed values are:
+  #     <true|false>
   config = true ### CHANGED, default = false
 
   # Debug monitoring of /etc/pihole filesystem events
+  #
+  # Allowed values are:
+  #     <true|false>
   inotify = true ### CHANGED, default = false
 
   # Debug monitoring of the webserver (CivetWeb) events
+  #
+  # Allowed values are:
+  #     <true|false>
   webserver = true ### CHANGED, default = false
 
   # Temporary flag that may print additional information. This debug flag is meant to be
   # used whenever needed for temporary investigations. The logged content may change
   # without further notice at any time.
+  #
+  # Allowed values are:
+  #     <true|false>
   extra = true ### CHANGED, default = false
 
   # Reserved debug flag
+  #
+  # Allowed values are:
+  #     <true|false>
   reserved = true ### CHANGED, default = false
 
   # Print information about NTP synchronization
+  #
+  # Allowed values are:
+  #     <true|false>
   ntp = true ### CHANGED, default = false
 
   # Print information about netlink communication and parsing
+  #
+  # Allowed values are:
+  #     <true|false>
   netlink = true ### CHANGED, default = false
 
   # Set all debug flags at once. This is a convenience option to enable all debug flags
   # at once. Note that this option is not persistent, setting it to true will enable all
   # *remaining* debug flags but unsetting it will disable *all* debug flags.
+  #
+  # Allowed values are:
+  #     <true|false>
   all = true ### CHANGED, default = false
 
 # Configuration statistics:

--- a/tools/pihole_toml_to_markdown.py
+++ b/tools/pihole_toml_to_markdown.py
@@ -1,0 +1,285 @@
+import re
+from pathlib import Path
+
+
+def parse_toml_with_comments(filepath):
+    """
+    Parse a TOML file with comments and generate a Markdown documentation string.
+
+    Args:
+        filepath (str or Path): Path to the TOML file.
+
+    Returns:
+        str: Markdown-formatted documentation.
+    """
+    with open(filepath, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    # Start with a Markdown header and introductory documentation block
+    documentation = [
+        """<!-- markdownlint-disable MD033 -->
+# Pi-hole FTL Configuration Reference
+
+This page documents the available options of `pihole-FTL`. They are typically managed via the [TOML](https://toml.io/)-formatted configuration file `/etc/pihole/pihole.toml`. This file may be edited directly or you can use the command line (CLI) option, the web interface, the application programming interface (API) or environment variables.
+
+Using the web interface, the API or the CLI is preferred as they can do error checking for you, trying to prevent any incompatible options which could prevent FTL from starting on a severely broken configuration.
+
+To edit with the command line, use the format `key.name=value`, e.g:
+
+```text
+sudo pihole-FTL --config dns.dnssec=true
+```
+
+!!! note "Environment Variables"
+    **⚙️ Configuration Precedence**
+    Every Pi-hole setting in this file can be overridden using an environment variable.
+    This is especially common in Docker deployments.
+    Environment variable names follow the format:
+    ```text
+    FTLCONF_<section>_<key>
+    ```
+    For example:
+    ```text
+    FTLCONF_dns_upstreams
+    FTLCONF_database_DBimport
+    ```
+    ⚠️ **If a setting is defined via an environment variable, it becomes read-only.**
+    You will not be able to override it through the TOML file, the command line, or the web interface until the variable is removed from the environment.
+
+---
+<!-- markdownlint-disable-file MD034 -->
+"""
+    ]
+    section_stack = []
+    comment_buffer = []
+    in_config = False  # <-- New flag to skip file header comments
+
+    lines_iter = iter(lines)
+    for line in lines_iter:
+        stripped = line.strip()
+
+        # Handle section headers
+        if re.match(r"^\[.*\]$", stripped):
+            in_config = True  # <-- Start processing comments now
+            section_stack = [stripped.strip("[]")]
+            documentation.append(f"\n## `[{'.'.join(section_stack)}]`\n")
+            continue
+        
+        # If we are in a config section, start buffering comments
+        elif stripped.startswith("#"):
+            if in_config:
+                comment_buffer.append(stripped.lstrip("#").strip())
+            continue
+
+        # Handle key-value pairs
+        elif "=" in stripped and in_config:
+            key, value = map(str.strip, stripped.split("=", 1))
+            value_lines = [value]
+
+            # Check if value is a multi-line array
+            if value.startswith("[") and not value.endswith("]"):
+                # Multi-line array
+                while not value_lines[-1].strip().endswith("]"):
+                    next_line = next(lines_iter).rstrip("\n")
+                    value_lines.append(next_line)
+                value = "\n".join(value_lines)
+
+            else:
+                value = value_lines[0]
+                
+            documentation.append(f"### `{key}`\n")
+
+            # Process the comments collected for this key
+            if comment_buffer:
+                adjusted_comments = []
+
+                i = 0
+                while i < len(comment_buffer):
+                    line = comment_buffer[i]
+                    is_bullet = line.lstrip().startswith("-")
+                    prev_is_bullet = i > 0 and comment_buffer[i - 1].lstrip().startswith("-")
+                    prev_is_blank = i > 0 and comment_buffer[i - 1].strip() == ""
+
+                    # Fix malformed emphasis due to underscores or asterisks
+                    line = re.sub(r'\b(_[a-zA-Z0-9.-]+)', r'`\1`', line)
+                    line = re.sub(r'\*\.[a-zA-Z0-9]+', lambda m: f"`{m.group(0)}`", line)
+
+                    # Bold "Allowed values are:"
+                    line = re.sub(
+                        r'(^|\s)(Allowed values are:)', 
+                        r'\1**Allowed values are:**', 
+                        line
+                    )
+
+                    # Bold "Example:"
+                    line = re.sub(
+                        r'(^|\s)(Example:)', 
+                        r'\1**Example:**', 
+                        line
+                    )                   
+
+                    # Insert blank line before bullet if needed
+                    if is_bullet and not prev_is_bullet and not prev_is_blank:
+                        adjusted_comments.append("")
+                   
+                    # Default: just append the line
+                    adjusted_comments.append(line)
+                    i += 1
+
+                documentation.append(wrap_examples_and_allowed_values("\n".join(adjusted_comments)))
+                documentation.append("")  # spacer after comment block
+            # Format default value for Markdown
+            if "\n" in value:
+                documentation.append("**Default value:**")
+                documentation.append("")
+                documentation.append("```toml")
+                documentation.append(f"{value}")
+                documentation.append("```")
+                documentation.append("")
+            else:
+                documentation.append(f"**Default value:** `{value}`\n")
+
+            # Compose full key for CLI/env var examples
+            full_key = ".".join(section_stack + [key])
+            env_var = "FTLCONF_" + "_".join(section_stack + [key])
+
+            # TOML example tab
+            documentation.append(f'=== "TOML"')
+            documentation.append("    ```toml")
+            documentation.append(f"    [{'.'.join(section_stack)}]")
+            # Indent multi-line values for TOML block
+            if "\n" in value:
+                indented_value = "\n".join("      " + v for v in value.splitlines())
+                documentation.append(f"      {key} = {indented_value}")
+            else:
+                documentation.append(f"      {key} = {value}")
+            documentation.append("    ```")
+
+            # CLI example tab
+            documentation.append(f'=== "CLI"')
+            documentation.append("    ```shell")
+            if "\n" in value and value.strip().startswith("["):
+                # Flatten multi-line array to single line for CLI
+                array_str = "".join(value.split())
+                documentation.append(f"    sudo pihole-FTL --config {full_key}='{array_str}'")           
+            else:
+                documentation.append(f"    sudo pihole-FTL --config {full_key}={value}")
+            documentation.append("    ```")
+
+            # Environment variable example tab (for Docker Compose)
+            documentation.append(f'=== "Environment (Docker Compose)"')
+            documentation.append("    ```yaml")
+            documentation.append("    environment:")
+            yaml_value = value.replace('"',"'")
+            if "\n" in yaml_value:
+                yaml_value = f"|\n        " + "\n        ".join(yaml_value.splitlines())
+            documentation.append(f"      {env_var}: {yaml_value}")
+            documentation.append("    ```\n")
+            comment_buffer = []
+
+    return "\n".join(documentation)
+
+def wrap_examples_and_allowed_values(line):
+    """
+    Wrap specific patterns in backticks:
+    - Complete arrays: [ "example" ] -> `[ "example" ]`
+    - Quoted strings: "example" -> `"example"`
+    - Angle brackets: <example> -> `<example>`
+    
+    Ensures no nested backticks appear within wrapped content.
+    """
+   
+    # Process other patterns
+    result = ''
+    i = 0
+    in_backticks = False
+    
+    while i < len(line):
+        # Skip content already in backticks
+        if in_backticks:
+            if line[i:i+1] == '`':
+                in_backticks = False
+            result += line[i]
+            i += 1
+            continue
+            
+        # Look for patterns to wrap
+        if line[i:i+1] == '"':
+            # Find the matching closing quote
+            j = i + 1
+            while j < len(line) and line[j] != '"':
+                j += 1
+            if j < len(line):  # Found closing quote
+                quoted_content = line[i:j+1]
+                result += f'`{quoted_content}`'
+                i = j + 1
+                in_backticks = False
+
+        elif line[i:i+1] == '<':
+            # Find the matching closing angle bracket
+            j = i + 1
+            while j < len(line) and line[j] != '>':
+                j += 1
+            if j < len(line):  # Found closing bracket
+                angle_content = line[i:j+1]
+                result += f'`{angle_content}`'
+                i = j + 1
+                in_backticks = False
+            else:  # No closing bracket found
+                result += line[i]
+                i += 1
+
+        elif line[i:i+1] == '[':
+            # Track nested square brackets
+            j = i + 1
+            bracket_count = 1
+            while j < len(line):
+                if line[j] == '[':
+                    bracket_count += 1
+                elif line[j] == ']':
+                    bracket_count -= 1
+                if bracket_count == 0:                    
+                    break
+                j += 1                
+            if bracket_count == 0 and j < len(line):  # Found matching closing bracket
+                square_content = line[i:j+1]
+                result += f'`{square_content}`'
+                i = j + 1
+                in_backticks = False
+                
+            else:  # No matching closing bracket found
+                result += line[i]
+                i += 1
+                
+        else:
+            result += line[i]
+            i += 1
+            
+    return result
+
+def write_markdown_doc(input_toml_path, output_md_path):
+    """
+    Generate Markdown documentation from a TOML file and write it to a file.
+
+    Args:
+        input_toml_path (str or Path): Path to the input TOML file.
+        output_md_path (str or Path): Path to the output Markdown file.
+    """
+    markdown = parse_toml_with_comments(input_toml_path)
+    Path(output_md_path).write_text(markdown, encoding="utf-8")
+    print(f"Documentation written to {output_md_path}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    # Expect exactly two arguments: input TOML and output Markdown
+    if len(sys.argv) != 3:
+        print("Usage: python pihole_toml_to_markdown.py <input.toml> <output.md>")
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+    write_markdown_doc(input_path, output_path)
+
+


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Utilises some python code to convert the generated default `pihole.toml` file to a markdown formatted page to PR directly to the docs repo.


Keeping draft for now as it is currently configured to always create the PR while we iron out the wrinkles. Once we are satisfied I can add in the conditon that it only runs on master and then open the PR fully

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_… formatted page to add to docs.pi-hole.net

Signed-off-by: Adam Warner <me@adamwarner.co.uk>