### PR TITLE
config: show totp_secret presence in CLI output

### DIFF
--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -571,10 +571,6 @@ int get_config_from_CLI(const char *key, const bool quiet)
 		    (!exactMatch && strncmp(item->k, key, strlen(key)))))
 			continue;
 
-		// Skip write-only options
-		if(item->f & FLAG_WRITE_ONLY)
-			continue;
-
 		// This is the config option we are looking for
 		conf_item = item;
 
@@ -584,9 +580,12 @@ int get_config_from_CLI(const char *key, const bool quiet)
 		if(key == NULL || strcmp(item->k, key) != 0)
 			printf("%s%s = ", is_default ? "" : red, item->k);
 
-		// Print value
-		if(conf_item-> f & FLAG_WRITE_ONLY)
-			puts("<write-only property>");
+		// Print value - for write-only items show "********" if set, nothing if not
+		if(conf_item->f & FLAG_WRITE_ONLY)
+		{
+			const bool is_set = conf_item->v.s != NULL && strlen(conf_item->v.s) > 0;
+			printf("%s", is_set ? PASSWORD_VALUE : "");
+		}
 		else
 			writeTOMLvalue(stdout, -1, conf_item->t, &conf_item->v);
 		puts(normal);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1212,7 +1212,7 @@ void initConfig(struct config *conf)
 	conf->webserver.api.password.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.totp_secret.k = "webserver.api.totp_secret";
-	conf->webserver.api.totp_secret.h = "Pi-hole 2FA TOTP secret. When set to something different than \"""\", 2FA authentication will be enforced for the API and the web interface. This setting is write-only, you can not read the secret back.";
+	conf->webserver.api.totp_secret.h = "Pi-hole 2FA TOTP secret. When set to something different than \"""\", 2FA authentication will be enforced for the API and the web interface. This setting is write-only, the secret itself cannot be read back, but the CLI will show \"" PASSWORD_VALUE "\" to indicate that 2FA is configured.";
 	conf->webserver.api.totp_secret.a = cJSON_CreateStringReference("A valid TOTP secret (20 Bytes in Base32 encoding)");
 	conf->webserver.api.totp_secret.t = CONF_STRING;
 	conf->webserver.api.totp_secret.f = FLAG_WRITE_ONLY | FLAG_INVALIDATE_SESSIONS;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1212,7 +1212,7 @@ void initConfig(struct config *conf)
 	conf->webserver.api.password.c = validate_stub; // Only type-based checking
 
 	conf->webserver.api.totp_secret.k = "webserver.api.totp_secret";
-	conf->webserver.api.totp_secret.h = "Pi-hole 2FA TOTP secret. When set to something different than \"""\", 2FA authentication will be enforced for the API and the web interface. This setting is write-only, the secret itself cannot be read back, but the CLI will show \"" PASSWORD_VALUE "\" to indicate that 2FA is configured.";
+	conf->webserver.api.totp_secret.h = "Pi-hole 2FA TOTP secret. When set to something different than an empty string, 2FA authentication will be enforced for the API and the web interface. This setting is write-only, the secret itself cannot be read back, but the CLI will show \"" PASSWORD_VALUE "\" to indicate that 2FA is configured.";
 	conf->webserver.api.totp_secret.a = cJSON_CreateStringReference("A valid TOTP secret (20 Bytes in Base32 encoding)");
 	conf->webserver.api.totp_secret.t = CONF_STRING;
 	conf->webserver.api.totp_secret.f = FLAG_WRITE_ONLY | FLAG_INVALIDATE_SESSIONS;

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.5-45-ge16ce864-dirty) on branch fix/print_totp_cli
+# Pi-hole configuration file (v6.5-46-gb55cb419-dirty) on branch fix/print_totp_cli
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2026-03-20 13:36:02 UTC
+# Last updated on 2026-03-20 19:18:20 UTC
 
 [dns]
   # Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not
@@ -1149,10 +1149,10 @@
     #     A valid Pi-hole password hash
     pwhash = ""
 
-    # Pi-hole 2FA TOTP secret. When set to something different than "", 2FA authentication
-    # will be enforced for the API and the web interface. This setting is write-only, the
-    # secret itself cannot be read back, but the CLI will show "********" to indicate that
-    # 2FA is configured.
+    # Pi-hole 2FA TOTP secret. When set to something different than an empty string, 2FA
+    # authentication will be enforced for the API and the web interface. This setting is
+    # write-only, the secret itself cannot be read back, but the CLI will show "********"
+    # to indicate that 2FA is configured.
     #
     # Allowed values are:
     #     A valid TOTP secret (20 Bytes in Base32 encoding)

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1,7 +1,7 @@
-# Pi-hole configuration file (v6.5-5-g93080420-dirty) on branch fix/names_behind_router
+# Pi-hole configuration file (v6.5-45-ge16ce864-dirty) on branch fix/print_totp_cli
 # Encoding: UTF-8
 # This file is managed by pihole-FTL
-# Last updated on 2026-02-27 11:29:26 UTC
+# Last updated on 2026-03-20 13:36:02 UTC
 
 [dns]
   # Upstream DNS Servers to be used by Pi-hole. If this is not set, Pi-hole will not
@@ -1150,8 +1150,9 @@
     pwhash = ""
 
     # Pi-hole 2FA TOTP secret. When set to something different than "", 2FA authentication
-    # will be enforced for the API and the web interface. This setting is write-only, you
-    # can not read the secret back.
+    # will be enforced for the API and the web interface. This setting is write-only, the
+    # secret itself cannot be read back, but the CLI will show "********" to indicate that
+    # 2FA is configured.
     #
     # Allowed values are:
     #     A valid TOTP secret (20 Bytes in Base32 encoding)


### PR DESCRIPTION
# What does this implement/fix?

`pihole-FTL --config webserver.api` previously silently omitted `webserver.api.totp_secret` because it carries FLAG_WRITE_ONLY, making it impossible to tell from the CLI whether 2FA was enabled.

Write-only config items are now included in CLI output but rendered as "********" when the secret is set (consistent with how `webserver.api.password` is displayed), or left blank when unset. The actual secret value is never exposed.

---

**Related issue or feature (if applicable):** Fixes #2435

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.