### PR TITLE
Accept punycode domains that libidn2 rejects under IDNA2008

### DIFF
--- a/src/api/list.c
+++ b/src/api/list.c
@@ -455,7 +455,18 @@ static int api_list_write(struct ftl_conn *api,
 					// Stripping the reference flag is
 					// necessary to signal cJSON to free the
 					// allocated string later
-					it->valuestring = strdup(it->valuestring);
+					char *domain = strdup(it->valuestring);
+					if(domain == NULL)
+					{
+						if(allocated_json)
+							cJSON_Delete(row.items);
+						return send_json_error(api, 500, // 500 Internal Server Error
+						                       "internal_error",
+						                       "Memory allocation failed",
+						                       NULL);
+					}
+					it->valuestring = domain;
+					// Remove reference flag
 					it->type &= ~cJSON_IsReference;
 				}
 

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -412,24 +412,61 @@ static int api_list_write(struct ftl_conn *api,
 			if(listtype == GRAVITY_DOMAINLIST_ALLOW_EXACT ||
 			   listtype == GRAVITY_DOMAINLIST_DENY_EXACT)
 			{
-				char *punycode = NULL;
-				const int rc = idn2_to_ascii_lz(it->valuestring, &punycode, IDN2_NFC_INPUT | IDN2_NONTRANSITIONAL);
-				if (rc != IDN2_OK)
+				// Check if domain contains non-ASCII characters
+				// that need IDN/punycode conversion
+				bool needs_idn = false;
+				for(const char *p = it->valuestring; *p != '\0'; p++)
 				{
-					// Invalid domain name
-					return send_json_error(api, 400,
-					                       "bad_request",
-					                       "Invalid request: Invalid domain name",
-					                       idn2_strerror(rc));
+					// 0x7F is the last ASCII character, so
+					// anything above that is non-ASCII and
+					// needs IDN conversion
+					if((unsigned char)*p > 0x7F)
+					{
+						needs_idn = true;
+						break;
+					}
 				}
-				// Convert punycode domain to lowercase
-				for(unsigned int i = 0u; i < strlen(punycode); i++)
-					punycode[i] = tolower(punycode[i]);
 
-				// Validate punycode domain
+				if(needs_idn)
+				{
+					char *punycode = NULL;
+					const int rc = idn2_to_ascii_lz(it->valuestring, &punycode, IDN2_NFC_INPUT | IDN2_NONTRANSITIONAL);
+					if (rc != IDN2_OK)
+					{
+						// Invalid domain name
+						return send_json_error(api, 400,
+						                       "bad_request",
+						                       "Invalid request: Invalid domain name",
+						                       idn2_strerror(rc));
+					}
+
+					// Replace domain with punycode version
+					if(!(it->type & cJSON_IsReference))
+						free(it->valuestring);
+					it->valuestring = punycode;
+					// Remove reference flag
+					it->type &= ~cJSON_IsReference;
+				}
+				else if(it->type & cJSON_IsReference)
+				{
+					// Domain is a cJSON reference pointing into
+					// the request buffer - make a writable copy
+					// before modifying it in-place below
+					// Stripping the reference flag is
+					// necessary to signal cJSON to free the
+					// allocated string later
+					it->valuestring = strdup(it->valuestring);
+					it->type &= ~cJSON_IsReference;
+				}
+
+				// Convert domain to lowercase
+				for(unsigned int i = 0u; i < strlen(it->valuestring); i++)
+					it->valuestring[i] = tolower((unsigned char)it->valuestring[i]);
+
+				// Validate domain
 				// This will reject domains like äöü{{{.com
 				// which convert to xn--{{{-pla4gpb.com
-				if(!valid_domain(punycode, strlen(punycode), false))
+				if(!valid_domain(it->valuestring, strlen(it->valuestring), false))
 				{
 					if(allocated_json)
 						cJSON_Delete(row.items);
@@ -438,13 +475,6 @@ static int api_list_write(struct ftl_conn *api,
 							"Invalid domain",
 							it->valuestring);
 				}
-
-				// Replace domain with punycode version
-				if(!(it->type & cJSON_IsReference))
-					free(it->valuestring);
-				it->valuestring = punycode;
-				// Remove reference flag
-				it->type &= ~cJSON_IsReference;
 			}
 		}
 	}

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -175,7 +175,7 @@ int api_search(struct ftl_conn *api)
 		}
 	}
 
-	// Convert domain to punycode
+	// Convert domain to punycode if it contains non-ASCII characters
 	// The IDNA document defines internationalized domain names (IDNs) and a
 	// mechanism called IDNA for handling them in a standard fashion. IDNs
 	// use characters drawn from a large repertoire (Unicode), but IDNA
@@ -187,20 +187,48 @@ int api_search(struct ftl_conn *api)
 	// Used flags:
 	// - IDN2_NFC_INPUT: Input is in Unicode Normalization Form C (NFC)
 	// - IDN2_NONTRANSITIONAL: Use Unicode TR46 non-transitional processing
+	//
+	// Skip IDN conversion for domains that are already pure ASCII (e.g.,
+	// punycode domains like xn--gi8h42h.ws) as libidn2 may reject valid
+	// punycode that represents characters not allowed by IDNA2008
 	char *punycode = NULL;
