### PR TITLE
Add dns.cache.rrtype

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -252,6 +252,8 @@ components:
                       type: integer
                     upstreamBlockedTTL:
                       type: integer
+                    rrtype:
+                      type: string
                 revServers:
                   type: array
                   items:
@@ -706,6 +708,7 @@ components:
               size: 10000
               optimizer: 3600
               upstreamBlockedTTL: 86400
+              rrtype: "ANY"
             revServers:
               - "true,192.168.0.0/24,192.168.0.1,lan"
             blocking:

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -635,6 +635,14 @@ void initConfig(struct config *conf)
 	conf->dns.cache.upstreamBlockedTTL.d.ui = 86400;
 	conf->dns.cache.upstreamBlockedTTL.c = validate_stub; // Only type-based checking
 
+	conf->dns.cache.rrtype.k = "dns.cache.rrtype";
+	conf->dns.cache.rrtype.h = "This is dnsmasq's --cache-rr option, which allows you to define which DNS record types should be cached by PiHole. This option can take a comma-separated list of RR-types as input. The default value ANY caches all record types.";
+	conf->dns.cache.rrtype.a = cJSON_CreateStringReference("Valid DNS record types in the following form: <rrtype>[,<rrtype>...]");
+	conf->dns.cache.rrtype.t = CONF_STRING;
+	conf->dns.cache.rrtype.f = FLAG_RESTART_FTL;
+	conf->dns.cache.rrtype.d.s = (char*)"ANY";
+	conf->dns.cache.rrtype.c = validate_stub; // Only type-based checking
+	
 	// sub-struct dns.blocking
 	conf->dns.blocking.active.k = "dns.blocking.active";
 	conf->dns.blocking.active.h = "Should FTL block queries?";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -160,6 +160,7 @@ struct config {
 			struct conf_item size;
 			struct conf_item optimizer;
 			struct conf_item upstreamBlockedTTL;
+			struct conf_item rrtype;
 		} cache;
 		struct {
 			struct conf_item active;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -775,9 +775,9 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		fputs("\n", pihole_conf);
 	}
 
-	// Add option for caching all DNS records
+	// Add option for which DNS records types to cache
 	fputs("# Cache all DNS records\n", pihole_conf);
-	fputs("cache-rr=ANY\n", pihole_conf);
+	fprintf(pihole_conf, "cache-rr=%s\n\n", conf->dns.cache.rrtype.v.s);
 	fputs("\n", pihole_conf);
 
 	// Add option for PCAP file recording

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -355,9 +355,12 @@
     #     blocked queries
     upstreamBlockedTTL = 86400
 
-    # This is dnsmasq's --cache-rr option, which allows you to define which DNS record 
-    # types should be cached by PiHole. This option can take a comma-separated list of 
+    # This is dnsmasq's --cache-rr option, which allows you to define which DNS record
+    # types should be cached by PiHole. This option can take a comma-separated list of
     # RR-types as input. The default value ANY caches all record types.
+    #
+    # Allowed values are:
+    #     Valid DNS record types in the following form: <rrtype>[,<rrtype>...]
     rrtype = "ANY"
 
   [dns.blocking]

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -355,6 +355,11 @@
     #     blocked queries
     upstreamBlockedTTL = 86400
 
+    # This is dnsmasq's --cache-rr option, which allows you to define which DNS record 
+    # types should be cached by PiHole. This option can take a comma-separated list of 
+    # RR-types as input. The default value ANY caches all record types.
+    rrtype = "ANY"
+
   [dns.blocking]
     # Should FTL block queries?
     #
@@ -1679,7 +1684,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 162 total entries out of which 108 entries are default
+# 163 total entries out of which 109 entries are default
 # --> 54 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Add a dns.cache.rrtype option to customize which types of DNS records get cached by PiHole. This dnsmasq option has been hardcoded so far.

**How does this PR accomplish the above?:**

New Setting in the WebGUI where the option can be changed. By default all record types get cached.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
