### PR TITLE
Revert "Clarify when --config cannot read the config file"

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -364,15 +364,7 @@ void parse_args(int argc, char *argv[])
 		// Enable stdout printing
 		cli_mode = true;
 		log_ctrl(false, false);
-		if(!readFTLconf(&config, false))
-		{
-			fprintf(stderr,
-			        "Error: Could not read or parse config file \"%s\" or its backup files. "
-			        "Please check that the file is accessible and that permissions are correct, "
-			        "or try running with sudo.\n",
-			        GLOBALTOMLPATH);
-			exit(EXIT_FAILURE);
-		}
+		readFTLconf(&config, false);
 		log_ctrl(false, true);
 		clear_debug_flags(); // No debug printing wanted
 		if(argc == 2)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -778,28 +778,6 @@ setup() {
   [[ "${lines[0]}" == "80o,443os,[::]:80o,[::]:443os" ]]
 }
 
-@test "CLI --config fails when config and backups are unavailable" {
-  run bash -c '
-    config_backup=/etc/pihole/pihole.toml.batsbak
-    backup_dir_backup=/etc/pihole/config_backups.batsbak
-    cleanup() {
-      if [[ -e "$config_backup" ]]; then
-        mv "$config_backup" /etc/pihole/pihole.toml || { echo "Failed to restore /etc/pihole/pihole.toml" >&2; return 1; }
-      fi
-      if [[ -e "$backup_dir_backup" ]]; then
-        mv "$backup_dir_backup" /etc/pihole/config_backups || { echo "Failed to restore /etc/pihole/config_backups" >&2; return 1; }
-      fi
-    }
-    trap cleanup EXIT
-    mv /etc/pihole/pihole.toml "$config_backup" || { echo "Failed to move /etc/pihole/pihole.toml for test setup" >&2; exit 1; }
-    mv /etc/pihole/config_backups "$backup_dir_backup" || { echo "Failed to move /etc/pihole/config_backups for test setup" >&2; exit 1; }
-    ./pihole-FTL --config debug.regex 2>&1
-  '
-  printf "%s\n" "${lines[@]}"
-  [[ $status -eq 1 ]]
-  [[ ${lines[0]} == *'Could not read or parse config file "/etc/pihole/pihole.toml" or its backup files.'* ]]
-}
-
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final
 # log scan in run.sh, which runs after both BATS and pytest complete.
 


### PR DESCRIPTION
I think we should revert this change...

Reasoning:

 - Tests in core and docker are now broken
 - Fresh installs are broken (i'm even running as root!)
 
<img width="1127" height="639" alt="image" src="https://github.com/user-attachments/assets/b618e22c-6e90-4486-876f-25be6e3b4607" />

Examining the `readFTLConf` function...

 - There is only one path that returns `true` which is path where the file is readable
 - If we don't explicitly call it with `rewrite=true` then we will return false (And FTL will log that we are using defaults)
 - If we call with `rewrite=true` then the file is created but for some reason we then return `false`.... this does not make sense to me. If we have created the file, why not return `true`?

IMO the true fix to @rdwebdesign's [original issue](https://github.com/pi-hole/FTL/issues/2849) thread would be to explicitly test whether the file is unreadable because either:
  1) It does not exist (maybe it does not exist + neither do backups)
		- In which case return `true`, use defaults as expected
  2) There are permissions issues
		- In which case return `false` - the file exists but there are issues reading it


Function as exists is below so you don't have to go searching for it:

```c
bool readFTLconf(struct config *conf, const bool rewrite)
{
	// Initialize config with default values
	initConfig(conf);

	// First, read the environment
	getEnvVars();

	// Try to read TOML config file
	// If we cannot parse /etc/pihole.toml (due to missing or invalid syntax),
	// we try to read the rotated files in /etc/pihole/config_backup starting at
	// the most recent one and going back in time until we find a valid config
	for(unsigned int i = 0; i < MAX_ROTATIONS; i++)
	{
		toml_datum_t toml = { 0 };
		if(readFTLtoml(NULL, conf, toml, rewrite, NULL, i, false))
		{
			// If successful, we write the config file back to disk
			// to ensure that all options are present and comments
			// about options deviating from the default are present
			if(rewrite)
			{
				writeFTLtoml(true, NULL);
				char errbuf[ERRBUF_SIZE] = { 0 };
				write_dnsmasq_config(conf, false, errbuf);
				write_custom_list();
			}
			return true;
		}
	}

	log_info("No config file nor backup available, using defaults");

	// If we reach this point, we could not read the TOML config file When
	// this functions is invoked to run without rewriting, we are likely
	// running interactively and do not want to migrate settings (yet):
	// using defaults is fine in this case
	if(!rewrite)
		return false;

	// When we reach this point but the FTL TOML config file exists, it may
	// contain errors such as syntax errors, etc. We move it into a
	// ".broken" location so it can be revisited later
	if(file_exists(GLOBALTOMLPATH))
	{
		const char new_name[] = GLOBALTOMLPATH ".broken";
		rotate_files(new_name, NULL);
		rename(GLOBALTOMLPATH, new_name);
	}

	// Determine and set default webserver ports if not imported from
	// setupVars.conf
	get_web_port(&config);

	// Initialize the TOML config file
	writeFTLtoml(true, NULL);
	char errbuf[ERRBUF_SIZE] = { 0 };
	write_dnsmasq_config(conf, false, errbuf);
	write_custom_list();

	return false;
}
```
