### PR TITLE
Try to load system load averages from /proc/loadavg first

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -346,6 +346,20 @@ static int check_space(const char *file, unsigned int LastUsage)
 	return perc;
 }
 
+static int getloadavg_proc(double * loadavg)
+{
+	FILE *f = fopen("/proc/loadavg", "r");
+	if(f == NULL)
+		return -1;
+
+	int count = fscanf(f, "%lf %lf %lf", &loadavg[0], &loadavg[1], &loadavg[2]);
+	fclose(f);
+	if (count != 3)
+		return -1;
+
+	return 0;
+}
+
 static void check_load(void)
 {
 	if(!config.misc.check.load.v.b)
@@ -353,8 +367,9 @@ static void check_load(void)
 
 	// Get CPU load averages
 	double load[3];
-	if (getloadavg(load, 3) == -1)
-		return;
+	if (getloadavg_proc(load) == -1)
+		if (getloadavg(load, 3) == -1)
+			return;
 
 	// Get total number of CPU cores
 	const int nprocs = get_nprocs_conf();

--- a/src/gc.c
+++ b/src/gc.c
@@ -346,7 +346,7 @@ static int check_space(const char *file, unsigned int LastUsage)
 	return perc;
 }
 
-static int getloadavg_proc(double * loadavg)
+static int getloadavg_proc(double loadavg[3])
 {
 	FILE *f = fopen("/proc/loadavg", "r");
 	if(f == NULL)


### PR DESCRIPTION
Try to load system load averages from /proc/loadavg first. This should prevent reporting the load averages being too high on Proxmox LXC installations.

## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

On Proxmox LXC installations the reported system load is the load of the host, not the LXC itself. This code change tries to retrieve the loads from /proc/loadavg first:

```
root@codedev:/home/pihole# cat loadavg.c 
#include <stdio.h>
#include <stdlib.h>

int getloadavg_proc(double * loadavg)
{
    FILE *f = fopen("/proc/loadavg", "r");
    if(f == NULL)
        return -1;

    int count = fscanf(f, "%lf %lf %lf", &loadavg[0], &loadavg[1], &loadavg[2]);
    fclose(f);
    if (count != 3)
        return -1;

    return 0;
}

int main() {
    double loadavg[3];

    if (getloadavg(loadavg, 3) == -1) {
        perror("Error getting sys load average");
        return 1;
    }

    printf("Sys load: %.2f %.2f %.2f\n", loadavg[0], loadavg[1], loadavg[2]);

    if (getloadavg_proc(loadavg) == -1) {
        perror("Error getting proc load average");
        return 1;
    }

    printf("Proc load: %.2f %.2f %.2f\n", loadavg[0], loadavg[1], loadavg[2]);
}

root@codedev:/home/pihole# ./loadavg 
Sys load: 2.66 2.85 2.70
Proc load: 0.00 0.00 0.00
```
To make sure the load averages make sense on Proxmox LXC installations, lxcfs on Proxmox should run with parameter  [--enable-loadavg](https://linuxcontainers.org/lxcfs/manpages/man1/lxcfs.1.html).

**How does this PR accomplish the above?:**

Try to retreive the load averages from /proc/loadavg first. In case it fails, the old method (getloadavg) is used.

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review.