### PR TITLE
Improve crash backtraces for non-reproducible faults

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -9,17 +9,22 @@
 *  Please see LICENSE file for your rights under this license. */
 
 #include "FTL.h"
-// Universal unwind backtrace via GCC's libgcc — works on glibc AND musl, static AND dynamic
+// Universal unwind backtrace via GCC's libgcc - works on glibc AND musl, static AND dynamic
 #if defined(USE_UNWIND)
 #  include <unwind.h>
 #  include <limits.h>    // PATH_MAX
-#  include <inttypes.h>  // SCNxPTR — portable sscanf format for uintptr_t
-#  include <sys/mman.h>  // mmap() — used for the intentional crash test subcommand
-#  include <dlfcn.h>     // dladdr() — dynamic symbol lookup from .dynsym
+#  include <sys/mman.h>  // mmap() - used for the intentional crash test subcommand
+#  include <dlfcn.h>     // dladdr() - dynamic symbol lookup from .dynsym
+#  include <ucontext.h>  // ucontext_t - register snapshot from SA_SIGINFO handlers
+#  include <fcntl.h>     // open() - raw, signal-safe /proc/self/maps reading
+#  include <poll.h>      // poll() - bound the addr2line subprocess wall-clock
+#  include <sys/wait.h>  // waitpid()/WIFEXITED() - reap the addr2line child
 #endif
 #include "signals.h"
 // logging routines
 #include "log.h"
+// cli_color() - ANSI colors only when stdout is an interactive terminal
+#include "args.h"
 // ls_dir()
 #include "files.h"
 // gettid()
@@ -49,19 +54,19 @@ static volatile uid_t term_sender_uid = 0;
 // earlier log lines have been lost (see #2818)
 static char term_source[256] = { 0 };
 
-// Binary path stored by init_backtrace() — signal-handler-safe static buffer,
+// Binary path stored by init_backtrace() - signal-handler-safe static buffer,
 // never reallocated, safe to read from any context including signal handlers
 #if defined(USE_UNWIND)
 static char bin_path[PATH_MAX] = { 0 };
 #endif
 
 #if defined(USE_UNWIND)
-// PIE load base address — set once at startup by init_backtrace() using the
+// PIE load base address - set once at startup by init_backtrace() using the
 // __ehdr_start linker symbol (GNU ld / lld / mold). __ehdr_start points to the
 // ELF header in memory, which equals the ASLR slide for PIE binaries and the
 // static load address for non-PIE. Either way: file_vaddr = runtime_addr -
 // exe_load_addr is exactly what addr2line expects. This is a linker symbol, not
-// a libc function, so it is reliable on glibc AND musl, static AND dynamic —
+// a libc function, so it is reliable on glibc AND musl, static AND dynamic -
 // unlike dl_iterate_phdr, whose behaviour for static executables varies across
 // musl versions and may leave exe_load_addr == 0.
 static uintptr_t exe_load_addr = 0;
@@ -91,7 +96,7 @@ void init_backtrace(const char *argv0)
 	// which equals the ASLR load base for PIE binaries.
 	exe_load_addr = (uintptr_t)&__ehdr_start;
 #else
-	// Unused, cannot generate backtraces right now on non-gcc targets —
+	// Unused, cannot generate backtraces right now on non-gcc targets -
 	// this silences a warning about unused parameters in this case
 	(void)argv0;
 #endif // USE_UNWIND
@@ -105,6 +110,12 @@ struct unwind_state {
 	int    max;
 };
 
+enum backtrace_source {
+	BT_SOURCE_NONE,
+	BT_SOURCE_SIGNAL_CONTEXT,
+	BT_SOURCE_UNWIND_FALLBACK,
+};
+
 // Callback invoked by _Unwind_Backtrace for each frame on the call stack.
 // Signal-handler-safe: no heap allocation, no stdio, no locks.
 static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context *ctx, void *arg)
@@ -112,137 +123,727 @@ static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context *ctx, void *ar
 	struct unwind_state *state = (struct unwind_state *)arg;
 	if(state->count >= state->max)
 		return _URC_END_OF_STACK;
-	uintptr_t ip = _Unwind_GetIP(ctx);
+	// _Unwind_GetIPInfo() reports whether the IP already points *at* the
+	// instruction (ip_before_insn != 0, as for signal frames) or is a return
+	// address pointing *past* the call (ip_before_insn == 0, the common case).
+	int ip_before_insn = 0;
+	uintptr_t ip = _Unwind_GetIPInfo(ctx, &ip_before_insn);
 	if(ip == 0)
 		return _URC_END_OF_STACK;
-	// Subtract 1 so the address points at the call instruction rather than
-	// the return address — addr2line then resolves the correct source line.
-	state->frames[state->count++] = (void *)(ip - 1u);
+	// For a return address, step back by one so the address falls inside the
+	// call instruction and addr2line resolves the correct source line.  An
+	// IP that is already "before insn" (e.g. a signal frame) must be kept
+	// as-is, otherwise it would shift to the previous instruction.
+	if(!ip_before_insn)
+		ip -= 1u;
+	state->frames[state->count++] = (void *)ip;
 	return _URC_NO_REASON;
 }
 #endif // USE_UNWIND (unwind_callback)
 
 #if defined(USE_UNWIND)
