### PR TITLE
Fix pihole.format_path() memory handling

### DIFF
--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -279,6 +279,7 @@ static int pihole_format_path(lua_State *L) {
 	}
 
 	// Strip leading webhome from page_copy (if it exists)
+	char *page_copy_start = page_copy;
 	if (config.webserver.paths.webhome.v.s != NULL)
 	{
 		const size_t webhome_len = strlen(config.webserver.paths.webhome.v.s);
@@ -302,8 +303,8 @@ static int pihole_format_path(lua_State *L) {
 		lua_pushstring(L, page_copy);
 	}
 
-	// Free allocated memory
-	free(page_copy);
+	// Free originally allocated memory (page_copy may have been modified)
+	free(page_copy_start);
 
 	return 1; // number of results
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a possible crash when using `pihole.format_path()` in the web interface by ensuring we do not modify the pointer that is passed to a subsequent `free()`.

Going straight to `master` is expected and per design. The first commit by @yubiuser would have ended up there even on a regular `this branch` -> `development` -> `master` workflow. This is going to become **FTL v6.3.2**

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.