### PR TITLE
Do not set domainname when the kernel replies with "(none)"

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -229,7 +229,13 @@ const char *hostname(void)
 		if(uname(&buf) == 0)
 		{
 			strncpy(nodename, buf.nodename, HOSTNAMESIZE);
-			strncpy(dname, buf.domainname, HOSTNAMESIZE);
+
+			// Only set domain name if node name is not empty: the
+			// kernel replies with '(none)' in this case. When the
+			// domainname starts with '(', we know this cannot be
+			// valid
+			if(buf.nodename[0] != '(')
+				strncpy(dname, buf.domainname, HOSTNAMESIZE);
 		}
 		nodename[HOSTNAMESIZE - 1] = '\0';
 		dname[HOSTNAMESIZE - 1] = '\0';

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -231,10 +231,8 @@ const char *hostname(void)
 			strncpy(nodename, buf.nodename, HOSTNAMESIZE);
 
 			// Only set domain name if node name is not empty: the
-			// kernel replies with '(none)' in this case. When the
-			// domainname starts with '(', we know this cannot be
-			// valid
-			if(buf.nodename[0] != '(')
+			// kernel replies with '(none)' in this case.
+			if(!(buf.domainname[0] == '(' && strncmp(buf.domainname, "(none)", 6) == 0))
 				strncpy(dname, buf.domainname, HOSTNAMESIZE);
 		}
 		nodename[HOSTNAMESIZE - 1] = '\0';


### PR DESCRIPTION
# What does this implement/fix?

See title.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** https://discourse.pi-hole.net/t/host-name-of-client-203-0-113-41-dns-vm-1-none-contains-at-least-one-invalid-character-hex-28-at-position-10/82042

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.