### PR TITLE
Fix computation of NTP server's root delay

### DIFF
--- a/src/ntp/ntp.h
+++ b/src/ntp/ntp.h
@@ -69,7 +69,7 @@ bool ntp_sync_rtc(void);
 #define ntoh64(x) ((((uint64_t)ntohl(x)) << 32) + ntohl((x) >> 32))
 
 extern uint64_t ntp_last_sync;
-extern int32_t ntp_root_delay;
+extern uint32_t ntp_root_delay;
 extern uint32_t ntp_root_dispersion;
 extern uint8_t ntp_stratum;
 

--- a/src/ntp/server.c
+++ b/src/ntp/server.c
@@ -46,7 +46,7 @@
 #include "timers.h"
 
 uint64_t ntp_last_sync = 0u;
-int32_t ntp_root_delay = 0u;
+uint32_t ntp_root_delay = 0u;
 uint32_t ntp_root_dispersion = 0u;
 uint8_t ntp_stratum = 0u;
 


### PR DESCRIPTION
# What does this implement/fix?

Fix computation of NTP server's root delay. This effectively reverts #2420 and applies the correct fix, instead.

---

**Related issue or feature (if applicable):** Fixes #2418 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.