### PR TITLE
Fix build without mbedtls [v2]

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -44,7 +44,7 @@
 #include <stddef.h>
 // logg_rate_limit_message()
 #include "database/message-table.h"
-// http_init()
+// http_init(), webserver_thread()
 #include "webserver/webserver.h"
 // type struct sqlite3_stmt_vec
 #include "vector.h"
@@ -3359,12 +3359,17 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 		exit(EXIT_FAILURE);
 	}
 
+#ifdef HAVE_MBEDTLS
 	// Start webserver thread
 	if(pthread_create( &threads[WEBSERVER], &attr, webserver_thread, NULL ) != 0)
 	{
 		log_crit("Unable to create webserver thread. Exiting...");
 		exit(EXIT_FAILURE);
 	}
+#else
+	// Initialize FTL HTTP server
+	http_init();
+#endif /* HAVE_MBEDTLS */
 
 	// Chown files if FTL started as user root but a dnsmasq config
 	// option states to run as a different user/group (e.g. "nobody")

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -33,7 +33,9 @@
 // thread_names
 #include "signals.h"
 
+#ifdef HAVE_MBEDTLS
 #include <mbedtls/ssl_ciphersuites.h>
+#endif /* HAVE_MBEDTLS */
 
 // Server context handle
 static struct mg_context *ctx = NULL;
@@ -996,6 +998,7 @@ void http_terminate(void)
 		free(login_uri);
 }
 
+#ifdef HAVE_MBEDTLS
 static void restart_http(void)
 {
 	// Stop the server
@@ -1004,6 +1007,7 @@ static void restart_http(void)
 	// Reinitialize the webserver
 	http_init();
 }
+#endif /* HAVE_MBEDTLS */
 
 /**
  * @brief Prints all supported TLS cipher suites by mbedTLS.
@@ -1019,6 +1023,7 @@ static void restart_http(void)
  */
 void get_all_supported_ciphersuites(void)
 {
+#ifdef HAVE_MBEDTLS
 	const int *all = mbedtls_ssl_list_ciphersuites();
 	printf("Supported TLS cipher suites:\n");
 	for (size_t i = 0; all[i] != 0; ++i)
@@ -1029,8 +1034,10 @@ void get_all_supported_ciphersuites(void)
 		const size_t bitlen = mbedtls_ssl_ciphersuite_get_cipher_key_bitlen(suite_info);
 		printf("- %s (Cipher ID: %d, Key length: %zu bits)\n", suite_name, all[i], bitlen);
 	}
+#endif /* HAVE_MBEDTLS */
 }
 
+#ifdef HAVE_MBEDTLS
 void *webserver_thread(void *val)
 {
 	(void)val;
@@ -1082,3 +1089,4 @@ void *webserver_thread(void *val)
 	log_info("Terminating webserver thread");
 	return NULL;
 }
+#endif /* HAVE_MBEDTLS */


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Commit 3b45213 (Implement automatic TLS/SSL certificate renewals) introduced functionality that requires mbedtls, but mbedtls is an optional dependency. This leads to the following compilation error:

```
pihole-ftl-6.5/src/webserver/webserver.c:36:10: fatal error: mbedtls/ssl_ciphersuites.h: No such file or directory
   36 | #include <mbedtls/ssl_ciphersuites.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

**How does this PR accomplish the above?:**

Use the HAVE_MBEDTLS preprocessor symbol to assert that certificate related code is only included if mbedtls is present in the build.

**Link documentation PRs if any are needed to support this PR:**

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x ] I have read the above and my PR is ready for review. *Check this box to confirm*
