### PR TITLE
Add rate-limit exempt client IPs

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -340,6 +340,11 @@ components:
                       type: integer
                     interval:
                       type: integer
+                    exemptIPs:
+                      type: array
+                      items:
+                        type: string
+                        x-format: ipv4|ipv6
             dhcp:
               type: object
               properties:
@@ -789,6 +794,9 @@ components:
             rateLimit:
               count: 0
               interval: 0
+              exemptIPs:
+                - "192.168.1.10"
+                - "fd00::10"
           dhcp:
             active: false
             start: "192.168.0.10"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -31,6 +31,7 @@
 #include "signals.h"
 // validation functions
 #include "config/validator.h"
+#include "datastructure.h"
 // getEnvVars()
 #include "config/env.h"
 // sha256sum()
@@ -769,6 +770,13 @@ void initConfig(struct config *conf)
 	conf->dns.rateLimit.interval.t = CONF_UINT;
 	conf->dns.rateLimit.interval.d.ui = 60;
 	conf->dns.rateLimit.interval.c = validate_stub; // Only type-based checking
+
+	conf->dns.rateLimit.exemptIPs.k = "dns.rateLimit.exemptIPs";
+	conf->dns.rateLimit.exemptIPs.h = "IP addresses that should bypass per-client DNS rate limiting. Matching is exact by IP address and applies only when rate limiting is enabled. This is intended for trusted clients that may generate short legitimate DNS bursts.\n\n Example: [ \"192.168.1.10\", \"fd00::10\" ]";
+	conf->dns.rateLimit.exemptIPs.a = cJSON_CreateStringReference("Array of valid IPv4 and/or IPv6 addresses");
+	conf->dns.rateLimit.exemptIPs.t = CONF_JSON_STRING_ARRAY;
+	conf->dns.rateLimit.exemptIPs.d.json = cJSON_CreateArray();
+	conf->dns.rateLimit.exemptIPs.c = validate_ip_array;
 
 	// sub-struct dhcp
 	conf->dhcp.active.k = "dhcp.active";
@@ -2033,6 +2041,7 @@ void replace_config(struct config *newconf)
 
 	// Replace old config struct by changed one atomically
 	memcpy(&config, newconf, sizeof(struct config));
