### PR TITLE
fix: check NULL returns from strdup/calloc in rotate_files()

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -487,22 +487,44 @@ void rotate_files(const char *path, char **first_file)
 	{
 		// Construct old and new paths
 		char *fname = strdup(path);
+		if(fname == NULL)
+		{
+			log_err("rotate_files(): strdup() failed: %s", strerror(errno));
+			return;
+		}
 		const char *filename = basename(fname);
 		// extra 6 bytes is enough space for up to 999 rotations ("/", ".", "\0", "999")
 		const size_t buflen = strlen(filename) + MAX(strlen(BACKUP_DIR), strlen(path)) + 6;
 		char *old_path = calloc(buflen, sizeof(char));
+		if(old_path == NULL)
+		{
+			log_err("rotate_files(): calloc() failed: %s", strerror(errno));
+			free(fname);
+			return;
+		}
 		if(i == 1)
 			snprintf(old_path, buflen, "%s", path);
 		else
 			snprintf(old_path, buflen, BACKUP_DIR"/%s.%u", filename, i-1);
 		char *new_path = calloc(buflen, sizeof(char));
+		if(new_path == NULL)
+		{
+			log_err("rotate_files(): calloc() failed: %s", strerror(errno));
+			free(fname);
+			free(old_path);
+			return;
+		}
 		snprintf(new_path, buflen, BACKUP_DIR"/%s.%u", filename, i);
 		free(fname);
 
 		// If this is the first file, export the path to the caller (if
 		// requested)
 		if(i == 1 && first_file != NULL)
+		{
 			*first_file = strdup(new_path);
+			if(*first_file == NULL)
+				log_err("rotate_files(): strdup() failed: %s", strerror(errno));
+		}
 
 		if(file_exists(old_path))
 		{


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

`rotate_files()` in `src/files.c` calls `strdup()` and `calloc()` four times in its loop body without checking the return values for NULL. On a system under memory pressure, which is more realistic on Pi hardware than on a typical server, any of those failures leads to either a NULL pointer dereference (crash) or a NULL being silently passed back to the caller through `*first_file`.

This is proactive hardening rather than a fix for a specific crash report. The same NULL-check pattern was already applied in #2043 for similar allocations in `src/config/` and `src/resolve.c`, so this brings `rotate_files()` in line with that existing approach.

**How does this PR accomplish the above?:**

Four NULL guards are added in the order the allocations occur:

- `strdup(path)` to `fname`: log error and return
- first `calloc()` to `old_path`: log error, free `fname`, return
- second `calloc()` to `new_path`: log error, free `fname` and `old_path`, return
- `strdup(new_path)` to `*first_file`: log error and continue. The rotation still proceeds, the caller just does not receive the first file path back

The cleanup order is intentional: `filename` points into `fname`'s buffer via `basename()`, so `fname` is freed only after `filename` is no longer referenced.

**Link documentation PRs if any are needed to support this PR:**

No documentation changes needed.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*