### PR TITLE
gravity update - silently discard unicode BOM if present

### DIFF
--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -272,6 +272,18 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 	unsigned int exact_domains = 0, abp_domains = 0, invalid_domains = 0;
 	while((read = getline(&line, &len, fpin)) != -1)
 	{
+
+		// Handle UTF-8 BOM (Byte Order Mark) if present at start of file
+		if (read >= 3 &&
+			(unsigned char)line[0] == 0xEF &&
+			(unsigned char)line[1] == 0xBB &&
+			(unsigned char)line[2] == 0xBF)
+		{
+			// Shift line contents left by 3 bytes to remove BOM
+			memmove(line, line + 3, read - 3);
+			read -= 3;
+		}
+
 		// Update total read bytes
 		total_read += read;
 		lineno++;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Prevent the Unicode [UTF-8 Byte order mark (BOM)](https://www.unicode.org/faq/utf_bom#BOM), if present in a list, from being flagged as a non-domain entry when updating gravity.

Some adlists in UTF-8 may contain (unnecessary) Unicode BOM at the start of the file. This is especially likely in the case of local files edited locally using microsoft tooling, and may also be present in some publicly maintained lists.

Raised in https://github.com/pi-hole/FTL/issues/2703

**How does this PR accomplish the above?:**

This change silently discards these, if present, in a similar manner to comments within the file, instead of flagging them as non-domain entries.

Before:

<img width="1922" height="284" alt="image" src="https://github.com/user-attachments/assets/1a563ac0-3712-48f4-8300-5632f3db21f3" />


After:

<img width="1920" height="213" alt="image" src="https://github.com/user-attachments/assets/df4a8856-ebf3-41d7-b8e3-c3a1cdeb1622" />


**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
