### PR TITLE
Fix HOSTS file rotation test  which was hiding in fast runners

### DIFF
--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1924,6 +1924,7 @@
   run bash -c './pihole-FTL --config dns.hosts'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == '[ 192.168.1.1 host1.local, 10.0.0.1 host2.local host3.local, 127.0.0.1 host4.local host5.local ]' ]]
+  run sleep 1
 }
 
 @test "DNS hosts sanitization: Comments are handled correctly" { 
@@ -1935,7 +1936,7 @@
   run bash -c './pihole-FTL --config dns.hosts'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == '[ 192.168.1.1 host1.local # this is a comment with  double spaces, 10.0.0.1 host2.local ]' ]]
-
+  run sleep 1
 }
 
 @test "Config validation working on the API (validator-based checking)" {
@@ -2228,7 +2229,7 @@
   [[ ${lines[0]} == "1" ]]
   run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/hosts/custom.list" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "2" ]]
+  [[ ${lines[0]} == "3" ]]
 }
 
 @test "Suggest expected completions" {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes a regression of https://github.com/pi-hole/FTL/pull/2624, which was hiding in fast runners. See
https://github.com/pi-hole/FTL/pull/2624#issuecomment-3291301176

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
