### PR TITLE
Ensure we can log until the very end

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -375,6 +375,10 @@ void free_config(struct config *conf, const bool terminating)
 				// Nothing to do
 				break;
 			case CONF_STRING_ALLOCATED:
+				// Do not free log file path if we are
+				// terminating or nothing can be logged anymore
+				if(terminating && conf_item->f & FLAG_FTL_LOG)
+					continue;
 				free(conf_item->v.s);
 				conf_item->v.s = NULL;
 				conf_item->t = CONF_STRING; // not allocated anymore
@@ -1883,6 +1887,7 @@ bool getLogFilePath(bool try_read)
 	config.files.log.ftl.d.s = (char*)"/var/log/pihole/FTL.log";
 	config.files.log.ftl.v.s = config.files.log.ftl.d.s;
 	config.files.log.ftl.c = validate_filepath;
+	config.files.log.ftl.f = FLAG_FTL_LOG;
 
 	// Check if the config file contains a different path
 	if(try_read && !getLogFilePathTOML())

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -103,6 +103,7 @@ enum conf_type {
 #define FLAG_ENV_VAR               (1 << 4)
 #define FLAG_CONF_IMPORTED         (1 << 5)
 #define FLAG_READ_ONLY             (1 << 6)
+#define FLAG_FTL_LOG               (1 << 7)
 
 struct conf_item {
 	const char *k;        // item Key

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -528,10 +528,14 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			const toml_datum_t val = toml_table_find(toml, key);
 			if(val.type == TOML_STRING)
 			{
-				if(conf_item->t == CONF_STRING_ALLOCATED)
-					free(conf_item->v.s);
-				conf_item->v.s = strdup(val.u.s); // allocated string
-				conf_item->t = CONF_STRING_ALLOCATED;
+				// Only use new value if it is different
+				if(conf_item->v.s && strcmp(conf_item->v.s, val.u.s) != 0)
+				{
+					if(conf_item->t == CONF_STRING_ALLOCATED)
+						free(conf_item->v.s);
+					conf_item->v.s = strdup(val.u.s); // allocated string
+					conf_item->t = CONF_STRING_ALLOCATED;
+				}
 			}
 			else
 				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -407,42 +407,53 @@ void cleanup(const int ret)
 	if(resolver_ready)
 	{
 		// Terminate threads
+		log_debug(DEBUG_ANY, "Terminating: Stopping threads");
 		terminate_threads();
 
 		// Close database connection
 		lock_shm();
+		log_debug(DEBUG_ANY, "Terminating: Closing gravity database");
 		gravityDB_close();
 		unlock_shm();
 	}
 
 	// Remove PID file
+	log_debug(DEBUG_ANY, "Terminating: Removing PID file");
 	removePID();
 
 	// Free regex filter memory
+	log_debug(DEBUG_ANY, "Terminating: Freeing regex filter memory");
 	free_regex();
 
 	// Terminate API
+	log_debug(DEBUG_ANY, "Terminating: Stopping API");
 	free_api();
 
 	// Terminate HTTP server (if running)
+	log_debug(DEBUG_ANY, "Terminating: Stopping HTTP server");
 	http_terminate();
 
 	// Close memory database
+	log_debug(DEBUG_ANY, "Terminating: Closing memory database");
 	close_memory_database();
 
 	// De-initialize the random number generator and entropy collector
+	log_debug(DEBUG_ANY, "Terminating: Freeing entropy collector");
 	destroy_entropy();
 
 	// Free environment variables
+	log_debug(DEBUG_ANY, "Terminating: Freeing environment variables");
 	freeEnvVars();
 
 	// Free config
+	log_debug(DEBUG_ANY, "Terminating: Freeing configuration");
 	free_config(&config, true);
 
 	// Remove shared memory objects
 	// Important: This invalidated all objects such as
 	//            counters-> ... etc.
 	// This should be the last action when cleaning up
+	log_debug(DEBUG_ANY, "Terminating: Removing shared memory");
 	destroy_shmem();
 
 	char buffer[42] = { 0 };
@@ -451,6 +462,10 @@ void cleanup(const int ret)
 		log_info("########## FTL terminated after%s (internal restart)! ##########", buffer);
 	else
 		log_info("########## FTL terminated after%s (code %i)! ##########", buffer, ret);
+
+	// Finally, free log config memory
+	if(config.files.log.ftl.t == CONF_STRING_ALLOCATED)
+		free(config.files.log.ftl.v.s);
 }
 
 static float ftl_cpu_usage = 0.0f;

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -17,8 +17,6 @@
 #include "gravity-db.h"
 // cli_mode
 #include "args.h"
-// cleanup()
-#include "daemon.h"
 // main_pid()
 #include "signals.h"
 // struct config

--- a/test/run.sh
+++ b/test/run.sh
@@ -143,10 +143,6 @@ if [[ $RET != 0 ]]; then
   echo ""
 fi
 
-# Kill pihole-FTL after having completed tests
-# This will also shut down the debugger
-kill "$(pidof pihole-FTL)"
-
 # Restore umask
 umask "$OLDUMASK"
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -2305,3 +2305,15 @@
   [[ ${lines[0]} == "true" ]]
   [[ ${lines[1]} == "" ]]
 }
+
+@test "FTL terminates with message" {
+  logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
+  # Kill pihole-FTL after having completed tests
+  # This will also shut down the debugger
+  run bash -c 'kill "$(pidof pihole-FTL)"'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+
+  # Wait until pihole-FTL has terminated
+  run bash -c "./pihole-FTL wait-for '########## FTL terminated after' /var/log/pihole/FTL.log 30 $logsize_before"
+}


### PR DESCRIPTION
# What does this implement/fix?

Ensure `FTL.log` location is available until the *really* very end. Otherwise, as soon as it is `free`d, logging stops as the logging routines don't know where to they'd need to write the log lines.

While I was at it, I wondered why the `FTL.log` location was actually allocated memory, because I have not changed it from the default on my testing system. This brought me to making another commit ensuring we do not duplicate/allocate memory for values that do not differ from the current value (initialized from the default value) when ingesting the TOML config.

---

**Related issue or feature (if applicable):** Noticed in https://github.com/pi-hole/docker-pi-hole/pull/1898#issuecomment-3330179883

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.