### PR TITLE
Fix POST /lists example

### DIFF
--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -143,6 +143,8 @@ components:
           On success, a new resource is created at `/lists/{list}`.
 
           The `database_error` with message `UNIQUE constraint failed` error indicates that this list already exists.
+        parameters:
+          - $ref: 'lists.yaml#/components/parameters/listtype'
         requestBody:
           description: Callback payload
           content:
@@ -268,7 +270,6 @@ components:
       post:
         allOf:
           - $ref: 'lists.yaml#/components/schemas/address_maybe_array'
-          - $ref: 'lists.yaml#/components/schemas/type'
           - $ref: 'lists.yaml#/components/schemas/comment'
           - $ref: 'lists.yaml#/components/schemas/groups'
           - $ref: 'lists.yaml#/components/schemas/enabled'


### PR DESCRIPTION
# What does this implement/fix?

The list type needs to be specified as path parameter instead of payload item for `POST /lists`. This has recently been changed, however, we missed to update the example, too.

This is now fixed:

<img width="978" height="1081" alt="image" src="https://github.com/user-attachments/assets/15c5b619-a869-40d7-a621-4ed8b9107415" />

---

**Related issue or feature (if applicable):** #2648 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.