### PR TITLE
Introduce CMake options for optional dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,10 +348,12 @@ add_subdirectory(config)
 add_subdirectory(tools)
 add_subdirectory(ntp)
 
+option(USE_READLINE "Build FTL with readline support, if available" ON)
+
 find_library(LIBREADLINE NAMES libreadline${LIBRARY_SUFFIX} readline)
 find_library(LIBHISTORY NAMES libhistory${LIBRARY_SUFFIX} history)
 find_library(LIBTERMCAP NAMES libtermcap${LIBRARY_SUFFIX} termcap)
-if(LIBREADLINE AND LIBHISTORY AND LIBTERMCAP)
+if(LIBREADLINE AND LIBHISTORY AND LIBTERMCAP AND USE_READLINE)
     message(STATUS "Building FTL with readline support: YES")
     target_compile_definitions(lua PRIVATE LUA_USE_READLINE)
     target_compile_definitions(sqlite3 PRIVATE HAVE_READLINE)
@@ -364,11 +366,13 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "..." FORCE)
 endif()
 
+option(USE_MBED_TLS "Build FTL with TLS support, if available" ON)
+
 find_library(LIBMBEDCRYPTO NAMES lmbedcrypto${LIBRARY_SUFFIX} mbedcrypto)
 find_library(LIBMBEDX509 NAMES lmbedx509${LIBRARY_SUFFIX} mbedx509)
 find_library(LIBMBEDTLS NAMES lmbedtls${LIBRARY_SUFFIX} mbedtls)
-if(LIBMBEDCRYPTO AND LIBMBEDX509 AND LIBMBEDTLS)
-    # Enable TLS support in civetweb if mbedTLS is available
+if(LIBMBEDCRYPTO AND LIBMBEDX509 AND LIBMBEDTLS AND USE_MBED_TLS)
+    # Enable TLS support in civetweb if mbedTLS is selected and available
     message(STATUS "Building FTL with TLS support: YES")
     target_compile_definitions(core PRIVATE HAVE_MBEDTLS)
     target_compile_definitions(civetweb PRIVATE USE_MBEDTLS)
@@ -376,7 +380,7 @@ if(LIBMBEDCRYPTO AND LIBMBEDX509 AND LIBMBEDTLS)
     # Link against the mbedTLS libraries, the order is important (!)
     target_link_libraries(pihole-FTL ${LIBMBEDTLS} ${LIBMBEDX509} ${LIBMBEDCRYPTO})
 else()
-    # Disable TLS support in civetweb if mbedTLS is not available
+    # Disable TLS support in civetweb if mbedTLS is not selected or not available
     message(STATUS "Building FTL with TLS support: NO")
     target_compile_definitions(civetweb PRIVATE NO_SSL)
 endif()


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Readline and Mbed TLS support are optional dependencies. CMake detects them, and automatically includes them if they are found. If this is not intended, currently the only way is to manually delete these liraries from the build system. While the default behaviour is beneficial, a more resilient method is looked for to exclude dependencies from the build.

**How does this PR accomplish the above?:**

Introduce CMake options for both dependencies, that allow controlling build inclusion by setting a build variable.

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
