### PR TITLE
Fix building on alpine 3.24

### DIFF
--- a/src/syscalls/vsprintf.c
+++ b/src/syscalls/vsprintf.c
@@ -11,6 +11,7 @@
 #include "FTL.h"
 //#include "syscalls.h" is implicitly done in FTL.h
 #include "log.h"
+#include <limits.h> // INT_MAX
 
 #undef vsprintf
 int FTLvsprintf(const char *file, const char *func, const int line, char *__restrict__ buffer, const char *format, va_list args)
@@ -38,7 +39,11 @@ int FTLvsprintf(const char *file, const char *func, const int line, char *__rest
 		// Reset errno before trying to get the string
 		errno = 0;
 		// Do the actual string transformation
-		length = vsprintf(buffer, format, _args);
+		// Use vsnprintf with INT_MAX instead of vsprintf to avoid
+		// -Werror=stringop-overflow= on Alpine 3.24+ where the fortify
+		// headers wrap vsprintf as vsnprintf(buf, SIZE_MAX, ...) which
+		// exceeds the compiler's maximum object size check
+		length = vsnprintf(buffer, INT_MAX, format, _args);
 		// Copy errno into buffer before calling va_end()
 		_errno = errno;
 		va_end(_args);


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes building on Alpine 3.24 as seen here: 

https://github.com/pi-hole/docker-base-images/actions/runs/27511439050/job/81373170621?pr=164

**How does this PR accomplish the above?:**

The issue is Alpine 3.24's fortify headers wrap vsprintf → vsnprintf with SIZE_MAX (4294967295), which now exceeds the maximum allowed object size of INT_MAX (2147483647) under the new `-Werror=stringop-overflow=` check.

The fix is to replace the vsprintf() call with vsnprintf() using INT_MAX as the size bound — it's functionally equivalent since vsprintf has no bounds anyway.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
