### PR TITLE
Fix overTime data when database.DBimport = false

### DIFF
--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -36,6 +36,8 @@
 #include "database/sqlite3-ext.h"
 // PRId64
 #include <inttypes.h>
+// db_import_done
+#include "gc.h"
 
 static bool analyze_database(sqlite3 *db)
 {
@@ -152,6 +154,9 @@ void *DB_thread(void *val)
 	// Asynchronously import queries from the on-disk database
 	if(config.database.DBimport.v.b)
 		DB_read_queries();
+
+	// Signify that the import is done, so garbage collection will run
+	db_import_done = true;
 
 	// Log some information about the imported queries (if any)
 	log_counter_info();

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -1535,14 +1535,9 @@ void DB_read_queries(void)
 	}
 
 	if( rc == SQLITE_DONE )
-	{
-		db_import_done = true;
 		log_info("Imported %zu queries from the long-term database", imported_queries);
-	}
 	else
-	{
 		log_err("DB_read_queries() - SQL error step: %s", sqlite3_errstr(rc));
-	}
 
 	if((int)imported_queries < counted_queries)
 	{


### PR DESCRIPTION
# What does this implement/fix?

Always mark database import as done even when `database.DBimport = false` or on database errors.

Otherwise, garbage collection will never run, causing the memory allocation to always grow and overtime information to be incorrect (handled in GC code as well)

---

**Related issue or feature (if applicable):** Fixes #2785 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.