### PR TITLE
Replace dots with underscores when creating env var examples

### DIFF
--- a/tools/pihole_toml_to_markdown.py
+++ b/tools/pihole_toml_to_markdown.py
@@ -156,7 +156,7 @@ sudo pihole-FTL --config dns.dnssec=true
 
             # Compose full key for CLI/env var examples
             full_key = ".".join(section_stack + [key])
-            env_var = "FTLCONF_" + "_".join(section_stack + [key])
+            env_var = "FTLCONF_" + full_key.replace(".", "_")
 
             # TOML example tab
             documentation.append(f'=== "TOML"')


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix https://github.com/pi-hole/docs/issues/1298

The environment variables should contain only underscore characters, not dots, but the current code is printing the section names with dots, resulting in invalid variable names.

<img width="1026" height="146" alt="image" src="https://github.com/user-attachments/assets/5f467764-45cf-4c92-a06c-c830adc900bd" />


### How does this PR accomplish the above?

Replacing the dots before printing

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
