### PR TITLE
Add query_frequency to /padd endpoint

### DIFF
--- a/src/api/docs/content/specs/padd.yaml
+++ b/src/api/docs/content/specs/padd.yaml
@@ -86,6 +86,10 @@ components:
               type: number
               description: "Percentage of blocked queries"
               example: 5.18
+            query_frequency:
+              type: number
+              description: "Average number of queries per second"
+              example: 1.1
         cache:
           type: object
           properties:

--- a/src/api/padd.c
+++ b/src/api/padd.c
@@ -129,6 +129,7 @@ int api_padd(struct ftl_conn *api)
 	JSON_ADD_NUMBER_TO_OBJECT(queries, "total", total);
 	JSON_ADD_NUMBER_TO_OBJECT(queries, "blocked", blocked);
 	JSON_ADD_NUMBER_TO_OBJECT(queries, "percent_blocked", percent_blocked);
+	JSON_ADD_NUMBER_TO_OBJECT(queries, "query_frequency", get_qps());
 	JSON_ADD_ITEM_TO_OBJECT(json, "queries", queries);
 
 	// Add cache statistics


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Add `query_frequency` to `/padd` endpoint. Can be used in the future in PADD. This was suggested in https://github.com/pi-hole/PADD/issues/494#event-22120489753 but we should not make an additional request just to get a single number.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