+// A single snapshot of all process memory mappings, taken once per unwind
+// attempt.  FTL's /proc/self/maps has well under 100 entries; 512 is a
+// generous ceiling that keeps the snapshot a fixed, allocation-free size.
+#define MAPS_MAX_ENTRIES 512
+struct map_entry {
+	uintptr_t start;
+	uintptr_t end;
+	bool readable;
+	bool executable;
+};
+struct maps_snapshot {
+	struct map_entry entries[MAPS_MAX_ENTRIES];
+	int count;
+};
+
+// Parse a run of hexadecimal digits, advancing *pp past them.
+// Returns false (without advancing) when no digit is present.
+static bool parse_hex(const char **pp, uintptr_t *out)
+{
+	const char *p = *pp;
+	uintptr_t val = 0;
+	int digits = 0;
+	for(;; p++)
+	{
+		const char c = *p;
+		uintptr_t d;
+		if(c >= '0' && c <= '9')      d = (uintptr_t)(c - '0');
+		else if(c >= 'a' && c <= 'f') d = (uintptr_t)(c - 'a' + 10);
+		else if(c >= 'A' && c <= 'F') d = (uintptr_t)(c - 'A' + 10);
+		else break;
+		val = (val << 4) | d;
+		digits++;
+	}
+	if(digits == 0)
+		return false;
+	*pp = p;
+	*out = val;
+	return true;
+}
+
+// Parse one "/proc/self/maps" line ("start-end perms ...") into snap.
+// Manual hex/character parsing keeps this free of stdio and sscanf, neither
+// of which is async-signal-safe.
+static void parse_maps_line(const char *line, struct maps_snapshot *snap)
+{
+	if(snap->count >= MAPS_MAX_ENTRIES)
+		return;
+
+	const char *p = line;
+	uintptr_t start = 0, end = 0;
+	if(!parse_hex(&p, &start) || *p++ != '-')
+		return;
+	if(!parse_hex(&p, &end) || *p++ != ' ')
+		return;
+
+	// Permission field, e.g. "r-xp"; need at least the r/w/x columns.
+	if(p[0] == '\0' || p[1] == '\0' || p[2] == '\0')
+		return;
+
+	struct map_entry *e = &snap->entries[snap->count++];
+	e->start = start;
+	e->end = end;
+	e->readable = (p[0] == 'r');
+	e->executable = (p[2] == 'x');
+}
+
+// Capture all process memory mappings into snap using raw open()/read()/close()
+// so this snapshot path avoids non-async-signal-safe stdio (fopen/fgets) - that
+// would risk a deadlock or secondary crash if the fault happened while libc held
+// an internal lock.  Taken once per unwind instead of per frame.
+static void capture_maps_snapshot(struct maps_snapshot *snap)
+{
+	snap->count = 0;
+
+	const int fd = open("/proc/self/maps", O_RDONLY | O_CLOEXEC);
+	if(fd < 0)
+		return;
+
+	char buf[4096];
+	char line[512];
+	size_t line_len = 0;
+	for(;;)
+	{
+		const ssize_t got = read(fd, buf, sizeof(buf));
+		if(got < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			break;
+		}
+		if(got == 0)
+			break;
+
+		for(ssize_t i = 0; i < got; i++)
+		{
+			const char c = buf[i];
+			if(c == '\n')
+			{
+				line[line_len] = '\0';
+				parse_maps_line(line, snap);
+				line_len = 0;
+			}
+			// Drop the overflow of an over-long line but keep scanning for
+			// the newline so the next line stays aligned.
+			else if(line_len < sizeof(line) - 1u)
+				line[line_len++] = c;
+		}
+
+		if(snap->count >= MAPS_MAX_ENTRIES)
+			break;
+	}
+
+	close(fd);
+}
+
+// True when [addr, addr+bytes) is inside a readable mapping of the snapshot.
+static bool is_readable_range(const struct maps_snapshot *snap, const uintptr_t addr, const size_t bytes)
+{
+	if(bytes == 0u)
+		return false;
+
+	for(int i = 0; i < snap->count; i++)
+	{
+		const struct map_entry *e = &snap->entries[i];
+		if(e->readable && addr >= e->start && addr < e->end &&
+		   (size_t)(e->end - addr) >= bytes)
+			return true;
+	}
+	return false;
+}
+
+// True when addr points into an executable mapping of the snapshot.
+static bool is_executable_address(const struct maps_snapshot *snap, const uintptr_t addr)
+{
+	for(int i = 0; i < snap->count; i++)
+	{
+		const struct map_entry *e = &snap->entries[i];
+		if(e->executable && addr >= e->start && addr < e->end)
+			return true;
+	}
+	return false;
+}
+
+// Try to unwind from signal context using frame pointers.
+// This captures caller frames before the signal trampoline on targets where
+// the frame pointer chain is available.
+// *complete is set true when the walk reached the outermost frame on its own
+// (the chain ended in a NULL frame pointer / return address) and false when it
+// had to stop early on a corrupt or not-yet-set-up frame pointer - the latter
+// is the cue for the caller to cross-check against the libgcc unwinder.
+static int collect_from_signal_context(void **frames, const int max_frames, void *context,
+                                       bool *complete)
+{
+	if(complete != NULL)
+		*complete = false;
+	if(context == NULL || max_frames <= 0)
+		return 0;
+
+	ucontext_t *uc = (ucontext_t *)context;
+	uintptr_t ip = 0;
+	uintptr_t fp = 0;
+
+#if defined(__x86_64__)
+	ip = (uintptr_t)uc->uc_mcontext.gregs[REG_RIP];
+	fp = (uintptr_t)uc->uc_mcontext.gregs[REG_RBP];
+#elif defined(__aarch64__)
+	ip = (uintptr_t)uc->uc_mcontext.pc;
+	fp = (uintptr_t)uc->uc_mcontext.regs[29];
+#else
+	(void)uc;
+	return 0;
+#endif
+
+	// Snapshot the mappings once up front.  The frame-pointer walk validates
+	// every candidate address against this snapshot instead of re-parsing
+	// /proc/self/maps per frame (previously O(frames) file opens).  Thread-local
+	// static storage keeps it off the 16 KiB alternate signal stack while giving
+	// each thread its own copy, so two threads taking a fatal signal at once do
+	// not corrupt each other's snapshot.  TLS in the executable uses the
+	// local-exec model, so it stays usable from the crash handler.
+	static _Thread_local struct maps_snapshot snap;
+	capture_maps_snapshot(&snap);
+
+	int count = 0;
+	// Frame 0 is the faulting instruction pointer straight from the signal
+	// context, not a return address, so record it as-is.  The caller frames
+	// below are return addresses and get the usual -1 adjustment to point
+	// back inside the call instruction for accurate addr2line/dladdr lookup.
+	if(ip != 0)
+		frames[count++] = (void *)ip;
+
+	bool walk_complete = false;
+	while(count < max_frames && fp != 0)
+	{
+		if((fp & (sizeof(uintptr_t) - 1u)) != 0)
+			break;
+
+		if(!is_readable_range(&snap, fp, 2u*sizeof(uintptr_t)))
+			break;
+
+		const uintptr_t *frame = (const uintptr_t *)fp;
+		const uintptr_t next_fp = frame[0];
+		const uintptr_t ret = frame[1];
+
+		if(ret == 0)
+		{
+			// Outermost frame: its saved return address is NULL, so the
+			// chain ended naturally rather than being cut short.
+			walk_complete = true;
+			break;
+		}
+		if(!is_executable_address(&snap, ret - 1u))
+			break;
+
+		frames[count++] = (void *)(ret - 1u);
+
+		if(next_fp == 0)
+		{
+			// Outermost frame reached: the ABI requires the topmost saved
+			// frame pointer to be NULL (e.g. _start zeroes it).
+			walk_complete = true;
+			break;
+		}
+		if(next_fp <= fp || next_fp - fp > 1u*1024u*1024u)
+			break;
+
+		fp = next_fp;
+	}
+
+	if(complete != NULL)
+		*complete = walk_complete;
+	return count;
+}
+
+// Collect a backtrace either from an interrupted signal context (preferred)
+// or from the current stack as fallback.
+static int collect_backtrace_frames(void **frames, const int max_frames, void *context,
+                                    enum backtrace_source *source, bool *complete)
+{
+	if(complete != NULL)
+		*complete = false;
+	if(max_frames <= 0)
+		return 0;
+
+	const int from_signal_context = collect_from_signal_context(frames, max_frames, context, complete);
+	if(from_signal_context > 0)
+	{
+		if(source != NULL)
+			*source = BT_SOURCE_SIGNAL_CONTEXT;
+		return from_signal_context;
+	}
+
+	struct unwind_state state = { frames, 0, max_frames };
+	_Unwind_Backtrace(unwind_callback, &state);
+	if(source != NULL)
+		*source = BT_SOURCE_UNWIND_FALLBACK;
+	// The libgcc unwinder walks the whole stack itself, so there is nothing to
+	// cross-check against - treat its result as complete.
+	if(complete != NULL)
+		*complete = true;
+	return state.count;
+}
+#endif // USE_UNWIND (collect_backtrace_frames)
+
+#if defined(USE_UNWIND)
+// Extract the mapped-file basename for a single "/proc/self/maps" line if it
+// contains addr.  Returns true (and fills buf) on a match with a path, false
+// otherwise.  Manual parsing keeps this free of sscanf (not async-signal-safe).
+static bool maps_line_name_for_addr(const char *line, const uintptr_t a,
+                                    char *buf, const size_t buflen)
+{
+	const char *p = line;
+	uintptr_t start = 0, end = 0;
+	if(!parse_hex(&p, &start) || *p++ != '-')
+		return false;
+	if(!parse_hex(&p, &end) || *p++ != ' ')
+		return false;
+	if(!(a >= start && a < end))
+		return false;
+
+	// Skip the perms, offset, dev and inode columns to reach the path:
+	// "perms offset dev inode <spaces> path".
+	for(int field = 0; field < 4 && *p != '\0'; field++)
+	{
+		while(*p != '\0' && *p != ' ') p++;
+		while(*p == ' ') p++;
+	}
+	if(*p == '\0')
+		return false; // anonymous mapping, no path
+
+	const char *base = strrchr(p, '/');
+	const char *name = base ? base + 1 : p;
+	strncpy(buf, name, buflen - 1u);
+	buf[buflen - 1u] = '\0';
+	return true;
+}
+
 // Look up which /proc/self/maps entry contains addr and copy the basename
