### PR TITLE
Guard query-count counters against unsigned underflow

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -909,11 +909,16 @@ bool delete_old_queries_from_db(const bool use_memdb, const double mintime)
 	if(okay)
 	{
 		// Update number of queries in either in-memory or on-disk
-		// database (depending on what was cleaned)
+		// database (depending on what was cleaned). Guard against
+		// underflow: if the counter is somehow already below the
+		// number deleted (e.g. after a failed import that set the
+		// counter to 0), clamp to 0 rather than wrapping to UINT64_MAX.
 		if(use_memdb)
-			memdb_queries_count -= deleted;
+			memdb_queries_count = (uint64_t)deleted <= memdb_queries_count
+			                      ? memdb_queries_count - (uint64_t)deleted : 0u;
 		else
-			diskdb_queries_count -= deleted;
+			diskdb_queries_count = (uint64_t)deleted <= diskdb_queries_count
+			                       ? diskdb_queries_count - (uint64_t)deleted : 0u;
 	}
 
 	// Finalize statement


### PR DESCRIPTION
# What does this implement/fix?

`memdb_queries_count` and `diskdb_queries_count` are `unsigned` counters tracking how many rows are in the in-memory and on-disk query databases. In `delete_old_queries_from_db()`, these counters are decremented by the number of rows GC just deleted.

The problem is a bit edge-case: if FTL's startup import (`import_queries_from_disk()`) fails or is interrupted while the database is being written to, it resets `memdb_queries_count = 0`. When GC then runs and deletes some rows, `0 - N` on an `unsigned` silently wraps to `UINT64_MAX` (≈ 1.84×10¹⁹). That value is then returned by the `/api/queries` endpoint as `recordsTotal`, which is why the query log shows an astronomically large page count right after startup.

The fix clamps the subtraction to 0 instead of letting it underflow, so a stale counter can never produce a nonsensical result.

---

**Related issue or feature (if applicable):** Fixes #2805 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.