### PR TITLE
Improve shutdown diagnostics to identify SIGTERM source

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,7 +110,7 @@ set(EXTRAWARN_GCC6 "-Werror \
                     -Woverlength-strings")
 
 # Extra warnings flags available only in GCC 7 and higher
-if(CMAKE_C_COMPILER_VERSION VERSION_EQUAL 7 OR CMAKE_C_COMPILER_VERSION VERSION_GREATER 7)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7)
     set(EXTRAWARN_GCC7 "-Wformat-overflow=2 \
                         -Wformat-truncation=2 \
                         -Wstringop-overflow=4 \
@@ -121,7 +121,7 @@ else()
 endif()
 
 # Extra warnings flags available only in GCC 8 and higher
-if(CMAKE_C_COMPILER_VERSION VERSION_EQUAL 8 OR CMAKE_C_COMPILER_VERSION VERSION_GREATER 8)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
     set(EXTRAWARN_GCC8 "-Wduplicated-cond \
                         -Wduplicated-branches \
                         -Wcast-align=strict \

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -461,6 +461,11 @@ void cleanup(const int ret)
 
 	char buffer[42] = { 0 };
 	format_time(buffer, 0, timer_elapsed_msec(EXIT_TIMER));
+	// Re-log the termination source near the final message so it is visible
+	// even when earlier log lines have been lost or rotated (#2818)
+	const char *source = get_term_source();
+	if(source != NULL)
+		log_info("Terminated by %s", source);
 	if(ret == RESTART_FTL_CODE)
 		log_info("########## FTL terminated after%s (internal restart)! ##########", buffer);
 	else

--- a/src/main.c
+++ b/src/main.c
@@ -160,7 +160,7 @@ int main (int argc, char *argv[])
 			sleepms(100);
 	}
 
-	log_debug(DEBUG_ANY, "Shutting down... // exit code %d // jmpret %d", exit_code, jmpret);
+	log_info("Shutting down (exit code %d, jmpret %d)", exit_code, jmpret);
 	// Extra grace time is needed as dnsmasq script-helpers and the API may not
 	// be terminating immediately
 	sleepms(250);

--- a/src/signals.c
+++ b/src/signals.c
@@ -700,13 +700,17 @@ pid_t main_pid(void)
 // pure annotation would let the compiler cache/hoist the result across an
 // asynchronous signal-handler update. Suppress the corresponding warning
 // for just this function (see #2839).
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#endif
 const char *get_term_source(void)
 {
 	return term_source[0] != '\0' ? term_source : NULL;
 }
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 
 void thread_sleepms(const enum thread_types thread, const int milliseconds)
 {

--- a/src/signals.c
+++ b/src/signals.c
@@ -38,6 +38,11 @@ static volatile pid_t mpid = 0;
 static time_t FTLstarttime = 0;
 volatile int exit_code = EXIT_SUCCESS;
 
+// Store the SIGTERM source for re-logging during cleanup so the termination
+// reason is always visible near the final "FTL terminated" message, even if
+// earlier log lines have been lost (see #2818)
+static char term_source[256] = { 0 };
+
 // Binary path stored by init_backtrace() — signal-handler-safe static buffer,
 // never reallocated, safe to read from any context including signal handlers
 #if defined(USE_UNWIND)
@@ -576,8 +581,11 @@ static void SIGTERM_handler(int signum, siginfo_t *si, void *context)
 		strcpy(kill_user, "N/A");
 	}
 
-	// Log who sent the signal
+	// Log who sent the signal and store for re-logging during cleanup (#2818)
 	log_info("Asked to terminate by \"%s\" (PID %ld, user %s UID %ld)",
+	         kill_name, (long int)kill_pid, kill_user, (long int)kill_uid);
+	snprintf(term_source, sizeof(term_source),
+	         "\"%s\" (PID %ld, user %s UID %ld)",
 	         kill_name, (long int)kill_pid, kill_user, (long int)kill_uid);
 
 	// Check if we can terminate
@@ -686,6 +694,19 @@ pid_t main_pid(void)
 		// Has not been set so far
 		return getpid();
 }
+
+// Deliberately NOT marked __attribute__((pure)): the buffer this reads is
+// written from SIGTERM_handler, which GCC's pure analysis cannot see, so a
+// pure annotation would let the compiler cache/hoist the result across an
+// asynchronous signal-handler update. Suppress the corresponding warning
+// for just this function (see #2839).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+const char *get_term_source(void)
+{
+	return term_source[0] != '\0' ? term_source : NULL;
+}
+#pragma GCC diagnostic pop
 
 void thread_sleepms(const enum thread_types thread, const int milliseconds)
 {

--- a/src/signals.h
+++ b/src/signals.h
@@ -28,6 +28,7 @@ void generate_backtrace(void);
 int sigtest(void);
 int sigrtmin(void);
 void restart_ftl(const char *reason);
+const char *get_term_source(void);
 pid_t debugger(void);
 
 extern volatile int exit_code;

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -1079,8 +1079,10 @@ void *webserver_thread(void *val)
 			}
 		}
 