-// of the mapped file (e.g. "libc.so.6", "[vdso]") into buf.
-// buf is left empty when the address is not found or has no path.
+// of the mapped file (e.g. "libc.so.6", "[vdso]") into buf.  buf is left empty
+// when the address is not found or has no path.  Uses raw open()/read() and
+// manual parsing to avoid the stdio (fopen/fgets/sscanf) that the rest of this
+// last-resort fallback would otherwise pull into the crash handler.  It still
+// calls a few plain string helpers (strrchr/strncpy/strcmp), so it is not
+// fully async-signal-safe.
 static void find_mapping_name(const void *addr, char *buf, const size_t buflen)
 {
-	FILE *maps = fopen("/proc/self/maps", "r");
-	if(maps == NULL)
+	if(buflen == 0u)
+		return;
+	// Honor the "left empty" contract for every early-return path below so
+	// callers never observe stale buffer contents.
+	buf[0] = '\0';
+
+	const int fd = open("/proc/self/maps", O_RDONLY | O_CLOEXEC);
+	if(fd < 0)
 		return;
 
 	const uintptr_t a = (uintptr_t)addr;
+	char rbuf[4096];
 	char line[512];
-	while(fgets(line, sizeof(line), maps) != NULL)
+	size_t line_len = 0;
+	bool done = false;
+	while(!done)
 	{
-		uintptr_t start = 0, end = 0;
-		char path[256] = { 0 };
-		// Format: start-end perms offset dev inode [path]
-		// Use %*s (not %*llx etc.) to avoid the GNU -Wformat= restriction
-		// that forbids combining the assignment-suppression modifier with a
-		// length modifier. We only care about start, end, and path.
-		const int n = sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %*s %*s %*s %*s %255s",
-		                     &start, &end, path);
-		if(n >= 2 && a >= start && a < end && path[0] != '\0')
+		const ssize_t got = read(fd, rbuf, sizeof(rbuf));
+		if(got < 0)
 		{
-			const char *base = strrchr(path, '/');
-			strncpy(buf, base ? base + 1 : path, buflen - 1u);
-			buf[buflen - 1u] = '\0';
+			if(errno == EINTR)
+				continue;
 			break;
 		}
+		if(got == 0)
+			break;
+
+		for(ssize_t i = 0; i < got; i++)
+		{
+			const char c = rbuf[i];
+			if(c == '\n')
+			{
+				line[line_len] = '\0';
+				if(maps_line_name_for_addr(line, a, buf, buflen))
+				{
+					done = true;
+					break;
+				}
+				line_len = 0;
+			}
+			else if(line_len < sizeof(line) - 1u)
+				line[line_len++] = c;
+		}
 	}
-	fclose(maps);
+
+	close(fd);
 }
 
