### PR TITLE
Be more gracefully when validating dns_hosts

### DIFF
--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -23,6 +23,8 @@
 #include "files.h"
 // git_branch()
 #include "version.h"
+// sanitize_dns_hosts()
+#include "config/validator.h"
 
 // defined in config/config.c
 extern uint8_t last_checksum[SHA256_DIGEST_SIZE];
@@ -107,6 +109,13 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 		// Write value
 		indentTOML(fp, level-1);
 		fprintf(fp, "%s = ", conf_item->p[level-1]);
+		
+		// Sanitize dns.hosts entries before writing them to TOML
+		if(conf_item == &config.dns.hosts)
+		{
+			sanitize_dns_hosts(&conf_item->v);
+		}
+		
 		writeTOMLvalue(fp, level-1, conf_item->t, &conf_item->v);
 
 		// Compare with default value and add a comment on difference

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -48,7 +48,16 @@ bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDAT
 		// Check if it's in the form "IP[ \t]HOSTNAME"
 		char *str = strdup(item->valuestring);
 		char *tmp = str;
+		
+		// Strip leading spaces/tabs
+		while(isspace((unsigned char)*tmp))
+			tmp++;
+		
 		char *ip = strsep(&tmp, " \t");
+
+		// Skip any extra whitespace/tabs after the IP
+		while(tmp && isspace((unsigned char)*tmp))
+			tmp++;
 
 		if(!ip || !*ip)
 		{
@@ -81,9 +90,9 @@ bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDAT
 				host++;
 
 			// Skip this entry if it's empty after trimming
-			// the whitespaces/tabs at the end of the line
+			// the whitespaces/tabs (due to multiple consecutive spaces)
 			if(strlen(host) == 0)
-				break;
+				continue;
 
 			// If this hostname is actually the start of a comment
 			// (first letter is '#'), skip parsing the rest of the

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -598,7 +598,8 @@ void sanitize_dns_hosts(union conf_value *val)
 			free(str);
 			continue;
 		}
-		strncpy(sanitized, ip, original_len);
+		strcpy(sanitized, ip);
+		size_t current_len = strlen(ip);
 		
 		// Process hostnames
 		char *host = NULL;
@@ -616,21 +617,45 @@ void sanitize_dns_hosts(union conf_value *val)
 			if(host[0] == '#')
 			{
 				// Add the comment part with single space separator
-				strncat(sanitized, " ", original_len - strlen(sanitized));
-				strncat(sanitized, host, original_len - strlen(sanitized));
+				if(current_len < original_len)
+				{
+					sanitized[current_len++] = ' ';
+				}
+				size_t host_len = strlen(host);
+				if(current_len + host_len <= original_len)
+				{
+					strcpy(sanitized + current_len, host);
+					current_len += host_len;
+				}
 				
 				// Add any remaining content after this comment token
 				if(tmp && strlen(tmp) > 0)
 				{
-					strncat(sanitized, " ", original_len - strlen(sanitized));
-					strncat(sanitized, tmp, original_len - strlen(sanitized));
+					size_t tmp_len = strlen(tmp);
+					if(current_len < original_len)
+					{
+						sanitized[current_len++] = ' ';
+					}
+					if(current_len + tmp_len <= original_len)
+					{
+						strcpy(sanitized + current_len, tmp);
+						current_len += tmp_len;
+					}
 				}
 				break;
 			}
 
 			// Add hostname to sanitized string with single space separator
-			strncat(sanitized, " ", original_len - strlen(sanitized));
-			strncat(sanitized, host, original_len - strlen(sanitized));
+			if(current_len < original_len)
+			{
+				sanitized[current_len++] = ' ';
+			}
+			size_t host_len = strlen(host);
+			if(current_len + host_len <= original_len)
+			{
+				strcpy(sanitized + current_len, host);
+				current_len += host_len;
+			}
 		}
 
 		// Update the JSON item with the sanitized string

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -612,9 +612,21 @@ void sanitize_dns_hosts(union conf_value *val)
 			if(strlen(host) == 0)
 				continue;
 
-			// If this hostname starts with a comment, stop processing
+			// If this hostname starts with a comment, add it and the rest to the sanitized string, then stop processing
 			if(host[0] == '#')
+			{
+				// Add the comment part with single space separator
+				strncat(sanitized, " ", original_len - strlen(sanitized));
+				strncat(sanitized, host, original_len - strlen(sanitized));
+				
+				// Add any remaining content after this comment token
+				if(tmp && strlen(tmp) > 0)
+				{
+					strncat(sanitized, " ", original_len - strlen(sanitized));
+					strncat(sanitized, tmp, original_len - strlen(sanitized));
+				}
 				break;
+			}
 
 			// Add hostname to sanitized string with single space separator
 			strncat(sanitized, " ", original_len - strlen(sanitized));

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -26,5 +26,6 @@ bool validate_filepath_empty(union conf_value *val, const char *key, char err[VA
 bool validate_filepath_dash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_regex_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_revServers(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+void sanitize_dns_hosts(union conf_value *val);
 
 #endif // CONFIG_VALIDATOR_H

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1919,7 +1919,7 @@
   # Set dns.hosts with various whitespace formatting issues
   run bash -c './pihole-FTL --config dns.hosts "[\"  192.168.1.1    host1.local  \", \"   10.0.0.1\\t\\thost2.local   host3.local\", \"127.0.0.1     host4.local\\t\\thost5.local\"]"'
   [[ $status == 0 ]]
-   
+
   # Check that the sanitized entries are properly formatted
   run bash -c './pihole-FTL --config dns.hosts'
   printf "%s\n" "${lines[@]}"
@@ -1931,7 +1931,7 @@
   run bash -c './pihole-FTL --config dns.hosts "[\"192.168.1.1   host1.local   # this is a comment with  double spaces\", \"   10.0.0.1\\thost2.local\\t\\t\\t\"]"'
   [[ $status == 0 ]]
 
-   # Check that the sanitized entries are properly formatted
+  # Check that the sanitized entries are properly formatted
   run bash -c './pihole-FTL --config dns.hosts'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == '[ 192.168.1.1 host1.local # this is a comment with  double spaces, 10.0.0.1 host2.local ]' ]]

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -733,6 +733,27 @@
   [[ ${lines[0]} == "The Pi-hole FTL engine - "* ]]
 }
 
