### PR TITLE
Add %MEM and %CPU of FTL to GET info/system

### DIFF
--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -481,6 +481,18 @@ components:
                       items:
                         type: number
                       example: [4.903157711029053, 5.415853023529053, 5.562337398529053]
+            ftl:
+              type: object
+              description: FTL process info
+              properties:
+                "%mem":
+                  type: number
+                  description: Percentage of total RAM memory used by FTL
+                  example: 0.1
+                "%cpu":
+                  type: number
+                  description: Percentage of total CPU used by FTL
+                  example: 1.2
 
     sensors:
       type: object

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -242,6 +242,13 @@ int get_system_obj(struct ftl_conn *api, cJSON *system)
 	JSON_ADD_ITEM_TO_OBJECT(cpu, "load", load);
 	JSON_ADD_ITEM_TO_OBJECT(system, "cpu", cpu);
 
+	cJSON *ftl = JSON_NEW_OBJECT();
+	struct proc_mem pmem = { 0 };
+	getProcessMemory(&pmem, mem.total);
+	JSON_ADD_NUMBER_TO_OBJECT(ftl, "%mem", pmem.VmRSS_percent);
+	JSON_ADD_NUMBER_TO_OBJECT(ftl, "%cpu", get_ftl_cpu_percentage());
+	JSON_ADD_ITEM_TO_OBJECT(system, "ftl", ftl);
+
 	// All okay
 	return 0;
 }

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -511,6 +511,9 @@ void calc_cpu_usage(const unsigned int interval)
 	// Store the current time for the next call to this function
 	last_total_idle = total_idle;
 	last_total_total = total_total;
+
+	log_debug(DEBUG_EXTRA, "CPU usage in the last %u seconds: FTL %.4f%%, total %.4f%%",
+	          interval, ftl_cpu_usage, total_cpu_usage);
 }
 
 float __attribute__((pure)) get_ftl_cpu_percentage(void)


### PR DESCRIPTION
# What does this implement/fix?

See title. Motivated by internal discussions about the updating interval of the CPU usage on the settings page.

Example:

<img width="388" height="991" alt="image" src="https://github.com/user-attachments/assets/a35f9533-58fa-401e-8fcd-79f99130a744" />


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.