### PR TITLE
Get earliest query timestamp from database

### DIFF
--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -994,8 +994,22 @@ components:
                   example: "pihole"
         queries:
           type: integer
-          description: Number of queries in long-term database
+          description: Number of queries in in-memory database
           example: 536956
+        earliest_timestamp:
+          type: number
+          description: Unix timestamp of the earliest query in the in-memory database
+          example: 1611742120.5
+          nullable: true
+        queries_disk:
+          type: integer
+          description: Number of queries in on-disk database
+          example: 1234567
+        earliest_timestamp_disk:
+          type: number
+          description: Unix timestamp of the earliest query in the on-disk database
+          example: 1608450520.3
+          nullable: true
         sqlite_version:
           type: string
           description: Version of embedded SQLite3 engine

--- a/src/api/docs/content/specs/info.yaml
+++ b/src/api/docs/content/specs/info.yaml
@@ -998,18 +998,16 @@ components:
           example: 536956
         earliest_timestamp:
           type: number
-          description: Unix timestamp of the earliest query in the in-memory database
+          description: Unix timestamp of the earliest query in the in-memory database (Defaults to 0.0 if no queries are stored in memory)
           example: 1611742120.5
-          nullable: true
         queries_disk:
           type: integer
           description: Number of queries in on-disk database
           example: 1234567
         earliest_timestamp_disk:
           type: number
-          description: Unix timestamp of the earliest query in the on-disk database
+          description: Unix timestamp of the earliest query in the on-disk database (Defaults to 0.0 if no queries are stored on disk)
           example: 1608450520.3
-          nullable: true
         sqlite_version:
           type: string
           description: Version of embedded SQLite3 engine

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -146,9 +146,17 @@ int api_info_database(struct ftl_conn *api)
 	JSON_ADD_ITEM_TO_OBJECT(owner, "group", group);
 	JSON_ADD_ITEM_TO_OBJECT(json, "owner", owner);
 
-	// Add number of queries in on-disk database
-	const int queries_in_database = get_number_of_queries_in_DB(NULL, "query_storage");
+	// Add number of queries and earliest timestamp in in-memory database
+	double earliest_timestamp_mem = 0.0;
+	const int queries_in_database = get_number_of_queries_in_DB(NULL, "query_storage", &earliest_timestamp_mem);
 	JSON_ADD_NUMBER_TO_OBJECT(json, "queries", queries_in_database);
+	JSON_ADD_NUMBER_TO_OBJECT(json, "earliest_timestamp", earliest_timestamp_mem);
+
+	// Add number of queries and earliest timestamp in on-disk database
+	double earliest_timestamp_disk = 0.0;
+	const int queries_in_disk_database = get_number_of_queries_in_DB(NULL, "disk.query_storage", &earliest_timestamp_disk);
+	JSON_ADD_NUMBER_TO_OBJECT(json, "queries_disk", queries_in_disk_database);
+	JSON_ADD_NUMBER_TO_OBJECT(json, "earliest_timestamp_disk", earliest_timestamp_disk);
 
 	// Add SQLite library version
 	JSON_REF_STR_IN_OBJECT(json, "sqlite_version", get_sqlite3_version());

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -113,7 +113,7 @@ void close_memory_database(void);
 bool import_queries_from_disk(void);
 bool attach_database(sqlite3* db, const char **message, const char *path, const char *alias);
 bool detach_database(sqlite3* db, const char **message, const char *alias);
-int get_number_of_queries_in_DB(sqlite3 *db, const char *tablename);
+int get_number_of_queries_in_DB(sqlite3 *db, const char *tablename, double *earliest_timestamp);
 bool export_queries_to_disk(const bool final);
 bool delete_old_queries_from_db(const bool use_memdb, const double mintime);
 bool add_additional_info_column(sqlite3 *db);


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Retrieves the the earliest timestamp found in the database for both in memory and on disk databses. Will be utilised on the web interface for determining the "all time" range in the datetimepicker of the query page.

We reuse the existing `get_number_of_queries_in_DB` function and add an optional pointer to determine if we actually need the earliest timestamp or not. Maybe the function should be renamed, now. Not sure - I'll leave that up to @DL6ER 


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_