### PR TITLE
Reduce DNS resolver locking during database interaction

### DIFF
--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -135,9 +135,7 @@ void *DB_thread(void *val)
 
 			// Save data to database
 			DBOPEN_OR_AGAIN();
-			lock_shm();
 			export_queries_to_disk(false);
-			unlock_shm();
 
 			// Intermediate cancellation-point
 			if(killed)

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -640,7 +640,7 @@ bool export_queries_to_disk(const bool final)
 
 	// Only try to export to database if it is known to not be broken
 	if(FTLDBerror())
-	return false;
+		return false;
 
 	// Start database timer
 	timer_start(DATABASE_WRITE_TIMER);


### PR DESCRIPTION
# What does this implement/fix?

We do not need to lock the SHM objects during export to disk database inside a `TRANSACTION`

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.