+@test "CLI config output as expected" {
+  # Partial match printing
+  run bash -c './pihole-FTL --config dns.upstream'
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "dns.upstreams = [ 127.0.0.1#5555 ]" ]]
+
+  # Exact match printing
+  run bash -c './pihole-FTL --config dns.upstreams'
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "[ 127.0.0.1#5555 ]" ]]
+  run bash -c './pihole-FTL --config dns.piholePTR'
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "PI.HOLE" ]]
+  run bash -c './pihole-FTL --config dns.hosts'
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "[ 1.1.1.1 abc-custom.com def-custom.de, 2.2.2.2 äste.com steä.com ]" ]]
+  run bash -c './pihole-FTL --config webserver.port'
+  printf "%s\n" "${lines[@]}"
+  [[ "${lines[0]}" == "80o,443os,[::]:80o,[::]:443os" ]]
+}
+
 @test "No WARNING messages in FTL.log (besides known warnings)" {
   run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|FTLCONF_|(Negative DS reply without NS record received for ftl)|(nameserver 127.0.0.1 refused to do a recursive query)"'
   printf "%s\n" "${lines[@]}"
@@ -1894,6 +1915,29 @@
   [[ $status == 3 ]]
 }
 
+@test "DNS hosts sanitization: Whitespace is normalized when saving" {
+  # Set dns.hosts with various whitespace formatting issues
+  run bash -c './pihole-FTL --config dns.hosts "[\"  192.168.1.1    host1.local  \", \"   10.0.0.1\\t\\thost2.local   host3.local\", \"127.0.0.1     host4.local\\t\\thost5.local\"]"'
+  [[ $status == 0 ]]
+   
+  # Check that the sanitized entries are properly formatted
+  run bash -c './pihole-FTL --config dns.hosts'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == '[ 192.168.1.1 host1.local, 10.0.0.1 host2.local host3.local, 127.0.0.1 host4.local host5.local ]' ]]
+}
+
+@test "DNS hosts sanitization: Comments are handled correctly" { 
+  # Set dns.hosts with entries containing comments
+  run bash -c './pihole-FTL --config dns.hosts "[\"192.168.1.1   host1.local   # this is a comment with  double spaces\", \"   10.0.0.1\\thost2.local\\t\\t\\t\"]"'
+  [[ $status == 0 ]]
+
+   # Check that the sanitized entries are properly formatted
+  run bash -c './pihole-FTL --config dns.hosts'
+  printf "%s\n" "${lines[@]}"
+  [[ ${lines[0]} == '[ 192.168.1.1 host1.local # this is a comment with  double spaces, 10.0.0.1 host2.local ]' ]]
+
+}
+
 @test "Config validation working on the API (validator-based checking)" {
   run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config -d "{\"config\":{\"files\":{\"pcap\":\"%gh4b\"}}}"'
   printf "%s\n" "${lines[@]}"
@@ -2151,27 +2195,6 @@
   [[ $status == 0 ]]
 }
 
-@test "CLI config output as expected" {
-  # Partial match printing
-  run bash -c './pihole-FTL --config dns.upstream'
-  printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "dns.upstreams = [ 127.0.0.1#5555 ]" ]]
-
-  # Exact match printing
-  run bash -c './pihole-FTL --config dns.upstreams'
-  printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "[ 127.0.0.1#5555 ]" ]]
-  run bash -c './pihole-FTL --config dns.piholePTR'
-  printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "PI.HOLE" ]]
-  run bash -c './pihole-FTL --config dns.hosts'
-  printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "[ 1.1.1.1 abc-custom.com def-custom.de, 2.2.2.2 äste.com steä.com ]" ]]
-  run bash -c './pihole-FTL --config webserver.port'
-  printf "%s\n" "${lines[@]}"
-  [[ "${lines[0]}" == "80o,443os,[::]:80o,[::]:443os" ]]
-}
-
 @test "Create, verify and re-import Teleporter file via CLI" {
   run bash -c './pihole-FTL --teleporter'
   printf "%s\n" "${lines[@]}"
@@ -2205,7 +2228,7 @@
   [[ ${lines[0]} == "1" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/hosts/custom.list" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "1" ]]
+  [[ ${lines[0]} == "2" ]]
 }
 
 @test "Suggest expected completions" {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allow users to pass data into `dns.hosts` more gracefully. It will now accept also lines with leading spaces and spaces between `IP` and the first `HOSTNAME`.
Note: multiple spaces between `HOSTNAME1` and `HOSTNAME2` were already tolerated.

It's a compromise between strictly adhering to HOSTS format and usability for users copy&pasting the data into the field.
Should fix https://github.com/pi-hole/FTL/issues/2625

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
