### PR TITLE
Fix client count inflation for rate-limited queries

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -817,7 +817,12 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		force_next_DNS_reply = REPLY_REFUSED;
 		blockingreason = "Rate-limiting";
 
-		// Do not further process this query, Pi-hole has never seen it
+		// Do not further process this query, Pi-hole has never seen it.
+		// Undo the client count increment from findClientID() above:
+		// no query record is created for rate-limited queries, so GC
+		// will never decrement this counter — leaving it permanently
+		// inflated for the lifetime of the process.
+		change_clientcount(client, -1, 0, -1, 0);
 		unlock_shm();
 		return true;
 	}


### PR DESCRIPTION
# What does this implement/fix?

`findClientID()` increments `client->count` for every incoming query, including those that are immediately refused by the rate-limiter. Because rate-limited queries never create a query record, GC has nothing to decrement and the count inflates permanently.

Undo the increment before the early return so the "Top Clients (total)" counter stays consistent with what Pi-hole actually processed.

---

**Related issue or feature (if applicable):** Fixes #2801 #2810

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.