### PR TITLE
fix: change type of disk parameter for GET /queries

### DIFF
--- a/src/api/docs/content/specs/queries.yaml
+++ b/src/api/docs/content/specs/queries.yaml
@@ -114,9 +114,7 @@ components:
             description: Load queries from on-disk database rather than from in-memory
             required: false
             schema:
-              enum:
-                - true
-                - false
+              type: boolean
               default: false
         responses:
           '200':


### PR DESCRIPTION
**What does this PR aim to accomplish?:**
Resolves #2546. In short, it fixes the type of the `disk` parameter for `GET /queries`, which was originally a true/false enum type instead of a `boolean`.

---
1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.
---
- [x] I have read the above and my PR is ready for review.
