### PR TITLE
Fix cache-optimizer queries in Query Log

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2027,6 +2027,18 @@ static void FTL_forwarded(const unsigned int flags, const char *name, const unio
 		return;
 	}
 
+	// Check if this query is already marked as complete
+	// This can happen when multiple upstream servers respond to the same
+	// query or when the query has already been replied to from stale cache
+	// data (cache-optimizer) and this is the followup to refresh the cache
+	// record with possibly changed data
+	if(query->flags.complete)
+	{
+		free(upstreamIP);
+		unlock_shm();
+		return;
+	}
+
 	// Get ID of upstream destination, create new upstream record
 	// if not found in current data structure
 	const unsigned int upstreamID = findUpstreamID(upstreamIP, upstreamPort);


### PR DESCRIPTION
# What does this implement/fix?

Ignore subsequent forwarding when a query has already been replied to. We do not want to show the "latest" status in the query log but the one that was responsible for the particular reply sent to the client. This fixes incorrectly shown query status for some cache-optimizer queries.

No functional change in DNS operation.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2608

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.