### PR TITLE
Fix linker error when compiling w/o optimization

### DIFF
--- a/src/tools/dhcp-discover.h
+++ b/src/tools/dhcp-discover.h
@@ -20,12 +20,12 @@ int get_hardware_address(const int sock, const char *iname, unsigned char *mac);
 // Global lock used by all threads
 extern pthread_mutex_t dhcp_lock;
 
-inline void start_lock(void)
+static inline void start_lock(void)
 {
 	pthread_mutex_lock(&dhcp_lock);
 }
 
-inline void end_lock(void)
+static inline void end_lock(void)
 {
 	pthread_mutex_unlock(&dhcp_lock);
 }


### PR DESCRIPTION

**What does this PR aim to accomplish?:**

Compiling Pi-hole FTL w/o optimization (release type `DEBUG`) results in the following error during linking:

```
host/x86_64-buildroot-linux-uclibc/bin/ld: tools/CMakeFiles/tools.dir/dhcp-discover.c.o: in function `create_dhcp_socket':
build/pihole-ftl-6.6/src/tools/dhcp-discover.c:88:(.text+0xac): undefined reference to `start_lock'
host/x86_64-buildroot-linux-uclibc/bin/ld: build/pihole-ftl-6.6/src/tools/dhcp-discover.c:90:(.text+0xe9): undefined reference to `end_lock'
[...]
host/x86_64-buildroot-linux-uclibc/bin/ld: tools/CMakeFiles/tools.dir/dhcpv6-discover.c.o: in function `recv_adv':
build/pihole-ftl-6.6/src/tools/dhcpv6-discover.c:706:(.text+0x137f): undefined reference to `start_lock'
host/x86_64-buildroot-linux-uclibc/bin/ld: build/pihole-ftl-6.6/src/tools/dhcpv6-discover.c:709:(.text+0x13b1): undefined reference to `end_lock'
[...]
```

When generating code without optimization, gcc ignores the inline directive. Code for this function is generated once, but not marked as global (because the `extern` keyword is missing), which results in the observed linker error for all other compilation units.

**How does this PR accomplish the above?:**

Change the function definition to static inline, which will force the compiler to include a static copy of the function in every compilation unit, if the function is not inlined.

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
