### PR TITLE
Preserve log file path config when fopen fails

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -59,6 +59,8 @@ void init_FTL_log(const char *name)
 			syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
 			ftl_log_available = false;
 		}
+		else
+			ftl_log_available = true;
 
 		// Close log file
 		if(logfile != NULL)

--- a/src/log.c
+++ b/src/log.c
@@ -30,6 +30,7 @@
 #include "gc.h"
 
 static bool print_log = true, print_stdout = true;
+static bool ftl_log_available = true;
 static const char *process = "";
 bool debug_flags[DEBUG_MAX] = { false };
 
@@ -56,7 +57,7 @@ void init_FTL_log(const char *name)
 			printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
 			       config.files.log.ftl.v.s, strerror(errno));
 			syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
-			config.files.log.ftl.v.s = NULL;
+			ftl_log_available = false;
 		}
 
 		// Close log file
@@ -294,7 +295,7 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		add_to_fifo_buffer(FIFO_FTL, buffer, prio, len > MAX_MSG_FIFO ? MAX_MSG_FIFO : len);
 
 		bool logged = false;
-		if(config.files.log.ftl.v.s != NULL)
+		if(ftl_log_available && config.files.log.ftl.v.s != NULL)
 		{
 			// Open log file
 			FILE *logfile = fopen(config.files.log.ftl.v.s, "a+");


### PR DESCRIPTION
# What does this implement/fix?

When `CAP_CHOWN` is missing (e.g. in Docker with `cap_drop`), `init_FTL_log()` could fail to open the log file and set `config.files.log.ftl.v.s = NULL`. This `NULL` value was then persisted as an empty string when the TOML config was rewritten shortly after during `readFTLconf()`. The empty path remained even after restoring `CAP_CHOWN`, permanently breaking file logging.

Use a separate static flag to track log file availability instead of clobbering the config value, so the configured path survives fopen failures and is correctly written back to `pihole.toml`

---

**Related issue or feature (if applicable):** Fixes: #2827

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.