### PR TITLE
Fix default value autocomplete suggestions

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -1445,20 +1445,15 @@ void suggest_complete(const int argc, char *argv[])
 						if(val != NULL && (value = cJSON_PrintUnformatted(val)) != NULL)
 						{
 							// Add '' to the output if it is a string
-							if(conf_item->t == CONF_STRING ||
-							   conf_item->t == CONF_STRING_ALLOCATED ||
-							   conf_item->t == CONF_JSON_STRING_ARRAY)
+							if(conf_item->t == CONF_JSON_STRING_ARRAY &&
+							   value[0] != '\'')
 							{
-								// If the value is a string, we need to add quotes
-								if(value[0] != '\'')
+								char *tmp = calloc(strlen(value) + 3, sizeof(char));
+								if(tmp != NULL)
 								{
-									char *tmp = malloc(strlen(value) + 3);
-									if(tmp != NULL)
-									{
-										sprintf(tmp, "'%s'", value);
-										free(value);
-										value = tmp;
-									}
+									sprintf(tmp, "'%s'", value);
+									free(value);
+									value = tmp;
 								}
 							}
 

--- a/src/args.c
+++ b/src/args.c
@@ -1419,164 +1419,191 @@ void suggest_complete(const int argc, char *argv[])
 				if(strcmp(conf_item->k, argv[4]) == 0)
 				{
 					// See if we can suggest a value
-					if(conf_item->t == CONF_BOOL || conf_item->t == CONF_ALL_DEBUG_BOOL)
+					switch(conf_item->t)
 					{
-						// pihole-FTL --config <boolean option>> ...
-						const char *options[] = {
-							"true", "false"
-						};
-
-						// Provide matching suggestions
-						list_matches(last_word, options, ArraySize(options), false);
-					}
-					else if(conf_item->t == CONF_INT ||
-					        conf_item->t == CONF_UINT ||
-					        conf_item->t == CONF_UINT16 ||
-					        conf_item->t == CONF_LONG ||
-					        conf_item->t == CONF_DOUBLE ||
-					        conf_item->t == CONF_STRING ||
-					        conf_item->t == CONF_STRING_ALLOCATED ||
-					        conf_item->t == CONF_JSON_STRING_ARRAY)
-					{
-						// pihole-FTL --config ... <int/long/double/string>
-						// Provide the default value as suggestion
-						char *value = NULL;
-						cJSON *val = addJSONConfValue(conf_item->t, &conf_item->d);
-						if(val != NULL && (value = cJSON_PrintUnformatted(val)) != NULL)
+						case CONF_BOOL:
+						case CONF_ALL_DEBUG_BOOL:
 						{
-							// Add '' to the output if it is a string
-							if(conf_item->t == CONF_JSON_STRING_ARRAY)
-							{
-								// Count number of ' in the string
-								char *p = value;
-								int count = 0;
-								while(p != NULL && *p != '\0')
-								{
-									if(*p == '\'')
-										count++;
-									p++;
-								}
+							// pihole-FTL --config <boolean option>> ...
+							const char *options[] = {
+								"true", "false"
+							};
 
-								// Allocate enough space for the new string
-								char *tmp = calloc(strlen(value) + 5*count + 3, sizeof(char));
-								if(tmp != NULL)
+							// Provide matching suggestions
+							list_matches(last_word, options, ArraySize(options), false);
+							break;
+						}
+
+						case CONF_INT:
+						case CONF_UINT:
+						case CONF_UINT16:
+						case CONF_LONG:
+						case CONF_DOUBLE:
+						case CONF_STRING:
+						case CONF_STRING_ALLOCATED:
+						case CONF_JSON_STRING_ARRAY:
+						{
+							// pihole-FTL --config ... <int/long/double/string>
+							// Provide the default value as suggestion
+							char *value = NULL;
+							cJSON *val = addJSONConfValue(conf_item->t, &conf_item->d);
+							if(val != NULL && (value = cJSON_PrintUnformatted(val)) != NULL)
+							{
+								// Add '' to the output if it is a string
+								if(conf_item->t == CONF_JSON_STRING_ARRAY)
 								{
-									memcpy(tmp + 1, value, strlen(value) + 1);
-									// We also need to replace all in-string ' by '"'"'
-									for(p = tmp + 1; *p != '\0'; p++)
+									// Count number of ' in the string
+									char *p = value;
+									unsigned int count = 0;
+									while(p != NULL && *p != '\0')
 									{
 										if(*p == '\'')
-										{
-											memmove(p + 4, p, strlen(p) + 1);
-											*(p++) = '\'';
-											*(p++) = '"';
-											*(p++) = '\'';
-											*(p++) = '"';
-										}
+											count++;
+										p++;
 									}
 
-									tmp[0] = '\'';
-									tmp[strlen(tmp)] = '\'';
-									free(value);
-									value = tmp;
+									// Allocate enough space for the new string
+									char *tmp = calloc(strlen(value) + 5*count + 3, sizeof(char));
+									if(tmp != NULL)
+									{
+										memcpy(tmp + 1, value, strlen(value) + 1);
+										// We also need to replace all in-string ' by '"'"'
+										for(p = tmp + 1; *p != '\0'; p++)
+										{
+											if(*p == '\'')
+											{
+												memmove(p + 4, p, strlen(p) + 1);
+												*(p++) = '\'';
+												*(p++) = '"';
+												*(p++) = '\'';
+												*(p++) = '"';
+											}
+										}
+
+										tmp[0] = '\'';
+										tmp[strlen(tmp)] = '\'';
+										free(value);
+										value = tmp;
+									}
 								}
+
+								// If the default value starts with the last word we are trying to complete,
+								// print it as a suggestion
+								// If the last word is empty, print the value anyway
+								if(strStartsWith(value, last_word) || strlen(last_word) == 0)
+									puts(value);
+								free(value);
 							}
+							cJSON_Delete(val);
+							break;
+						}
 
-							// If the default value starts with the last word we are trying to complete,
-							// print it as a suggestion
-							// If the last word is empty, print the value anyway
-							if(strStartsWith(value, last_word) || strlen(last_word) == 0)
-								puts(value);
-							free(value);
-						}
-						cJSON_Delete(val);
-					}
-					else if(conf_item->t == CONF_ENUM_PTR_TYPE)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < PTR_MAX; j++)
-						{
-							const char *ptr = get_ptr_type_str(j);
-							if(strStartsWithIgnoreCase(ptr, last_word) || strlen(last_word) == 0)
-								puts(ptr);
-						}
-					}
-					else if(conf_item->t == CONF_ENUM_BUSY_TYPE)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < BUSY_MAX; j++)
-						{
-							const char *busy = get_busy_reply_str(j);
-							if(strStartsWithIgnoreCase(busy, last_word) || strlen(last_word) == 0)
-								puts(busy);
-						}
-					}
-					else if(conf_item->t == CONF_ENUM_BLOCKING_MODE)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < MODE_MAX; j++)
-						{
-							const char *mode = get_blocking_mode_str(j);
-							if(strStartsWithIgnoreCase(mode, last_word) || strlen(last_word) == 0)
-								puts(mode);
-						}
-					}
-					else if(conf_item->t == CONF_ENUM_REFRESH_HOSTNAMES)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < REFRESH_MAX; j++)
-						{
-							const char *refresh = get_refresh_hostnames_str(j);
-							if(strStartsWithIgnoreCase(refresh, last_word) || strlen(last_word) == 0)
-								puts(refresh);
-						}
-					}
-					else if(conf_item->t == CONF_ENUM_LISTENING_MODE)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < LISTEN_MAX; j++)
-						{
-							const char *listen = get_listeningMode_str(j);
-							if(strStartsWithIgnoreCase(listen, last_word) || strlen(last_word) == 0)
-								puts(listen);
-						}
-					}
-					else if(conf_item->t == CONF_ENUM_WEB_THEME)
-					{
-						// pihole-FTL --config webserver.interface.theme ...
+						case CONF_ENUM_PTR_TYPE:
+							// Provide matching suggestions
+							for(size_t j = 0; j < PTR_MAX; j++)
+							{
+								const char *ptr = get_ptr_type_str(j);
+								if(strStartsWithIgnoreCase(ptr, last_word) || strlen(last_word) == 0)
+									puts(ptr);
+							}
+							break;
 
-						// Provide matching suggestions
-						for(size_t j = 0; j < THEME_MAX; j++)
+						case CONF_ENUM_BUSY_TYPE:
+							// Provide matching suggestions
+							for(size_t j = 0; j < BUSY_MAX; j++)
+							{
+								const char *busy = get_busy_reply_str(j);
+								if(strStartsWithIgnoreCase(busy, last_word) || strlen(last_word) == 0)
+									puts(busy);
+							}
+							break;
+
+						case CONF_ENUM_BLOCKING_MODE:
+							// Provide matching suggestions
+							for(size_t j = 0; j < MODE_MAX; j++)
+							{
+								const char *mode = get_blocking_mode_str(j);
+								if(strStartsWithIgnoreCase(mode, last_word) || strlen(last_word) == 0)
+									puts(mode);
+							}
+							break;
+
+						case CONF_ENUM_REFRESH_HOSTNAMES:
+							// Provide matching suggestions
+							for(size_t j = 0; j < REFRESH_MAX; j++)
+							{
+								const char *refresh = get_refresh_hostnames_str(j);
+								if(strStartsWithIgnoreCase(refresh, last_word) || strlen(last_word) == 0)
+									puts(refresh);
+							}
+							break;
+
+						case CONF_ENUM_LISTENING_MODE:
+							// Provide matching suggestions
+							for(size_t j = 0; j < LISTEN_MAX; j++)
+							{
+								const char *listen = get_listeningMode_str(j);
+								if(strStartsWithIgnoreCase(listen, last_word) || strlen(last_word) == 0)
+									puts(listen);
+							}
+							break;
+
+						case CONF_ENUM_WEB_THEME:
+							// pihole-FTL --config webserver.interface.theme ...
+
+							// Provide matching suggestions
+							for(size_t j = 0; j < THEME_MAX; j++)
+							{
+								const char *theme = get_web_theme_str(j);
+								if(strStartsWithIgnoreCase(theme, last_word) || strlen(last_word) == 0)
+									puts(theme);
+							}
+							break;
+
+						case CONF_ENUM_BLOCKING_EDNS_MODE:
+							// Provide matching suggestions
+							for(size_t j = 0; j < EDNS_MODE_MAX; j++)
+							{
+								const char *edns = get_edns_mode_str(j);
+								if(strStartsWithIgnoreCase(edns, last_word) || strlen(last_word) == 0)
+									puts(edns);
+							}
+							break;
+
+						case CONF_ENUM_TEMP_UNIT:
+							// Provide matching suggestions
+							for(size_t j = 0; j < TEMP_UNIT_MAX; j++)
+							{
+								const char *temp = get_temp_unit_str(j);
+								if(strStartsWithIgnoreCase(temp, last_word) || strlen(last_word) == 0)
+									puts(temp);
+							}
+							break;
+
+						case CONF_ENUM_PRIVACY_LEVEL:
+							// This enum is in reality a numeric value
+							printf("%d\n", (int)conf_item->d.privacy_level);
+							break;
+
+							case CONF_PASSWORD:
+							// No suggestions
+							break;
+
+						case CONF_STRUCT_IN_ADDR:
 						{
-							const char *theme = get_web_theme_str(j);
-							if(strStartsWithIgnoreCase(theme, last_word) || strlen(last_word) == 0)
-								puts(theme);
+							char ip[INET_ADDRSTRLEN] = { 0 };
+							inet_ntop(AF_INET, &conf_item->d.in_addr.s_addr, ip, sizeof(ip));
+							printf("%s\n", ip);
 						}
-					}
-					else if(conf_item->t == CONF_ENUM_BLOCKING_EDNS_MODE)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < EDNS_MODE_MAX; j++)
+						break;
+
+						case CONF_STRUCT_IN6_ADDR:
 						{
-							const char *edns = get_edns_mode_str(j);
-							if(strStartsWithIgnoreCase(edns, last_word) || strlen(last_word) == 0)
-								puts(edns);
+							char ip[INET6_ADDRSTRLEN] = { 0 };
+							inet_ntop(AF_INET6, &conf_item->d.in6_addr, ip, sizeof(ip));
+							printf("%s\n", ip);
 						}
