### PR TITLE
Add custom SQLite busy callback

### DIFF
--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -471,7 +471,7 @@ static bool import_json_table(cJSON *json, struct teleporter_files *file)
 		return false;
 	}
 
-	// Set busy timeout to 1 second to access the database in a
+	// Set busy timeout to access the database in a
 	// multi-threaded environment
 	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
 		log_warn("import_json_table(%s): Unable to set busy handler: %s", file->filename, sqlite3_errmsg(db));

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -473,8 +473,8 @@ static bool import_json_table(cJSON *json, struct teleporter_files *file)
 
 	// Set busy timeout to 1 second to access the database in a
 	// multi-threaded environment
-	if(sqlite3_busy_timeout(db, 1000) != SQLITE_OK)
-		log_warn("import_json_table(%s): Unable to set busy timeout: %s", file->filename, sqlite3_errmsg(db));
+	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
+		log_warn("import_json_table(%s): Unable to set busy handler: %s", file->filename, sqlite3_errmsg(db));
 
 	// Disable foreign key constraints
 	if(sqlite3_exec(db, "PRAGMA foreign_keys = OFF;", NULL, NULL, NULL) != SQLITE_OK)

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -92,7 +92,7 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
  * This function is called by SQLite when the database is locked and cannot be accessed
  * immediately. It implements an exponential backoff strategy using predefined delay and
  * total wait time arrays. The function waits for a specified delay (in milliseconds)
- * before retrying, up to a maximum timeout specified by the caller.
+ * before retrying, up to DATABASE_BUSY_TIMEOUT.
  *
  * @param ptr Pointer to an unsigned int specifying the maximum allowed wait time (in ms).
  * @param count The number of times the busy handler has been invoked for the same operation.

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -30,9 +30,12 @@
 #include "signals.h"
 // create_session_table()
 #include "database/session-table.h"
+// assert()
+#include <assert.h>
 
 bool DBdeleteoldqueries = false;
 static bool DBerror = false;
+static int dbopen_cnt = 0; // Number of times the database has been opened
 
 bool __attribute__ ((pure)) FTLDBerror(void)
 {
@@ -65,7 +68,7 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 		return;
 
 	if(config.debug.database.v.b)
-		log_debug(DEBUG_DATABASE, "Closing FTL database in %s() (%s:%i)", func, file, line);
+		log_debug(DEBUG_DATABASE, "Closing FTL database in %s() (%s:%i)", func, short_path(file), line);
 
 	// Only try to close an existing database connection
 	int rc = SQLITE_OK;
@@ -78,6 +81,69 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 
 	// Always set database pointer to NULL, even when closing failed
 	if(db) *db = NULL;
+
+	// Decrement the number of open database connections
+	dbopen_cnt--;
+}
+
+/**
+ * @brief Callback function for handling SQLite database busy events.
+ *
+ * This function is called by SQLite when the database is locked and cannot be accessed
+ * immediately. It implements an exponential backoff strategy using predefined delay and
+ * total wait time arrays. The function waits for a specified delay (in milliseconds)
+ * before retrying, up to a maximum timeout specified by the caller.
+ *
+ * @param ptr Pointer to an unsigned int specifying the maximum allowed wait time (in ms).
+ * @param count The number of times the busy handler has been invoked for the same operation.
+ * @return int Returns 1 to indicate that SQLite should retry the operation after the delay,
+ *             or 0 to indicate that the operation should fail because the timeout has been exceeded.
+ *
+ * The function logs a warning if the total wait time exceeds the allowed timeout, and
+ * logs debug information for each wait period.
+ */
+int sqliteBusyCallback(void *ptr, int count)
+{
+	static const uint8_t delays[] = { 1, 2, 5, 10, 15, 20, 25, 25,  25,  50,  50, 100 };
+	static const uint8_t totals[] = { 0, 1, 3,  8, 18, 33, 53, 78, 103, 128, 178, 228 };
+	# define NDELAY ArraySize(delays)
+
+	int delay, prior;
+
+	assert(count >= 0);
+	if(count < (int)NDELAY)
+	{
+		// Use the predefined delays and totals
+		delay = delays[count];
+		prior = totals[count];
+	}
+	else
+	{
+		// Use the last predefined delay and total
+		delay = delays[NDELAY - 1];
+		prior = totals[NDELAY - 1] + delay*(count - (NDELAY - 1));
+	}
+
+	if(prior + delay > DATABASE_BUSY_TIMEOUT)
+	{
+		delay = DATABASE_BUSY_TIMEOUT - prior;
+		if(delay <= 0)
+		{
+			// If the total time waited so far plus the next delay exceeds
+			// the maximum allowed time, return 0 to indicate that the
+			// database is busy beyond the allowed time and that we will not
+			// wait any longer.
+			log_debug(DEBUG_DATABASE, "Database busy for %d ms > %d ms, not waiting any longer",
+			         prior + delay, DATABASE_BUSY_TIMEOUT);
+			return 0;
+		}
+	}
+	log_debug(DEBUG_DATABASE, "Database busy - waiting %d ms (dbopen: %d)", delay, dbopen_cnt);
+	usleep(delay * 1000); // Convert ms to us
+
+	// Return 1 to indicate that we will wait for the database to become
+	// available again
+	return 1;
 }
 
 sqlite3* _dbopen(const bool readonly, const bool create, const char *func, const int line, const char *file)
