### PR TITLE
Add webserver.advancedOpts

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -423,6 +423,10 @@ components:
                     type: string
                 serve_all:
                   type: boolean
+                advancedOpts:
+                  type: array
+                  items:
+                    type: string
                 session:
                   type: object
                   properties:
@@ -770,6 +774,8 @@ components:
               - "X-Content-Type-Options: nosniff"
               - "Referrer-Policy: strict-origin-when-cross-origin"
             serve_all: false
+            advancedOpts:
+              - "ssl_protocol_version=4"
             session:
               timeout: 300
               restore: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1064,6 +1064,14 @@ void initConfig(struct config *conf)
 	conf->webserver.serve_all.d.b = false;
 	conf->webserver.serve_all.c = validate_stub;
 
+	conf->webserver.advancedOpts.k = "webserver.advancedOpts";
+	conf->webserver.advancedOpts.h = "Additional options passed directly to the web server.\n\n This can be used to set any option supported by the underlying web server (CivetWeb). See the CivetWeb documentation for a list of supported options. The options are passed as an array of strings, where each string is an option in the form \"<option>=<value>\". Be aware that this is an advanced option and that setting options here may break the web server if invalid or conflicting with other settings applied based on other settings in this file. The config options specified here are added to the end of the passed options. This makes it possible to overwrite settings set by Pi-hole (only the last values is used when a config option is specified multiple times). Use with caution.\n\n Example: [ \"ssl_protocol_version=4\", \"ssl_cipher_list=AES128:!MD5\" ]";
+	conf->webserver.advancedOpts.a = cJSON_CreateStringReference("An array of valid CivetWeb options");
+	conf->webserver.advancedOpts.t = CONF_JSON_STRING_ARRAY;
+	conf->webserver.advancedOpts.f = FLAG_RESTART_FTL;
+	conf->webserver.advancedOpts.d.json = cJSON_CreateArray();
+	conf->webserver.advancedOpts.c = validate_stub; // Only type-based checking
+
 	conf->webserver.tls.validity.k = "webserver.tls.validity";
 	conf->webserver.tls.validity.h = "Number of days the automatically generated self-signed TLS/SSL certificate will be valid for.\n\n Defaults to 47 days. A minimum of 7 days is enforced.\n Some devices may enforce shorter validity ranges. Note that defining a lower validity range may require you to accept the self-signed certificate more often in your browser.\n Pi-hole will regenerate certificates it created itself two days prior to expiration. If you are using your own certificate, you need to regenerate it yourself. In this case, it is advised to set the validity range to 0 days, so that Pi-hole does not try to regenerate your certificate. If you set the validity range to 0 days and still try to generate a certificate, Pi-hole will set a fixed validity range of roughly 30 years for the certificate.";
 	conf->webserver.tls.validity.t = CONF_UINT;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -249,6 +249,7 @@ struct config {
 		struct conf_item threads;
 		struct conf_item headers;
 		struct conf_item serve_all;
+		struct conf_item advancedOpts;
 		struct {
 			struct conf_item timeout;
 			struct conf_item restore;

--- a/src/log.c
+++ b/src/log.c
@@ -585,7 +585,7 @@ int binbuf_to_escaped_C_literal(const char *src_buf, size_t src_sz,
 	{
 		// Check if we have enough space before writing
 		// Worst case: we need 4 chars for "\x00" + null terminator
-		if (dst >= dst_str + dst_sz - 5)
+		if (dst >= dst_str + dst_sz - 4)
 			break;
 
 		if (isprint(*src))
@@ -635,6 +635,32 @@ int binbuf_to_escaped_C_literal(const char *src_buf, size_t src_sz,
 	*dst = '\0';
 
 	return src - src_buf;
+}
+
+/**
+ * @brief Escapes a given input string into a C-style escaped string literal.
+ *
+ * This function takes an input string and returns a newly allocated string
+ * where all characters are escaped as necessary to form a valid C string literal.
+ * The returned string must be freed by the caller.
+ *
+ * @param input The input string to escape. May be NULL.
+ * @return A pointer to the newly allocated escaped string, or NULL if input is NULL
+ *         or memory allocation fails.
+ *
+ * @note The returned string is allocated with calloc and must be freed by the caller.
+ * @note Uses binbuf_to_escaped_C_literal to perform the actual escaping.
+ */
+char * __attribute__ ((malloc)) escape_string(const char *input)
+{
+	if(input == NULL)
+		return NULL;
+	const size_t inlen = strlen(input);
+	// Worst case: every character is escaped as "0x00" + zero-terminator
+	const size_t bufsiz = 4 * inlen + 1;
+	char *buffer = calloc(bufsiz, sizeof(char));
+	binbuf_to_escaped_C_literal(input, inlen, buffer, bufsiz);
+	return buffer;
 }
 
 const char * __attribute__ ((pure)) short_path(const char *full_path)

--- a/src/log.c
+++ b/src/log.c
@@ -584,8 +584,9 @@ int binbuf_to_escaped_C_literal(const char *src_buf, size_t src_sz,
 	while (src < src_buf + src_sz)
 	{
 		// Check if we have enough space before writing
-		// Worst case: we need 4 chars for "\x00" + null terminator
-		if (dst >= dst_str + dst_sz - 4)
+		// Worst case: we need 4 chars for "0x00" + null terminator for
+		// one byte of input
+		if (dst > dst_str + dst_sz - 5)
 			break;
 
 		if (isprint(*src))

--- a/src/log.h
+++ b/src/log.h
@@ -75,6 +75,7 @@ void log_ctrl(bool vlog, bool vstdout);
 void FTL_log_helper(const unsigned int n, ...);
 
 int binbuf_to_escaped_C_literal(const char *src_buf, size_t src_sz, char *dst_str, size_t dst_sz);
+char *escape_string(const char *input) __attribute__ ((malloc));
 
 const char *short_path(const char *full_path) __attribute__ ((pure));
 

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -548,13 +548,23 @@ static void print_webserver_opts(const bool debug, const size_t idx, const char 
 		char *escaped_value = escape_string(static_options[i * 2 + 1]);
 		if(debug)
 		{
-			log_debug(DEBUG_WEBSERVER, "Webserver option %zu/%zu: %s=%s%s",
-			          i, idx, escaped_key, escaped_value, i == idx ? " (END OF OPTIONS)" : "");
+			if(i == idx)
+			{
+				log_debug(DEBUG_WEBSERVER, "Webserver option %zu/%zu: <END OF OPTIONS>", i, idx);
+				break;
+			}
+			log_debug(DEBUG_WEBSERVER, "Webserver option %zu/%zu: %s=%s",
+			          i, idx, escaped_key, escaped_value);
 		}
 		else
 		{
-			log_err("Webserver option %zu/%zu: %s=%s%s",
-			        i, idx, escaped_key, escaped_value, i == idx ? " (END OF OPTIONS)" : "");
+			if(i == idx)
+			{
+				log_err("Webserver option %zu/%zu: <END OF OPTIONS>", i, idx);
+				break;
+			}
+			log_err("Webserver option %zu/%zu: %s=%s",
+			        i, idx, escaped_key, escaped_value);
 		}
 		if(escaped_key != NULL)
 			free(escaped_key);
@@ -669,7 +679,7 @@ void http_init(void)
 		return;
 	}
 	size_t idx = 0;
-	while(idx < ArraySize(static_options) / 2 - 2)
+	while(idx < (ArraySize(static_options) / 2 - 3)) // -3 for the 6 NULL slots above
 	{
 		conf_opts[idx * 2] = strdup(static_options[idx * 2]);
 		conf_opts[idx * 2 + 1] = strdup(static_options[idx * 2 + 1]);

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -790,7 +790,6 @@ void http_init(void)
 		// above)
 		conf_opts[idx * 2] = key;
 		conf_opts[idx * 2 + 1] = value;
-		log_info("Using advanced webserver option %zu: \"%s\"=\"%s\"", idx, key, value);
 		idx++;
 	}
 
@@ -816,7 +815,7 @@ void http_init(void)
 	/* Start the server */
 	if((ctx = mg_start2(&init, &error)) == NULL || !get_server_ports())
 	{
-		log_err("Start of webserver failed!. Web interface will not be available!");
+		log_err("Start of webserver failed! Web interface will not be available!");
 		print_webserver_opts(false, idx, (const char **)conf_opts);
 		log_err("       Error: %s (error code %u.%u)", error.text, error.code, error.code_sub);
 		log_err("       Hint: Check the webserver log at %s", config.files.log.webserver.v.s);

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -40,7 +40,6 @@ static char *prefix_webhome = NULL;
 static char *api_uri = NULL;
 static char *admin_api_uri = NULL;
 static char *login_uri = NULL;
-static char *webheaders = NULL;
 
 // Private prototypes
 static char *append_to_path(char *path, const char *append);
@@ -531,6 +530,39 @@ unsigned short get_api_string(char **buf, const bool domain)
 	return (unsigned short)len;
 }
 
+/**
+ * @brief Prints webserver options with optional debug logging.
+ *
+ * Iterates over the provided array of static webserver options, escapes both keys and values,
+ * and logs each option. If debug is enabled, logs with debug level; otherwise, logs as an error.
+ *
+ * @param debug           If true, use debug logging; otherwise, use error logging.
+ * @param idx             The number of option pairs in the static_options array.
+ * @param static_options  Array of key-value string pairs (size: idx * 2).
+ */
+static void print_webserver_opts(const bool debug, const size_t idx, const char **static_options)
+{
+	for(size_t i = 0; i <= idx; i++)
+	{
+		char *escaped_key = escape_string(static_options[i * 2]);
+		char *escaped_value = escape_string(static_options[i * 2 + 1]);
+		if(debug)
+		{
+			log_debug(DEBUG_WEBSERVER, "Webserver option %zu/%zu: %s=%s%s",
+			          i, idx, escaped_key, escaped_value, i == idx ? " (END OF OPTIONS)" : "");
+		}
+		else
+		{
+			log_err("Webserver option %zu/%zu: %s=%s%s",
+			        i, idx, escaped_key, escaped_value, i == idx ? " (END OF OPTIONS)" : "");
+		}
+		if(escaped_key != NULL)
+			free(escaped_key);
+		if(escaped_value != NULL)
+			free(escaped_value);
+	}
+}
+
 void http_init(void)
 {
 	// Don't start web server if port is not set
@@ -580,7 +612,7 @@ void http_init(void)
 	}
 
 	// Construct additional headers
-	webheaders = strdup("");
+	char *webheaders = strdup("");
 	if (webheaders == NULL) {
 		log_err("Failed to allocate memory for webheaders!");
 		return;
@@ -602,7 +634,6 @@ void http_init(void)
 		if (new_webheaders == NULL) {
 			log_err("Failed to (re)allocate memory for webheaders!");
 			free(webheaders);
-			webheaders = NULL;
 			return;
 		}
 		webheaders = new_webheaders;
@@ -611,7 +642,7 @@ void http_init(void)
 	}
 
 	// Prepare options for HTTP server (NULL-terminated list)
-	const char *options[] = {
+	const char *static_options[] = {
 		"document_root", config.webserver.paths.webroot.v.s,
 		"error_pages", error_pages,
 		"listening_ports", config.webserver.port.v.s,
@@ -623,15 +654,27 @@ void http_init(void)
 		"index_files", "index.html,index.htm,index.lp",
 		"enable_keep_alive", "yes",
 		"keep_alive_timeout_ms", "5000",
-		NULL, NULL,
-		NULL, NULL, // Leave slots for access control list (ACL) and TLS configuration at the end
-		NULL
+		NULL, NULL, // Optional slots for TLS configuration
+		NULL, NULL, // Optional slots for access control list (ACL)
+		NULL, NULL  // Termination of the array
 	};
-
-	// Get index of next free option
-	// Note: The first options are always present, so start at the counting
-	// from the end of the array.
-	unsigned int next_option = ArraySize(options) - 6;
+	const size_t opt_size = (ArraySize(static_options) / 2) + cJSON_GetArraySize(config.webserver.advancedOpts.v.json);
+	// We allocate two additional slots for ACL and TLS configuration
+	// which are added later if configured
+	// The last NULL is for the NULL-termination of the array
+	char **conf_opts = calloc(opt_size * 2 + 1, sizeof(char*));
+	if (conf_opts == NULL) {
+		log_err("Failed to allocate memory (%zu slots) for advanced webserver options!", opt_size * 2 + 1);
+		free(webheaders);
+		return;
+	}
+	size_t idx = 0;
+	while(idx < ArraySize(static_options) / 2 - 2)
+	{
+		conf_opts[idx * 2] = strdup(static_options[idx * 2]);
+		conf_opts[idx * 2 + 1] = strdup(static_options[idx * 2 + 1]);
+		idx++;
+	}
 
 #ifdef HAVE_MBEDTLS
 	// Add TLS options if configured
@@ -671,8 +714,9 @@ void http_init(void)
 			{
 				log_certificate_domain_mismatch(config.webserver.tls.cert.v.s, config.webserver.domain.v.s);
 			}
-			options[++next_option] = "ssl_certificate";
-			options[++next_option] = config.webserver.tls.cert.v.s;
+			conf_opts[idx * 2] = strdup("ssl_certificate");
+			conf_opts[idx * 2 + 1] = strdup(config.webserver.tls.cert.v.s);
+			idx++;
 
 			log_info("Using SSL/TLS certificate file %s",
 			         config.webserver.tls.cert.v.s);
@@ -687,11 +731,57 @@ void http_init(void)
 	// Add access control list if configured (last two options)
 	if(strlen(config.webserver.acl.v.s) > 0)
 	{
-		options[++next_option] = "access_control_list";
+		conf_opts[idx * 2] = strdup("access_control_list");
 		// Note: The string is duplicated by CivetWeb, so it doesn't matter if
 		//       the original string is freed (config changes) after mg_start()
 		//       returns below.
-		options[++next_option] = config.webserver.acl.v.s;
+		conf_opts[idx * 2 + 1] = strdup(config.webserver.acl.v.s);
+		idx++;
+	}
+
+	cJSON *option = NULL;
+	cJSON_ArrayForEach(option, config.webserver.advancedOpts.v.json)
+	{
+		if(!cJSON_IsString(option))
+		{
+			log_err("Invalid option in webserver.advancedOpts!");
+			continue;
+		}
+
+		// Get option value
+		const char *opt = cJSON_GetStringValue(option);
+
+		// Split option into key and value at the first '='
+		char *equal_sign = strchr(opt, '=');
+		if(equal_sign == NULL)
+		{
+			log_err("Invalid option in webserver.advancedOpts: %s (missing '=')", opt);
+			continue;
+		}
+
+		// Allocate memory for key and value
+		size_t key_len = (size_t)(equal_sign - opt);
+		char *key = calloc(key_len + 1, sizeof(char));
+		if (key == NULL) {
+			log_err("Failed to allocate memory for advanced webserver option key!");
+			continue;
+		}
+		strncpy(key, opt, key_len);
+		key[key_len] = '\0';
+
+		char *value = strdup(equal_sign + 1);
+		if (value == NULL) {
+			log_err("Failed to allocate memory for advanced webserver option value!");
+			free(key);
+			continue;
+		}
+
+		// Store key and value in options array (already allocated
+		// above)
+		conf_opts[idx * 2] = key;
+		conf_opts[idx * 2 + 1] = value;
+		log_info("Using advanced webserver option %zu: \"%s\"=\"%s\"", idx, key, value);
+		idx++;
 	}
 
 	// Configure logging handlers
@@ -711,16 +801,32 @@ void http_init(void)
 	struct mg_init_data init = { 0 };
 	init.callbacks = &callbacks;
 	init.user_data = NULL;
-	init.configuration_options = options;
+	init.configuration_options = (const char**)conf_opts;
 
 	/* Start the server */
 	if((ctx = mg_start2(&init, &error)) == NULL || !get_server_ports())
 	{
 		log_err("Start of webserver failed!. Web interface will not be available!");
+		print_webserver_opts(false, idx, (const char **)conf_opts);
 		log_err("       Error: %s (error code %u.%u)", error.text, error.code, error.code_sub);
 		log_err("       Hint: Check the webserver log at %s", config.files.log.webserver.v.s);
 		return;
 	}
+
+	// Success: Print used options only if in debug mode
+	if(config.debug.webserver.v.b)
+		print_webserver_opts(true, idx, (const char **)conf_opts);
+
+	// All configuration options have been copied by CivetWeb, so we
+	// can free them here
+	for(size_t i = 0; i < idx * 2; i++)
+	{
+		if(conf_opts[i] != NULL)
+			free(conf_opts[i]);
+	}
+	free(conf_opts);
+	free(webheaders);
+	webheaders = NULL;
 
 	// Register API handler, use "/api" even when a prefix is defined as the
 	// prefix should be stripped away by the reverse proxy
@@ -876,9 +982,6 @@ void http_terminate(void)
 	// Free login_uri path
 	if(login_uri != NULL)
 		free(login_uri);
-
-	if(webheaders != NULL)
-		free(webheaders);
 }
 
 static void restart_http(void)

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.2.3-158-g0476f281-dirty) on branch new/renew_tls_cert
+# Pi-hole configuration file (v6.2.3-253-gdc7a9fd3-dirty) on branch new/civetweb_advanced
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-08-10 06:08:44 UTC
+# Last updated on 2025-09-26 16:51:38 UTC
 
 [dns]
   # Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not
@@ -945,6 +945,24 @@
   #     true or false
   serve_all = false
 
+  # Additional options passed directly to the web server.
+  #
+  # This can be used to set any option supported by the underlying web server
+  # (CivetWeb). See the CivetWeb documentation for a list of supported options. The
+  # options are passed as an array of strings, where each string is an option in the
+  # form "<option>=<value>". Be aware that this is an advanced option and that setting
+  # options here may break the web server if invalid or conflicting with other settings
+  # applied based on other settings in this file. The config options specified here are
+  # added to the end of the passed options. This makes it possible to overwrite settings
+  # set by Pi-hole (only the last values is used when a config option is specified
+  # multiple times). Use with caution.
+  #
+  # Example: [ "ssl_protocol_version=4", "ssl_cipher_list=AES128:!MD5" ]
+  #
+  # Allowed values are:
+  #     An array of valid CivetWeb options
+  advancedOpts = []
+
   [webserver.session]
     # Session timeout in seconds.
     #
@@ -1616,7 +1634,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 157 total entries out of which 104 entries are default
+# 158 total entries out of which 105 entries are default
 # --> 53 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -2311,3 +2311,32 @@
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "1" ]]
 }
+
+@test "Webserver options are logged as expected" {
+  run bash -c 'grep -F "Webserver option 0/12: document_root=/var/www/html" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 1/12: error_pages=/var/www/html/admin/" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 2/12: listening_ports=80o,443os,[::]:80o,[::]:443os" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 3/12: decode_url=yes" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 4/12: enable_directory_listing=no" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 5/12: num_threads=50" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 6/12: authentication_domain=pi.hole" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 7/12: additional_header=X-DNS-Prefetch-Control: off\r\nContent-Security-Policy: default-src '"'self'"'; style-src '"'self'"' '"'unsafe-inline'"'; img-src '"'self'"' data:;\r\nX-Frame-Options: DENY\r\nX-XSS-Protection: 0\r\nX-Content-Type-Options: nosniff\r\nReferrer-Policy: strict-origin-when-cross-origin\r\n" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 8/12: index_files=index.html,index.htm,index.lp" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 9/12: enable_keep_alive=yes" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 10/12: keep_alive_timeout_ms=5000" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 11/12: ssl_certificate=/etc/pihole/test.pem" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+  run bash -c 'grep -F "Webserver option 12/12: (null)=(null) (END OF OPTIONS)" /var/log/pihole/FTL.log'
+  [[ $status == 0 ]]
+}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -2337,6 +2337,6 @@
   [[ $status == 0 ]]
   run bash -c 'grep -F "Webserver option 11/12: ssl_certificate=/etc/pihole/test.pem" /var/log/pihole/FTL.log'
   [[ $status == 0 ]]
-  run bash -c 'grep -F "Webserver option 12/12: (null)=(null) (END OF OPTIONS)" /var/log/pihole/FTL.log'
+  run bash -c 'grep -F "Webserver option 12/12: <END OF OPTIONS>" /var/log/pihole/FTL.log'
   [[ $status == 0 ]]
 }


### PR DESCRIPTION
# What does this implement/fix?

Add `webserver.advancedOpts` to allow specifying arbitrary CivetWeb options. This feature has been requested on Discourse.

Using this feature, it is possible to overwrite all options set by Pi-hole as CivetWeb will use only the last value of options given more than once.

As this may cause conflicts with the options Pi-hole, we log the actually passed options (a) on error and (b) always when `debug.webserver == true` to `FTL.log`.

Example of how to use:

``` bash
sudo pihole-FTL --config webserver.advancedOpts '[ "ssl_protocol_version=4", "ssl_cipher_list=AES128:!MD5" ]'
```

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/custom-ssl-hsts/81930

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.