-// Result of a single-frame addr2line resolution attempt.
-// Used by generate_backtrace() to decide whether to print manual guidance.
-enum frame_result {
-	FRAME_RESOLVED,    // addr2line resolved function name + source location
-	FRAME_UNRESOLVED,  // addr2line was attempted but did not resolve the frame
-	FRAME_SKIPPED,     // addr2line was not attempted (disabled or binary path unknown)
+// Per-frame resolution state.  Stored in a fixed static array (not on the
+// 16 KiB alternate signal stack) so the symbolization pass cannot overflow it.
+struct frame_info {
+	void *addr;        // absolute return/instruction address
+	const char *obj;   // object file path for "addr2line -e" ("" if unknown)
+	uintptr_t rel;     // address relative to that object's load base
+	Dl_info dl;        // dladdr() result (valid only when have_dl)
+	bool have_dl;      // dladdr() succeeded for this frame
+	bool resolved;     // addr2line produced a function name + source location
+	char func[256];    // addr2line function name (when resolved)
+	char loc[256];     // addr2line "file:line" (when resolved)
 };
 
-// Log one backtrace frame as a single line.
-// Resolved:   "  #N  func_name                    src/file.c:line"
-// Unresolved: "  #N  0xADDRESS  (reason)"
-// Returns FRAME_RESOLVED when addr2line produced a result, FRAME_UNRESOLVED
-// when addr2line was tried but failed, FRAME_SKIPPED when it was not attempted.
-static enum frame_result log_frame(const int idx, const void *addr, const void *rel_addr)
+// Resolve a frame's object file and relative address with a single dladdr()
+// call, reused for the reproducer command, addr2line, and the symbol fallback.
+// Frames in the main executable prefer the canonical bin_path over dladdr's
+// reported name.
+static void resolve_frame_object(void *addr, struct frame_info *fi)
 {
-	if(!config.misc.addr2line.v.b)
-	{
-		log_info("  #%-2i  %p  (addr2line disabled via config)", idx, addr);
-		return FRAME_SKIPPED;
-	}
-	if(bin_path[0] == '\0')
-	{
-		log_info("  #%-2i  %p  (binary path unknown)", idx, addr);
-		return FRAME_SKIPPED;
-	}
+	fi->addr = addr;
+	fi->resolved = false;
+	fi->func[0] = '\0';
+	fi->loc[0] = '\0';
 
-	char cmd[512];
-	snprintf(cmd, sizeof(cmd), "addr2line -f -e \"%s\" %p", bin_path, rel_addr);
-
-	FILE *fp = popen(cmd, "r");
-	if(fp == NULL)
+	Dl_info dl = { 0 };
+	if(dladdr(addr, &dl) != 0 && dl.dli_fname != NULL && dl.dli_fbase != NULL)
 	{
-		log_info("  #%-2i  %p  (addr2line not available)", idx, addr);
-		return FRAME_UNRESOLVED;
-	}
-
-	char func[256] = { 0 }, loc[256] = { 0 };
-	if(fgets(func, sizeof(func), fp) != NULL)
-	{
-		char *nl = strchr(func, '\n');
-		if(nl != NULL) *nl = '\0';
-	}
-	if(fgets(loc, sizeof(loc), fp) != NULL)
-	{
-		char *nl = strchr(loc, '\n');
-		if(nl != NULL) *nl = '\0';
-	}
-	pclose(fp);
-
-	if(func[0] == '\0' || strcmp(func, "??") == 0)
-	{
-		// addr2line found nothing — the frame is in a shared library or a
-		// stripped section.  Try dladdr() which reads .dynsym, the dynamic
-		// symbol table present in every shared library (even stripped ones).
-		Dl_info dl = { 0 };
-		if(dladdr(addr, &dl) != 0 && dl.dli_sname != NULL)
+		fi->dl = dl;
+		fi->have_dl = true;
+		if((uintptr_t)dl.dli_fbase == exe_load_addr && bin_path[0] != '\0')
 		{
-			// Library basename (e.g. "libc.so.6")
-			const char *lib = dl.dli_fname ? strrchr(dl.dli_fname, '/') : NULL;
-			const char *libname = lib ? lib + 1 : (dl.dli_fname ? dl.dli_fname : "?");
-			const uintptr_t offset = (uintptr_t)addr - (uintptr_t)dl.dli_saddr;
-			log_info("  #%-2d  %p in %s (+0x%zx) from %s",
-			         idx, addr, dl.dli_sname, (size_t)offset, libname);
+			fi->obj = bin_path;
+			fi->rel = (uintptr_t)addr - exe_load_addr;
 		}
 		else
 		{
-			// dladdr() gave nothing — fall back to /proc/self/maps for at
-			// least the library/mapping name ([vdso], [stack], etc.).
-			char mapping[128] = { 0 };
-			find_mapping_name(addr, mapping, sizeof(mapping));
-			if(mapping[0] != '\0')
-				log_info("  #%-2d  %p in ?? () from %s", idx, addr, mapping);
-			else
-				log_info("  #%-2d  %p in ?? ()", idx, addr);
+			fi->obj = dl.dli_fname;
+			fi->rel = (uintptr_t)addr - (uintptr_t)dl.dli_fbase;
 		}
-		return FRAME_UNRESOLVED;
+	}
+	else
+	{
+		fi->have_dl = false;
+		fi->obj = bin_path; // may be "" when the binary path is unknown
+		fi->rel = (uintptr_t)addr - exe_load_addr;
+	}
+}
+
+// Outcome of the batched addr2line pass, used to print a single closing hint.
+enum a2l_status {
+	A2L_OK,          // addr2line ran (some frames may still lack debug info)
+	A2L_DISABLED,    // addr2line resolution disabled via config
+	A2L_UNAVAILABLE, // addr2line could not be executed (not installed)
+	A2L_TIMED_OUT,   // addr2line exceeded the watchdog deadline
+};
+
+#define ADDR2LINE_TIMEOUT_SECONDS 5
+#define ADDR2LINE_MAX_BATCH 128
+
+// Parse a chunk of addr2line's "func\nloc\n" output (one pair per requested
+// address, in order) into the frames listed in `order`.  Splitting the byte
+// stream into lines here keeps the reader free of stdio buffering.  Carries
+// line state across chunks via *line_len/*lineno and sets *done once every
+// frame in the batch has a result.
+static void parse_addr2line_output(const char *chunk, const ssize_t chunklen,
+                                   struct frame_info *fi, const int *order, const int ng,
+                                   char *line, size_t *line_len, int *lineno, bool *done)
+{
+	for(ssize_t b = 0; b < chunklen && !*done; b++)
+	{
+		const char c = chunk[b];
+		if(c != '\n')
+		{
+			if(*line_len < 511u)
+				line[(*line_len)++] = c;
+			continue;
+		}
+		line[*line_len] = '\0';
+		*line_len = 0;
+
+		const int frame = *lineno / 2;
+		if(frame < ng)
+		{
+			struct frame_info *f = &fi[order[frame]];
+			if(*lineno % 2 == 0)
+			{
+				// Function-name line; ignore addr2line's "??" placeholder.
+				if(line[0] != '\0' && strcmp(line, "??") != 0)
+				{
+					strncpy(f->func, line, sizeof(f->func) - 1u);
+					f->func[sizeof(f->func) - 1u] = '\0';
+				}
+			}
+			else if(f->func[0] != '\0')
+			{
+				// "file:line" line; only a frame with a function name counts
+				// as resolved.
+				strncpy(f->loc, line, sizeof(f->loc) - 1u);
+				f->loc[sizeof(f->loc) - 1u] = '\0';
+				f->resolved = true;
+			}
+		}
+		(*lineno)++;
+		if(*lineno >= 2 * ng)
+			*done = true;
+	}
+}
+
+// Outcome of a single addr2line invocation.  A2L_RUN_MISSING (addr2line not
+// installed) is reported to the user; A2L_RUN_SPAWN_FAIL (a transient pipe/fork
+// failure) is not — it just means this batch could not be symbolized.
+enum a2l_run {
+	A2L_RUN_OK = 0,          // addr2line ran (frames may still lack debug info)
+	A2L_RUN_TIMED_OUT = 1,   // exceeded the wall-clock deadline
+	A2L_RUN_MISSING = -1,    // addr2line could not be executed (exit 127)
+	A2L_RUN_SPAWN_FAIL = -2, // pipe2()/fork() failed (resource exhaustion)
+};
+
+// Spawn "addr2line -f -e <obj> <rel...>" for one object and read its output,
+// bounded by a wall-clock deadline enforced with poll() + kill().  Unlike a
+// SIGALRM/itimer watchdog this keeps no process-wide signal or timer state and
+// performs no cross-thread siglongjmp(), so it is safe in the multi-threaded
+// daemon.  Spawning directly avoids popen()'s /bin/sh and stdio buffering.
+// This is not async-signal-safe (it uses snprintf(), poll() and execvp());
+// symbolization is a best-effort step that runs only after the raw frame
+// addresses have already been collected and can be logged.
+static enum a2l_run run_addr2line_object(const char *obj, struct frame_info *fi,
+                                         const int *order, const int ng)
+{
+	// argv and the per-address strings.  Thread-local static storage keeps the
+	// 16 KiB alternate signal stack free while giving concurrent callers
+	// (e.g. the lock-debug paths) independent, race-free workspaces.  TLS in
+	// the executable uses the local-exec model: a direct thread-pointer offset,
+	// no lazy allocation, so it stays usable from the crash handler.
+	static _Thread_local char addrbuf[ADDR2LINE_MAX_BATCH][2 + 2 * sizeof(uintptr_t) + 1];
+	static _Thread_local char *argv[4 + ADDR2LINE_MAX_BATCH + 1];
+	int argc = 0;
+	argv[argc++] = (char *)"addr2line";
+	argv[argc++] = (char *)"-f";
+	argv[argc++] = (char *)"-e";
+	argv[argc++] = (char *)obj;
+	for(int k = 0; k < ng && k < ADDR2LINE_MAX_BATCH; k++)
+	{
+		snprintf(addrbuf[k], sizeof(addrbuf[k]), "0x%zx", (size_t)fi[order[k]].rel);
+		argv[argc++] = addrbuf[k];
+	}
+	argv[argc] = NULL;
+
+	int pipefd[2];
+	if(pipe2(pipefd, O_CLOEXEC) != 0)
+		return A2L_RUN_SPAWN_FAIL;
+
+	const pid_t pid = fork();
+	if(pid < 0)
+	{
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return A2L_RUN_SPAWN_FAIL;
+	}
+	if(pid == 0)
+	{
+		// Child: stdout -> pipe, stderr -> /dev/null, then exec.  dup2() clears
+		// O_CLOEXEC on the duplicate so fds 1/2 survive exec; the originals are
+		// closed here so the exec'd addr2line inherits no extra descriptors.
+		dup2(pipefd[1], STDOUT_FILENO);
+		const int devnull = open("/dev/null", O_WRONLY | O_CLOEXEC);
+		if(devnull >= 0)
+		{
+			dup2(devnull, STDERR_FILENO);
+			close(devnull);
+		}
+		close(pipefd[0]);
+		close(pipefd[1]);
+		execvp("addr2line", argv);
+		_exit(127); // addr2line not found / not executable
 	}
 
-	// Strip the compile-time source root to show project-relative paths
-	// (e.g. "src/signals.c:42" instead of "/home/user/FTL/src/signals.c:42").
-	const char *display_loc = loc;
-#if defined(SOURCE_ROOT)
-	if(strncmp(loc, SOURCE_ROOT, sizeof(SOURCE_ROOT) - 1u) == 0)
-		display_loc = loc + sizeof(SOURCE_ROOT) - 1u;
-#endif
+	// Parent: read the response until EOF or the monotonic deadline.
+	close(pipefd[1]);
 
-	log_info("  #%-2i  %-30s  %s", idx, func, display_loc);
-	return FRAME_RESOLVED;
+	struct timespec deadline;
+	clock_gettime(CLOCK_MONOTONIC, &deadline);
+	deadline.tv_sec += ADDR2LINE_TIMEOUT_SECONDS;
+
+	char buf[4096];
+	char line[512];
+	size_t line_len = 0;
+	int lineno = 0;
+	bool done = false;
+	bool timed_out = false;
+	while(!done)
+	{
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		const long remaining_ms = (deadline.tv_sec - now.tv_sec) * 1000L +
+		                          (deadline.tv_nsec - now.tv_nsec) / 1000000L;
+		if(remaining_ms <= 0)
+		{
+			timed_out = true;
+			break;
+		}
+
+		struct pollfd pfd = { .fd = pipefd[0], .events = POLLIN };
+		const int pr = poll(&pfd, 1, (int)remaining_ms);
+		if(pr < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			break;
+		}
+		if(pr == 0)
+		{
+			timed_out = true;
+			break;
+		}
+
+		const ssize_t got = read(pipefd[0], buf, sizeof(buf));
+		if(got < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			break;
+		}
+		if(got == 0)
+			break; // EOF: addr2line finished
+
+		parse_addr2line_output(buf, got, fi, order, ng, line, &line_len, &lineno, &done);
+	}
+
+	close(pipefd[0]);
+	if(timed_out)
+		kill(pid, SIGKILL);
+
+	int status = 0;
+	// Loop on EINTR so the child is always reaped (no zombie) and status is
+	// populated before we classify the run below.
+	while(waitpid(pid, &status, 0) < 0 && errno == EINTR)
+		; // retry
+
+	if(timed_out)
+		return A2L_RUN_TIMED_OUT;
+	if(WIFEXITED(status) && WEXITSTATUS(status) == 127)
+		return A2L_RUN_MISSING;
+	return A2L_RUN_OK;
+}
+
+// Resolve as many frames as possible by running addr2line once per distinct
+// object (so a static-pie build resolves the whole stack in a single
+// subprocess).  Returns whether addr2line ran, was disabled, missing, or
+// timed out.
+static enum a2l_status resolve_frames_addr2line(struct frame_info *fi, const int n)
+{
+	if(!config.misc.addr2line.v.b)
+		return A2L_DISABLED;
+
+	bool processed[ADDR2LINE_MAX_BATCH] = { false };
+	bool any_unavailable = false;
+	for(int i = 0; i < n && i < ADDR2LINE_MAX_BATCH; i++)
+	{
+		if(processed[i])
+			continue;
+		processed[i] = true;
+		if(fi[i].obj == NULL || fi[i].obj[0] == '\0')
+			continue;
+
+		// Gather every remaining frame that shares this object, in order.
+		int order[ADDR2LINE_MAX_BATCH];
+		int ng = 0;
+		order[ng++] = i;
+		for(int j = i + 1; j < n && ng < ADDR2LINE_MAX_BATCH; j++)
+		{
+			if(processed[j] || fi[j].obj == NULL || strcmp(fi[j].obj, fi[i].obj) != 0)
+				continue;
+			processed[j] = true;
+			order[ng++] = j;
+		}
+
+		switch(run_addr2line_object(fi[i].obj, fi, order, ng))
+		{
+			case A2L_RUN_TIMED_OUT:
+				// Hung addr2line: stop and fall back to dladdr symbols.
+				return A2L_TIMED_OUT;
+			case A2L_RUN_MISSING:
+				// addr2line is genuinely not installed; advise the user.
+				any_unavailable = true;
+				break;
+			case A2L_RUN_SPAWN_FAIL:
+			case A2L_RUN_OK:
+				// A transient pipe/fork failure just leaves this batch
+				// unresolved; do not claim addr2line is missing.
+				break;
+		}
+	}
+
+	return any_unavailable ? A2L_UNAVAILABLE : A2L_OK;
+}
+
+// Log one resolved/unresolved backtrace frame as a single line.  Mirrors gdb's
+// coloring: function names in yellow, source locations / object names in green.
+// cli_color() yields the codes only on an interactive terminal, so the daemon's
+// crash log in FTL.log stays plain text.
+// Resolved:   "  #N  func_name                    src/file.c:line"
+// Symbol:     "  #N  0xADDR in func (+0xoff) from libc.so.6"
+// Raw:        "  #N  0xADDR in ?? () from <mapping>"
+static void log_frame(const int idx, const struct frame_info *fi)
+{
+	const char *col_func = cli_color(COL_YELLOW); // function names
+	const char *col_loc = cli_color(COL_GREEN);   // source paths / objects
+	const char *col_off = cli_color(COL_NC);       // reset
+
+	if(fi->resolved)
+	{
+		// Strip the compile-time source root to show project-relative paths
+		// (e.g. "src/signals.c:42" not "/home/user/FTL/src/signals.c:42").
+		const char *display_loc = fi->loc;
+#if defined(SOURCE_ROOT)
+		if(strncmp(fi->loc, SOURCE_ROOT, sizeof(SOURCE_ROOT) - 1u) == 0)
+			display_loc = fi->loc + sizeof(SOURCE_ROOT) - 1u;
+#endif
+		// %-30s pads the (uncolored) function name argument, so column
+		// alignment is unaffected by the surrounding escape codes.
+		log_info("  #%-2i  %s%-30s%s  %s%s%s", idx,
+		         col_func, fi->func, col_off, col_loc, display_loc, col_off);
+		return;
+	}
+
+	// addr2line produced nothing (disabled, missing, timed out, or no debug
+	// info).  Fall back to the dladdr() symbol from .dynsym, present even in
+	// stripped shared libraries.
+	if(fi->have_dl && fi->dl.dli_sname != NULL)
+	{
+		const char *lib = fi->dl.dli_fname ? strrchr(fi->dl.dli_fname, '/') : NULL;
+		const char *libname = lib ? lib + 1 : (fi->dl.dli_fname ? fi->dl.dli_fname : "?");
+		const uintptr_t offset = (uintptr_t)fi->addr - (uintptr_t)fi->dl.dli_saddr;
+		log_info("  #%-2d  %p in %s%s%s (+0x%zx) from %s%s%s",
+		         idx, fi->addr, col_func, fi->dl.dli_sname, col_off,
+		         (size_t)offset, col_loc, libname, col_off);
+		return;
+	}
+
+	// No symbol at all - fall back to the mapping name ([vdso], [stack], ...).
+	char mapping[128] = { 0 };
+	find_mapping_name(fi->addr, mapping, sizeof(mapping));
+	if(mapping[0] != '\0')
+		log_info("  #%-2d  %p in ?? () from %s%s%s",
+		         idx, fi->addr, col_loc, mapping, col_off);
+	else
+		log_info("  #%-2d  %p in ?? ()", idx, fi->addr);
 }
 #endif // USE_UNWIND
 
@@ -270,52 +871,127 @@ static char * __attribute__ ((nonnull (1))) getthread_name(char buffer[16])
 }
 
 
