### PR TITLE
Fix `dns.hosts` help text to show multiple hostnames per IP are allowed

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -479,7 +479,7 @@ void initConfig(struct config *conf)
 
 	conf->dns.hosts.k = "dns.hosts";
 	conf->dns.hosts.h = "Array of custom DNS records\n\n Example: [ \"127.0.0.1 mylocal\", \"192.168.0.1 therouter\" ]";
-	conf->dns.hosts.a = cJSON_CreateStringReference("Array of custom DNS records each one in HOSTS form: \"IP HOSTNAME\"");
+	conf->dns.hosts.a = cJSON_CreateStringReference("Array of custom DNS records each one in HOSTS form: \"IP HOSTNAME [HOSTNAME ...]\"");
 	conf->dns.hosts.t = CONF_JSON_STRING_ARRAY;
 	conf->dns.hosts.d.json = cJSON_CreateArray();
 	conf->dns.hosts.c = validate_dns_hosts;

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -124,7 +124,7 @@
   # Example: [ "127.0.0.1 mylocal", "192.168.0.1 therouter" ]
   #
   # Allowed values are:
-  #     Array of custom DNS records each one in HOSTS form: "IP HOSTNAME"
+  #     Array of custom DNS records each one in HOSTS form: "IP HOSTNAME [HOSTNAME ...]"
   hosts = [
     "1.1.1.1 abc-custom.com def-custom.de",
     "2.2.2.2 äste.com steä.com"


### PR DESCRIPTION
### What does this PR aim to accomplish?

`dns.hosts` uses hosts file format.

This PR adjusts the text to show `dns.hosts` option also allows more than one host name per IP.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
