### PR TITLE
dnsmasq: check address= rules before following cached CNAME chain

### DIFF
--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -1729,6 +1729,56 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 	  }  
 	
 	cname_target = cache_get_cname_target(crecp);
+
+	/*********** Pi-hole modification ***********
+	   address= rules must take priority over cached CNAME chains. A CNAME
+	   cached via an AAAA query (where no IPv6 address= match exists) would
+	   otherwise cause subsequent A queries to bypass lookup_domain entirely.
+	   Check for a local address= match before following the chain. */
+	if (qtype == T_A || qtype == T_AAAA)
+	  {
+	    int addr_flags = (qtype == T_AAAA) ? F_IPV6 : F_IPV4;
+	    int first_addr, last_addr, addr_index;
+	    if (lookup_domain(name, addr_flags, &first_addr, &last_addr) &&
+		(is_local_answer(now, first_addr, name) & addr_flags))
+	      {
+		union all_addr local_addr;
+		ans = 1;
+		sec_data = 0;
+		auth = 0;
+		if (addr_flags & F_IPV4)
+		  {
+		    for (addr_index = first_addr; addr_index != last_addr; addr_index++)
+		      {
+			struct serv_addr4 *srv = (struct serv_addr4 *)daemon->serverarray[addr_index];
+			if (srv->flags & SERV_ALL_ZEROS)
+			  memset(&local_addr, 0, sizeof(local_addr));
+			else
+			  local_addr.addr4 = srv->addr;
+			log_query(F_FORWARD | F_CONFIG | F_IPV4, name, &local_addr, NULL, 0);
+			if (add_resource_record(header, limit, &trunc, nameoffset, &ansp,
+						daemon->local_ttl, NULL, T_A, C_IN, "4", &local_addr))
+			  anscount++;
+		      }
+		  }
+		else
+		  {
+		    for (addr_index = first_addr; addr_index != last_addr; addr_index++)
+		      {
+			struct serv_addr6 *srv = (struct serv_addr6 *)daemon->serverarray[addr_index];
+			if (srv->flags & SERV_ALL_ZEROS)
+			  memset(&local_addr, 0, sizeof(local_addr));
+			else
+			  local_addr.addr6 = srv->addr;
+			log_query(F_FORWARD | F_CONFIG | F_IPV6, name, &local_addr, NULL, 0);
+			if (add_resource_record(header, limit, &trunc, nameoffset, &ansp,
+						daemon->local_ttl, NULL, T_AAAA, C_IN, "6", &local_addr))
+			  anscount++;
+		      }
+		  }
+		break;
+	      }
+	  }
 	
 	/* If the client asked for DNSSEC  don't use cached data. */
 	if ((crecp->flags & (F_HOSTS | F_DHCP | F_CONFIG)) ||


### PR DESCRIPTION

**What does this PR aim to accomplish?:**

Fixes `address=` rules being bypassed when a subdomain has a cached CNAME entry from a prior AAAA query.

When `address=/example.com/192.168.0.1` is configured, subdomains that resolve upstream via a CNAME chain intermittently return the real upstream IP instead of the configured address. The bypass is triggered by this sequence:

1. **A query** for `api.example.com` — `lookup_domain` finds the `address=` rule, returns the configured IP correctly ✓
2. **AAAA query** for `api.example.com` — no IPv6 `address=` rule exists, query goes upstream, `api.example.com CNAME → something.cdn.net` gets written into the cache ✗
3. **Subsequent A query** — `answer_request` finds the cached CNAME at the top of its lookup loop and follows the chain, returning the CDN's real IP. `lookup_domain` is never reached ✗

The same bypass can occur when another network client has already queried the subdomain and populated the shared cache with the CNAME.

This is distinct from the existing deep CNAME inspection for blocklists — `FTL_CNAME` calls `FTL_check_blocking` for each CNAME hop but never checks `address=` rules. The same issue has been reported twice to the upstream dnsmasq mailing list but I don't believe anything has changed from this being raised:
- [April 2024](https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2024q2/017559.html)
- [September 2025](https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2025q3/018320.html)

**How does this PR accomplish the above?:**

In the CNAME-following loop of `answer_request` (`rfc1035.c`), before following a cached CNAME chain for `A` or `AAAA` queries, `lookup_domain` is called for the queried name. If an `address=` rule matches, the configured local address response is returned directly and the loop breaks. This mirrors the existing `forward_query` path: `lookup_domain` finds the matching configured entries, `is_local_answer` confirms they apply to the requested address family, and all matching configured addresses for that family are emitted.

Verified on a Pi 3B+ running Pi-hole v6.6.1:

1. Configure `address=/imgur.com/192.168.8.3`, restart FTL to flush cache
2. `dig AAAA apidocs.imgur.com` — upstream returns `apidocs.imgur.com CNAME phs.getpostman.com`, CNAME written to cache
3. `dig A apidocs.imgur.com` — returns `192.168.8.3` (0ms, served from cache) ✓

Without this fix, step 3 returns the real upstream IP.

**Link documentation PRs if any are needed to support this PR:**

No documentation changes required.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.