@@ -87,7 +153,8 @@ sqlite3* _dbopen(const bool readonly, const bool create, const char *func, const
 		return NULL;
 
 	// Try to open database
-	log_debug(DEBUG_DATABASE, "Opening FTL database in %s() (%s:%i)", func, file, line);
+	log_debug(DEBUG_DATABASE, "Opening FTL database in %s() (node %s%s) (%s:%i)",
+	          func, readonly ? "RO" : "RW", create ? ",C" : "", short_path(file), line);
 
 	int flags = readonly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE;
 	if(create && !readonly)
@@ -112,15 +179,18 @@ sqlite3* _dbopen(const bool readonly, const bool create, const char *func, const
 	}
 
 	// Explicitly set busy handler to value defined in FTL.h
-	rc = sqlite3_busy_timeout(db, DATABASE_BUSY_TIMEOUT);
+	rc = sqlite3_busy_handler(db, sqliteBusyCallback, NULL);
 	if( rc != SQLITE_OK )
 	{
-		log_err("Error while trying to set busy timeout (%d ms) on database: %s",
-		        DATABASE_BUSY_TIMEOUT, sqlite3_errstr(rc));
+		log_err("Error while trying to set busy timeout on database: %s",
+		        sqlite3_errstr(rc));
 		dbclose(&db);
 		checkFTLDBrc(rc);
 		return NULL;
 	}
+
+	// Increment the number of open database connections
+	dbopen_cnt++;
 
 	return db;
 }

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -36,6 +36,7 @@ bool db_set_FTL_property(sqlite3* db, const enum ftl_table_props ID, const int v
 /// Execute a formatted SQL query and get the return code
 int dbquery(sqlite3* db, const char *format, ...) __attribute__ ((format (printf, 2, 3)));;
 
+int sqliteBusyCallback(void *ptr, int count);
 #define dbopen(readonly, create) _dbopen(readonly, create, __FUNCTION__, __LINE__, __FILE__)
 sqlite3 *_dbopen(const bool readonly, const bool create, const char *func, const int line, const char *file) __attribute__((warn_unused_result));
 #define dbclose(db) _dbclose(db, __FUNCTION__, __LINE__, __FILE__)

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -62,6 +62,7 @@ static bool analyze_database(sqlite3 *db)
 	// stores the collected information in internal tables of the database
 	// where the query optimizer can access the information and use it to
 	// help make better query planning choices.
+	log_debug(DEBUG_DATABASE, "Optimizing database %s", config.files.database.v.s);
 
 	// Measure time
 	struct timespec start, end;

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -89,17 +89,12 @@ void *DB_thread(void *val)
 	time_t before = time(NULL);
 	time_t lastDBsave = before - before%config.database.DBinterval.v.ui;
 
-	// Other timestamps, made independent from the exact time FTL was
-	// started
-	time_t lastAnalyze = before - before % DATABASE_ANALYZE_INTERVAL;
-	time_t lastMACVendor = before - before % DATABASE_MACVENDOR_INTERVAL;
-
-	// Add some randomness (up to one hour) to these timestamps to avoid
-	// them running at the same time. This is not a security feature, so
-	// using rand() is fine. Database analyze is not to be run soon after
-	// startup, so we add another hour to the lastAnalyze timestamp.
-	lastAnalyze += 3600 + rand() % 3600;
-	lastMACVendor += rand() % 3600;
+	// Add some randomness (between one and two hours) to these timestamps
+	// to avoid them running at the same time and immediately after FTL was
+	// (re)started. We really only want them to run in the background when
+	// FTL is running for a while.
+	time_t lastAnalyze = before + 3600 + (rand() % 3600);
+	time_t lastMACVendor = before + 3600 + (rand() % 3600);
 
 	// This thread runs until shutdown of the process. We keep this thread
 	// running when pihole-FTL.db is corrupted because reloading of privacy

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2728,7 +2728,7 @@ bool gravity_updated(void)
 		return false;
 	}
 
