### PR TITLE
Fix gzip.c inflate_buffer CRC signed left shift undefined behavior

### DIFF
--- a/src/zip/gzip.c
+++ b/src/zip/gzip.c
@@ -247,7 +247,7 @@ bool inflate_buffer(unsigned char *buffer_compressed, mz_ulong size_compressed,
 	// bytes of the file)
 	 *size_uncompressed = 0u;
 	for(unsigned int i = 0; i < 4; i++)
-		*size_uncompressed |= buffer_compressed[size_compressed - 4 + i] << (i * 8);
+		*size_uncompressed |= (mz_ulong)buffer_compressed[size_compressed - 4 + i] << (i * 8);
 	*size_uncompressed = le32toh(*size_uncompressed);
 	if(*size_uncompressed == 0 || *size_uncompressed > 0x10000000)
 	{
@@ -263,7 +263,7 @@ bool inflate_buffer(unsigned char *buffer_compressed, mz_ulong size_compressed,
 	// file)
 	uint32_t crc = 0u;
 	for(unsigned int i = 0; i < 4; i++)
-		crc |= buffer_compressed[size_compressed - 8 + i] << (i * 8);
+		crc |= (uint32_t)buffer_compressed[size_compressed - 8 + i] << (i * 8);
 	crc = le32toh(crc);
 
 	// ZLIB trailer/footer is an Adler-32 checksum of the uncompressed data.


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

Fixes undefined behavior in gzip.c inflate_buffer

**How does this PR accomplish the above?:**

Cast buffer_compressed[size_compressed - 8 + i] to uint32_t before the left shift. C promotes buffer_compressed[size_compressed - 8 + i] (which is unsigned char) to signed int before the shift, and that causes undefined behavior during the CRC calculation. I am also able to reproduce the UB with UBSan.

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ x ] I have read the above and my PR is ready for review. *Check this box to confirm*
