### PR TITLE
Make colour output optional in streaming gravity API call

### DIFF
--- a/src/api/docs/content/specs/action.yaml
+++ b/src/api/docs/content/specs/action.yaml
@@ -4,11 +4,13 @@ components:
     gravity:
       post:
         summary: Run gravity
+        parameters:
+          - $ref: 'action.yaml#/components/parameters/color'
         tags:
           - Actions
         operationId: "action_gravity"
         description: |
-          Update Pi-hole's adlists by running `pihole -g`. The output of the process is streamed with chunked encoding.
+          Update Pi-hole's adlists by running `pihole -g`. The output of the process is streamed with chunked encoding. Use the optional `color` query parameter to include ANSI color escape codes in the output.
         responses:
           '200':
             description: OK
@@ -182,6 +184,17 @@ components:
                   allOf:
                     - $ref: 'action.yaml#/components/errors/forbidden'
                     - $ref: 'common.yaml#/components/schemas/took'
+
+  parameters:
+    color:
+      name: color
+      in: query
+      description: Include ANSI color escape codes in the streamed output. Defaults to false to prevent colored output for API consumers that don't need formatting.
+      schema:
+        type: boolean
+        default: false
+        example: true
+      required: false
 
   errors:
     forbidden:


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Addresses https://github.com/pi-hole/FTL/issues/2671#issuecomment-3451402543

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_