### PR TITLE
Remove domain type from domainNeeded help text

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -488,7 +488,7 @@ static void initConfig(struct config *conf)
 	conf->dns.hosts.c = validate_dns_hosts;
 
 	conf->dns.domainNeeded.k = "dns.domainNeeded";
-	conf->dns.domainNeeded.h = "If set, A and AAAA queries for plain names, without dots or domain parts, are never forwarded to upstream nameservers";
+	conf->dns.domainNeeded.h = "If set, queries for plain names, without dots or domain parts, are never forwarded to upstream nameservers";
 	conf->dns.domainNeeded.t = CONF_BOOL;
 	conf->dns.domainNeeded.f = FLAG_RESTART_FTL;
 	conf->dns.domainNeeded.d.b = false;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -554,7 +554,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	// that non-FQDNs queries should never be sent to any upstream servers
 	if(conf->dns.domainNeeded.v.b)
 	{
-		fputs("# Never forward A or AAAA queries for plain names, without\n",pihole_conf);
+		fputs("# Never forward queries for plain names, without\n",pihole_conf);
 		fputs("# dots or domain parts, to upstream nameservers. If the name\n", pihole_conf);
 		fputs("# is not known from /etc/hosts or DHCP, NXDOMAIN is returned\n", pihole_conf);
 		fputs("local=//\n\n", pihole_conf);

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -104,8 +104,8 @@
     "2.2.2.2 äste.com steä.com"
   ] ### CHANGED, default = []
 
-  # If set, A and AAAA queries for plain names, without dots or domain parts, are never
-  # forwarded to upstream nameservers
+  # If set, queries for plain names, without dots or domain parts, are never forwarded to
+  # upstream nameservers
   domainNeeded = false
 
   # If set, the domain is added to simple names (without a period) in /etc/hosts in the


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes the help text of the `domainNeeded` option. Discussion from https://github.com/pi-hole/FTL/issues/2563#issuecomment-3053552328

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
