### PR TITLE
Add rate-limiting for TOTP validation

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -114,6 +114,7 @@ enum totp_status {
 	TOTP_INVALID,
 	TOTP_CORRECT,
 	TOTP_REUSED,
+	TOTP_RATE_LIMIT
 } __attribute__ ((packed));
 enum totp_status verifyTOTP(const uint32_t code);
 int generateTOTP(struct ftl_conn *api);

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -559,6 +559,14 @@ int api_auth(struct ftl_conn *api)
 				                       "Reused 2FA token",
 				                       "wait for new token");
 			}
+			else if(totp == TOTP_RATE_LIMIT)
+			{
+				// 2FA validation requested too often
+				return send_json_error(api, 429,
+				                       "rate_limiting",
+				                       "Rate-limiting 2FA token requests, try again later",
+				                       NULL);
+			}
 			else if(totp != TOTP_CORRECT)
 			{
 				// 2FA token is invalid

--- a/src/api/docs/content/specs/auth.yaml
+++ b/src/api/docs/content/specs/auth.yaml
@@ -117,6 +117,8 @@ components:
                     $ref: 'auth.yaml#/components/examples/errors/rate_limit'
                   no_seats:
                     $ref: 'auth.yaml#/components/examples/errors/no_seats'
+                  totp_rate_limit:
+                    $ref: 'auth.yaml#/components/examples/errors/totp_rate_limit'
       delete:
         summary: Delete session
         tags:
@@ -588,6 +590,14 @@ components:
             message: "Reused 2FA token"
             hint: "wait for new token"
           took: 0.003
+      totp_rate_limit:
+        summary: 2FA token requested too soon
+        value:
+          error:
+            key: "rate_limiting"
+            message: "Rate-limiting 2FA token requests, try again later"
+            hint: null
+          took: 0.001
       rate_limit:
         summary: Rate limit exceeded
         value:


### PR DESCRIPTION
# What does this implement/fix?

Add rate-limiting (max 1/sec) for TOTP validation attempts. Note that this rate-limit applies only *after* already successful login using the first factor (password). This seeks to avoid a possibility of an DoS attack *with known password* when 2FA is enabled.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.