### PR TITLE
Add option to hide network connection errors

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -557,6 +557,8 @@ components:
                   type: boolean
                 hide_dnsmasq_warn:
                   type: boolean
+                hide_connection_error:
+                  type: boolean
                 check:
                   type: object
                   properties:
@@ -845,6 +847,7 @@ components:
             readOnly: false
             normalizeCPU: false
             hide_dnsmasq_warn: false
+            hide_connection_error: false
             check:
               load: true
               shmem: 90

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -937,7 +937,8 @@ static int api_info_messages_GET(struct ftl_conn *api)
 	}
 
 	// Filter messages if requested
-	if(config.misc.hide_dnsmasq_warn.v.b)
+	if(config.misc.hide_dnsmasq_warn.v.b ||
+	   config.misc.hide_connection_error.v.b)
 	{
 		// Create new array
 		cJSON *filtered = cJSON_CreateArray();
@@ -956,7 +957,11 @@ static int api_info_messages_GET(struct ftl_conn *api)
 				continue;
 
 			// Skip if it is a DNSMASQ_WARN message
-			if(strcmp(type->valuestring, "DNSMASQ_WARN") == 0)
+			if(config.misc.hide_dnsmasq_warn.v.b && strcmp(type->valuestring, "DNSMASQ_WARN") == 0)
+				continue;
+
+			// Skip if it is a CONNECTION_ERROR message
+			if(config.misc.hide_connection_error.v.b && strcmp(type->valuestring, "CONNECTION_ERROR") == 0)
 				continue;
 
 			// else: Add a copy to the filtered array

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1436,6 +1436,12 @@ void initConfig(struct config *conf)
 	conf->misc.hide_dnsmasq_warn.d.b = false;
 	conf->misc.hide_dnsmasq_warn.c = validate_stub; // Only type-based checking
 
+	conf->misc.hide_connection_error.k = "misc.hide_connection_error";
+	conf->misc.hide_connection_error.h = "Should FTL hide network connection errors?\n\n By default, FTL reports network connection errors (e.g., Connection prematurely closed by remote server) to the FTL log file. These warnings can be useful to identify intermittent network problems or general problem with upstream servers. However, in some setups, these warnings may be expected (e.g. due to low-quality Internet connectivity) and cannot be fixed. Enabling this setting will hide all connection warnings.";
+	conf->misc.hide_connection_error.t = CONF_BOOL;
+	conf->misc.hide_connection_error.d.b = false;
+	conf->misc.hide_connection_error.c = validate_stub; // Only type-based checking
+
 	// sub-struct misc.check
 	conf->misc.check.load.k = "misc.check.load";
 	conf->misc.check.load.h = "Pi-hole is very lightweight on resources. Nevertheless, this does not mean that you should run Pi-hole on a server that is otherwise extremely busy as queuing on the system can lead to unnecessary delays in DNS operation as the system becomes less and less usable as the system load increases because all resources are permanently in use. To account for this, FTL regularly checks the system load. To bring this to your attention, FTL warns about excessive load when the 15 minute system load average exceeds the number of cores.\n\n This check can be disabled with this setting.";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -319,6 +319,7 @@ struct config {
 		struct conf_item readOnly;
 		struct conf_item normalizeCPU;
 		struct conf_item hide_dnsmasq_warn;
+		struct conf_item hide_connection_error;
 		struct {
 			struct conf_item load;
 			struct conf_item shmem;

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1002,11 +1002,18 @@ int count_messages(void)
 		return count;
 	}
 
-	// Get message
+	// Count messages
 	sqlite3_stmt* stmt = NULL;
-	const char *querystr = config.misc.hide_dnsmasq_warn.v.b ?
-			"SELECT COUNT(*) FROM message WHERE type != 'DNSMASQ_WARN'" :
-			"SELECT COUNT(*) FROM message";
+	const char *querystr;
+	if(config.misc.hide_dnsmasq_warn.v.b && config.misc.hide_connection_error.v.b)
+		querystr = "SELECT COUNT(*) FROM message WHERE type NOT IN ('DNSMASQ_WARN', 'CONNECTION_ERROR')";
+	else if(config.misc.hide_dnsmasq_warn.v.b)
+		querystr = "SELECT COUNT(*) FROM message WHERE type != 'DNSMASQ_WARN'";
+	else if(config.misc.hide_connection_error.v.b)
+		querystr = "SELECT COUNT(*) FROM message WHERE type != 'CONNECTION_ERROR'";
+	else
+		querystr = "SELECT COUNT(*) FROM message";
+
 	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK ){
 		log_err("count_messages() - SQL error prepare SELECT: %s",

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.3.2-8-g58a618e2-dirty) on branch tweak/db_performance
+# Pi-hole configuration file (v6.4.1-55-g7208be13) on branch new/hide_connection_errors
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-11-01 13:12:20 UTC
+# Last updated on 2025-12-21 11:13:49 UTC
 
 [dns]
   # Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not
@@ -1435,6 +1435,19 @@
   #     true or false
   hide_dnsmasq_warn = false
 
+  # Should FTL hide network connection errors?
+  #
+  # By default, FTL reports network connection errors (e.g., Connection prematurely
+  # closed by remote server) to the FTL log file. These warnings can be useful to
+  # identify intermittent network problems or general problem with upstream servers.
+  # However, in some setups, these warnings may be expected (e.g. due to low-quality
+  # Internet connectivity) and cannot be fixed. Enabling this setting will hide all
+  # connection warnings.
+  #
+  # Allowed values are:
+  #     true or false
+  hide_connection_error = false
+
   [misc.check]
     # Pi-hole is very lightweight on resources. Nevertheless, this does not mean that you
     # should run Pi-hole on a server that is otherwise extremely busy as queuing on the
@@ -1690,7 +1703,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 163 total entries out of which 109 entries are default
+# 164 total entries out of which 110 entries are default
 # --> 54 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

Add new `misc.hide_connection_error` setting defaulting to `false`. 

Description:

> Should FTL hide network connection errors?
> 
> By default, FTL reports network connection errors (e.g., Connection prematurely closed by remote server) to the FTL log file. These warnings can be useful to identify intermittent network problems or general problem with upstream servers. However, in some setups, these warnings may be expected (e.g. due to low-quality Internet connectivity) and cannot be fixed. Enabling this setting will hide all connection warnings.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.