### PR TITLE
Be more explicit about required path and query parameters for list manipulation

### DIFF
--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -46,7 +46,7 @@ components:
           - "List management"
         operationId: "replace_lists"
         description: |
-          Items may be updated by replacing them. `{list}` is required.
+          Items may be updated by replacing them. `{list}` and `{listtype}` are required.
 
           Ensure to send all the required parameters (such as `comment`) to ensure these properties are retained.
           The read-only fields `id` and `date_added` are preserved, `date_modified` is automatically updated on success.
@@ -96,6 +96,7 @@ components:
           - "List management"
         operationId: "delete_lists"
         description: |
+          `{list}` and `{listtype}` are required.
           *Note:* There will be no content on success.
         responses:
           '204':


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Follow-up on https://github.com/pi-hole/FTL/pull/2530 to be even more explicit about the requirement to add `{listtype}` for `PUT` and `DELETE` requests.

Fixes https://github.com/pi-hole/FTL/issues/2685

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
