### PR TITLE
Improve CNAME behavior of pi.hole

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -604,7 +604,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	fputs("# NXDOMAIN responses for queries on this domain. The actual response\n", pihole_conf);
 	fputs("# is handled by FTL at runtime\n", pihole_conf);
 	fputs("local=/pi.hole/\n", pihole_conf);
-	fputs("host-record=pi.hole,0.0.0.0\n", pihole_conf);
+	fputs("host-record=pi.hole,0.0.0.0,::\n", pihole_conf);
 
 	if(conf->dhcp.active.v.b)
 	{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1805,7 +1805,7 @@ static void update_pihole_cache_record(void)
 			if(config.dns.reply.host.force6.v.b)
 				memcpy(&lookup->addr.addr6, &config.dns.reply.host.v6.v.in6_addr, sizeof(lookup->addr.addr6));
 			else
-				memcpy(&lookup->addr.addr6, &next_iface.addr6.addr6, sizeof(next_iface.addr6.addr6));
+				memcpy(&lookup->addr.addr6, &next_iface.addr6.addr6, sizeof(lookup->addr.addr6));
 			log_debug(DEBUG_NETWORKING, "Updating IPv6 address in cache");
 		}
 	}

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1794,17 +1794,19 @@ static void update_pihole_cache_record(void)
 		log_debug(DEBUG_NETWORKING, "Found cache entry for pi.hole: %p", lookup);
 		if(lookup->flags & F_IPV4)
 		{
-			memcpy(&lookup->addr.addr4, &next_iface.addr4.addr4, sizeof(next_iface.addr4.addr4));
-			next_iface.haveIPv4 = true;
-			log_debug(DEBUG_NETWORKING, "Using IPv4 address from cache: %s",
-			          inet_ntoa(next_iface.addr4.addr4));
+			if(config.dns.reply.host.force4.v.b)
+				memcpy(&lookup->addr.addr4, &config.dns.reply.host.v4.v.in_addr, sizeof(lookup->addr.addr4));
+			else
+				memcpy(&lookup->addr.addr4, &next_iface.addr4.addr4, sizeof(lookup->addr.addr4));
+			log_debug(DEBUG_NETWORKING, "Updating IPv4 address in cache");
 		}
 		if(lookup->flags & F_IPV6)
 		{
-			memcpy(&lookup->addr.addr6, &next_iface.addr6.addr6, sizeof(next_iface.addr6.addr6));
-			next_iface.haveIPv6 = true;
-			log_debug(DEBUG_NETWORKING, "Using IPv6 address from cache: %s",
-			          inet_ntop(AF_INET6, &next_iface.addr6.addr6, next_iface.name, ADDRSTRLEN));
+			if(config.dns.reply.host.force6.v.b)
+				memcpy(&lookup->addr.addr6, &config.dns.reply.host.v6.v.in6_addr, sizeof(lookup->addr.addr6));
+			else
+				memcpy(&lookup->addr.addr6, &next_iface.addr6.addr6, sizeof(next_iface.addr6.addr6));
+			log_debug(DEBUG_NETWORKING, "Updating IPv6 address in cache");
 		}
 	}
 }

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -247,7 +247,8 @@
   # Allowed values are:
   #     Array of CNAMEs, each one in the following form: "<cname>,<target>[,<TTL>]"
   cnameRecords = [
-    "brücke.com,äste.com,2"
+    "brücke.com,äste.com,2",
+    "pihole.mydomain.net,pi.hole"
   ] ### CHANGED, default = []
 
   # Port used by the DNS server
@@ -431,26 +432,26 @@
       #
       # Allowed values are:
       #     true or false
-      force4 = true ### CHANGED, default = false
+      force4 = false
 
       # Custom IPv4 address for the Pi-hole host
       #
       # Allowed values are:
       #     A valid IPv4 address or empty string ("")
-      IPv4 = "10.100.0.10" ### CHANGED, default = ""
+      IPv4 = ""
 
       # Use a specific IPv6 address for the Pi-hole host? See description for the IPv4
       # variant above for further details.
       #
       # Allowed values are:
       #     true or false
-      force6 = true ### CHANGED, default = false
+      force6 = false
 
       # Custom IPv6 address for the Pi-hole host
       #
       # Allowed values are:
       #     A valid IPv6 address or empty string ("")
-      IPv6 = "fe80::10" ### CHANGED, default = ""
+      IPv6 = ""
 
     [dns.reply.blocking]
       # Use a specific IPv4 address in IP blocking mode? By default, FTL determines the
@@ -1591,8 +1592,8 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 156 total entries out of which 99 entries are default
-# --> 57 entries are modified
+# 156 total entries out of which 103 entries are default
+# --> 53 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice
 #   - misc.check.shmem

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1437,7 +1437,32 @@
   [[ "${lines[0]}" == "" ]]
 }
 
+@test "Pi-hole use interface-dependent replies for pi.hole" {
+  run bash -c "dig A pi.hole +short @127.0.0.1"
+  printf "A: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "127.0.0.1" ]]
+
+  run bash -c "dig AAAA pi.hole +short @127.0.0.1"
+  printf "AAAA: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "::1" ]]
+}
+
+@test "Pi-hole uses interface-dependent replies inside CNAME chains" {
+  run bash -c "dig A pihole.mydomain.net +short @127.0.0.1"
+  printf "A: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "pi.hole." ]]
+  [[ "${lines[1]}" == "127.0.0.1" ]]
+
+  run bash -c "dig AAAA pihole.mydomain.net +short @127.0.0.1"
+  printf "AAAA: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "pi.hole." ]]
+  [[ "${lines[1]}" == "::1" ]]
+}
+
 @test "Pi-hole uses dns.reply.host.IPv4/6 for pi.hole" {
+  # Set the reply for pi.hole to custom IPv4 and IPv6 addresses
+  run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config -d "{\"config\":{\"dns\":{\"reply\":{\"host\":{\"force4\":true,\"IPv4\":\"10.100.0.10\",\"force6\":true,\"IPv6\":\"fe80::10\"}}}}}"'
+  sleep 1
   run bash -c "dig A pi.hole +short @127.0.0.1"
   printf "A: %s\n" "${lines[@]}"
   [[ "${lines[0]}" == "10.100.0.10" ]]
@@ -1453,6 +1478,18 @@
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == *"EDE: 29: (synthesized)" ]]
   [[ ${lines[1]} == "" ]]
+}
+
+@test "Pi-hole uses dns.reply.host.IPv4/6 replies inside CNAME chains" {
+  run bash -c "dig A pihole.mydomain.net +short @127.0.0.1"
+  printf "A: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "pi.hole." ]]
+  [[ "${lines[1]}" == "10.100.0.10" ]]
+
+  run bash -c "dig AAAA pihole.mydomain.net +short @127.0.0.1"
+  printf "AAAA: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "pi.hole." ]]
+  [[ "${lines[1]}" == "fe80::10" ]]
 }
 
 @test "Pi-hole uses dns.reply.host.IPv4/6 for hostname" {
@@ -2162,7 +2199,7 @@
 @test "Expected number of config file rotations" {
   run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "2" ]]
+  [[ ${lines[0]} == "3" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]


### PR DESCRIPTION
# What does this implement/fix?

This PR improves the behavior of the special hostname `pi.hole` when encountered throughout deep CNAME inspection. This ensures that any defined custom CNAME rules that eventually end up in `pi.hole` get the correct interface-dependent IP addresses both for IPv4 (`A`) and IPv6 (`AAAA`). 

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2581

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.