### PR TITLE
Fix documentation - Do not use equal sign with `pihole-FTL --config` command

### DIFF
--- a/tools/pihole_toml_to_markdown.py
+++ b/tools/pihole_toml_to_markdown.py
@@ -29,10 +29,10 @@ This page documents the available options of `pihole-FTL`. They are typically ma
 
 Using the web interface, the API or the CLI is preferred as they can do error checking for you, trying to prevent any incompatible options which could prevent FTL from starting on a severely broken configuration.
 
-To edit with the command line, use the format `key.name=value`, e.g:
+To edit with the command line, use the format `--config key.name value`, e.g:
 
 ```text
-sudo pihole-FTL --config dns.dnssec=true
+sudo pihole-FTL --config dns.dnssec true
 ```
 
 !!! note "Environment Variables"
@@ -176,9 +176,9 @@ sudo pihole-FTL --config dns.dnssec=true
             if "\n" in value and value.strip().startswith("["):
                 # Flatten multi-line array to single line for CLI
                 array_str = "".join(value.split())
-                documentation.append(f"    sudo pihole-FTL --config {full_key}='{array_str}'")
+                documentation.append(f"    sudo pihole-FTL --config {full_key} '{array_str}'")
             else:
-                documentation.append(f"    sudo pihole-FTL --config {full_key}={value}")
+                documentation.append(f"    sudo pihole-FTL --config {full_key} {value}")
             documentation.append("    ```")
 
             # Environment variable example tab (for Docker Compose)


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix the function that creates the CLI examples to use a space instead of an equal sign.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
