### PR TITLE
Use custom message for UNIQUE constraint error message

### DIFF
--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -484,7 +484,7 @@ components:
             error:
               key: "database_error"
               message: "Could not add to gravity database"
-              hint: "Client already exists (UNIQUE constraint failed)"
+              hint: "The item is already present"
             took: 0.003
   parameters:
     client:

--- a/src/api/docs/content/specs/clients.yaml
+++ b/src/api/docs/content/specs/clients.yaml
@@ -164,7 +164,7 @@ components:
 
           On success, a new resource is created at `/clients/{client}`.
 
-          The `database_error` with message `UNIQUE constraint failed` error indicates that this client already exists.
+          The `database_error` with message `The item is already present` error indicates that this client already exists.
         requestBody:
           description: Callback payload
           content:
@@ -434,7 +434,7 @@ components:
               - item: "::1"
             errors:
               - item: "192.168.2.5"
-                error: "UNIQUE constraint failed: client.ip"
+                error: "The item is already present"
   examples:
     clients:
       value:
@@ -457,7 +457,7 @@ components:
             - item: "127.0.0.1"
           failed:
             - item: "127.0.0.2"
-              error: "UNIQUE constraint failed: clientlist.client"
+              error: "The item is already present"
     errors:
       uri_error:
         item_missing:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -526,7 +526,7 @@ components:
             error:
               key: "database_error"
               message: "Could not add to gravity database"
-              hint: "Domain already exists (UNIQUE constraint failed)"
+              hint: "The item is already present"
             took: 0.003
       regex_error:
         invalid_regex:

--- a/src/api/docs/content/specs/domains.yaml
+++ b/src/api/docs/content/specs/domains.yaml
@@ -177,7 +177,7 @@ components:
 
           On success, a new resource is created at `/domains/{type}/{kind}/{domain}`.
 
-          The `database_error` with message `UNIQUE constraint failed` error indicates that the same entry (`domain`, `type`, `kind`) already exists.
+          The `database_error` with message `The item is already present` error indicates that the same entry (`domain`, `type`, `kind`) already exists.
 
           When adding a regular expression, ensure the request body is properly JSON-escaped.
         requestBody:
@@ -462,7 +462,7 @@ components:
               - item: "example3.com"
             errors:
               - item: "example2.com"
-                error: "UNIQUE constraint failed: domainlist.domain"
+                error: "The item is already present"
   examples:
     domains:
       summary: Example domains

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -398,7 +398,7 @@ components:
             error:
               key: "database_error"
               message: "Could not add to gravity database"
-              hint: "Group already exists (UNIQUE constraint failed)"
+              hint: "The item is already present"
             took: 0.003
 
   parameters:

--- a/src/api/docs/content/specs/groups.yaml
+++ b/src/api/docs/content/specs/groups.yaml
@@ -135,7 +135,7 @@ components:
 
           On success, a new resource is created at `/groups/{name}`.
 
-          The `database_error` with message `UNIQUE constraint failed` error indicates that a group with the same name already exists.
+          The `database_error` with message `The item is already present` error indicates that a group with the same name already exists.
         requestBody:
           description: Callback payload
           content:
@@ -353,7 +353,7 @@ components:
               - item: "Children"
             errors:
               - item: "Garden"
-                error: "UNIQUE constraint failed: group.name"
+                error: "The item is already present"
   examples:
     groups:
       value:

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -145,7 +145,7 @@ components:
 
           On success, a new resource is created at `/lists/{list}`.
 
-          The `database_error` with message `UNIQUE constraint failed` error indicates that this list already exists.
+          The `database_error` with message `The item is already present` error indicates that this list already exists.
         parameters:
           - $ref: 'lists.yaml#/components/parameters/listtype'
         requestBody:
@@ -417,7 +417,7 @@ components:
               - item: "https://mirror1.malwaredomains.com/files/justdomains"
             errors:
               - item: "https://raw.githubusercontent.com/abc/def/master/hosts"
-                error: "UNIQUE constraint failed: adlist.address"
+                error: "The item is already present"
   examples:
     lists:
       value:

--- a/src/api/docs/content/specs/lists.yaml
+++ b/src/api/docs/content/specs/lists.yaml
@@ -466,7 +466,7 @@ components:
             error:
               key: "database_error"
               message: "Could not add to gravity database"
-              hint: "List already exists (UNIQUE constraint failed)"
+              hint: "The item is already present"
             took: 0.003
   parameters:
     list:

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2020,7 +2020,10 @@ bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
 	}
 	else
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		if(rc == SQLITE_CONSTRAINT)
+			*message = "The item is already present";
+		else
+			*message = sqlite3_errmsg(gravity_db);
 	}
 
 	// Finalize statement and close database handle


### PR DESCRIPTION
### What does this PR aim to accomplish?

Currently, when an "UNIQUE constraint" error is found while adding items to group management tables, the returned message is not very user friendly.

This PR uses a custom error message.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/68a6e6e8-4f1e-4cd8-a4d3-3a5445b5c189" />

Redo of https://github.com/pi-hole/FTL/pull/2878
Suggested in https://github.com/pi-hole/web/issues/3773#issuecomment-4365942542

### How does this PR accomplish the above?

Testing the returned error code.

If the error code is `SQLITE_CONSTRAINT` (19), we show a custom message.
We still show the original message for other error codes.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
