### PR TITLE
Fix debug output association

### DIFF
--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -47,7 +47,7 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	const struct mg_request_info *req_info = mg_get_request_info(conn);
 
 	// Do not redirect for ACME challenges
-	log_debug(DEBUG_API, "Local URI: \"%s\"", req_info->local_uri_raw);
+	log_debug(DEBUG_WEBSERVER, "Local URI: \"%s\"", req_info->local_uri_raw);
 	const char acme_challenge[] = "/.well-known/acme-challenge/";
 	const bool is_acme = strncmp(req_info->local_uri_raw, acme_challenge, strlen(acme_challenge)) == 0;
 	if(is_acme)
@@ -100,7 +100,7 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 
 	// Check if the request is for something in the webhome directory
 	const bool in_webhome = (strncmp(req_info->local_uri_raw, prefix_webhome, strlen(prefix_webhome)) == 0);
-	log_debug(DEBUG_API, "Request for %s, login: %d, in_webhome: %d, no_dot: %d",
+	log_debug(DEBUG_WEBSERVER, "Request for %s, login: %d, in_webhome: %d, no_dot: %d",
 	          req_info->local_uri_raw, login, in_webhome, no_dot);
 
 	// Check if the request is for a LUA page (every XYZ.lp has already been


### PR DESCRIPTION
# What does this implement/fix?

Move two debug settings that have nothing to do with the API but with the embedded webserver from `DEBUG_API` -> `DEBUG_WEBSERVER`

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.