### PR TITLE
Add sigrtmin action

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -220,6 +220,11 @@ void parse_args(int argc, char *argv[])
 	if(argc == 2 && strcmp(argv[1], "sigtest") == 0)
 		exit(sigtest());
 
+	// Print the value of SIGRTMIN, for use in the scripts to avoid issues
+	// caused by its inconsistent value across environments
+	if(argc == 2 && strcmp(argv[1], "sigrtmin") == 0)
+		exit(sigrtmin());
+
 	// If the binary name is "sqlite3"  (e.g., symlink /usr/bin/sqlite3 -> /usr/bin/pihole-FTL),
 	// we operate in drop-in mode and consume all arguments for the embedded SQLite3 engine
 	// Also, we do this if the first argument is a file with ".db" ending

--- a/src/signals.c
+++ b/src/signals.c
@@ -557,6 +557,12 @@ int sigtest(void)
 	return EXIT_SUCCESS;
 }
 
+int sigrtmin(void)
+{
+	printf("%d\n", SIGRTMIN);
+	return EXIT_SUCCESS;
+}
+
 void restart_ftl(const char *reason)
 {
 	log_info("Restarting FTL: %s", reason);

--- a/src/signals.h
+++ b/src/signals.h
@@ -24,6 +24,7 @@ pid_t main_pid(void);
 void thread_sleepms(const enum thread_types thread, const int milliseconds);
 void generate_backtrace(void);
 int sigtest(void);
+int sigrtmin(void);
 void restart_ftl(const char *reason);
 pid_t debugger(void);
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

In some cases `kill -RTMIN` can send incorrect signal value to the FTL causing it to terminate instead of performing lists reload.
https://github.com/pi-hole/FTL/issues/2573

**How does this PR accomplish the above?:**

Undocumented `sigrtmin` action is added which returns the value of `SIGRTMIN` FTL expects
That value can be used by the `pihole` script to send the correct signal

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