+#if defined(USE_UNWIND)
+// Resolve and log one set of collected frames: one dladdr() per frame, a
+// batched addr2line pass, the per-frame lines, then - only when needed - a note
+// about why symbolization was incomplete plus copy-pasteable offline addr2line
+// commands for any frame that stayed unresolved.
+static void symbolize_and_render_frames(void **frames, const int frame_count)
+{
+	// Thread-local static storage keeps this off the 16 KiB alternate signal
+	// stack while giving concurrent callers (e.g. the lock-debug paths)
+	// independent, race-free workspaces.  TLS in the executable uses the
+	// local-exec model, so it stays usable from the crash handler.
+	static _Thread_local struct frame_info fi[128];
+	const int n = frame_count > 128 ? 128 : frame_count;
+
+	// Resolve each frame's object + relative address once (one dladdr() per
+	// frame, reused below for addr2line, the symbol fallback, and the
+	// reproducer command).
+	for(int i = 0; i < n; i++)
+		resolve_frame_object(frames[i], &fi[i]);
+
+	// Symbolize via batched addr2line (one invocation per object, bounded by a
+	// watchdog timer), then render every frame in order.
+	const enum a2l_status st = resolve_frames_addr2line(fi, n);
+	for(int i = 0; i < n; i++)
+		log_frame(i, &fi[i]);
+
+	// Explain why symbolization was incomplete, if it was.
+	if(st == A2L_DISABLED)
+		log_info("  (addr2line resolution disabled via config; frames shown via dladdr only)");
+	else if(st == A2L_UNAVAILABLE)
+		log_info("  addr2line is not installed (e.g. \"apt install binutils\" or \"apk add binutils\").");
+	else if(st == A2L_TIMED_OUT)
+		log_info("  addr2line exceeded its %d s watchdog.", ADDR2LINE_TIMEOUT_SECONDS);
+
+	// For any frame addr2line could not pin to a source location, print a
+	// copy-pasteable command to resolve it offline (after installing binutils,
+	// or on a build that still has matching debug info).  When every frame
+	// resolved, this stays silent.
+	int unresolved = 0;
+	for(int i = 0; i < n; i++)
+		if(!fi[i].resolved)
+			unresolved++;
+
+	if(unresolved > 0)
+	{
+		log_info("  Resolve the %d unresolved frame%s offline by running:",
+		         unresolved, unresolved == 1 ? "" : "s");
+		for(int i = 0; i < n; i++)
+		{
+			if(fi[i].resolved)
+				continue;
+			if(fi[i].obj != NULL && fi[i].obj[0] != '\0')
+				log_info("    addr2line -f -e \"%s\" %p", fi[i].obj, (void *)fi[i].rel);
+			else
+				log_info("    #%-2i  %p  (object unknown)", i, fi[i].addr);
+		}
+	}
+}
+#endif // USE_UNWIND
+
 // Log backtrace to the FTL log.
-// Uses _Unwind_Backtrace (GCC libgcc) on all targets — glibc AND musl,
+// Prefers walking the interrupted signal context (frame pointers) and falls
+// back to _Unwind_Backtrace (GCC libgcc) when no context is available or the
+// walk yields nothing.  Both paths work on all targets - glibc AND musl,
 // static-pie AND dynamic, all architectures.