-	// Set busy timeout to 1 second to access the database in a
+	// Set busy timeout to access the database in a
 	// multi-threaded environment and other threads may be writing to the
 	// database (e.g. Teleporter restoring a backup)
 	rc = sqlite3_busy_handler(gravity_db, sqliteBusyCallback, NULL);

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -32,6 +32,8 @@
 #include "regex_r.h"
 // file_readable()
 #include "files.h"
+// sqliteBusyCallback()
+#include "common.h"
 
 // Prefix of interface names in the client table
 #define INTERFACE_SEP ":"
@@ -190,12 +192,6 @@ static bool gravityDB_open(void)
 		return false;
 	}
 
-	// Set SQLite3 busy timeout to a user-defined value (defaults to 1 second)
-	// to avoid immediate failures when the gravity database is still busy
-	// writing the changes to disk
-	log_debug(DEBUG_DATABASE, "gravityDB_open(): Setting busy timeout to %d", DATABASE_BUSY_TIMEOUT);
-	sqlite3_busy_timeout(gravity_db, DATABASE_BUSY_TIMEOUT);
-
 	// Prepare private vector of statements for this process (might be a TCP fork!)
 	if(whitelist_stmt == NULL)
 		whitelist_stmt = new_sqlite3_stmt_vec(counters->clients);
@@ -206,9 +202,9 @@ static bool gravityDB_open(void)
 	if(antigravity_stmt == NULL)
 		antigravity_stmt = new_sqlite3_stmt_vec(counters->clients);
 
-	// Explicitly set busy handler to zero milliseconds
-	log_debug(DEBUG_DATABASE, "gravityDB_open(): Setting busy timeout to zero");
-	rc = sqlite3_busy_timeout(gravity_db, 0);
+	// Explicitly set busy handler to zero milliseconds for gravity
+	log_debug(DEBUG_DATABASE, "gravityDB_open(): Unsetting busy handler");
+	rc = sqlite3_busy_handler(gravity_db, NULL, NULL);
 	if(rc != SQLITE_OK)
 		log_err("gravityDB_open() - Cannot set busy handler: %s", sqlite3_errstr(rc));
 
@@ -2735,8 +2731,12 @@ bool gravity_updated(void)
 	// Set busy timeout to 1 second to access the database in a
 	// multi-threaded environment and other threads may be writing to the
 	// database (e.g. Teleporter restoring a backup)
-	if(sqlite3_busy_timeout(db, 1000) != SQLITE_OK)
-		log_warn("gravity_updated(): %s - Failed to set busy timeout", config.files.gravity.v.s);
+	if(sqlite3_busy_handler(gravity_db, sqliteBusyCallback, NULL) != SQLITE_OK)
+	{
+		log_err("gravity_updated(): %s - Cannot set busy handler: %s", config.files.gravity.v.s, sqlite3_errstr(rc));
+		gravityDB_close();
+		return false;
+	}
 
 	// Get *updated* timestamp from gravity database
 	const char *querystr = "SELECT value FROM info WHERE property = 'updated';";

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2731,7 +2731,8 @@ bool gravity_updated(void)
 	// Set busy timeout to 1 second to access the database in a
 	// multi-threaded environment and other threads may be writing to the
 	// database (e.g. Teleporter restoring a backup)
