### PR TITLE
Tests: auto-detect upstream DNSSEC state for query-count assertions

### DIFF
--- a/test/api/conftest.py
+++ b/test/api/conftest.py
@@ -2,8 +2,12 @@
 Shared pytest fixtures for FTL API integration tests.
 """
 
+import socket
 import sys
 import os
+import time
+
+import dns.resolver
 import pytest
 import requests
 
@@ -11,6 +15,79 @@ import requests
 sys.path.insert(0, os.path.dirname(__file__))
 
 FTL_URL = "http://127.0.0.1"
+
+# ---------------------------------------------------------------------------
+# Upstream DNSSEC detection helpers
+# ---------------------------------------------------------------------------
+
+def _wait_for_pdns(host="127.0.0.1", port=5555, attempts=10, delay=2.0):
+    """Block until host:port accepts connections, or attempts are exhausted.
+
+    Returns True if the port opened within the allotted retries, False
+    otherwise.
+    """
+    for attempt in range(attempts):
+        try:
+            with socket.create_connection((host, port), timeout=2.0):
+                return True
+        except OSError:
+            if attempt < attempts - 1:
+                time.sleep(delay)
+    return False
+
+
+def _has_ds_record(resolver, domain):
+    """Return True if *domain* currently has a DS record."""
+    try:
+        resolver.resolve(domain, "DS")
+        return True
+    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN,
+            dns.resolver.NoNameservers, dns.exception.Timeout):
+        return False
+
+
+@pytest.fixture(scope="session", autouse=True)
+def detect_upstream_dnssec():
+    """Detect upstream DNSSEC state and populate query-counter constants.
+
+    Waits for the local pdns_recursor (port 5555) to become available
+    with retry/backoff before probing, avoiding false-negatives from a
+    slow daemon startup.  Probes DS records on icloud.com and
+    apple-dns.net — the two zones crossed by the mask.icloud.com CNAME
+    chain — to determine whether dnsmasq will fire extra DNSKEY
+    validation queries.
+
+    The module-level expected-counter constants in test_api are updated
+    in-place so all assertions there reflect the current upstream
+    DNSSEC posture without requiring changes to the individual tests.
+    """
+    import test_api  # imported here to ensure test_api is fully loaded before modifying its globals
+
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.nameservers = ["127.0.0.1"]
+    resolver.port = 5555
+    resolver.lifetime = 5
+
+    # Wait for pdns_recursor to accept connections before probing
+    if not _wait_for_pdns():
+        import warnings
+        warnings.warn(
+            "pdns_recursor on 127.0.0.1:5555 did not become available; "
+            "DNSSEC detection skipped — using non-DNSSEC counter defaults.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return
+
+    upstream_dnssec = (
+        _has_ds_record(resolver, "icloud.com") and
+        _has_ds_record(resolver, "apple-dns.net")
+    )
+
+    test_api.TOTAL      = 137 if upstream_dnssec else 135
+    test_api.FORWARDED  = 47  if upstream_dnssec else 45
+    test_api.DNSKEY     = 9   if upstream_dnssec else 7
+    test_api.TOP_DOMAIN = "." if upstream_dnssec else "localhost"
 
 
 @pytest.fixture(scope="session")

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -11,7 +11,6 @@ Usage:
 
 import json
 
-import dns.resolver
 import pytest
 
 FTL_URL = "http://127.0.0.1"
@@ -24,32 +23,16 @@ FTL_URL = "http://127.0.0.1"
 # forwards the query upstream.  The CNAME chain crosses icloud.com and
 # apple-dns.net.  When both zones carry DS records (DNSSEC-signed), dnsmasq
 # fires two extra DNSKEY validation queries, shifting several counters by +2.
-# Detect the current state once per session so the assertions below match
-# whichever configuration the upstream zones happen to be in.
 #
-# The check queries the local pdns_recursor on port 5555 directly (not through
-# FTL) to avoid polluting FTL's query counters.
+# These constants are populated by the session-scoped detect_upstream_dnssec
+# fixture in conftest.py (which waits for pdns_recursor to be available and
+# probes DS records with retry/backoff).  The values below are safe defaults
+# for the non-DNSSEC case and are overwritten before any test runs.
 
-def _has_ds_record(domain):
-    """Return True if *domain* currently has a DS record."""
-    try:
-        resolver = dns.resolver.Resolver(configure=False)
-        resolver.nameservers = ["127.0.0.1"]
-        resolver.port = 5555
-        resolver.lifetime = 10
-        resolver.resolve(domain, "DS")
-        return True
-    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN,
-            dns.resolver.NoNameservers, dns.exception.Timeout):
-        return False
-
-UPSTREAM_DNSSEC = _has_ds_record("icloud.com") and _has_ds_record("apple-dns.net")
-
-# Counters that shift when upstream DNSSEC is active
-TOTAL       = 137 if UPSTREAM_DNSSEC else 135
-FORWARDED   = 47  if UPSTREAM_DNSSEC else 45
-DNSKEY      = 9   if UPSTREAM_DNSSEC else 7
-TOP_DOMAIN  = "." if UPSTREAM_DNSSEC else "localhost"
+TOTAL       = 135
+FORWARDED   = 45
+DNSKEY      = 7
+TOP_DOMAIN  = "localhost"
 
 
 # ---------------------------------------------------------------------------

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -11,9 +11,45 @@ Usage:
 
 import json
 
+import dns.resolver
 import pytest
 
 FTL_URL = "http://127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Upstream DNSSEC detection
+# ---------------------------------------------------------------------------
+# The bats test suite queries mask.icloud.com via an allowlisted client, which
+# forwards the query upstream.  The CNAME chain crosses icloud.com and
+# apple-dns.net.  When both zones carry DS records (DNSSEC-signed), dnsmasq
+# fires two extra DNSKEY validation queries, shifting several counters by +2.
+# Detect the current state once per session so the assertions below match
+# whichever configuration the upstream zones happen to be in.
+#
+# The check queries the local pdns_recursor on port 5555 directly (not through
+# FTL) to avoid polluting FTL's query counters.
+
+def _has_ds_record(domain):
+    """Return True if *domain* currently has a DS record."""
+    try:
+        resolver = dns.resolver.Resolver(configure=False)
+        resolver.nameservers = ["127.0.0.1"]
+        resolver.port = 5555
+        resolver.lifetime = 10
+        resolver.resolve(domain, "DS")
+        return True
+    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN,
+            dns.resolver.NoNameservers, dns.exception.Timeout):
+        return False
+
+UPSTREAM_DNSSEC = _has_ds_record("icloud.com") and _has_ds_record("apple-dns.net")
+
+# Counters that shift when upstream DNSSEC is active
+TOTAL       = 137 if UPSTREAM_DNSSEC else 135
+FORWARDED   = 47  if UPSTREAM_DNSSEC else 45
+DNSKEY      = 9   if UPSTREAM_DNSSEC else 7
+TOP_DOMAIN  = "." if UPSTREAM_DNSSEC else "localhost"
 
 
 # ---------------------------------------------------------------------------
@@ -494,14 +530,14 @@ class TestStatsSummary:
     def test_summary_structure(self, api_session):
         data = _j(api_session.get(f"{FTL_URL}/api/stats/summary", timeout=5), dump="stats_summary")
         q = data["queries"]
-        assert q["total"] == 137, json.dumps(data, indent=2)
+        assert q["total"] == TOTAL, json.dumps(data, indent=2)
         assert q["blocked"] == 49
-        assert q["forwarded"] == 47
+        assert q["forwarded"] == FORWARDED
         assert q["cached"] == 41
         assert q["unique_domains"] == 77
         assert q["status"]["UNKNOWN"] == 0
         assert q["status"]["GRAVITY"] == 7
-        assert q["status"]["FORWARDED"] == 47
+        assert q["status"]["FORWARDED"] == FORWARDED
         assert q["status"]["CACHE"] == 41
         assert q["status"]["REGEX"] == 21
         assert q["status"]["DENYLIST"] == 4
@@ -527,7 +563,7 @@ class TestStatsTopDomains:
         counts = [d["count"] for d in domains]
         assert counts == sorted(counts, reverse=True), \
             f"Not sorted descending: {counts}"
-        assert data["total_queries"] == 137
+        assert data["total_queries"] == TOTAL
         assert data["blocked_queries"] == 49
 
     def test_top_domains_blocked(self, api_session):
@@ -559,7 +595,7 @@ class TestStatsTopClients:
         counts = [c["count"] for c in clients]
         assert counts == sorted(counts, reverse=True), \
             f"Not sorted descending: {counts}"
-        assert data["total_queries"] == 137
+        assert data["total_queries"] == TOTAL
 
 
 # ---------------------------------------------------------------------------
@@ -572,8 +608,8 @@ class TestStatsUpstreams:
         data = _j(api_session.get(f"{FTL_URL}/api/stats/upstreams", timeout=5), dump="upstreams")
         upstreams = data["upstreams"]
         assert len(upstreams) == 4, json.dumps(upstreams, indent=2)
-        assert data["total_queries"] == 137
-        assert data["forwarded_queries"] == 47
+        assert data["total_queries"] == TOTAL
+        assert data["forwarded_queries"] == FORWARDED
 
         blocklist = next(u for u in upstreams if u["ip"] == "blocklist")
         assert blocklist["count"] == 49
@@ -595,7 +631,7 @@ class TestStatsQueryTypes:
         assert data["types"] == {
             "A": 69, "AAAA": 19, "ANY": 3, "SRV": 1, "SOA": 0,
             "PTR": 8, "TXT": 10, "NAPTR": 1, "MX": 1, "DS": 7,
-            "RRSIG": 0, "DNSKEY": 9, "NS": 0, "SVCB": 3, "HTTPS": 3,
+            "RRSIG": 0, "DNSKEY": DNSKEY, "NS": 0, "SVCB": 3, "HTTPS": 3,
             "OTHER": 1,
         }, json.dumps(data, indent=2)
 
@@ -839,11 +875,11 @@ class TestPADD:
         assert data["blocking"] == "enabled"
         assert data["gravity_size"] == 8
         assert data["active_clients"] == 11
-        assert data["top_domain"] == "."
+        assert data["top_domain"] == TOP_DOMAIN
         assert data["top_blocked"] == "gravity.ftl"
         assert data["top_client"] == "127.0.0.1"
         q = data["queries"]
-        assert q["total"] == 137, json.dumps(data, indent=2)
+        assert q["total"] == TOTAL, json.dumps(data, indent=2)
         assert q["blocked"] == 49
         cache = data["cache"]
         assert cache["size"] == 10000
@@ -967,7 +1003,7 @@ class TestQueriesAdditional:
         queries = data["queries"]
         assert isinstance(queries, list)
         assert len(queries) > 0
-        assert data["recordsTotal"] == 137
+        assert data["recordsTotal"] == TOTAL
         # Check structure of a query entry
         q = queries[0]
         assert "id" in q


### PR DESCRIPTION
# What does this implement/fix?

The `pytest` API tests assert exact query counts that depend on whether `icloud.com` and `apple-dns.net` are DNSSEC-signed.  When Apple removed DNSSEC from those zones (April 2026), dnsmasq stopped firing two `DNSKEY` validation queries during the `mask.icloud.com` `CNAME` chain walk, breaking 7 tests on every CI run - including re-runs of previously green commits.

Instead of hardcoding either set of numbers, detect the current DNSSEC state at test startup by querying the local `pdns_recursor` (port 5555, bypassing FTL to avoid counter pollution) for DS records on both domains.  Four module-level constants (`TOTAL`, `FORWARDED`, `DNSKEY`, `TOP_DOMAIN`) are set accordingly, and the 11 affected assertions now reference these constants.

The bats "Special domain: Record is returned when explicitly allowed" test is preserved unchanged - the hybrid detection makes it safe regardless of upstream DNSSEC posture.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.