### PR TITLE
 Fix database busy handler initialization

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2772,7 +2772,7 @@ bool gravity_updated(void)
 	// Set busy timeout to access the database in a
 	// multi-threaded environment and other threads may be writing to the
 	// database (e.g. Teleporter restoring a backup)
-	rc = sqlite3_busy_handler(gravity_db, sqliteBusyCallback, NULL);
+	rc = sqlite3_busy_handler(db, sqliteBusyCallback, NULL);
 	if(rc != SQLITE_OK)
 	{
 		log_err("gravity_updated(): %s - Cannot set busy handler: %s", config.files.gravity.v.s, sqlite3_errstr(rc));


### PR DESCRIPTION
# What does this implement/fix?

Fix a small copy-pate error where we're setting the busy handler for the wrong database

This is a recent regression from https://github.com/pi-hole/FTL/pull/2602

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.