-		// Idle for 1 day (24 hours)
-		thread_sleepms(WEBSERVER, 86400000);
+		// Idle for 1 day (24 hours), sleeping in 1-hour intervals
+		// so the thread is not permanently marked as idle (#2818)
+		for(int h = 0; h < 24 && !killed; h++)
+			thread_sleepms(WEBSERVER, 3600000);
 	}
 
 	log_info("Terminating webserver thread");

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -93,3 +93,26 @@
   printf "%s\n" "${lines[@]}"
   [[ $status == 0 ]]
 }
+
+@test "Shutdown reason logged at INFO level (#2818)" {
+  # Verify the shutdown path now logs at INFO level instead of DEBUG-only
+  run bash -c 'grep "INFO: Shutting down (exit code" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+}
+
+@test "SIGTERM source re-logged near final termination message (#2818)" {
+  # Verify the SIGTERM sender is re-logged during cleanup so it appears
+  # near the "FTL terminated" message even in truncated logs
+  run bash -c 'grep "INFO: Terminated by" /var/log/pihole/FTL.log'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+
+  # Verify ordering: "Terminated by" must appear AFTER "Shutting down" and
+  # BEFORE the final "FTL terminated" message
+  run bash -c 'grep -n "Shutting down (exit code\|Terminated by\|FTL terminated after" /var/log/pihole/FTL.log | tail -3'
+  printf "ordering: %s\n" "${lines[@]}"
+  [[ "${lines[0]}" == *"Shutting down (exit code"* ]]
+  [[ "${lines[1]}" == *"Terminated by"* ]]
+  [[ "${lines[2]}" == *"FTL terminated after"* ]]
+}


### PR DESCRIPTION
# What does this implement/fix?

Issue #2818 reports FTL terminating cleanly (code 0) after ~15-16 hours of uptime, with the only captured log lines being:

```
  Thread webserver (7) is idle, terminating it.
  All threads joined
  ########## FTL terminated after 15h 50m 45s (code 0)! ##########
```

A thorough audit of all paths that can set the global `killed` flag confirms there is no internal code path leading to spontaneous termination - every shutdown is either test-mode (`pihole-FTL test`), a `die()`/longjmp from dnsmasq, or an external SIGTERM mapped to dnsmasq's EVENT_TERM via SIGUSR6. The "Thread webserver (7) is idle" message is a red herring: the webserver cert-renewal thread sleeps for 24 hours between checks, so it is essentially always cancellable when shutdown begins.

The reason the reporter could not diagnose the cause is that the relevant information was either logged at DEBUG level (and therefore invisible) or emitted far above the final termination message (and therefore lost when the log was truncated). This commit closes both gaps so the next occurrence will be diagnosable from a tail of FTL.log alone:

- signals.c: persist the SIGTERM sender info ("name (PID, user UID)") into a static buffer in SIGTERM_handler, exposed via get_term_source(). The buffer is sized 256 bytes and only ever read after being written by the signal handler, so no locking is needed.

- daemon.c: in cleanup(), re-log the stored SIGTERM source as "Terminated by ..." right before the final "FTL terminated after" banner. Even when the log is truncated to the last few lines, the termination source will now be visible alongside the final message.

- main.c: promote the "Shutting down (exit code, jmpret)" log from log_debug to log_info so the entry into the cleanup path is always recorded, not just under DEBUG_ANY.

- webserver/webserver.c: split the webserver thread's 24-hour cert-check sleep into 24 x 1-hour sleeps with intermediate `killed` checks. This is a robustness improvement, not a bug fix: the thread is no longer marked as cancellable for 24 hours straight, so the misleading "is idle" log on shutdown happens at most an hour after the last cert check rather than at any point in a 24-hour window.

- test/test_final.bats: add two regression tests that run after the existing "FTL terminates with message" test:
    * Verify "INFO: Shutting down (exit code" is present (catches accidental regression of the log_debug -> log_info change).
    * Verify "INFO: Terminated by" is present AND that the three key
      messages appear in order: Shutting down -> Terminated by ->
      FTL terminated after.

After this change, a SIGTERM-triggered shutdown produces:

```
  INFO: Asked to terminate by "systemd" (PID 1, user root UID 0)
  ...
  INFO: Shutting down (exit code 0, jmpret 0)
  INFO: Finished final database update
  INFO: Waiting for threads to join
  INFO: Thread webserver (7) is idle, terminating it.
  INFO: All threads joined
  INFO: Terminated by "systemd" (PID 1, user root UID 0)
  INFO: ########## FTL terminated after 15h 50m 45s (code 0)! ##########
```

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.