### PR TITLE
Resolve empty backtraces when addr2line is not installed

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -147,17 +147,18 @@ static void find_mapping_name(const void *addr, char *buf, const size_t buflen)
 // Log one backtrace frame as a single line.
 // Resolved:   "  #N  func_name                    src/file.c:line"
 // Unresolved: "  #N  0xADDRESS  (reason)"
-static void log_frame(const int idx, const void *addr, const void *rel_addr)
+// Returns true if addr2line resolved the frame, false otherwise.
+static bool log_frame(const int idx, const void *addr, const void *rel_addr)
 {
 	if(!config.misc.addr2line.v.b)
 	{
 		log_info("  #%-2i  %p  (addr2line disabled via config)", idx, addr);
-		return;
+		return false;
 	}
 	if(bin_path[0] == '\0')
 	{
 		log_info("  #%-2i  %p  (binary path unknown)", idx, addr);
-		return;
+		return false;
 	}
 
 	char cmd[512];
@@ -167,7 +168,7 @@ static void log_frame(const int idx, const void *addr, const void *rel_addr)
 	if(fp == NULL)
 	{
 		log_info("  #%-2i  %p  (addr2line not available)", idx, addr);
-		return;
+		return false;
 	}
 
 	char func[256] = { 0 }, loc[256] = { 0 };
@@ -183,7 +184,7 @@ static void log_frame(const int idx, const void *addr, const void *rel_addr)
 	}
 	pclose(fp);
 
-	if(strcmp(func, "??") == 0)
+	if(func[0] == '\0' || strcmp(func, "??") == 0)
 	{
 		// addr2line found nothing — the frame is in a shared library or a
 		// stripped section.  Try dladdr() which reads .dynsym, the dynamic
@@ -209,7 +210,7 @@ static void log_frame(const int idx, const void *addr, const void *rel_addr)
 			else
 				log_info("  #%-2i  %p  (no debug info)", idx, addr);
 		}
-		return;
+		return false;
 	}
 
 	// Strip the compile-time source root to show project-relative paths
@@ -221,6 +222,7 @@ static void log_frame(const int idx, const void *addr, const void *rel_addr)
 #endif
 
 	log_info("  #%-2i  %-30s  %s", idx, func, display_loc);
+	return true;
 }
 #endif // USE_UNWIND
 
@@ -259,10 +261,26 @@ void generate_backtrace(void)
 	_Unwind_Backtrace(unwind_callback, &state);
 
 	log_info("Backtrace (%d frames):", state.count);
+	bool all_resolved = true;
 	for(int i = 0; i < state.count; i++)
 	{
 		void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
-		log_frame(i, frames[i], rel);
+		if(!log_frame(i, frames[i], rel))
+			all_resolved = false;
+	}
+
+	// If any frame could not be resolved via addr2line (e.g. because
+	// addr2line is not installed), print the commands the user can run
+	// manually after installing binutils/addr2line.
+	if(!all_resolved && bin_path[0] != '\0')
+	{
+		log_info("One or more frames could not be resolved. Install addr2line");
+		log_info("(e.g. \"apt install binutils\" or \"apk add binutils\") and run:");
+		for(int i = 0; i < state.count; i++)
+		{
+			void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
+			log_info("  addr2line -f -e %s %p", bin_path, rel);
+		}
 	}
 #else
 	log_info("!!! INFO: pihole-FTL has not been compiled with unwinding support, cannot generate backtrace !!!");

--- a/src/signals.c
+++ b/src/signals.c
@@ -144,31 +144,40 @@ static void find_mapping_name(const void *addr, char *buf, const size_t buflen)
 	fclose(maps);
 }
 
+// Result of a single-frame addr2line resolution attempt.
+// Used by generate_backtrace() to decide whether to print manual guidance.
+enum frame_result {
+	FRAME_RESOLVED,    // addr2line resolved function name + source location
+	FRAME_UNRESOLVED,  // addr2line was attempted but did not resolve the frame
+	FRAME_SKIPPED,     // addr2line was not attempted (disabled or binary path unknown)
+};
+
 // Log one backtrace frame as a single line.
 // Resolved:   "  #N  func_name                    src/file.c:line"
 // Unresolved: "  #N  0xADDRESS  (reason)"