+	reload_all_per_client_rate_limit_exemption();
 
 	// Free old backup struct
 	free_config(&old_conf, false);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -192,6 +192,7 @@ struct config {
 		struct {
 			struct conf_item count;
 			struct conf_item interval;
+			struct conf_item exemptIPs;
 		} rateLimit;
 	} dns;
 

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -206,6 +206,60 @@ bool validate_dns_domain(union conf_value *val, const char *key, char err[VALIDA
 	return true;
 }
 
+// Validate arrays of IP addresses (IPv4 and/or IPv6)
+bool validate_ip_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	if(!cJSON_IsArray(val->json))
+	{
+		snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: not an array", key);
+		return false;
+	}
+
+	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	{
+		cJSON *item = cJSON_GetArrayItem(val->json, i);
+
+		if(!cJSON_IsString(item) || item->valuestring == NULL)
+		{
+			snprintf(err, VALIDATOR_ERRBUF_LEN, "%s[%d]: not a string", key, i);
+			return false;
+		}
+
+		const char *raw = item->valuestring;
+		while(isspace((unsigned char)*raw))
+			raw++;
+
+		size_t len = strlen(raw);
+		while(len > 0 && isspace((unsigned char)raw[len-1]))
+			len--;
+
+		if(len == 0)
+		{
+			snprintf(err, VALIDATOR_ERRBUF_LEN, "%s[%d]: empty string", key, i);
+			return false;
+		}
+
+		if(len > INET6_ADDRSTRLEN)
+		{
+			snprintf(err, VALIDATOR_ERRBUF_LEN, "%s[%d]: address too long (\"%s\")", key, i, item->valuestring);
+			return false;
+		}
+
+		char ip[INET6_ADDRSTRLEN + 1] = { 0 };
+		memcpy(ip, raw, len);
+
+		struct in_addr addr4;
+		struct in6_addr addr6;
+		if(inet_pton(AF_INET, ip, &addr4) != 1 && inet_pton(AF_INET6, ip, &addr6) != 1)
+		{
+			snprintf(err, VALIDATOR_ERRBUF_LEN, "%s[%d]: neither a valid IPv4 nor IPv6 address (\"%s\")", key, i, item->valuestring);
+			return false;
+		}
+	}
+
+	return true;
+}
+
 // Validate IPs in CIDR notation
 bool validate_cidr(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
 {

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -18,6 +18,7 @@ bool validate_stub(union conf_value *val, const char *key, char err[VALIDATOR_ER
 bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_cnames(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+bool validate_ip_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_cidr(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -72,6 +72,78 @@ static uint32_t __attribute__ ((pure)) hashStr(const char *s)
 	return hash;
 }
 
+static bool client_matches_rate_limit_exempt_ip(const char *clientIP)
+{
+	if(clientIP == NULL || config.dns.rateLimit.exemptIPs.v.json == NULL)
+		return false;
+
+	struct in_addr client4;
+	struct in6_addr client6;
+	const sa_family_t family = inet_pton(AF_INET, clientIP, &client4) == 1 ? AF_INET :
+	                           inet_pton(AF_INET6, clientIP, &client6) == 1 ? AF_INET6 : AF_UNSPEC;
+	if(family == AF_UNSPEC)
+		return false;
+
+	cJSON *item = NULL;
+	cJSON_ArrayForEach(item, config.dns.rateLimit.exemptIPs.v.json)
+	{
+		if(!cJSON_IsString(item) || item->valuestring == NULL)
+			continue;
+
+		const char *raw = item->valuestring;
+		while(isspace((unsigned char)*raw))
+			raw++;
+
+		size_t len = strlen(raw);
+		while(len > 0 && isspace((unsigned char)raw[len-1]))
+			len--;
+
+		if(len == 0 || len > INET6_ADDRSTRLEN)
+			continue;
+
+		char exemptIP[INET6_ADDRSTRLEN + 1] = { 0 };
+		memcpy(exemptIP, raw, len);
+
+		if(family == AF_INET)
+		{
+			struct in_addr exempt4;
+			if(inet_pton(AF_INET, exemptIP, &exempt4) == 1 && memcmp(&client4, &exempt4, sizeof(exempt4)) == 0)
+				return true;
+		}
+		else
+		{
+			struct in6_addr exempt6;
+			if(inet_pton(AF_INET6, exemptIP, &exempt6) == 1 && memcmp(&client6, &exempt6, sizeof(exempt6)) == 0)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+void reload_per_client_rate_limit_exemption(clientsData *client)
+{
+	if(client == NULL || client->flags.aliasclient)
+		return;
+
+	client->flags.rate_limit_exempt = client_matches_rate_limit_exempt_ip(getstr(client->ippos));
+}
+
+void reload_all_per_client_rate_limit_exemption(void)
+{
+	if(counters == NULL)
+		return;
+
+	for(unsigned int clientID = 0; clientID < counters->clients; clientID++)
+	{
+		clientsData *client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
+
+		reload_per_client_rate_limit_exemption(client);
+	}
+}
+
 /**
  * @brief Computes a hash value for the cache IDs using a simple XOR operation.
  *
@@ -356,6 +428,7 @@ int _findClientID(const char *clientIP, const bool count, const bool aliasclient
 	client->blockedcount = 0;
 	// Store client IP - no need to check for NULL here as it doesn't harm
 	client->ippos = addstr(clientIP);
+	reload_per_client_rate_limit_exemption(client);
 	// Store pre-computed hash for faster lookups later on
 	client->hash = hash;
 	// Initialize client hostname

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -81,6 +81,7 @@ typedef struct {
 		bool found_group:1;
 		bool aliasclient:1;
 		bool rate_limited:1;
+		bool rate_limit_exempt:1;
 	} flags;
 	int count;
 	int blockedcount;
@@ -160,6 +161,8 @@ void _query_set_status(queriesData *query, const enum query_status new_status, c
 
 void FTL_reload_all_domainlists(void);
 void FTL_reset_per_client_domain_data(void);
+void reload_per_client_rate_limit_exemption(clientsData *client);
+void reload_all_per_client_rate_limit_exemption(void);
 
 const char *getDomainString(const queriesData *query);
 const char *getCNAMEDomainString(const queriesData *query);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -794,9 +794,8 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	// Interface name is only available for regular queries, not for
 	// automatically generated DNSSEC queries
 	const char *interface = internal_query ? "-" : next_iface.name;
-
 	// Check rate-limit for this client
-	if(!internal_query && config.dns.rateLimit.count.v.ui > 0 &&
+	if(!internal_query && !client->flags.rate_limit_exempt && config.dns.rateLimit.count.v.ui > 0 &&
 	   (++client->rate_limit > config.dns.rateLimit.count.v.ui  || client->flags.rate_limited))
 	{
 		if(!client->flags.rate_limited)

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -553,15 +553,18 @@
     #     A positive integer value in seconds
     interval = 0 ### CHANGED, default = 60
 
-    # IP addresses that should bypass per-client DNS rate limiting. Matching is exact by
-    # IP address and applies only when rate limiting is enabled. This is intended for
-    # trusted clients that may generate short legitimate DNS bursts.
+    # IP addresses that should bypass per-client DNS rate limiting. Matching is exact by IP
+    # address and applies only when rate limiting is enabled. This is intended for trusted
+    # clients that may generate short legitimate DNS bursts.
     #
     # Example: [ "192.168.1.10", "fd00::10" ]
     #
     # Allowed values are:
-    #     An array of valid IPv4 and/or IPv6 addresses
-    exemptIPs = ["192.168.1.10", "fd00::10"] ### CHANGED, default = []
+    #     Array of valid IPv4 and/or IPv6 addresses
+    exemptIPs = [
+      "192.168.1.10",
+      "fd00::10"
+    ] ### CHANGED, default = []
 
 [dhcp]
   # Is the embedded DHCP server enabled?
@@ -1747,8 +1750,8 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 166 total entries out of which 112 entries are default
-# --> 54 entries are modified
+# 167 total entries out of which 112 entries are default
+# --> 55 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice
 #   - misc.check.shmem

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -553,6 +553,16 @@
     #     A positive integer value in seconds
     interval = 0 ### CHANGED, default = 60
 
+    # IP addresses that should bypass per-client DNS rate limiting. Matching is exact by
+    # IP address and applies only when rate limiting is enabled. This is intended for
+    # trusted clients that may generate short legitimate DNS bursts.
+    #
+    # Example: [ "192.168.1.10", "fd00::10" ]
+    #
+    # Allowed values are:
+    #     An array of valid IPv4 and/or IPv6 addresses
+    exemptIPs = ["192.168.1.10", "fd00::10"] ### CHANGED, default = []
+
 [dhcp]
   # Is the embedded DHCP server enabled?
   #

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -43,7 +43,7 @@
   if [[ "${CI_ARCH}" == "linux/riscv64" ]]; then
     [[ ${lines[0]} == "1" ]]
   else
-    [[ ${lines[0]} == "16" ]]
+    [[ ${lines[0]} == "17" ]]
   fi
   # CLI password set/remove trigger inotify reload but result in
   # "pihole.toml unchanged" as the in-memory config already matches


### PR DESCRIPTION
This adds a small escape hatch for setups where a trusted client can legitimately generate short DNS bursts and ends up tripping Pi-hole's per-client rate limiting.

A practical example is a work laptop coming back after a restart, VPN reconnect, or similar network reset. In that state it can generate a short burst of DNS traffic that is genuine, but still large enough to hit the global per-client limit. For users who want to keep rate limiting enabled overall, this adds a narrow opt-in way to exempt specific trusted clients.

The change adds a new `dns.rateLimit.exemptIPs` setting. When a client IP matches one of the configured addresses exactly, that client bypasses the per-client rate-limit check. Other clients still use the existing rate-limit behaviour unchanged.

What is included here:
- config schema/help text for `dns.rateLimit.exemptIPs`
- validation for arrays of IPv4 and IPv6 addresses
- rate-limit bypass for exact client IP matches
- test config coverage for the new key
- API spec/example coverage for the new key

Validation:
- tested on a Raspberry Pi after deployment
- Pi-hole remained healthy and no rate-limit recurrences were observed
- logs showed no new rate-limit or config-related errors after deployment
- during a restart-associated DNS spike, with the global rate limit set to `1000 queries / 60s`, an exempt client reached `1663` and `1853` queries in FTL-aligned 60s buckets, with a rolling 60s peak of `2140`, without being rate-limited

Related user report:
- ["Excluded" client causing rate limits?](https://discourse.pi-hole.net/t/excluded-client-causing-rate-limits/70801) mentions a work laptop using a VPN almost exclusively

This is intentionally narrow. Matching is exact by IP address, and only applies when rate limiting is enabled.