-					}
-					else if(conf_item->t == CONF_ENUM_TEMP_UNIT)
-					{
-						// Provide matching suggestions
-						for(size_t j = 0; j < TEMP_UNIT_MAX; j++)
-						{
-							const char *temp = get_temp_unit_str(j);
-							if(strStartsWithIgnoreCase(temp, last_word) || strlen(last_word) == 0)
-								puts(temp);
-						}
-					}
-					else if(conf_item->t == CONF_ENUM_PRIVACY_LEVEL)
-					{
-						// This enum is in reality a numeric value
-						printf("%d\n", (int)conf_item->d.privacy_level);
+						break;
 					}
 				}
 			}

--- a/src/args.c
+++ b/src/args.c
@@ -1467,17 +1467,20 @@ void suggest_complete(const int argc, char *argv[])
 									if(tmp != NULL)
 									{
 										memcpy(tmp + 1, value, strlen(value) + 1);
-										// We also need to replace all in-string ' by '"'"'
-										for(p = tmp + 1; *p != '\0'; p++)
+										// Scan for ' characters ...
+										p = tmp + 1;
+										while(*p != '\0')
 										{
 											if(*p == '\'')
 											{
+												// ... and replace them by '"'"'
 												memmove(p + 4, p, strlen(p) + 1);
 												*(p++) = '\'';
 												*(p++) = '"';
 												*(p++) = '\'';
 												*(p++) = '"';
 											}
+											p++;
 										}
 
 										tmp[0] = '\'';

--- a/src/args.c
+++ b/src/args.c
@@ -1445,13 +1445,38 @@ void suggest_complete(const int argc, char *argv[])
 						if(val != NULL && (value = cJSON_PrintUnformatted(val)) != NULL)
 						{
 							// Add '' to the output if it is a string
-							if(conf_item->t == CONF_JSON_STRING_ARRAY &&
-							   value[0] != '\'')
+							if(conf_item->t == CONF_JSON_STRING_ARRAY)
 							{
-								char *tmp = calloc(strlen(value) + 3, sizeof(char));
+								// Count number of ' in the string
+								char *p = value;
+								int count = 0;
+								while(p != NULL && *p != '\0')
+								{
+									if(*p == '\'')
+										count++;
+									p++;
+								}
+
+								// Allocate enough space for the new string
+								char *tmp = calloc(strlen(value) + 5*count + 3, sizeof(char));
 								if(tmp != NULL)
 								{
-									sprintf(tmp, "'%s'", value);
+									memcpy(tmp + 1, value, strlen(value) + 1);
+									// We also need to replace all in-string ' by '"'"'
+									for(p = tmp + 1; *p != '\0'; p++)
+									{
+										if(*p == '\'')
+										{
+											memmove(p + 4, p, strlen(p) + 1);
+											*(p++) = '\'';
+											*(p++) = '"';
+											*(p++) = '\'';
+											*(p++) = '"';
+										}
+									}
+
+									tmp[0] = '\'';
+									tmp[strlen(tmp)] = '\'';
 									free(value);
 									value = tmp;
 								}

--- a/src/args.c
+++ b/src/args.c
@@ -1436,7 +1436,7 @@ void suggest_complete(const int argc, char *argv[])
 					        conf_item->t == CONF_DOUBLE ||
 					        conf_item->t == CONF_STRING ||
 					        conf_item->t == CONF_STRING_ALLOCATED ||
-						conf_item->t == CONF_JSON_STRING_ARRAY)
+					        conf_item->t == CONF_JSON_STRING_ARRAY)
 					{
 						// pihole-FTL --config ... <int/long/double/string>
 						// Provide the default value as suggestion
@@ -1572,6 +1572,11 @@ void suggest_complete(const int argc, char *argv[])
 							if(strStartsWithIgnoreCase(temp, last_word) || strlen(last_word) == 0)
 								puts(temp);
 						}
+					}
+					else if(conf_item->t == CONF_ENUM_PRIVACY_LEVEL)
+					{
+						// This enum is in reality a numeric value
+						printf("%d\n", (int)conf_item->d.privacy_level);
 					}
 				}
 			}


### PR DESCRIPTION
# What does this implement/fix?

Currently, `pihole-FTL --config dns.domain <Tab>` leads to `pihole-FTL --config dns.domain '"lan"'` which is incorrect due to the extra single-quotes. This PR fixes that by ensuring single-quotes are not added for ordinary strings (as double-quotes are already added by `cJSON_PrintUnformatted()`), but only for JSON arrays (like `dns.upstreams`) where they are still needed, e.g., `--config webserver.headers`.

Hence, on this branch, the autocomplete suggestion above: `pihole-FTL --config dns.domain <Tab>` now correctly leads to `pihole-FTL --config dns.domain "lan"` (mind the missing extra `''`).

The second commit furthermore adds the special escaping needed for single quotes `'"'"'` as (`ba`)`sh` do not support escaping single quotes in the C-like style `\'`.


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.