-	const int rc = idn2_to_ascii_lz(domain, &punycode, IDN2_NFC_INPUT | IDN2_NONTRANSITIONAL);
-	if (rc != IDN2_OK)
+	bool needs_idn = false;
+	for(const char *p = domain; *p != '\0'; p++)
 	{
-		// Invalid domain name
-		return send_json_error(api, 400,
-		                       "bad_request",
-		                       "Invalid request: Invalid domain name",
-		                       idn2_strerror(rc));
+		// 0x7F is the last ASCII character, so anything above that is
+		// non-ASCII and needs IDN conversion
+		if((unsigned char)*p > 0x7F)
+		{
+			needs_idn = true;
+			break;
+		}
+	}
+	if(needs_idn)
+	{
+		const int rc = idn2_to_ascii_lz(domain, &punycode, IDN2_NFC_INPUT | IDN2_NONTRANSITIONAL);
+		if (rc != IDN2_OK)
+		{
+			// Invalid domain name
+			return send_json_error(api, 400,
+			                       "bad_request",
+			                       "Invalid request: Invalid domain name",
+			                       idn2_strerror(rc));
+		}
+	}
+	else
+	{
+		// Domain is already ASCII, duplicate it for uniform handling
+		punycode = strdup(domain);
+		if(punycode == NULL)
+			return send_json_error(api, 500,
+			                       "internal_error",
+			                       "Memory allocation failed",
+			                       NULL);
 	}
 
-	// Convert punycode domain to lowercase
+	// Convert domain to lowercase
 	for(unsigned int i = 0u; i < strlen(punycode); i++)
-		punycode[i] = tolower(punycode[i]);
+		punycode[i] = tolower((unsigned char)punycode[i]);
 
 	// Search through all exact domains
 	cJSON *domains = JSON_NEW_ARRAY();

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -243,7 +243,7 @@ class TestDomainSearch:
         Regression test for https://github.com/pi-hole/FTL/issues/2837
         libidn2 rejects punycode for characters not in IDNA2008 (e.g. emoji),
         but the ASCII punycode form is a perfectly valid DNS name.
-        xn--4ca0bs45142c.com is the punycode encoding of äöü😀.com
+        xn--4ca0bs45142c.com is the punycode encoding of äöü😀.com.
         """
         data = _j(api_session.get(f"{FTL_URL}/api/search/xn--4ca0bs45142c.com",
                                   params={"debug": "true"}, timeout=5))

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -237,6 +237,21 @@ class TestDomainSearch:
             json.dumps(data, indent=2)
         assert data["search"]["results"]["total"] == 0
 
+    def test_punycode_domain_accepted(self, api_session):
+        """Punycode domains (e.g. emoji IDNs) must not be rejected by the API.
+
+        Regression test for https://github.com/pi-hole/FTL/issues/2837
+        libidn2 rejects punycode for characters not in IDNA2008 (e.g. emoji),
+        but the ASCII punycode form is a perfectly valid DNS name.
+        xn--4ca0bs45142c.com is the punycode encoding of äöü😀.com
+        """
+        data = _j(api_session.get(f"{FTL_URL}/api/search/xn--4ca0bs45142c.com",
+                                  params={"debug": "true"}, timeout=5))
+        assert data["search"]["debug"]["punycode"] == "xn--4ca0bs45142c.com", \
+            json.dumps(data, indent=2)
+        # The domain does not exist in gravity, so total should be 0
+        assert data["search"]["results"]["total"] == 0
+
     def test_partial_matching(self, api_session):
         """Partial matching returns substring hits in gravity."""
         data = _j(api_session.get(f"{FTL_URL}/api/search/gravity",

--- a/test/api/test_m_mutations.py
+++ b/test/api/test_m_mutations.py
@@ -357,6 +357,34 @@ class TestPutDomains:
         # Clean up
         api_session.delete(url, timeout=10)
 
+    def test_put_punycode_domain(self, api_session):
+        """Punycode domains with IDNA2008-disallowed chars must be accepted.
+
+        Regression test for https://github.com/pi-hole/FTL/issues/2837
+        xn--4ca0bs45142c.com encodes äöü😀.com — the emoji makes libidn2 reject
+        it under IDNA2008 even though the ASCII punycode form is a perfectly
+        valid DNS name.
+        """
+        domain = "xn--4ca0bs45142c.com"
+        url = f"{FTL_URL}/api/domains/deny/exact/{domain}"
+
+        r = api_session.put(url,
+                            json={"comment": "pytest punycode", "groups": [0],
+                                  "enabled": True},
+                            timeout=10)
+        assert r.status_code in (200, 201), \
+            f"PUT punycode domain failed: {r.status_code} {r.text}"
+        data = _j(r)
+        domains = data["domains"]
+        assert len(domains) == 1
+        assert domains[0]["domain"] == domain
+        assert domains[0]["type"] == "deny"
+        assert domains[0]["kind"] == "exact"
+
+        # Clean up
+        r = api_session.delete(url, timeout=10)
+        assert r.status_code == 204
+
 
 # ---------------------------------------------------------------------------
 # PUT clients


### PR DESCRIPTION
# What does this implement/fix?

When adding or searching for exact domains, the API unconditionally passes the input through `idn2_to_ascii_lz()` for IDN normalization. This round-trips punycode domains: decode to Unicode, validate against IDNA2008, re-encode to ASCII. Characters like emoji are disallowed by IDNA2008 (RFC 5892), so valid punycode domains such as `xn--4ca0bs45142c.com` (`äöü😀.com`) are rejected with "`string contains a disallowed character`" even though they are perfectly valid DNS names.

Fix by checking whether the input is already pure ASCII before calling `idn2_to_ascii_lz()`. If every byte is `<= 0x7F`, skip IDN conversion entirely — the domain is already in a DNS-compatible form and only needs lowercasing and `valid_domain()` validation. Non-ASCII input (actual Unicode domains) still goes through the IDN conversion path.

Applied to both the list and the search API and also added tests for both.

---

**Related issue or feature (if applicable):** Fixes: https://github.com/pi-hole/FTL/issues/2837

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.