### PR TITLE
Don't skip device lookup when resolver.macNames is disabled

### DIFF
--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -278,13 +278,6 @@ static int find_device_by_hwaddr(sqlite3 *db, const char hwaddr[])
 	if(FTLDBerror())
 		return DB_FAILED;
 
-	// Return early if we know MAC addresses are not unique
-	if(!config.resolver.macNames.v.b)
-	{
-		log_debug(DEBUG_ARP, "find_device_by_hwaddr(%s) - returning early", hwaddr);
-		return DB_NODATA;
-	}
-
 	log_debug(DEBUG_ARP, "find_device_by_hwaddr(%s)", hwaddr);
 
 	const char *querystr = "SELECT id FROM network WHERE hwaddr = ?1 COLLATE NOCASE;";


### PR DESCRIPTION
# What does this implement/fix?

`find_device_by_hwaddr()` returned `DB_NODATA` without querying the database when `resolver.macNames` was `false`. This caused all three callers (`parse_neighbor_cache`, `add_FTL_clients_to_network_table`, `add_local_interfaces_to_network_table`) to treat every device as new and attempt `INSERT` on each periodic run, hitting the `UNIQUE` constraint on `network.hwaddr` every 60 seconds.

The `macNames` setting controls name resolution from MAC addresses, not device tracking — the early return was conflating the two. The other two uses of the flag (`getNameFromMAC` and the gravity-db MAC lookup) correctly gate name resolution only and are unaffected.



---

**Related issue or feature (if applicable):** Closes #2844

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.