-// Returns true if addr2line resolved the frame, false otherwise.
-static bool log_frame(const int idx, const void *addr, const void *rel_addr)
+// Returns FRAME_RESOLVED when addr2line produced a result, FRAME_UNRESOLVED
+// when addr2line was tried but failed, FRAME_SKIPPED when it was not attempted.
+static enum frame_result log_frame(const int idx, const void *addr, const void *rel_addr)
 {
 	if(!config.misc.addr2line.v.b)
 	{
 		log_info("  #%-2i  %p  (addr2line disabled via config)", idx, addr);
-		return false;
+		return FRAME_SKIPPED;
 	}
 	if(bin_path[0] == '\0')
 	{
 		log_info("  #%-2i  %p  (binary path unknown)", idx, addr);
-		return false;
+		return FRAME_SKIPPED;
 	}
 
 	char cmd[512];
-	snprintf(cmd, sizeof(cmd), "addr2line -f -e %s %p", bin_path, rel_addr);
+	snprintf(cmd, sizeof(cmd), "addr2line -f -e \"%s\" %p", bin_path, rel_addr);
 
 	FILE *fp = popen(cmd, "r");
 	if(fp == NULL)
 	{
 		log_info("  #%-2i  %p  (addr2line not available)", idx, addr);
-		return false;
+		return FRAME_UNRESOLVED;
 	}
 
 	char func[256] = { 0 }, loc[256] = { 0 };
@@ -210,7 +219,7 @@ static bool log_frame(const int idx, const void *addr, const void *rel_addr)
 			else
 				log_info("  #%-2i  %p  (no debug info)", idx, addr);
 		}
-		return false;
+		return FRAME_UNRESOLVED;
 	}
 
 	// Strip the compile-time source root to show project-relative paths
@@ -222,7 +231,7 @@ static bool log_frame(const int idx, const void *addr, const void *rel_addr)
 #endif
 
 	log_info("  #%-2i  %-30s  %s", idx, func, display_loc);
-	return true;
+	return FRAME_RESOLVED;
 }
 #endif // USE_UNWIND
 
@@ -261,25 +270,34 @@ void generate_backtrace(void)
 	_Unwind_Backtrace(unwind_callback, &state);
 
 	log_info("Backtrace (%d frames):", state.count);
-	bool all_resolved = true;
+	bool any_addr2line_failed = false;
 	for(int i = 0; i < state.count; i++)
 	{
 		void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
-		if(!log_frame(i, frames[i], rel))
-			all_resolved = false;
+		if(log_frame(i, frames[i], rel) == FRAME_UNRESOLVED)
+			any_addr2line_failed = true;
 	}
 
-	// If any frame could not be resolved via addr2line (e.g. because
-	// addr2line is not installed), print the commands the user can run
-	// manually after installing binutils/addr2line.
-	if(!all_resolved && bin_path[0] != '\0')
+	// If addr2line was attempted but could not resolve one or more frames
+	// (e.g. because it is not installed), print per-frame commands the
+	// user can run manually after installing binutils.  Use dladdr() to
+	// determine the correct object file and base address for each frame
+	// so the commands are actionable for shared-library frames too.
+	if(any_addr2line_failed)
 	{
 		log_info("One or more frames could not be resolved. Install addr2line");
 		log_info("(e.g. \"apt install binutils\" or \"apk add binutils\") and run:");
 		for(int i = 0; i < state.count; i++)
 		{
+			Dl_info dl = { 0 };
+			const char *obj = bin_path;
 			void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
-			log_info("  addr2line -f -e %s %p", bin_path, rel);
+			if(dladdr(frames[i], &dl) != 0 && dl.dli_fname != NULL && dl.dli_fbase != NULL)
+			{
+				obj = dl.dli_fname;
+				rel = (void *)((uintptr_t)frames[i] - (uintptr_t)dl.dli_fbase);
+			}
+			log_info("  addr2line -f -e \"%s\" %p", obj, rel);
 		}
 	}
 #else


### PR DESCRIPTION
# What does this implement/fix?

When addr2line was absent from the runtime system, popen() succeeded but produced no output, leaving func as an empty string. The check `strcmp(func, "??")` did not match "", so the code fell through to the success branch and logged only bare frame numbers (#0, #1, ...) with no addresses or symbols.

Fix the condition to also check for empty func, so the dladdr() and /proc/self/maps fallbacks execute correctly. Additionally, when any frame cannot be resolved, print the addr2line commands the user can run manually after installing binutils in case the tool was missing.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.