### PR TITLE
Fix mbedTLS 100% CPU busy-spin on non-blocking TLS sockets

### DIFF
--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -6219,6 +6219,10 @@ push_inner(struct mg_context *ctx,
 	/* Try to read until it succeeds, fails, times out, or the server
 	 * shuts down. */
 	for (;;) {
+		/* Which socket event to wait for before retrying a write that made
+		 * no progress. Default to write-readiness; a non-blocking TLS write
+		 * can instead need read-readiness (see the mbedTLS branch below). */
+		int want_events = POLLOUT;
 
 #if defined(USE_MBEDTLS)
 		if (ssl != NULL) {
@@ -6227,6 +6231,14 @@ push_inner(struct mg_context *ctx,
 				if ((n == MBEDTLS_ERR_SSL_WANT_READ)
 				    || (n == MBEDTLS_ERR_SSL_WANT_WRITE)
 				    || n == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+					/* mbedTLS may need to read (e.g. during a
+					 * renegotiation) before it can write. Wait for the
+					 * operation it actually asked for: polling for write-
+					 * readiness while it wants to read busy-spins at 100%
+					 * CPU because the socket is almost always writable. */
+					if (n == MBEDTLS_ERR_SSL_WANT_READ) {
+						want_events = POLLIN;
+					}
 					n = 0;
 				} else {
 					fprintf(stderr, "SSL write failed, error %d\n", n);
@@ -6328,7 +6340,7 @@ push_inner(struct mg_context *ctx,
 			unsigned int num_sock = 1;
 
 			pfd[0].fd = sock;
-			pfd[0].events = POLLOUT;
+			pfd[0].events = (short)want_events;
 
 			if (ctx->context_type == CONTEXT_SERVER) {
 				pfd[num_sock].fd = ctx->thread_shutdown_notification_socket;
@@ -6488,6 +6500,30 @@ pull_inner(FILE *fp,
 				if ((nread == MBEDTLS_ERR_SSL_WANT_READ)
 				    || (nread == MBEDTLS_ERR_SSL_WANT_WRITE)
 				    || nread == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+					/* mbedTLS consumed data from the socket (e.g. a non-
+					 * application TLS record) or holds buffered data that
+					 * does not yield application bytes yet, so the socket can
+					 * stay poll-readable while no progress is visible here.
+					 * Wait for the socket to become ready for the operation
+					 * mbedTLS asked for (read vs. write), bounded by the
+					 * request timeout, instead of returning immediately and
+					 * letting the request loop busy-spin at 100% CPU. */
+					num_sock = 1;
+					pfd[0].fd = conn->client.sock;
+					pfd[0].events =
+					    (nread == MBEDTLS_ERR_SSL_WANT_WRITE) ? POLLOUT : POLLIN;
+
+					if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
+						pfd[num_sock].fd =
+						    conn->phys_ctx->thread_shutdown_notification_socket;
+						pfd[num_sock].events = POLLIN;
+						num_sock++;
+					}
+
+					mg_poll(pfd,
+					        num_sock,
+					        (int)(timeout * 1000.0),
+					        &(conn->phys_ctx->stop_flag));
 					nread = 0;
 				} else {
 					fprintf(stderr, "SSL read failed, error %d\n", nread);

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -479,6 +479,13 @@ _civet_safe_clock_gettime(int clk_id, struct timespec *t)
 #define SOCKET_TIMEOUT_QUANTUM (2000) /* in ms */
 #endif
 
+/* Non-blocking mbedTLS operations can repeatedly return WANT_READ/WRITE
+ * without making application-visible progress. Add a tiny backoff to avoid
+ * tight retry loops on idle HTTPS keep-alive connections. */
+#if !defined(MG_MBEDTLS_WANT_RETRY_DELAY_MS)
+#define MG_MBEDTLS_WANT_RETRY_DELAY_MS (5)
+#endif
+
 /* Do not try to compress files smaller than this limit. */
 #if !defined(MG_FILE_COMPRESSION_SIZE_LIMIT)
 #define MG_FILE_COMPRESSION_SIZE_LIMIT (1024) /* in bytes */
@@ -6488,6 +6495,10 @@ pull_inner(FILE *fp,
 				if ((nread == MBEDTLS_ERR_SSL_WANT_READ)
 				    || (nread == MBEDTLS_ERR_SSL_WANT_WRITE)
 				    || nread == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+					/* The socket may stay poll-readable while mbedTLS still has
+					 * no application data to return. Without a small backoff,
+					 * higher-level request loops can devolve into a busy spin. */
+					mg_sleep(MG_MBEDTLS_WANT_RETRY_DELAY_MS);
 					nread = 0;
 				} else {
 					fprintf(stderr, "SSL read failed, error %d\n", nread);

--- a/src/webserver/civetweb/mod_mbedtls.inl
+++ b/src/webserver/civetweb/mod_mbedtls.inl
@@ -65,7 +65,8 @@ static void mbed_debug(void *context,
                        const char *file,
                        int line,
                        const char *str);
-static int mbed_ssl_handshake(mbedtls_ssl_context *ssl);
+static int mbed_ssl_handshake(mbedtls_ssl_context *ssl,
+                              mbedtls_net_context *client_fd);
 
 /**
  * @brief Sets the list of allowed ciphersuites for an mbedTLS SSL configuration.
@@ -292,7 +293,10 @@ mbed_ssl_accept(mbedtls_ssl_context **ssl,
 	mbedtls_ssl_init(*ssl);
 	mbedtls_ssl_setup(*ssl, &ssl_ctx->conf);
 	mbedtls_ssl_set_bio(*ssl, sock, mbedtls_net_send, mbedtls_net_recv, NULL);
-	rc = mbed_ssl_handshake(*ssl);
+	/* The bio context is the accepted (non-blocking) socket fd. mbedTLS
+	 * treats it as an mbedtls_net_context, whose only member is that fd, so
+	 * we can poll it directly while driving the handshake. */
+	rc = mbed_ssl_handshake(*ssl, (mbedtls_net_context *)sock);
 	if (rc != 0) {
 		DEBUG_TRACE("TLS handshake failed (%i)", rc);
 		mbedtls_ssl_free(*ssl);
@@ -323,14 +327,37 @@ mbed_ssl_close(mbedtls_ssl_context *ssl)
 
 
 static int
-mbed_ssl_handshake(mbedtls_ssl_context *ssl)
+mbed_ssl_handshake(mbedtls_ssl_context *ssl, mbedtls_net_context *client_fd)
 {
 	int rc;
 	while ((rc = mbedtls_ssl_handshake(ssl)) != 0) {
-		if (rc != MBEDTLS_ERR_SSL_WANT_READ && rc != MBEDTLS_ERR_SSL_WANT_WRITE
-		    && rc != MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+		uint32_t rw;
+
+		if (rc == MBEDTLS_ERR_SSL_WANT_READ) {
+			rw = MBEDTLS_NET_POLL_READ;
+		} else if (rc == MBEDTLS_ERR_SSL_WANT_WRITE) {
+			rw = MBEDTLS_NET_POLL_WRITE;
+		} else if (rc == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+			/* The crypto operation was offloaded to an async provider:
+			 * there is no socket event to wait for, so yield briefly and
+			 * retry instead of spinning the worker thread. */
+			mg_sleep(1);
+			continue;
+		} else {
+			/* Genuine handshake error */
 			break;
 		}
+
+		/* Accepted HTTPS sockets are non-blocking. Block until the socket is
+		 * ready for the operation mbedTLS is waiting for, instead of spinning
+		 * a worker thread at 100% CPU. The finite timeout keeps the loop
+		 * responsive (e.g. to the socket being closed on server shutdown). */
+		rc = mbedtls_net_poll(client_fd, rw, SOCKET_TIMEOUT_QUANTUM);
+		if (rc < 0) {
+			/* Poll error: abort the handshake */
+			break;
+		}
+		/* rc >= 0: socket became ready or the poll timed out; retry. */
 	}
 
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000

--- a/src/webserver/civetweb/mod_mbedtls.inl
+++ b/src/webserver/civetweb/mod_mbedtls.inl
@@ -321,6 +321,11 @@ mbed_ssl_handshake(mbedtls_ssl_context *ssl)
 		    && rc != MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
 			break;
 		}
+
+		/* Accepted HTTPS sockets are non-blocking. If the handshake cannot
+		 * progress yet, yield briefly so we do not spin a worker thread at
+		 * 100% CPU waiting for the peer. */
+		mg_sleep(MG_MBEDTLS_WANT_RETRY_DELAY_MS);
 	}
 
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000

--- a/test/civetweb_handshake_cpu.sh
+++ b/test/civetweb_handshake_cpu.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Regression check for the mbedTLS 100% CPU busy-spin on stalled TLS handshakes
+# (pi-hole/FTL#2882). A client that opens a TCP connection to the HTTPS port but
+# never sends a ClientHello must not peg a webserver worker thread. Before the
+# fix, each such connection spun a full CPU core in the mbedTLS handshake loop.
+#
+# Opens several stalled handshakes (plain TCP, no ClientHello), samples FTL's
+# CPU time across a short window, and exits non-zero if it exceeds a generous
+# threshold. Prints the measured value either way.
+#
+# Usage: civetweb_handshake_cpu.sh [host] [port] [connections] [window_seconds]
+
+set -u
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-443}"
+CONNS="${3:-6}"
+WINDOW="${4:-3}"
+# Pass threshold in percent of a single core. The spin pegs ~100% per
+# connection (hundreds of %); the fix stays near zero, so 50% has wide margin.
+LIMIT=50
+
+pid="$(cat /run/pihole-FTL.pid)"
+
+# /proc/<pid>/stat utime+stime, summed over all threads (clock ticks, 1/100 s
+# per core). FTL's comm field contains no spaces, so positional fields are safe.
+cpu_ticks() {
+	local a
+	read -ra a < "/proc/${pid}/stat"
+	echo "$(( a[13] + a[14] ))"
+}
+
+# Open the stalled connections: each subshell holds a bare TCP socket open
+# (no TLS ClientHello is ever sent) for longer than the measurement window.
+for _ in $(seq 1 "${CONNS}"); do
+	( exec 3<>"/dev/tcp/${HOST}/${PORT}"; sleep $(( WINDOW + 10 )) ) &
+done
+
+sleep 1
+t0="$(cpu_ticks)"
+sleep "${WINDOW}"
+t1="$(cpu_ticks)"
+
+# Stop the stalled connections before reporting so cleanup always runs.
+kill $(jobs -p) 2>/dev/null
+
+# (delta ticks) / (window seconds) == %CPU of one core.
+cpu=$(( (t1 - t0) / WINDOW ))
+echo "FTL CPU during ${CONNS} stalled TLS handshakes: ${cpu}% of one core"
+
+if [ "${cpu}" -ge "${LIMIT}" ]; then
+	echo "FAIL: exceeds ${LIMIT}% of one core (busy-spin present)"
+	exit 1
+fi
+echo "PASS: stayed below ${LIMIT}% of one core"
+exit 0

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1704,6 +1704,16 @@ setup() {
   assert_success
 }
 
+@test "Stalled TLS handshakes do not busy-spin the CPU" {
+  # Regression test for the mbedTLS 100% CPU busy-spin (pi-hole/FTL#2882):
+  # a client that opens a TCP connection to the HTTPS port but never sends a
+  # ClientHello must not peg a webserver worker thread. See the helper script
+  # for the measurement details.
+  run bash -c "bash test/civetweb_handshake_cpu.sh"
+  assert_success
+  assert_output --partial "% of one core"
+}
+
 @test "X.509 certificate parser returns expected result" {
   # We are getting the certificate from the config
   run bash -c './pihole-FTL --read-x509'


### PR DESCRIPTION
## What does this PR aim to accomplish?

Fixes a 100% CPU busy-spin in the embedded CivetWeb web server when it is built with the mbedTLS backend. A single misbehaving or slow TLS client can peg one CPU core per connection - e.g. opening a TCP connection to the HTTPS port and never completing the handshake spins a worker thread at 100% indefinitely. With a handful of such connections FTL saturates every core. This is trivially reachable from the network, so it is effectively a low-effort DoS as well as the source of the high-CPU reports against idle HTTPS keep-alive connections. This replaces the temporary backoff-sleep mitigation (the `MG_MBEDTLS_WANT_RETRY_DELAY_MS` workaround) with a proper event-driven fix that is suitable for upstreaming to CivetWeb.

## How does this PR accomplish the above?

Non-blocking mbedTLS calls can repeatedly return `MBEDTLS_ERR_SSL_WANT_READ` / `WANT_WRITE` without making application-visible progress. Three code paths reacted by retrying immediately (or by waiting on the wrong socket event), which is what spun the CPU. Each now waits for the operation mbedTLS actually asked for, mirroring what the OpenSSL path (`sslize()`) already does:

- **Handshake** (`mbed_ssl_handshake`, `mod_mbedtls.inl`): the loop had no wait at all. It now waits with `mbedtls_net_poll()` for read- or write-readiness (matching `WANT_READ` / `WANT_WRITE`), with a finite timeout so it stays responsive to shutdown; `ASYNC_IN_PROGRESS` yields briefly. The accepted socket fd is passed in via the existing bio context.
- **Reads** (`pull_inner`, `civetweb.c`): instead of mapping `WANT_*` to "0 bytes" and returning immediately, it now waits with the existing `mg_poll()` on `POLLIN` / `POLLOUT`, bounded by the request timeout and the server stop flag.
- **Writes** (`push_inner`, `civetweb.c`): it already polled before retrying, but always for `POLLOUT`. When `mbedtls_ssl_write()` returns `WANT_READ` (e.g. during a renegotiation) the socket is almost always writable, so it spun; it now polls for the event mbedTLS requested.

No new configuration and no magic constants - the change is behaviour-only and confined to the mbedTLS paths. The same change is being submitted upstream to CivetWeb so the vendored copy can eventually drop the local delta.

Changes:
- `src/webserver/civetweb/mod_mbedtls.inl`: event-driven handshake wait via `mbedtls_net_poll()`; `mbed_ssl_handshake()` now takes the socket context.
- `src/webserver/civetweb/civetweb.c`: `pull_inner()` and `push_inner()` mbedTLS branches wait on the correct socket event via `mg_poll()`; removes the `MG_MBEDTLS_WANT_RETRY_DELAY_MS` backoff.
- `test/repro_idle_https_keepalive.py`: regression probe for the spin.

## How can this actually be tested?

Built with the mbedTLS backend and exercised against a running FTL, sampling process CPU. The probe is sensitive - built against the pre-fix code it shows the spin, against this PR it does not:

| Scenario | Before (busy-loop) | After (this PR) |
|----------------------------------------|--------------------|-----------------|
| 4 stalled TLS handshakes (8 s) | ~390% (4 cores) | <1% |
| 4 idle HTTPS keep-alive conns (8 s) | idle | idle |
| 20 concurrent HTTPS requests | 200 OK | 200 OK |
| Large HTTPS responses (write path) | 200 OK | 200 OK |
| Handshake that stalls 3 s then resumes | n/a | 200 OK |

The "resumes after stalling" case confirms the poll wait wakes and the handshake completes - it is an event wait, not a fixed delay. The handshake and read spins are directly reproducible; the write spin requires a renegotiation that makes `mbedtls_ssl_write()` return `WANT_READ`, so it is addressed by inspection (wait for the requested event) and verified not to regress normal writes.

The handshake spin needs no special tooling - **any plain-TCP client that connects to the HTTPS port and never sends a ClientHello makes the pre-fix server spin**. Open a few stalled connections with bash's `/dev/tcp` and sample the FTL process' CPU straight from `/proc` (cores summed).

Check out `test/civetweb_handshake_cpu.sh` for a simple demonstration. The regression test is provided on my laptop:
- this branch: 0% CPU - PASS (exit 0),
- `development` branch 577% CPU - FAIL (exit 1).

---

**Related issue or feature (if applicable):** https://github.com/civetweb/civetweb/pull/1405

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.