### PR TITLE
Do not try to renew certificate that is not used

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -335,6 +335,7 @@ enum cert_check {
 	CERT_NOT_YET_VALID,
 	CERT_EXPIRES_SOON,
 	CERT_OKAY,
+	CERT_NOT_IN_USE
 } __attribute__ ((packed));
 
 enum http_method {

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -1042,7 +1042,10 @@ void *webserver_thread(void *val)
 	while(!killed)
 	{
 		// Check if the certificate is about to expire soon
-		const enum cert_check status = cert_currently_valid(config.webserver.tls.cert.v.s, 2);
+		// We check only if HTTPS is enabled (https_port > 0)
+		const enum cert_check status = https_port == 0 ?
+			CERT_NOT_IN_USE :
+			cert_currently_valid(config.webserver.tls.cert.v.s, 2);
 
 		if(status == CERT_EXPIRES_SOON &&
 		   config.webserver.tls.validity.v.ui > 0)


### PR DESCRIPTION
# What does this implement/fix?

We should not attempt to renew the self-signed certificate when the user is not using it (no HTTPS ports defined)

Fixes https://github.com/pi-hole/FTL/issues/2662

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/issues/2662

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
