### PR TITLE
Remove dns.blockESNI

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -192,8 +192,6 @@ components:
                     type: string
                 CNAMEdeepInspect:
                   type: boolean
-                blockESNI:
-                  type: boolean
                 EDNS0ECS:
                   type: boolean
                 ignoreLocalhost:
@@ -674,7 +672,6 @@ components:
           dns:
             upstreams: [ "127.0.0.1#5353", "8.8.8.8" ]
             CNAMEdeepInspect: true
-            blockESNI: true
             EDNS0ECS: true
             ignoreLocalhost: false
             showDNSSEC: true

--- a/src/args.c
+++ b/src/args.c
@@ -341,7 +341,7 @@ void parse_args(int argc, char *argv[])
 		else
 		{
 			printf("Usage: %s --config [<config item key>] [<value>]\n", argv[0]);
-			printf("Example: %s --config dns.blockESNI true\n", argv[0]);
+			printf("Example: %s --config dns.EDNS0ECS true\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -418,12 +418,6 @@ void initConfig(struct config *conf)
 	conf->dns.CNAMEdeepInspect.d.b = true;
 	conf->dns.CNAMEdeepInspect.c = validate_stub; // Only type-based checking
 
-	conf->dns.blockESNI.k = "dns.blockESNI";
-	conf->dns.blockESNI.h = "Should _esni. subdomains be blocked by default? Encrypted Server Name Indication (ESNI) is certainly a good step into the right direction to enhance privacy on the web. It prevents on-path observers, including ISPs, coffee shop owners and firewalls, from intercepting the TLS Server Name Indication (SNI) extension by encrypting it. This prevents the SNI from being used to determine which websites users are visiting.\n\n ESNI will obviously cause issues for pixelserv-tls which will be unable to generate matching certificates on-the-fly when it cannot read the SNI. Cloudflare and Firefox are already enabling ESNI. According to the IETF draft (link above), we can easily restore pixelserv-tls's operation by replying NXDOMAIN to _esni. subdomains of blocked domains as this mimics a \"not configured for this domain\" behavior.";
-	conf->dns.blockESNI.t = CONF_BOOL;
-	conf->dns.blockESNI.d.b = true;
-	conf->dns.blockESNI.c = validate_stub; // Only type-based checking
-
 	conf->dns.EDNS0ECS.k = "dns.EDNS0ECS";
 	conf->dns.EDNS0ECS.h = "Should we overwrite the query source when client information is provided through EDNS0 client subnet (ECS) information? This allows Pi-hole to obtain client IPs even if they are hidden behind the NAT of a router. This feature has been requested and discussed on Discourse where further information how to use it can be found: https://discourse.pi-hole.net/t/support-for-add-subnet-option-from-dnsmasq-ecs-edns0-client-subnet/35940";
 	conf->dns.EDNS0ECS.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -131,7 +131,6 @@ struct config {
 	struct {
 		struct conf_item upstreams;
 		struct conf_item CNAMEdeepInspect;
-		struct conf_item blockESNI;
 		struct conf_item EDNS0ECS;
 		struct conf_item ignoreLocalhost;
 		struct conf_item showDNSSEC;

--- a/src/config/legacy_reader.c
+++ b/src/config/legacy_reader.c
@@ -268,11 +268,6 @@ const char *readFTLlegacy(struct config *conf)
 	if(buffer != NULL && sscanf(buffer, "%u", &unum) == 1 && unum > 0 && unum <= 300)
 		conf->misc.delay_startup.v.ui = unum;
 
-	// BLOCK_ESNI
-	// defaults to: true
-	buffer = parseFTLconf(fp, "BLOCK_ESNI");
-	parseBool(buffer, &conf->dns.blockESNI.v.b);
-
 	// WEBROOT
 	conf->webserver.paths.webroot.v.s = getPath(fp, "WEBROOT", conf->webserver.paths.webroot.v.s);
 

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -22,23 +22,6 @@
   #     true or false
   CNAMEdeepInspect = true
 
-  # Should _esni. subdomains be blocked by default? Encrypted Server Name Indication
-  # (ESNI) is certainly a good step into the right direction to enhance privacy on the
-  # web. It prevents on-path observers, including ISPs, coffee shop owners and
-  # firewalls, from intercepting the TLS Server Name Indication (SNI) extension by
-  # encrypting it. This prevents the SNI from being used to determine which websites
-  # users are visiting.
-  #
-  # ESNI will obviously cause issues for pixelserv-tls which will be unable to generate
-  # matching certificates on-the-fly when it cannot read the SNI. Cloudflare and Firefox
-  # are already enabling ESNI. According to the IETF draft (link above), we can easily
-  # restore pixelserv-tls's operation by replying NXDOMAIN to _esni. subdomains of
-  # blocked domains as this mimics a "not configured for this domain" behavior.
-  #
-  # Allowed values are:
-  #     true or false
-  blockESNI = true
-
   # Should we overwrite the query source when client information is provided through
   # EDNS0 client subnet (ECS) information? This allows Pi-hole to obtain client IPs even
   # if they are hidden behind the NAT of a router. This feature has been requested and
@@ -1673,7 +1656,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 161 total entries out of which 108 entries are default
+# 160 total entries out of which 107 entries are default
 # --> 53 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1907,9 +1907,9 @@
 }
 
 @test "Config validation working on the API (type-based checking)" {
-  run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config -d "{\"config\":{\"dns\":{\"blockESNI\":15.5}}}"'
+  run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config -d "{\"config\":{\"dns\":{\"EDNS0ECS\":15.5}}}"'
   printf "%s\n" "${lines[@]}"
-  [[ ${lines[0]} == "{\"error\":{\"key\":\"bad_request\",\"message\":\"Config item is invalid\",\"hint\":\"dns.blockESNI: not of type bool\"},\"took\":"*"}" ]]
+  [[ ${lines[0]} == "{\"error\":{\"key\":\"bad_request\",\"message\":\"Config item is invalid\",\"hint\":\"dns.EDNS0ECS: not of type bool\"},\"took\":"*"}" ]]
 
   run bash -c 'curl -s -X PATCH http://127.0.0.1/api/config -d "{\"config\":{\"dns\":{\"piholePTR\":\"something_else\"}}}"'
   printf "%s\n" "${lines[@]}"


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

This PR will remove the option `dns.blockESNI` as it is no longer relevant.

It was originally added in #733 with a feature request being on Discourse: https://discourse.pi-hole.net/t/support-dropping-esni-records-for-blocked-domains/13250
This feature was added based on  [draft-ietf-tls-esni-06(2020-03-09)](https://datatracker.ietf.org/doc/draft-ietf-tls-esni/06/), but since [draft-ietf-tls-esni-07(2020-06-01)](https://datatracker.ietf.org/doc/draft-ietf-tls-esni/07/) the _esni.* TXT Records are no longer used. This is also true for the current version  [draft-ietf-tls-esni-25(2025-06-14)](https://datatracker.ietf.org/doc/draft-ietf-tls-esni/25/). The co-developers and main adopters, Cloudflare and Mozilla, have stopped using ESNI in favor of ECH around 2020/21:
https://blog.mozilla.org/security/2021/01/07/encrypted-client-hello-the-future-of-esni-in-firefox/
https://blog.cloudflare.com/encrypted-client-hello/

ECH is already blocked by Pi-hole for blocked domains, since it uses the HTTPS record type located on the same name.

Demo for blocking ECH:
```
$ dig +short tls-ech.dev @127.0.0.1
0.0.0.0
$ dig +short tls-ech.dev @127.0.0.1 HTTPS
$ dig +short tls-ech.dev @1.1.1.1
34.138.246.121
$ dig +short tls-ech.dev @1.1.1.1 HTTPS
1 . ech=AEn+DQBFKwAgACABWIHUGj4u+PIggYXcR5JF0gYk3dCRioBW8uJq9H4mKAAIAAEAAQABAANAEnB1YmxpYy50bHMtZWNoLmRldgAA
```

**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
