### PR TITLE
fix: fix rare race condition for SHM strings in API handlers

### DIFF
--- a/src/api/history.c
+++ b/src/api/history.c
@@ -233,15 +233,20 @@ int api_history_clients(struct ftl_conn *api)
 
 		// Create JSON object for this client
 		cJSON *item = JSON_NEW_OBJECT();
-		JSON_REF_STR_IN_OBJECT(item, "name", client_name);
+		// Must COPY, not reference: the SHM strings buffer can be
+		// relocated by mremap(MREMAP_MAYMOVE) in another thread after
+		// we release the lock below, which would leave a dangling
+		// pointer if we used JSON_REF_STR_IN_OBJECT here (see #2786)
+		JSON_COPY_STR_TO_OBJECT(item, "name", client_name);
 		JSON_ADD_NUMBER_TO_OBJECT(item, "total", client->count);
 		JSON_ADD_ITEM_TO_OBJECT(clients, client_ip, item);
 	}
 
-	// Unlock already here to avoid keeping the lock during JSON generation
-	// This is safe because we don't access any shared memory after this
-	// point and all strings in the JSON are references to idempotent shared
-	// memory and can, thus, be accessed at any time without locking
+	// Unlock here to avoid keeping the lock during JSON generation.
+	// All shared memory strings used above are either copied into cJSON
+	// (via JSON_COPY_STR_TO_OBJECT) or used as cJSON object keys (which
+	// cJSON_AddItemToObject always duplicates), so no dangling pointers
+	// can occur if the strings SHM segment is remapped by another thread.
 	unlock_shm();
 
 	// Add "others" client only if there are more clients than we return

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -784,7 +784,12 @@ int api_stats_recentblocked(struct ftl_conn *api)
 			if(domain == NULL)
 				continue;
 
-			JSON_REF_STR_IN_ARRAY(blocked, domain);
+			// Must COPY, not reference: the SHM strings buffer can
+			// be relocated by mremap(MREMAP_MAYMOVE) in another
+			// thread after we release the lock below, which would
+			// leave a dangling pointer if we used
+			// JSON_REF_STR_IN_ARRAY here (see #2786)
+			JSON_COPY_STR_TO_ARRAY(blocked, domain);
 
 			// Only count when added successfully
 			found++;


### PR DESCRIPTION
What does this implement/fix?
=============================

Two API handlers stored direct pointers into the shared memory strings buffer (via `cJSON_CreateStringReference()`), released the SHM lock, and then serialized the JSON - dereferencing those pointers after the lock was no longer held.

Between unlock and serialization, another thread (DNS processing, GC, or another civetweb worker) can call `realloc_shm()` which invokes `mremap(..., MREMAP_MAYMOVE)`, moving the entire strings buffer to a new virtual address and leaving dangling pointers in the JSON tree.

This caused `SIGSEGV` crashes in `civetweb-worker` threads, always while the dashboard was open. Symptoms included `NULL` dereferences (unmapped old region) and faulting addresses containing domain string fragments (stale data at the former buffer location).

Affected handlers:

*   `api_history_clients()`: client\_name from `getstr()` stored as reference, lock released before `JSON_SEND_OBJECT` serialization
*   api\_stats\_recent\_blocked(): domain from `getDomainString()` stored as reference, lock released before serialization

Fix: replace `JSON_REF_STR_IN_OBJECT/ARRAY` with `JSON_COPY_STR_TO_OBJECT/ARRAY`, which copy the string into cJSON-owned heap memory while the lock is still held. Also correct the misleading comment in `history.c` claiming shared memory strings are "idempotent".

* * *

**Related issue or feature (if applicable):** Closes [pi-hole/FTL#2786](https://github.com/pi-hole/FTL/issues/2786)

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

* * *

**By submitting this pull request, I confirm the following:**

1.  I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2.  I have commented my proposed changes within the code.
3.  I am willing to help maintain this change if there are issues with it later.
4.  It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5.  I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Checklist:
----------

*    The code change is tested and works locally.
*    I based my code and PRs against the repositories `development` branch.
*    I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
*    I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
*    I have read the above and my PR is ready for review.