### PR TITLE
Add new option for controling name resolution via MAC address

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -391,6 +391,8 @@ components:
                   type: boolean
                 resolveIPv6:
                   type: boolean
+                macNames:
+                  type: boolean
                 networkNames:
                   type: boolean
                 refreshNames:
@@ -773,6 +775,7 @@ components:
           resolver:
             resolveIPv4: true
             resolveIPv6: true
+            macNames: true
             networkNames: true
             refreshNames: IPV4_ONLY
           database:

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -948,6 +948,12 @@ void initConfig(struct config *conf)
 	conf->resolver.resolveIPv6.d.b = true;
 	conf->resolver.resolveIPv6.c = validate_stub; // Only type-based checking
 
+	conf->resolver.macNames.k = "resolver.macNames";
+	conf->resolver.macNames.h = "Control whether FTL should attempt to obtain client names from the network table by MAC address.\n\nThis can provide hostnames for devices that do not have a hostname or have multiple IP addresses (e.g. IPv4 and IPv6).\nHowever, MAC-derived names can be ambiguous (e.g., when a MAC appears for multiple IPs due to a router/NAT or MAC reuse), which may lead to incorrect hostnames being shown. Disabling this option can prevent such issues but may lead to more clients without hostnames.";
+	conf->resolver.macNames.t = CONF_BOOL;
+	conf->resolver.macNames.d.b = true;
+	conf->resolver.macNames.c = validate_stub; // Only type-based checking
+
 	conf->resolver.resolveIPv4.k = "resolver.resolveIPv4";
 	conf->resolver.resolveIPv4.h = "Should FTL try to resolve IPv4 addresses to hostnames?";
 	conf->resolver.resolveIPv4.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -232,6 +232,7 @@ struct config {
 	struct {
 		struct conf_item resolveIPv4;
 		struct conf_item resolveIPv6;
+		struct conf_item macNames;
 		struct conf_item networkNames;
 		struct conf_item refreshNames;
 	} resolver;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -357,7 +357,7 @@ static bool get_client_groupids(clientsData *client)
 	// 2. If found -> Get groups by looking up MAC address in client table
 	char hwaddr[MAXMACLEN] = { 0 };
 	bool got_hwaddr = false;
-	if(chosen_match_id < 0)
+	if(chosen_match_id < 0 && config.resolver.macNames.v.b)
 	{
 		log_debug(DEBUG_CLIENTS, "Querying gravity database for MAC address of %s...", ip);
 
@@ -413,7 +413,7 @@ static bool get_client_groupids(clientsData *client)
 		// Check if client is configured through the client table
 		// This will return nothing if the client is unknown/unconfigured
 		// We use COLLATE NOCASE to ensure the comparison is done case-insensitive
-		querystr = "SELECT id FROM client WHERE ip = ? COLLATE NOCASE;";
+		querystr = "SELECT id FROM client WHERE ip = ? COLLATE NOCASE";
 
 		// Prepare query
 		rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &table_stmt, NULL);

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -2231,6 +2231,13 @@ bool getNameFromMAC(const char *client, char hostn[MAXDOMAINLEN])
 	if(FTLDBerror())
 		return false;
 
+	// Check if we want to obtain names from MAC addresses at all
+	if(!config.resolver.macNames.v.b)
+	{
+		log_debug(DEBUG_RESOLVER, "getNameFromMAC(\"%s\") - configured to not obtain host name from MAC", client);
+		return false;
+	}
+
 	// Open pihole-FTL.db database file
 	sqlite3 *db = NULL;
 	if((db = dbopen(false, false)) == NULL)

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -278,6 +278,13 @@ static int find_device_by_hwaddr(sqlite3 *db, const char hwaddr[])
 	if(FTLDBerror())
 		return DB_FAILED;
 
+	// Return early if we know MAC addresses are not unique
+	if(!config.resolver.macNames.v.b)
+	{
+		log_debug(DEBUG_ARP, "find_device_by_hwaddr(%s) - returning early", hwaddr);
+		return DB_NODATA;
+	}
+
 	log_debug(DEBUG_ARP, "find_device_by_hwaddr(%s)", hwaddr);
 
 	const char *querystr = "SELECT id FROM network WHERE hwaddr = ?1 COLLATE NOCASE;";

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.4.1-55-g7208be13) on branch new/hide_connection_errors
+# Pi-hole configuration file (v6.5-5-g93080420-dirty) on branch fix/names_behind_router
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2025-12-21 11:13:49 UTC
+# Last updated on 2026-02-27 11:29:26 UTC
 
 [dns]
   # Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not
@@ -751,6 +751,20 @@
   # Allowed values are:
   #     true or false
   resolveIPv6 = false ### CHANGED, default = true
+
+  # Control whether FTL should attempt to obtain client names from the network table by
+  # MAC address.
+  #
+  #This can provide hostnames for devices that do not have a hostname or have multiple
+  # IP addresses (e.g. IPv4 and IPv6).
+  #However, MAC-derived names can be ambiguous (e.g., when a MAC appears for multiple
+  # IPs due to a router/NAT or MAC reuse), which may lead to incorrect hostnames being
+  # shown. Disabling this option can prevent such issues but may lead to more clients
+  # without hostnames.
+  #
+  # Allowed values are:
+  #     true or false
+  macNames = true
 
   # Control whether FTL should use the fallback option to try to obtain client names from
   # checking the network table. This behavior can be disabled with this option.
@@ -1723,7 +1737,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 166 total entries out of which 112 entries are default
+# 167 total entries out of which 113 entries are default
 # --> 54 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

Add config option `resolver.macNames` which can be used to control whether FTL tries to resolve host names via MAC addresses. This may not work in special network configurations where clients aren't all on the same link (Layer 2 but not Layer 3 connection).

The default value is `true`, preserving existing behavior.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2779

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.