-void generate_backtrace(void)
+static void generate_backtrace_internal(void *context)
 {
 #if defined(USE_UNWIND)
 	void *frames[128];
-	struct unwind_state state = { frames, 0, 128 };
-	_Unwind_Backtrace(unwind_callback, &state);
+	enum backtrace_source source = BT_SOURCE_NONE;
+	bool complete = false;
+	const int frame_count = collect_backtrace_frames(frames, 128, context, &source, &complete);
+	const char *source_str = source == BT_SOURCE_SIGNAL_CONTEXT ?
+	                         " from signal context" : "";
 
-	log_info("Backtrace (%d frames):", state.count);
-	bool any_addr2line_failed = false;
-	for(int i = 0; i < state.count; i++)
-	{
-		void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
-		if(log_frame(i, frames[i], rel) == FRAME_UNRESOLVED)
-			any_addr2line_failed = true;
-	}
+	log_info("Backtrace (%d frames%s):", frame_count, source_str);
+	symbolize_and_render_frames(frames, frame_count);
 
-	// If addr2line was attempted but could not resolve one or more frames
-	// (e.g. because it is not installed), print per-frame commands the
-	// user can run manually after installing binutils.  Use dladdr() to
-	// determine the correct object file and base address for each frame
-	// so the commands are actionable for shared-library frames too.
-	if(any_addr2line_failed)
+	// When the signal-context frame-pointer walk stopped early (a corrupt or
+	// not-yet-set-up frame pointer - exactly the kind of damaged stack that
+	// tends to cause the crash), cross-check it against libgcc's DWARF-CFI
+	// unwinder, which can cross frame-pointer-less boundaries the walk cannot.
+	// Only shown when it actually recovers more frames than the truncated walk.
+	if(source == BT_SOURCE_SIGNAL_CONTEXT && !complete && frame_count > 0)
 	{
-		log_info("One or more frames could not be resolved. Install addr2line");
-		log_info("(e.g. \"apt install binutils\" or \"apk add binutils\") and run:");
+		void *cross[128];
+		struct unwind_state state = { cross, 0, 128 };
+		_Unwind_Backtrace(unwind_callback, &state);
+
+		// frames[0] is the exact faulting PC; the libgcc unwinder records the
+		// same value for the interrupted frame (kept as-is by _Unwind_GetIPInfo
+		// because it is a signal frame), so it marks where the real stack
+		// begins - everything above it is our own handler + the signal
+		// trampoline and is skipped.  If the value is not found, libgcc could
+		// not unwind past the signal frame, so there is nothing trustworthy to
+		// add and the cross-check is omitted.
+		int start = -1;
 		for(int i = 0; i < state.count; i++)
-		{
-			Dl_info dl = { 0 };
-			const char *obj = bin_path;
-			void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
-			if(dladdr(frames[i], &dl) != 0 && dl.dli_fname != NULL && dl.dli_fbase != NULL)
+			if(cross[i] == frames[0])
 			{
-				obj = dl.dli_fname;
-				rel = (void *)((uintptr_t)frames[i] - (uintptr_t)dl.dli_fbase);
+				start = i;
+				break;
 			}
-			log_info("  addr2line -f -e \"%s\" %p", obj, rel);
+
+		const int cross_count = (start >= 0) ? state.count - start : 0;
+		if(cross_count > frame_count)
+		{
+			log_info("Cross-check backtrace (libgcc/_Unwind, %d frames):", cross_count);
+			symbolize_and_render_frames(cross + start, cross_count);
 		}
 	}
-	log_info("  --- end of backtrace (%d frame%s) ---",
-	         state.count, state.count == 1 ? "" : "s");
+
+	log_info("  --- end of backtrace ---");
 #else
 	log_info("!!! INFO: pihole-FTL has not been compiled with unwinding support, cannot generate backtrace !!!");
 #endif
+}
+
+void generate_backtrace(void)
+{
+	generate_backtrace_internal(NULL);
 }
 
 /**
@@ -333,7 +1009,6 @@ static void terminate_error(void)
 
 static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, void *context)
 {
-	(void)context;
 	log_info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 	log_info("---------------------------->  FTL crashed!  <----------------------------");
 	log_info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
@@ -443,7 +1118,7 @@ static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, voi
 		}
 	}
 
-	generate_backtrace();
+	generate_backtrace_internal(context);
 
 	// Flush stdout immediately so the backtrace is visible even if a
 	// subsequent fault in cleanup() kills the process before exit() runs.
@@ -500,7 +1175,7 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *context)
 		return;
 	}
 
-	// Do NOT call log_info() or strsignal() here — they are not
+	// Do NOT call log_info() or strsignal() here - they are not
 	// async-signal-safe and can deadlock if the signal arrives while
 	// malloc's internal lock is held. The events set below are logged
 	// when processed in the main loop / database thread.
@@ -570,7 +1245,7 @@ static void SIGTERM_handler(int signum, siginfo_t *si, void *context)
 
 	// Request deferred termination. The actual raise(SIGUSR6)/killed
 	// assignment happens in terminate(), called from check_if_want_terminate()
-	// which is invoked periodically from the main loop (gc.c) — keeping
+	// which is invoked periodically from the main loop (gc.c) - keeping
 	// the signal handler free of non-async-signal-safe calls like
 	// log_info(), time(), and gravity_running checks.
 	want_terminate = true;
@@ -597,7 +1272,7 @@ void log_sigterm_info(void)
 		size_t read = 0;
 		if((read = fread(kill_name, sizeof(char), sizeof(kill_name), fp)) > 0)
 		{
-			// cmdline contains null-separated arguments — replace
+			// cmdline contains null-separated arguments - replace
 			// null bytes with spaces for display
 			for(unsigned int i = 0; i < min((size_t)read, sizeof(kill_name)); i++)
 			{
@@ -638,7 +1313,7 @@ void log_sigterm_info(void)
 }
 
 // Checks if the program should terminate or not. Called periodically from
-// the main loop (gc.c) and API action handlers — never from signal context.
+// the main loop (gc.c) and API action handlers - never from signal context.
 static time_t last_term_warning = 0;
 void check_if_want_terminate(void)
 {
@@ -721,7 +1396,7 @@ void handle_signals(void)
 		}
 	}
 
-	// SIGTERM: graceful shutdown — no SA_ONSTACK or SA_RESETHAND needed
+	// SIGTERM: graceful shutdown - no SA_ONSTACK or SA_RESETHAND needed
 	sigaction(SIGTERM, NULL, &old_action);
 	if(old_action.sa_handler != SIG_IGN)
 	{

--- a/src/signals.c
+++ b/src/signals.c
@@ -16,6 +16,7 @@
 #  include <inttypes.h>  // SCNxPTR — portable sscanf format for uintptr_t
 #  include <sys/mman.h>  // mmap() — used for the intentional crash test subcommand
 #  include <dlfcn.h>     // dladdr() — dynamic symbol lookup from .dynsym
+#  include <ucontext.h>  // ucontext_t — register snapshot from SA_SIGINFO handlers
 #endif
 #include "signals.h"
 // logging routines
@@ -105,6 +106,11 @@ struct unwind_state {
 	int    max;
 };
 
+enum backtrace_source {
+	BT_SOURCE_SIGNAL_CONTEXT,
+	BT_SOURCE_UNWIND_FALLBACK,
+};
+
 // Callback invoked by _Unwind_Backtrace for each frame on the call stack.
 // Signal-handler-safe: no heap allocation, no stdio, no locks.
 static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context *ctx, void *arg)
@@ -121,6 +127,145 @@ static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context *ctx, void *ar
 	return _URC_NO_REASON;
 }
 #endif // USE_UNWIND (unwind_callback)
+
+#if defined(USE_UNWIND)
+// True when [addr, addr+bytes) is inside a readable mapping in /proc/self/maps.
+static bool is_readable_range(const uintptr_t addr, const size_t bytes)
+{
+	if(bytes == 0u)
+		return false;
+
+	FILE *maps = fopen("/proc/self/maps", "r");
+	if(maps == NULL)
+		return false;
+
+	bool readable = false;
+	char line[512];
+	while(fgets(line, sizeof(line), maps) != NULL)
+	{
+		uintptr_t start = 0, end = 0;
+		char perms[8] = { 0 };
+		const int n = sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %7s %*s %*s %*s",
+		                     &start, &end, perms);
+		if(n != 3 || perms[0] != 'r')
+			continue;
+
+		if(addr >= start && addr < end && (size_t)(end - addr) >= bytes)
+		{
+			readable = true;
+			break;
+		}
+	}
+
+	fclose(maps);
+	return readable;
+}
+
+// True when addr points into an executable mapping.
+static bool is_executable_address(const uintptr_t addr)
+{
+	FILE *maps = fopen("/proc/self/maps", "r");
+	if(maps == NULL)
+		return false;
+
+	bool executable = false;
+	char line[512];
+	while(fgets(line, sizeof(line), maps) != NULL)
+	{
+		uintptr_t start = 0, end = 0;
+		char perms[8] = { 0 };
+		const int n = sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %7s %*s %*s %*s",
+		                     &start, &end, perms);
+		if(n != 3 || perms[2] != 'x')
+			continue;
+
+		if(addr >= start && addr < end)
+		{
+			executable = true;
+			break;
+		}
+	}
+
+	fclose(maps);
+	return executable;
+}
+
+// Try to unwind from signal context using frame pointers.
+// This captures caller frames before the signal trampoline on targets where
+// the frame pointer chain is available.
+static int collect_from_signal_context(void **frames, const int max_frames, void *context)
+{
+	if(context == NULL || max_frames <= 0)
+		return 0;
+
+	ucontext_t *uc = (ucontext_t *)context;
+	uintptr_t ip = 0;
+	uintptr_t fp = 0;
+
+#if defined(__x86_64__)
+	ip = (uintptr_t)uc->uc_mcontext.gregs[REG_RIP];
+	fp = (uintptr_t)uc->uc_mcontext.gregs[REG_RBP];
+#elif defined(__aarch64__)
+	ip = (uintptr_t)uc->uc_mcontext.pc;
+	fp = (uintptr_t)uc->uc_mcontext.regs[29];
+#else
+	(void)uc;
+	return 0;
+#endif
+
+	int count = 0;
+	if(ip != 0)
+		frames[count++] = (void *)(ip - 1u);
+
+	while(count < max_frames && fp != 0)
+	{
+		if((fp & (sizeof(uintptr_t) - 1u)) != 0)
+			break;
+
+		if(!is_readable_range(fp, 2u*sizeof(uintptr_t)))
+			break;
+
+		const uintptr_t *frame = (const uintptr_t *)fp;
+		const uintptr_t next_fp = frame[0];
+		const uintptr_t ret = frame[1];
+
+		if(ret == 0 || !is_executable_address(ret - 1u))
+			break;
+
+		frames[count++] = (void *)(ret - 1u);
+
+		if(next_fp <= fp || next_fp - fp > 1u*1024u*1024u)
+			break;
+
+		fp = next_fp;
+	}
+
+	return count;
+}
+
+// Collect a backtrace either from an interrupted signal context (preferred)
+// or from the current stack as fallback.
+static int collect_backtrace_frames(void **frames, const int max_frames, void *context,
+                                    enum backtrace_source *source)
+{
+	if(max_frames <= 0)
+		return 0;
+
+	const int from_signal_context = collect_from_signal_context(frames, max_frames, context);
+	if(from_signal_context > 0)
+	{
+		if(source != NULL)
+			*source = BT_SOURCE_SIGNAL_CONTEXT;
+		return from_signal_context;
+	}
+
+	struct unwind_state state = { frames, 0, max_frames };
+	_Unwind_Backtrace(unwind_callback, &state);
+	if(source != NULL)
+		*source = BT_SOURCE_UNWIND_FALLBACK;
+	return state.count;
+}
+#endif // USE_UNWIND (collect_backtrace_frames)
 
 #if defined(USE_UNWIND)
 // Look up which /proc/self/maps entry contains addr and copy the basename
@@ -158,9 +303,10 @@ static void find_mapping_name(const void *addr, char *buf, const size_t buflen)
 // Result of a single-frame addr2line resolution attempt.
 // Used by generate_backtrace() to decide whether to print manual guidance.
 enum frame_result {
-	FRAME_RESOLVED,    // addr2line resolved function name + source location
-	FRAME_UNRESOLVED,  // addr2line was attempted but did not resolve the frame
-	FRAME_SKIPPED,     // addr2line was not attempted (disabled or binary path unknown)
+	FRAME_RESOLVED,     // addr2line resolved function name + source location
+	FRAME_UNRESOLVED,   // addr2line was attempted but is not installed
+	FRAME_UNRESOLVABLE, // addr2line was attempted but could not resolve the frame, even with dladdr() fallback
+	FRAME_SKIPPED,      // addr2line was not attempted (disabled or binary path unknown)
 };
 
 // Log one backtrace frame as a single line.
@@ -230,7 +376,7 @@ static enum frame_result log_frame(const int idx, const void *addr, const void *
 			else
 				log_info("  #%-2d  %p in ?? ()", idx, addr);
 		}
-		return FRAME_UNRESOLVED;
+		return FRAME_UNRESOLVABLE;
 	}
 
 	// Strip the compile-time source root to show project-relative paths
@@ -273,16 +419,18 @@ static char * __attribute__ ((nonnull (1))) getthread_name(char buffer[16])
 // Log backtrace to the FTL log.
 // Uses _Unwind_Backtrace (GCC libgcc) on all targets — glibc AND musl,
 // static-pie AND dynamic, all architectures.
-void generate_backtrace(void)
+static void generate_backtrace_internal(void *context)
 {
 #if defined(USE_UNWIND)
 	void *frames[128];
-	struct unwind_state state = { frames, 0, 128 };
-	_Unwind_Backtrace(unwind_callback, &state);
+	enum backtrace_source source = BT_SOURCE_UNWIND_FALLBACK;
+	const int frame_count = collect_backtrace_frames(frames, 128, context, &source);
+	const char *source_str = source == BT_SOURCE_SIGNAL_CONTEXT ?
+	                         "signal context" : "_Unwind_Backtrace fallback";
 
-	log_info("Backtrace (%d frames):", state.count);
+	log_info("Backtrace (%d frames, source: %s):", frame_count, source_str);
 	bool any_addr2line_failed = false;
-	for(int i = 0; i < state.count; i++)
+	for(int i = 0; i < frame_count; i++)
 	{
 		void *rel = (void *)((uintptr_t)frames[i] - exe_load_addr);
 		if(log_frame(i, frames[i], rel) == FRAME_UNRESOLVED)
@@ -298,7 +446,7 @@ void generate_backtrace(void)
 	{
 		log_info("One or more frames could not be resolved. Install addr2line");
 		log_info("(e.g. \"apt install binutils\" or \"apk add binutils\") and run:");
-		for(int i = 0; i < state.count; i++)
+		for(int i = 0; i < frame_count; i++)
 		{
 			Dl_info dl = { 0 };
 			const char *obj = bin_path;
@@ -312,10 +460,15 @@ void generate_backtrace(void)
 		}
 	}
 	log_info("  --- end of backtrace (%d frame%s) ---",
-	         state.count, state.count == 1 ? "" : "s");
+	         frame_count, frame_count == 1 ? "" : "s");
 #else
 	log_info("!!! INFO: pihole-FTL has not been compiled with unwinding support, cannot generate backtrace !!!");
 #endif
+}
+
+void generate_backtrace(void)
+{
+	generate_backtrace_internal(NULL);
 }
 
 /**
@@ -333,7 +486,6 @@ static void terminate_error(void)
 
 static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, void *context)
 {
-	(void)context;
 	log_info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 	log_info("---------------------------->  FTL crashed!  <----------------------------");
 	log_info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
@@ -443,7 +595,7 @@ static void __attribute__((noreturn)) signal_handler(int sig, siginfo_t *si, voi
 		}
 	}
 
-	generate_backtrace();
+	generate_backtrace_internal(context);
 
 	// Flush stdout immediately so the backtrace is visible even if a
 	// subsequent fault in cleanup() kills the process before exit() runs.

--- a/test/arch_test.sh
+++ b/test/arch_test.sh
@@ -97,16 +97,52 @@ check_crash() {
   # Run the intentional-crash subcommand and capture combined stdout+stderr.
   # The process exits non-zero (killed by SIGSEGV), so we suppress the error.
   output="$(./pihole-FTL crash 2>&1 || true)"
-  if echo "$output" | grep -q "FTL crashed"; then
-    if echo "$output" | grep -q "Backtrace ("; then
-      echo "Crash handler test: OK (crash handler invoked, backtrace generated)"
-    else
-      # Handler ran but no backtrace — warn rather than fail.
-      # This can happen if addr2line is absent or the binary has no debug info.
-      echo "Crash handler test: WARNING (crash handler invoked, no backtrace)"
-    fi
-  else
+  if ! echo "$output" | grep -q "FTL crashed"; then
     echo "Crash handler test: FAILED (FTL crash handler was not invoked)"
+    okay=false
+    return
+  fi
+  if ! echo "$output" | grep -q "Backtrace ("; then
+    # Handler ran but no backtrace — warn rather than fail.
+    # This can happen if addr2line is absent or the binary has no debug info.
+    echo "Crash handler test: WARNING (crash handler invoked, no backtrace)"
+    return
+  fi
+  echo "Crash handler test: OK (crash handler invoked, backtrace generated)"
+
+  # On x86_64/aarch64 the crash backtrace must be collected from the
+  # interrupted signal context (the preferred frame-pointer walk), not the
+  # _Unwind_Backtrace fallback. Other architectures have no signal-context
+  # walker and legitimately use the fallback, so only assert it where it
+  # applies and runs natively/reliably (amd64 and local runs).
+  case "${CI_ARCH}" in
+    linux/amd64|"")
+      if echo "$output" | grep -q "from signal context"; then
+        echo "Crash backtrace source test: OK (collected from signal context)"
+      else
+        echo "Crash backtrace source test: FAILED (expected 'from signal context')"
+        echo "$output" | grep "Backtrace (" || true
+        okay=false
+      fi
+      ;;
+  esac
+}
+
+check_backtrace() {
+  # The 'backtrace' subcommand prints a backtrace without crashing and must
+  # exit cleanly.
+  output="$(./pihole-FTL backtrace 2>&1)"
+  status=$?
+  if [[ "${status}" -ne 0 ]]; then
+    echo "Backtrace subcommand test: FAILED (exit status ${status})"
+    okay=false
+    return
+  fi
+  if echo "$output" | grep -q "Backtrace (" && echo "$output" | grep -q -- "--- end of backtrace"; then
+    echo "Backtrace subcommand test: OK (backtrace generated)"
+  else
+    echo "Backtrace subcommand test: FAILED (no backtrace produced)"
+    echo "$output"
     okay=false
   fi
 }
@@ -186,6 +222,7 @@ else
 
 fi
 
+check_backtrace
 check_crash
 
 if [[ "${okay}" == "false" ]]; then

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -705,18 +705,18 @@ setup() {
   run bash -c './pihole-FTL backtrace'
   printf "%s\n" "${lines[@]}"
   # This path generates a backtrace without crashing, so it exits cleanly
-  [[ $status == 0 ]]
+  assert_success
   # The header reports a frame count (and, for a real crash, the unwind source)
-  [[ "${lines[0]}" == "Backtrace ("*"frames"*"):" ]]
+  assert_line --regexp --index 0 '^Backtrace \([^)]*frames[^)]*\):$'
   # At least the first two frames are collected
-  [[ "${output}" == *"#0"* ]]
-  [[ "${output}" == *"#1"* ]]
+  assert_output --partial "#0"
+  assert_output --partial "#1"
   # The calling chain is symbolized (addr2line or the dladdr fallback): the
   # 'backtrace' subcommand is reached via parse_args() from main()
-  [[ "${output}" == *"parse_args"* ]]
-  [[ "${output}" == *"main"* ]]
+  assert_output --partial "parse_args"
+  assert_output --partial "main"
   # The closing marker is present
-  [[ "${output}" == *"--- end of backtrace"* ]]
+  assert_output --partial "--- end of backtrace"
 }
 
 @test "'pihole-FTL backtrace' resolves source locations when addr2line is present" {
@@ -725,11 +725,11 @@ setup() {
   fi
   run bash -c './pihole-FTL backtrace'
   printf "%s\n" "${lines[@]}"
-  [[ $status == 0 ]]
+  assert_success
   # parse_args() resolves to its project-relative source location
-  [[ "${output}" == *"src/args.c"* ]]
+  assert_output --partial "src/args.c"
   # addr2line is available, so the 'not installed' hint must not be printed
-  [[ "${output}" != *"addr2line is not installed"* ]]
+  refute_output --partial "addr2line is not installed"
 }
 
 @test "'pihole-FTL backtrace' prints resolve guidance when addr2line is unavailable" {
@@ -740,11 +740,11 @@ setup() {
   # reproducer command.
   run bash -c 'PATH="" ./pihole-FTL backtrace'
   printf "%s\n" "${lines[@]}"
-  [[ $status == 0 ]]
-  [[ "${output}" == *"Backtrace ("* ]]
-  [[ "${output}" == *"addr2line is not installed"* ]]
-  [[ "${output}" == *"unresolved frame"* ]]
-  [[ "${output}" == *"addr2line -f -e"* ]]
+  assert_success
+  assert_output --partial "Backtrace ("
+  assert_output --partial "addr2line is not installed"
+  assert_output --partial "unresolved frame"
+  assert_output --partial "addr2line -f -e"
 }
 
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -795,6 +795,52 @@ setup() {
   [[ "${lines[0]}" == "80o,443os,[::]:80o,[::]:443os" ]]
 }
 
+@test "'pihole-FTL backtrace' generates a structured backtrace" {
+  run bash -c './pihole-FTL backtrace'
+  printf "%s\n" "${lines[@]}"
+  # This path generates a backtrace without crashing, so it exits cleanly
+  [[ $status == 0 ]]
+  # The header reports a frame count (and, for a real crash, the unwind source)
+  [[ "${lines[0]}" == "Backtrace ("*"frames"*"):" ]]
+  # At least the first two frames are collected
+  [[ "${output}" == *"#0"* ]]
+  [[ "${output}" == *"#1"* ]]
+  # The calling chain is symbolized (addr2line or the dladdr fallback): the
+  # 'backtrace' subcommand is reached via parse_args() from main()
+  [[ "${output}" == *"parse_args"* ]]
+  [[ "${output}" == *"main"* ]]
+  # The closing marker is present
+  [[ "${output}" == *"--- end of backtrace"* ]]
+}
+
+@test "'pihole-FTL backtrace' resolves source locations when addr2line is present" {
+  if ! command -v addr2line >/dev/null 2>&1; then
+    skip "addr2line not installed; resolution-dependent assertion skipped"
+  fi
+  run bash -c './pihole-FTL backtrace'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  # parse_args() resolves to its project-relative source location
+  [[ "${output}" == *"src/args.c"* ]]
+  # addr2line is available, so the 'not installed' hint must not be printed
+  [[ "${output}" != *"addr2line is not installed"* ]]
+}
+
+@test "'pihole-FTL backtrace' prints resolve guidance when addr2line is unavailable" {
+  # Hide addr2line via an empty PATH (the binary itself is launched by an
+  # explicit relative path, so it still runs). The directly spawned addr2line
+  # child then fails to exec and exits 127, which must be reported as
+  # 'not installed' and every unresolved frame must get a copy-pasteable
+  # reproducer command.
+  run bash -c 'PATH="" ./pihole-FTL backtrace'
+  printf "%s\n" "${lines[@]}"
+  [[ $status == 0 ]]
+  [[ "${output}" == *"Backtrace ("* ]]
+  [[ "${output}" == *"addr2line is not installed"* ]]
+  [[ "${output}" == *"unresolved frame"* ]]
+  [[ "${output}" == *"addr2line -f -e"* ]]
+}
+
 # NOTE: Log validation (WARNING/ERROR/CRIT/DB checks) moved to the final
 # log scan in run.sh, which runs after both BATS and pytest complete.
 


### PR DESCRIPTION
# What does this implement/fix?

Prefer signal-context frame walking in crash handlers, with `_Unwind_Backtrace` fallback. Add mapping safety checks and log the unwind source so field crash reports show whether frames came from signal context or fallback.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.