### PR TITLE
Clarify when --config cannot read the config file

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -366,7 +366,11 @@ void parse_args(int argc, char *argv[])
 		log_ctrl(false, false);
 		if(!readFTLconf(&config, false))
 		{
-			printf("Error: Could not read config file\n");
+			fprintf(stderr,
+			        "Error: Could not read or parse config file \"%s\" or its backup files. "
+			        "Please check that the file is accessible and that permissions are correct, "
+			        "or try running with sudo.\n",
+			        GLOBALTOMLPATH);
 			exit(EXIT_FAILURE);
 		}
 		log_ctrl(false, true);

--- a/src/args.c
+++ b/src/args.c
@@ -364,7 +364,11 @@ void parse_args(int argc, char *argv[])
 		// Enable stdout printing
 		cli_mode = true;
 		log_ctrl(false, false);
-		readFTLconf(&config, false);
+		if(!readFTLconf(&config, false))
+		{
+			printf("Error: Could not read config file\n");
+			exit(EXIT_FAILURE);
+		}
 		log_ctrl(false, true);
 		clear_debug_flags(); // No debug printing wanted
 		if(argc == 2)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -797,7 +797,7 @@ setup() {
   '
   printf "%s\n" "${lines[@]}"
   [[ $status -eq 1 ]]
-  [[ ${lines[0]} =~ Could not read or parse config file.*pihole\.toml.*backup files ]]
+  [[ ${lines[0]} == *'Could not read or parse config file "/etc/pihole/pihole.toml" or its backup files.'* ]]
 }
 
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -782,14 +782,20 @@ setup() {
   run bash -c '
     config_backup=/etc/pihole/pihole.toml.batsbak
     backup_dir_backup=/etc/pihole/config_backups.batsbak
+    cleanup() {
+      [[ -e "$config_backup" ]] && mv "$config_backup" /etc/pihole/pihole.toml || true
+      [[ -e "$backup_dir_backup" ]] && mv "$backup_dir_backup" /etc/pihole/config_backups || true
+    }
+    trap cleanup EXIT
     mv /etc/pihole/pihole.toml "$config_backup"
     mv /etc/pihole/config_backups "$backup_dir_backup"
-    trap "mv \"$config_backup\" /etc/pihole/pihole.toml; mv \"$backup_dir_backup\" /etc/pihole/config_backups" EXIT
     ./pihole-FTL --config debug.regex 2>&1
   '
   printf "%s\n" "${lines[@]}"
   [[ $status == 1 ]]
-  [[ ${lines[0]} == 'Error: Could not read or parse config file "/etc/pihole/pihole.toml" or its backup files. Please check that the file is accessible and that permissions are correct, or try running with sudo.' ]]
+  [[ ${lines[0]} == *"Could not read or parse config file"* ]]
+  [[ ${lines[0]} == *'"/etc/pihole/pihole.toml"'* ]]
+  [[ ${lines[0]} == *"backup files"* ]]
 }
 
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -778,6 +778,20 @@ setup() {
   [[ "${lines[0]}" == "80o,443os,[::]:80o,[::]:443os" ]]
 }
 
+@test "CLI --config fails when config and backups are unavailable" {
+  run bash -c '
+    config_backup=/etc/pihole/pihole.toml.batsbak
+    backup_dir_backup=/etc/pihole/config_backups.batsbak
+    mv /etc/pihole/pihole.toml "$config_backup"
+    mv /etc/pihole/config_backups "$backup_dir_backup"
+    trap "mv \"$config_backup\" /etc/pihole/pihole.toml; mv \"$backup_dir_backup\" /etc/pihole/config_backups" EXIT
+    ./pihole-FTL --config debug.regex 2>&1
+  '
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 1 ]]
+  [[ ${lines[0]} == 'Error: Could not read or parse config file "/etc/pihole/pihole.toml" or its backup files. Please check that the file is accessible and that permissions are correct, or try running with sudo.' ]]
+}
+
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final
 # log scan in run.sh, which runs after both BATS and pytest complete.
 

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -783,19 +783,21 @@ setup() {
     config_backup=/etc/pihole/pihole.toml.batsbak
     backup_dir_backup=/etc/pihole/config_backups.batsbak
     cleanup() {
-      [[ -e "$config_backup" ]] && mv "$config_backup" /etc/pihole/pihole.toml || true
-      [[ -e "$backup_dir_backup" ]] && mv "$backup_dir_backup" /etc/pihole/config_backups || true
+      if [[ -e "$config_backup" ]]; then
+        mv "$config_backup" /etc/pihole/pihole.toml || { echo "Failed to restore /etc/pihole/pihole.toml" >&2; return 1; }
+      fi
+      if [[ -e "$backup_dir_backup" ]]; then
+        mv "$backup_dir_backup" /etc/pihole/config_backups || { echo "Failed to restore /etc/pihole/config_backups" >&2; return 1; }
+      fi
     }
     trap cleanup EXIT
-    mv /etc/pihole/pihole.toml "$config_backup"
-    mv /etc/pihole/config_backups "$backup_dir_backup"
+    mv /etc/pihole/pihole.toml "$config_backup" || { echo "Failed to move /etc/pihole/pihole.toml for test setup" >&2; exit 1; }
+    mv /etc/pihole/config_backups "$backup_dir_backup" || { echo "Failed to move /etc/pihole/config_backups for test setup" >&2; exit 1; }
     ./pihole-FTL --config debug.regex 2>&1
   '
   printf "%s\n" "${lines[@]}"
-  [[ $status == 1 ]]
-  [[ ${lines[0]} == *"Could not read or parse config file"* ]]
-  [[ ${lines[0]} == *'"/etc/pihole/pihole.toml"'* ]]
-  [[ ${lines[0]} == *"backup files"* ]]
+  [[ $status -eq 1 ]]
+  [[ ${lines[0]} =~ Could not read or parse config file.*pihole\.toml.*backup files ]]
 }
 
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final


### PR DESCRIPTION
# What does this implement/fix?

Don't reply with default values to `--config` when config file couldn't be read.

How to reproduce:
``` 
$ pihole-FTL --config debug.regex
false

$ sudo mv /etc/pihole/pihole.toml /etc/pihole/pihole.toml_
$ sudo mv /etc/pihole/config_backups/ /etc/pihole/config_backups_

$ pihole-FTL --config debug.regex
Error: Could not read config file

$ sudo mv /etc/pihole/pihole.toml_ /etc/pihole/pihole.toml
$ sudo mv /etc/pihole/config_backups_ /etc/pihole/config_backups

$ pihole-FTL --config debug.regex
false
```

---

**Related issue or feature (if applicable):** Fixes #2849

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.