### PR TITLE
Fix logic in automatic interface determination (when dns.interface = "")

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -448,8 +448,12 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		fputs("\n", pihole_conf);
 	}
 
+	// Check if an explicit interface is configured
 	char *interface = conf->dns.interface.v.s;
-	const bool interface_allocated = strlen(interface) > 0;
+
+	// If not, get the name of the current gateway (we need to free this
+	// memory later on)
+	const bool interface_allocated = strlen(interface) < 1;
 	if(interface_allocated)
 		interface = get_gateway_name();
 


### PR DESCRIPTION
# What does this implement/fix?

There is a 50:50 chance to do boolean logic right. We chose the wrong half of it in `development`. This PR makes us use the right one (only auto-suggest the interface when the setting is *empty*). This bug has not been released but found by a very helpful `development` tester @jacklul .

For reference: The bug was introduced three weeks ago in https://github.com/pi-hole/FTL/commit/f14bf6ad2b06dcd7425e02ec96d07e031dd92cf7 (part of https://github.com/pi-hole/FTL/pull/2456).

---

**Related issue or feature (if applicable):** Fixes #2606 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.