### PR TITLE
api/dhcp/leases Allow for hwaddr > 48 bits

### DIFF
--- a/src/api/dhcp.c
+++ b/src/api/dhcp.c
@@ -45,11 +45,11 @@ int api_dhcp_leases_GET(struct ftl_conn *api)
 
 		// Parse line
 		unsigned long expires = 0;
-		char hwaddr[18] = { 0 };
+		char hwaddr[48] = { 0 };
 		char ip[INET6_ADDRSTRLEN] = { 0 };
 		char name[65] = { 0 };
 		char clientid[765] = { 0 };
-		const int ret = sscanf(line, "%lu %17s %45s %64s %764s", &expires, hwaddr, ip, name, clientid);
+		const int ret = sscanf(line, "%lu %47s %45s %64s %764s", &expires, hwaddr, ip, name, clientid);
 
 		// Skip invalid lines
 		if(ret != 5)


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allow the API to correctly return the hwaddr present in dhcp.leases, even when it is longer than 48 bits. (Which subsequently permits UI deletion of such leases).

Issue https://github.com/pi-hole/FTL/issues/2723, also https://github.com/pi-hole/pi-hole/issues/6394

**How does this PR accomplish the above?:**

Adjust buffer and string formatting capability for hwaddr up to 16 octets in length, as per rfc2131 https://www.rfc-editor.org/rfc/rfc2131#section-2

<img width="925" height="427" alt="image" src="https://github.com/user-attachments/assets/9bbae107-249e-4396-aa69-e42d22cd1973" />

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
