### PR TITLE
Make restarting optional in API config endpoints

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -688,6 +688,13 @@ static int api_config_patch(struct ftl_conn *api)
 		                       "The config is currently in read-only mode",
 		                       NULL);
 	}
+	// Users may specify ?restart=false to avoid a restart of dnsmasq
+	// even if the changed config item would require it
+	bool restart = true;
+	if(api->request->query_string != NULL)
+	{
+		get_bool_var(api->request->query_string, "restart", &restart);
+	}
 
 	// Read all known config items
 	bool config_changed = false;
@@ -828,7 +835,7 @@ static int api_config_patch(struct ftl_conn *api)
 			if(write_dnsmasq_config(&newconf, true, errbuf))
 			{
 				api->ftl.restart_reason = "dnsmasq config changed";
-				api->ftl.restart = true;
+				api->ftl.restart = restart;
 			}
 			else
 			{

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -38,6 +38,8 @@ components:
         operationId: "patch_config"
         description: |
           This API hook allows to modify the config of your Pi-hole. This endpoint supports changing multiple properties at once when you specify several in the payload. See examples below.
+        parameters:
+          - $ref: 'config.yaml#/components/parameters/restart'
         requestBody:
           description: Callback payload
           content:

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -107,6 +107,7 @@ components:
         parameters:
           - $ref: 'config.yaml#/components/parameters/element'
           - $ref: 'config.yaml#/components/parameters/value'
+          - $ref: 'config.yaml#/components/parameters/restart'
         responses:
           '201':
             description: Item created
@@ -141,6 +142,7 @@ components:
         parameters:
           - $ref: 'config.yaml#/components/parameters/element'
           - $ref: 'config.yaml#/components/parameters/value'
+          - $ref: 'config.yaml#/components/parameters/restart'
         responses:
           '204':
             description: Item deleted
@@ -932,3 +934,12 @@ components:
       required: true
       description: config value
       example: "8.8.8.8"
+    restart:
+      name: restart
+      in: query
+      description: Restart FTL after a change would require this. This option can be used if you want to avoid a restart, e.g., when adding multiple items independently instead of all together at once. Note that you will have to restart FTL manually later to apply the changes.
+      required: false
+      schema:
+        type: boolean
+        default: true
+        example: true


### PR DESCRIPTION
# What does this implement/fix?

Add new optional `?restart={true,false}` boolean to the `PATCH`, `PUT`, and `DELETE` `/config` endpoints for array-valued items (e.g. `dns.upstreams`, `dns.hosts` or `dns.cnameRecords`). This is the necessary change in FTL to support what we requested in https://github.com/pi-hole/pi-hole/issues/6176.

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/pi-hole/issues/6176

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.