### PR TITLE
Fix stack buffer overflow in get_process_name()

### DIFF
--- a/src/procps.c
+++ b/src/procps.c
@@ -42,7 +42,7 @@ bool get_process_name(const pid_t pid, char name[PROC_PATH_SIZ])
 	snprintf(filename, sizeof(filename), "/proc/%d/exe", pid);
 
 	// Read link destination
-	ssize_t len = readlink(filename, name, PROC_PATH_SIZ);
+	ssize_t len = readlink(filename, name, PROC_PATH_SIZ - 1);
 	if(len > 0)
 	{
 		// If readlink() succeeded, terminate string

--- a/src/procps.h
+++ b/src/procps.h
@@ -14,7 +14,7 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
-#define PROC_PATH_SIZ  32
+#define PROC_PATH_SIZ 64
 
 bool get_process_name(const pid_t pid, char name[PROC_PATH_SIZ]);
 bool another_FTL(void);


### PR DESCRIPTION
# What does this implement/fix?

`readlink()` was called with `PROC_PATH_SIZ` (32) as the buffer size limit, allowing it to fill all 32 bytes. The subsequent null-termination `name[len] = '\0'` then wrote one byte past the buffer end when the symlink target was >= 32 characters, corrupting the stack canary and causing a `SIGSEGV` via `__stack_chk_fail`.

This was triggered in `set_dnsmasq_debug()` which allocates exactly `PROC_PATH_SIZ` bytes for the name buffer. The housekeeper thread would crash immediately when a debugger (`gdb`/`valgrind`) was attached and the path to debug being very long, because it tries to read the debugger's process name via `/proc/<pid>/exe`.

This is not the root cause of #2786 (current assumption: heap corruption in `civetweb-worker` threads) but it blocks from debugging that issue under `gdb` in specific setups.

The fix is simple: tell `readlink()` to use at most one byte less, reserving one byte for the terminator and increase the buffer size.

See #2786

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.