### PR TITLE
Fix long-term database insertion

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -654,26 +654,6 @@ bool export_queries_to_disk(const bool final)
 		// Finalize statement
 		sqlite3_finalize(stmt);
 
-
-		// Update last_disk_db_idx
-		// Prepare SQLite3 statement
-		rc = sqlite3_prepare_v2(memdb, "SELECT MAX(id) FROM disk.query_storage;", -1, &stmt, NULL);
-		if(rc != SQLITE_OK)
-		{
-			log_err("export_queries_to_disk(): SQL error prepare: %s", sqlite3_errstr(rc));
-			return false;
-		}
-
-		// Perform step
-		if((rc = sqlite3_step(stmt)) == SQLITE_ROW)
-			last_disk_db_idx = sqlite3_column_int64(stmt, 0);
-		else
-			log_err("Failed to get MAX(id) from query_storage: %s",
-			        sqlite3_errstr(rc));
-
-		// Finalize statement
-		sqlite3_finalize(stmt);
-
 		/*
 		 * If there are any insertions, we:
 		 * 1. Insert (or replace) the last timestamp into the `disk.ftl` table.


### PR DESCRIPTION
# What does this implement/fix?

Avoid double-incrementing the `last_disk_db_idx` counter. This leads to a situation where some queries are not stored in the on-disk database. How much this affects you depends on the activity of the aforegoing database storing interval and, hence, is rather subtle.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/web-ui-and-api-show-different-query-block-totals-database-summary-discrepancy/81359

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.