### PR TITLE
Ensure API sessions are restored before starting the HTTP server

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -101,7 +101,7 @@ int api_list(struct ftl_conn *api);
 int api_group(struct ftl_conn *api);
 
 // Auth method
-void init_api(void);
+void init_api_sessions(void);
 void free_api(void);
 int check_client_auth(struct ftl_conn *api, const bool is_api);
 int api_auth(struct ftl_conn *api);

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -43,9 +43,10 @@ static void add_request_info(struct ftl_conn *api, const char *csrf)
 	memset((int*)&api->request->is_authenticated, 1, sizeof(api->request->is_authenticated));
 }
 
-void init_api(void)
+void init_api_sessions(void)
 {
 	// Restore sessions from database
+	log_debug(DEBUG_API, "Initializing API sessions, maximum sessions: %u", config.webserver.api.max_sessions.v.u16);
 	max_sessions = config.webserver.api.max_sessions.v.u16;
 	auth_data = calloc(max_sessions, sizeof(struct session));
 	if(auth_data == NULL)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -58,6 +58,8 @@
 #include "ntp/ntp.h"
 // get_process_name()
 #include "procps.h"
+// init_api_sessions()
+#include "api/api.h"
 
 // Private prototypes
 static void print_flags(const unsigned int flags);
@@ -3324,6 +3326,11 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 
 	// Start NTP sync thread
 	ntp_start_sync_thread(&attr);
+
+	// Restore sessions from database before starting the database thread to
+	// ensure that sessions import is not blocked by asynchronous query
+	// import in the database thread
+	init_api_sessions();
 
 	// Start database thread if database is used
 	if(pthread_create( &threads[DB], &attr, DB_thread, NULL ) != 0)

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -878,9 +878,6 @@ void http_init(void)
 	// Prepare prerequisites for Lua
 	allocate_lua(login_uri, admin_api_uri, prefix_webhome);
 
-	// Restore sessions from database
-	init_api();
-
 	// Create CLI password (if enabled)
 	create_cli_password();
 }

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1,5 +1,11 @@
 #!./test/libs/bats/bin/bats
 
+# Log the current test description to the FTL log at the start of each test.
+# `setup()` is run by bats before every `@test` block.
+setup() {
+  printf 'Starting test: %s\n' "$BATS_TEST_DESCRIPTION" >> /var/log/pihole/FTL.log
+}
+
 @test "Compare template and test TOML config files" {
   # We skip the first 5 lines of the files as they contain the version and
   # timestamp of the file creation/modification
@@ -792,7 +798,7 @@
   [[ "${lines[@]}" == "" ]]
 }
 
-@test "No \"database not available\" messages in FTL.log" {
+@test "No \"DB not available\" messages in FTL.log" {
   run bash -c 'grep -c "database not available" /var/log/pihole/FTL.log'
   printf "%s\n" "${lines[@]}"
   [[ ${lines[0]} == "0" ]]
@@ -2243,7 +2249,17 @@
 }
 
 @test "API validation" {
+  if [ "${CI_ARCH:-}" = "linux/riscv64" ]; then
+    skip "Skipping API validation on linux/riscv64"
+  fi
+  logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
   run python3 test/api/checkAPI.py
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+
+  # Wait here until FTL has finished restarting after the teleporter import,
+  # otherwise the next test might start before FTL is ready
+  run bash -c "./pihole-FTL wait-for 'PID of FTL process:' /var/log/pihole/FTL.log 90 $logsize_before"
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
 }
@@ -2342,7 +2358,10 @@
   logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
   # Kill pihole-FTL after having completed tests
   # This will also shut down the debugger
-  run bash -c 'kill "$(pidof pihole-FTL)"'
+  pid=$(cat /run/pihole-FTL.pid)
+  printf "Killing pihole-FTL with PID %s\n" "$pid"
+
+  run bash -c "kill $pid"
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
 


### PR DESCRIPTION
# What does this implement/fix?

Restore API sessions way ahead of starting the web server to ensure we are not falsely rejecting still valid sessions. This is a regression of the asynchronous query importing as the thread importing the queries may get queued to only be able to restore the API sessions once history importing is done. This can take some time on slow devices.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2802

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.