### PR TITLE
Fix FTL running behing reverse-proxy with prefix

### DIFF
--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -99,7 +99,9 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	const bool login = (strcmp(req_info->local_uri_raw, login_uri) == 0);
 
 	// Check if the request is for something in the webhome directory
-	const bool in_webhome = (strncmp(req_info->local_uri_raw, prefix_webhome, strlen(prefix_webhome)) == 0);
+	const bool in_webhome = (strncmp(req_info->local_uri_raw,
+	                                 config.webserver.paths.webhome.v.s,
+	                                 strlen(config.webserver.paths.webhome.v.s)) == 0);
 	log_debug(DEBUG_API, "Request for %s, login: %d, in_webhome: %d, no_dot: %d",
 	          req_info->local_uri_raw, login, in_webhome, no_dot);
 

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -160,7 +160,7 @@ static int redirect_root_handler(struct mg_connection *conn, void *input)
 	if(host != NULL && strncmp(host, config.webserver.domain.v.s, host_len) == 0)
 	{
 		// 308 Permanent Redirect from http://pi.hole -> http://pi.hole/admin/
-		if(strcmp(uri, "/") == 0)
+		if(strcmp(uri, "/") == 0 || strcmp(uri, config.webserver.paths.prefix.v.s) == 0)
 		{
 			if(strcmp(uri, prefix_webhome) == 0)
 			{
@@ -734,7 +734,7 @@ void http_init(void)
 		// Replace trailing slash with end-of-string marker for matcher
 		char *prefix_webhome_matcher = strdup(prefix_webhome);
 		prefix_webhome_matcher[strlen(prefix_webhome_matcher)-1] = '$';
-	
+
 		log_debug(DEBUG_API, "Redirecting %s --308--> %s",
 		          prefix_webhome, config.webserver.paths.webhome.v.s);
 		mg_set_request_handler(ctx, prefix_webhome_matcher, redirect_admin_handler, NULL);


### PR DESCRIPTION
# What does this implement/fix?

As the prefix is stripped away by the proxy, we shouldn't check for it when deciding if we need to authenticate.

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/issues/2596

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.