### PR TITLE
Add validation for ntp.sync.server

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -897,7 +897,7 @@ void initConfig(struct config *conf)
 	conf->ntp.sync.server.a = cJSON_CreateStringReference("A valid NTP upstream server");
 	conf->ntp.sync.server.t = CONF_STRING;
 	conf->ntp.sync.server.d.s = (char*)"pool.ntp.org";
-	conf->ntp.sync.server.c = validate_stub; // Only type-based checking
+	conf->ntp.sync.server.c = validate_dns_domain_or_ip;
 
 	conf->ntp.sync.interval.k = "ntp.sync.interval";
 	conf->ntp.sync.interval.h = "Interval in seconds between successive synchronization attempts with the NTP server";

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -676,3 +676,26 @@ void sanitize_dns_hosts(union conf_value *val)
 		free(str);
 	}
 }
+
+// Validate a single domain or IP address
+bool validate_dns_domain_or_ip(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	// Check if it's a valid domain
+	if(valid_domain(val->s, strlen(val->s), false))
+	{
+		return true;
+	}
+
+	// Check if IP is valid
+	struct in_addr addr;
+	struct in6_addr addr6;
+	int ip4 = 0, ip6 = 0;
+	if((ip4 = inet_pton(AF_INET, val->s, &addr) == 1) || (ip6 = inet_pton(AF_INET6, val->s, &addr6)) == 1)
+	{
+		return true;
+	}
+
+	// If neither, return an error
+	snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: neither a valid domain nor IP address", key);
+	return false;
+}

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -28,5 +28,6 @@ bool validate_regex_array(union conf_value *val, const char *key, char err[VALID
 bool validate_dns_revServers(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_ui_min_7_or_0(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 void sanitize_dns_hosts(union conf_value *val);
+bool validate_dns_domain_or_ip(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 
 #endif // CONFIG_VALIDATOR_H

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -764,9 +764,15 @@ bool ntp_start_sync_thread(pthread_attr_t *attr)
 	}
 	// Return early if a clock disciplining NTP client is detected
 	// Checks chrony, the ntp family (ntp, ntpsec and openntpd), and ntpd-rs
-	if(search_proc("chronyd") > 0 || search_proc("ntpd") > 0 || search_proc("ntp-daemon") > 0)
+	const int chronyd_found = search_proc("chronyd");
+	const int ntpd_found = search_proc("ntpd");
+	const int ntp_daemon_found = search_proc("ntp-daemon");
+	if(chronyd_found > 0 || ntpd_found > 0 || ntp_daemon_found > 0)
 	{
-		log_info("Clock disciplining NTP client detected, not starting embedded NTP client/server");
+		log_info("Clock disciplining NTP client detected ( %s%s%s), not starting embedded NTP client/server",
+		         chronyd_found > 0 ? "chronyd " : "",
+		         ntpd_found > 0 ? "ntpd " : "",
+		         ntp_daemon_found > 0 ? "ntp-daemon " : "");
 		return false;
 	}
 


### PR DESCRIPTION
# What does this implement/fix?

Validation should ensure that `ntp.sync.server` can only be either a valid IP or a hostname.

Fixes #2660 

~~Note: I'm opening this as draft because - right now - the resulting crash was not reproducible by me. It is impossible on this branch, however, I'd still like to also fix the underlying issue in case the user responds with the requested backtrace.~~ The actual crash is fixed by #2684 

This PR also adds printing which NTP service has been detected when FTL decides not to launch its own NTP server. This makes it easier to see what needs to be disabled in order to test NTP related functionality on a given machine.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.