-	if(sqlite3_busy_handler(gravity_db, sqliteBusyCallback, NULL) != SQLITE_OK)
+	rc = sqlite3_busy_handler(gravity_db, sqliteBusyCallback, NULL);
+	if(rc != SQLITE_OK)
 	{
 		log_err("gravity_updated(): %s - Cannot set busy handler: %s", config.files.gravity.v.s, sqlite3_errstr(rc));
 		gravityDB_close();

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -389,7 +389,8 @@ static int _add_message(const enum message_type type,
 		goto end_of_add_message;
 	}
 
-	// Execute and finalize
+	// Execute and finalize (we accept both SQLITE_OK = removed and
+	// SQLITE_DONE = nothing to remove)
 	if((rc = sqlite3_step(stmt)) != SQLITE_OK && rc != SQLITE_DONE)
 	{
 		log_err("add_message(type=%u, message=%s) - SQL error step DELETE: %s",

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1201,7 +1201,7 @@ void parse_neighbor_cache(sqlite3 *db)
 	// Start transaction to speed up database queries, to avoid that the
 	// database is locked by other processes and to allow for a rollback in
 	// case of an error
-	if(dbquery(db, "BEGIN TRANSACTION"))
+	if(dbquery(db, "BEGIN TRANSACTION") != SQLITE_OK)
 	{
 		// dbquery() above already logs the reason for why the query failed
 		log_warn("Starting first transaction failed during ARP parsing");

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1746,6 +1746,8 @@ bool updateMACVendorRecords(sqlite3 *db)
 	if(FTLDBerror())
 		return false;
 
+	log_debug(DEBUG_DATABASE, "Updating MAC vendor records");
+
 	struct stat st;
 	if(stat(config.files.macvendor.v.s, &st) != 0)
 	{

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1659,6 +1659,8 @@ static bool getMACVendor(const char *hwaddr, char vendor[MAXVENDORLEN])
 
 	log_debug(DEBUG_ARP, "getMACVendor(\"%s\")", hwaddr);
 
+	log_debug(DEBUG_ARP, "getMACVendor(\"%s\")", hwaddr);
+
 	struct stat st;
 	if(stat(config.files.macvendor.v.s, &st) != 0)
 	{

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -98,11 +98,11 @@ bool init_memory_database(void)
 	}
 
 	// Explicitly set busy handler to value defined in FTL.h
-	rc = sqlite3_busy_timeout(_memdb, DATABASE_BUSY_TIMEOUT);
+	rc = sqlite3_busy_handler(_memdb, sqliteBusyCallback, NULL);
 	if( rc != SQLITE_OK )
 	{
-		log_err("init_memory_database(): Step error while trying to set busy timeout (%d ms): %s",
-		        DATABASE_BUSY_TIMEOUT, sqlite3_errstr(rc));
+		log_err("init_memory_database(): Step error while trying to set busy timeout: %s",
+		        sqlite3_errstr(rc));
 		sqlite3_close(_memdb);
 		return false;
 	}

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -87,7 +87,7 @@ static bool create_teleporter_database(const char *filename, const char **tables
 
 	snprintf(attach_stmt, sizeof(attach_stmt), "ATTACH DATABASE '%s' AS \"disk\";", filename);
 
-	// Set busy timeout to 1 second to access the database in a
+	// Set busy timeout to access the database in a
 	// multi-threaded environment
 	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
 		log_warn("Failed to set busy timeout during creation of in-memory Teleporter database: %s", sqlite3_errmsg(db));

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -41,6 +41,8 @@
 #include "webserver/json_macros.h"
 // exit_code
 #include "signals.h"
+// sqliteBusyCallback()
+#include "database/common.h"
 
 // Tables to copy from the gravity database to the Teleporter database
 static const char *gravity_tables[] = {
@@ -87,7 +89,7 @@ static bool create_teleporter_database(const char *filename, const char **tables
 
 	// Set busy timeout to 1 second to access the database in a
 	// multi-threaded environment
-	if(sqlite3_busy_timeout(db, 1000) != SQLITE_OK)
+	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
 		log_warn("Failed to set busy timeout during creation of in-memory Teleporter database: %s", sqlite3_errmsg(db));
 
 	if(sqlite3_exec(db, attach_stmt, NULL, NULL, &err) != SQLITE_OK)


### PR DESCRIPTION
# What does this implement/fix?

Adds an exponentially backing off busy handler giving us control (and debugging capabilities) of what happens while the database is busy. This has already proven to be useful in the context of researching a database deadlock, see PR #2600 

The actual implementation has been heavily inspired by the default busy handler defined in `database/sqlite3.c`.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.