### PR TITLE
Teleporter: Fix for custom gravity.db path

### DIFF
--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -63,13 +63,6 @@ static const char *ftl_tables[] = {
 	"network_addresses"
 };
 
-// List of files to process from a Teleporter ZIP archive
-static const char *extract_files[] = {
-	"etc/pihole/pihole.toml",
-	"etc/pihole/dhcp.leases",
-	"etc/pihole/gravity.db"
-};
-
 // Create database in memory, copy selected tables to it, serialize and return a memory pointer to it
 static bool create_teleporter_database(const char *filename, const char **tables, const unsigned int num_tables,
                                        void **buffer, size_t *size)
@@ -559,6 +552,13 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 			continue;
 		}
 
+		// List of files to process from a Teleporter ZIP archive
+		const char *extract_files[] = {
+			"etc/pihole/pihole.toml",
+			"etc/pihole/dhcp.leases",
+			config.files.gravity.v.s[0] == '/' ? config.files.gravity.v.s + 1 : config.files.gravity.v.s
+		};
+
 		// Check if this file is one of the files we want to extract and process
 		bool extract = false;
 		for(size_t j = 0; j < ArraySize(extract_files); j++)
@@ -570,7 +570,10 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 			}
 		}
 		if(!extract)
+		{
+			log_info("Skipping file %s in Teleporter archive", file_stat.m_filename);
 			continue;
+		}
 
 		// Read file into its dedicated memory buffer
 		void *ptr = malloc(file_stat.m_uncomp_size);


### PR DESCRIPTION
# What does this implement/fix?

Acknowledge that gravity.db may be on another path than the hard-coded etc/pihole/gravity.db. Also mention explicitly which files we are skipping in the archive than just silently skipping them

---

**Related issue or feature (if applicable):** Fixes #2756 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.