### PR TITLE
Update a single text description "PRIVATE KEY"

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1126,7 +1126,7 @@ void initConfig(struct config *conf)
 	conf->webserver.session.restore.c = validate_stub; // Only type-based checking
 
 	conf->webserver.tls.cert.k = "webserver.tls.cert";
-	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file.\n\n All directories along the path must be readable and accessible by the user running FTL (typically 'pihole'). This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).\n\n The *.pem file can be created using `cp server.crt server.pem && cat server.key >> server.pem` if you have these files instead";
+	conf->webserver.tls.cert.h = "Path to the TLS (SSL) certificate file.\n\n All directories along the path must be readable and accessible by the user running FTL (typically 'pihole'). This option is only required when at least one of webserver.port is TLS. The file must be in PEM format, and it must have both, private key and certificate (the *.pem file created must contain a 'CERTIFICATE' section as well as a 'PRIVATE KEY' section).\n\n The *.pem file can be created using `cp server.crt server.pem && cat server.key >> server.pem` if you have these files instead";
 	conf->webserver.tls.cert.a = cJSON_CreateStringReference("A valid TLS certificate file (*.pem)");
 	conf->webserver.tls.cert.f = FLAG_RESTART_FTL;
 	conf->webserver.tls.cert.t = CONF_STRING;

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1050,7 +1050,7 @@
     # FTL (typically 'pihole'). This option is only required when at least one of
     # webserver.port is TLS. The file must be in PEM format, and it must have both,
     # private key and certificate (the *.pem file created must contain a 'CERTIFICATE'
-    # section as well as a 'RSA PRIVATE KEY' section).
+    # section as well as a 'PRIVATE KEY' section).
     #
     # The *.pem file can be created using `cp server.crt server.pem && cat server.key >>
     # server.pem` if you have these files instead


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Extend the meaning of “PRIVATE KEY” in the `webserver.tls.cert` description to include RSA and ECC keys.

**How does this PR accomplish the above?:**

The term “RSA PRIVATE KEY” has been replaced with the more general “PRIVATE KEY,” as ECC keys are also accepted.
I also followed the instruction received in #2883

**Link documentation PRs if any are needed to support this PR:**

Please note that keys based on “Curve25519” and “Curve 448” (Ed25519/Ed448) for SSL/TLS server certificates are not yet supported by browsers, so they would cause an error during navigation if used.

According to the [Baseline Requirements for TLS Server Certificates](https://cabforum.org/working-groups/server/baseline-requirements/documents/), specifically section 6.1.5, currently only RSA keys greater than 2048 bits and ECDSA keys (NIST P-256, NIST P-384, or NIST P-521) are accepted.

*This is merely a note for future reference.*

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.