### PR TITLE
Add colors to the --config output

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -985,6 +985,7 @@ void parse_args(int argc, char *argv[])
 			const char *bold = cli_bold();
 			const char *uline = cli_underline();
 			const char *normal = cli_normal();
+			const char *red = cli_color(COL_RED);
 			const char *blue = cli_color(COL_BLUE);
 			const char *cyan = cli_color(COL_CYAN);
 			const char *green = cli_color(COL_GREEN);
@@ -1081,6 +1082,8 @@ void parse_args(int argc, char *argv[])
 
 			printf("%sConfig options:%s\n", yellow, normal);
 			printf("\t%s--config %skey%s        Get current value of config item %skey%s\n", green, blue, normal, blue, normal);
+			printf("\t                    Config items with non-default values may\n");
+			printf("\t                    be colored in %sred%s\n", red, normal);
 			printf("\t%s--config %skey %svalue%s  Set new %svalue%s of config item %skey%s\n\n", green, blue, cyan, normal, cyan, normal, blue, normal);
 
 			printf("%sEmbedded GZIP un-/compressor:%s\n", yellow, normal);

--- a/src/args.c
+++ b/src/args.c
@@ -87,32 +87,6 @@ bool daemonmode = true, cli_mode = false;
 int argc_dnsmasq = 0;
 const char** argv_dnsmasq = NULL;
 
-// Extended SGR sequence:
-//
-// "\x1b[%dm"
-//
-// where %d is one of the following values for commonly supported colors:
-//
-// 0: reset colors/style
-// 1: bold
-// 4: underline
-// 30 - 37: black, red, green, yellow, blue, magenta, cyan, and white text
-// 40 - 47: black, red, green, yellow, blue, magenta, cyan, and white background
-//
-// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR
-//
-#define COL_NC		"\x1b[0m"  // normal font
-#define COL_BOLD	"\x1b[1m"  // bold font
-#define COL_ITALIC	"\x1b[3m"  // italic font
-#define COL_ULINE	"\x1b[4m"  // underline font
-#define COL_GREEN	"\x1b[32m" // normal foreground color
-#define COL_YELLOW	"\x1b[33m" // normal foreground color
-#define COL_RED		"\x1b[91m" // bright foreground color
-#define COL_BLUE	"\x1b[94m" // bright foreground color
-#define COL_PURPLE	"\x1b[95m" // bright foreground color
-#define COL_CYAN	"\x1b[96m" // bright foreground color
-#define CLI_OVER	"\r\x1b[K" // go back to beginning of line and erase to end of line
-
 static bool __attribute__ ((pure)) is_term(void)
 {
 	// test whether STDOUT refers to a terminal or if env variable
@@ -173,7 +147,7 @@ const char __attribute__ ((pure)) *cli_normal(void)
 }
 
 // Set color if STDOUT is a terminal
-static const char __attribute__ ((pure)) *cli_color(const char *color)
+const char __attribute__ ((pure)) *cli_color(const char *color)
 {
 	return is_term() ? color : "";
 }

--- a/src/args.h
+++ b/src/args.h
@@ -23,10 +23,37 @@ const char *cli_qst(void) __attribute__ ((const));
 const char *cli_done(void) __attribute__ ((pure));
 const char *cli_bold(void) __attribute__ ((pure));
 const char *cli_normal(void) __attribute__ ((pure));
+const char *cli_color(const char *color) __attribute__ ((pure));
 const char *cli_over(void) __attribute__ ((pure));
 const char *cli_underline(void) __attribute__ ((pure));
 const char *cli_italics(void) __attribute__ ((pure));
 
 void test_dnsmasq_options(int argc, const char *argv[]);
+
+// Extended SGR sequence:
+//
+// "\x1b[%dm"
+//
+// where %d is one of the following values for commonly supported colors:
+//
+// 0: reset colors/style
+// 1: bold
+// 4: underline
+// 30 - 37: black, red, green, yellow, blue, magenta, cyan, and white text
+// 40 - 47: black, red, green, yellow, blue, magenta, cyan, and white background
+//
+// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR
+//
+#define COL_NC		"\x1b[0m"  // normal font
+#define COL_BOLD	"\x1b[1m"  // bold font
+#define COL_ITALIC	"\x1b[3m"  // italic font
+#define COL_ULINE	"\x1b[4m"  // underline font
+#define COL_GREEN	"\x1b[32m" // normal foreground color
+#define COL_YELLOW	"\x1b[33m" // normal foreground color
+#define COL_RED		"\x1b[91m" // bright foreground color
+#define COL_BLUE	"\x1b[94m" // bright foreground color
+#define COL_PURPLE	"\x1b[95m" // bright foreground color
+#define COL_CYAN	"\x1b[96m" // bright foreground color
+#define CLI_OVER	"\r\x1b[K" // go back to beginning of line and erase to end of line
 
 #endif //ARGS_H

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -24,6 +24,8 @@
 #include "capabilities.h"
 // suggest_closest_conf_key()
 #include "config/suggest.h"
+// CLI colors
+#include "args.h"
 
 enum exit_codes {
 	OKAY = 0,
@@ -554,6 +556,8 @@ int get_config_from_CLI(const char *key, const bool quiet)
 
 	// Loop over all config options again to find the one we are looking for
 	// (possibly partial match)
+	const char *red = cli_color(COL_RED);
+	const char *normal = cli_normal();
 	for(unsigned int i = 0; i < CONFIG_ELEMENTS; i++)
 	{
 		// Get pointer to memory location of this conf_item
@@ -572,16 +576,18 @@ int get_config_from_CLI(const char *key, const bool quiet)
 		// This is the config option we are looking for
 		conf_item = item;
 
+		const bool is_default = compare_config_item(item->t, &item->v, &item->d);
+
 		// Print key if this is not an exact match
 		if(key == NULL || strcmp(item->k, key) != 0)
-			printf("%s = ", item->k);
+			printf("%s%s = ", is_default ? "" : red, item->k);
 
 		// Print value
 		if(conf_item-> f & FLAG_WRITE_ONLY)
 			puts("<write-only property>");
 		else
 			writeTOMLvalue(stdout, -1, conf_item->t, &conf_item->v);
-		putchar('\n');
+		puts(normal);
 	}
 
 	// Check if we found the config option

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -554,10 +554,12 @@ int get_config_from_CLI(const char *key, const bool quiet)
 		}
 	}
 
+	// Do not allow enforcing colors from --config
+	const char *red = getenv("FORCE_COLOR") == NULL ? cli_color(COL_RED) : "";
+	const char *normal = getenv("FORCE_COLOR") == NULL ? cli_normal() : "";
+
 	// Loop over all config options again to find the one we are looking for
 	// (possibly partial match)
-	const char *red = cli_color(COL_RED);
-	const char *normal = cli_normal();
 	for(unsigned int i = 0; i < CONFIG_ELEMENTS; i++)
 	{
 		// Get pointer to memory location of this conf_item


### PR DESCRIPTION
# What does this implement/fix?

Add colorful output to CLI if running in an interactive terminal. Config items changed from their default value are now shown in red, similarly to how we do it in the debug log. This makes reading settings much easier, especially if you want to see which `debug` flags are enabled, e.g.

<img width="428" height="528" alt="image" src="https://github.com/user-attachments/assets/1845b280-8ed1-4ccf-89e4-c7e4689efc1b" />

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.