### PR TITLE
Disable flush_logs endpoint inside docker containers

### DIFF
--- a/src/api/action.c
+++ b/src/api/action.c
@@ -137,6 +137,30 @@ int api_action_restartDNS(struct ftl_conn *api)
 	return send_json_success(api);
 }
 
+// This function checks if a given PID is running inside a docker container
+static bool is_in_docker(const pid_t pid)
+{
+	char filename[sizeof("/proc/%u/cgroup") + sizeof(int)*3];
+	snprintf(filename, sizeof(filename), "/proc/%d/cgroup", pid);
+
+	FILE *f = fopen(filename, "r");
+	if(f == NULL)
+		return false;
+
+	char buffer[128];
+	while(fgets(buffer, sizeof(buffer), f) != NULL)
+	{
+		if(strstr(buffer, "/docker") != NULL)
+		{
+			fclose(f);
+			return true;
+		}
+	}
+	fclose(f);
+
+	return false;
+}
+
 int api_action_flush_logs(struct ftl_conn *api)
 {
 	if(!config.webserver.api.allow_destructive.v.b)
@@ -144,6 +168,14 @@ int api_action_flush_logs(struct ftl_conn *api)
 		                       "forbidden",
 		                       "Flushing the logs is not allowed",
 		                       "Check setting webserver.api.allow_destructive");
+
+	// Disable flush_logs endpoint inside containers because the operation needs
+	// FTL restart and this is not possible inside containers
+	if(is_in_docker(getpid()))
+		return send_json_error(api, 403,
+		                       "forbidden",
+		                       "Flushing the logs is not possible in containers",
+		                       "Not enough permissions inside docker containers");
 
 	log_info("Received API request to flush the logs");
 

--- a/src/api/docs/content/specs/action.yaml
+++ b/src/api/docs/content/specs/action.yaml
@@ -115,6 +115,13 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
+          '403':
+            description: Forbidden
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: 'action.yaml#/components/errors/forbidden'
     flush_arp:
       post:
         summary: Flush the network table


### PR DESCRIPTION
### What does this PR aim to accomplish?

The flush process needs a FTL restart, but this is not possible inside docker containers (not enough permissions). Currently, if the API endpoint is called inside a container, it returns "success" and FTL logs success messages, but in reality FTL is never restarted and the process is not correctly completed.

This PR effectively disables the `flush_logs` endpoint when FTL is inside a container. Inside containers the API will respond with `403 forbidden`.

This is related to: https://github.com/pi-hole/pi-hole/pull/6391

### How does this PR accomplish the above?

FTL checks if it is running inside docker and, if so, returns a 403 error message.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
