### PR TITLE
Fix compile defintion sourcing for VSCode

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,7 +5,7 @@
             "includePath": [
                 "${workspaceFolder}/src/**"
             ],
-            "compileCommands": "${workspaceFolder}/build/compile_commands.json",
+            "compileCommands": "${workspaceFolder}/cmake/compile_commands.json",
             "defines": [],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "gnu17",

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,13 @@ set -e
 # Set builddir
 builddir="cmake/"
 
+# Enable export of compile commands so IDEs like VSCode can use this information
+# when rendering active and disabled code paths, e.g., for #ifdefs. The
+# compile_commands.json file is generated in the package specific build
+# directory containing the exact compiler calls for all translation units of the
+# project in machine-readable form (JSON).
+export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+
 # Parse arguments
 # If the first argument starts in "-D", we pass it to CMake
 if [[ "${1}" == "-D"* ]]; then
@@ -152,9 +159,9 @@ fi
 mkdir -p "${builddir}"
 cd "${builddir}"
 if [[ -n ${cmake_args} ]]; then
-    cmake "${cmake_args}" .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    cmake "${cmake_args}" ..
 else
-    cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    cmake ..
 fi
 
 # If MAKEFLAGS is unset, we set it to "-j$(nproc)"

--- a/build.sh
+++ b/build.sh
@@ -152,9 +152,9 @@ fi
 mkdir -p "${builddir}"
 cd "${builddir}"
 if [[ -n ${cmake_args} ]]; then
-    cmake "${cmake_args}" ..
+    cmake "${cmake_args}" .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 else
-    cmake ..
+    cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 fi
 
 # If MAKEFLAGS is unset, we set it to "-j$(nproc)"

--- a/src/webserver/x509.c
+++ b/src/webserver/x509.c
@@ -12,10 +12,6 @@
 #include "log.h"
 #include "x509.h"
 
-#ifndef HAVE_MBEDTLS
-#define HAVE_MBEDTLS
-#endif
-
 #ifdef HAVE_MBEDTLS
 # ifndef MBEDTLS_MPI_INIT
 # define MBEDTLS_MPI_INIT { 0, 1, 0 }


### PR DESCRIPTION
# What does this implement/fix?

Add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` so `compile_commands.json` is actually created and VSCode knows about the defines used during compilation

### BEFORE

<img width="1167" height="817" alt="image" src="https://github.com/user-attachments/assets/78448eb4-54d7-4d13-9285-ae345657d3c1" />

(VSCode is not aware of the compile-time definitions, hence, all code is grayed out)

### AFTER

<img width="1167" height="817" alt="image" src="https://github.com/user-attachments/assets/19bbe6a1-eafe-4748-acbc-eb12e5036083" />


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.