### PR TITLE
Fix for iCloud Private Relay zones

### DIFF
--- a/test/api/conftest.py
+++ b/test/api/conftest.py
@@ -2,12 +2,9 @@
 Shared pytest fixtures for FTL API integration tests.
 """
 
-import socket
 import sys
 import os
-import time
 
-import dns.resolver
 import pytest
 import requests
 
@@ -15,79 +12,6 @@ import requests
 sys.path.insert(0, os.path.dirname(__file__))
 
 FTL_URL = "http://127.0.0.1"
-
-# ---------------------------------------------------------------------------
-# Upstream DNSSEC detection helpers
-# ---------------------------------------------------------------------------
-
-def _wait_for_pdns(host="127.0.0.1", port=5555, attempts=10, delay=2.0):
-    """Block until host:port accepts connections, or attempts are exhausted.
-
-    Returns True if the port opened within the allotted retries, False
-    otherwise.
-    """
-    for attempt in range(attempts):
-        try:
-            with socket.create_connection((host, port), timeout=2.0):
-                return True
-        except OSError:
-            if attempt < attempts - 1:
-                time.sleep(delay)
-    return False
-
-
-def _has_ds_record(resolver, domain):
-    """Return True if *domain* currently has a DS record."""
-    try:
-        resolver.resolve(domain, "DS")
-        return True
-    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN,
-            dns.resolver.NoNameservers, dns.exception.Timeout):
-        return False
-
-
-@pytest.fixture(scope="session", autouse=True)
-def detect_upstream_dnssec():
-    """Detect upstream DNSSEC state and populate query-counter constants.
-
-    Waits for the local pdns_recursor (port 5555) to become available
-    with retry/backoff before probing, avoiding false-negatives from a
-    slow daemon startup.  Probes DS records on icloud.com and
-    apple-dns.net — the two zones crossed by the mask.icloud.com CNAME
-    chain — to determine whether dnsmasq will fire extra DNSKEY
-    validation queries.
-
-    The module-level expected-counter constants in test_api are updated
-    in-place so all assertions there reflect the current upstream
-    DNSSEC posture without requiring changes to the individual tests.
-    """
-    import test_api  # imported here to ensure test_api is fully loaded before modifying its globals
-
-    resolver = dns.resolver.Resolver(configure=False)
-    resolver.nameservers = ["127.0.0.1"]
-    resolver.port = 5555
-    resolver.lifetime = 5
-
-    # Wait for pdns_recursor to accept connections before probing
-    if not _wait_for_pdns():
-        import warnings
-        warnings.warn(
-            "pdns_recursor on 127.0.0.1:5555 did not become available; "
-            "DNSSEC detection skipped — using non-DNSSEC counter defaults.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return
-
-    upstream_dnssec = (
-        _has_ds_record(resolver, "icloud.com") and
-        _has_ds_record(resolver, "apple-dns.net")
-    )
-
-    test_api.TOTAL      = 137 if upstream_dnssec else 135
-    test_api.FORWARDED  = 47  if upstream_dnssec else 45
-    test_api.DNSKEY     = 9   if upstream_dnssec else 7
-    test_api.TOP_DOMAIN = "." if upstream_dnssec else "localhost"
 
 
 @pytest.fixture(scope="session")

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -17,22 +17,21 @@ FTL_URL = "http://127.0.0.1"
 
 
 # ---------------------------------------------------------------------------
-# Upstream DNSSEC detection
+# Expected query counters
 # ---------------------------------------------------------------------------
 # The bats test suite queries mask.icloud.com via an allowlisted client, which
-# forwards the query upstream.  The CNAME chain crosses icloud.com and
-# apple-dns.net.  When both zones carry DS records (DNSSEC-signed), dnsmasq
-# fires two extra DNSKEY validation queries, shifting several counters by +2.
-#
-# These constants are populated by the session-scoped detect_upstream_dnssec
-# fixture in conftest.py (which waits for pdns_recursor to be available and
-# probes DS records with retry/backoff).  The values below are safe defaults
-# for the non-DNSSEC case and are overwritten before any test runs.
+# forwards the query upstream.  The mask.icloud.com -> mask.apple-dns.net CNAME
+# chain is served by the local (unsigned) PowerDNS authoritative server (see
+# test/pdns/setup.sh and recursor.conf) instead of being recursed to the public
+# internet.  This keeps the resolution hermetic and the query counts below
+# deterministic — previously they drifted by +2 whenever Apple toggled DNSSEC
+# signing on these zones, which made the suite flaky (see issue #2908 / PR
+# #2845).  If you add or remove queries in test_suite.bats, update these.
 
-TOTAL       = 135
-FORWARDED   = 45
-DNSKEY      = 7
-TOP_DOMAIN  = "localhost"
+TOTAL       = 137
+FORWARDED   = 47
+DNSKEY      = 9
+TOP_DOMAIN  = "."
 
 
 # ---------------------------------------------------------------------------

--- a/test/pdns/recursor.conf
+++ b/test/pdns/recursor.conf
@@ -34,4 +34,15 @@ recursor:
     recurse: false
     forwarders:
     - 127.0.0.1:5554
+  # Resolve Apple's iCloud Private Relay zones from the local authoritative
+  # server (see test/pdns/setup.sh) instead of the public internet, keeping
+  # the mask.icloud.com query counts deterministic.
+  - zone: icloud.com
+    recurse: false
+    forwarders:
+    - 127.0.0.1:5554
+  - zone: apple-dns.net
+    recurse: false
+    forwarders:
+    - 127.0.0.1:5554
   lua_dns_script: /etc/pdns/luadns.lua

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -135,6 +135,17 @@ pdnsutil rrset add ftl. umbrella-multi.ftl. A 8.8.8.8
 pdnsutil rrset add ftl. null.ftl. A 0.0.0.0
 pdnsutil rrset add ftl. null.ftl. AAAA ::
 
+# Serve Apple's iCloud Private Relay domains locally (unsigned) instead of
+# recursing to the public internet. The bats suite resolves mask.icloud.com
+# through an allowlisted client; hosting the mask.icloud.com -> mask.apple-dns.net
+# CNAME chain here keeps the query counts deterministic regardless of whether
+# Apple currently DNSSEC-signs these zones (see test/api/test_api.py).
+pdnsutil zone create icloud.com ns1.ftl
+pdnsutil rrset add icloud.com. mask.icloud.com. CNAME mask.apple-dns.net.
+pdnsutil rrset add icloud.com. mask-h2.icloud.com. CNAME mask.apple-dns.net.
+pdnsutil zone create apple-dns.net ns1.ftl
+pdnsutil rrset add apple-dns.net. mask.apple-dns.net. A 172.224.181.14
+
 # Create valid internal DNSSEC zone
 pdnsutil zone create dnssec ns1.ftl
 pdnsutil rrset add dnssec. a.dnssec. A 192.168.4.1


### PR DESCRIPTION
# What does this implement/fix?

The API query-count assertions depend on resolving `mask.icloud.com`, whose `mask.icloud.com -> mask.apple-dns.net` CNAME chain was recursed to the public internet. dnsmasq fires extra DNSKEY validation queries depending on whether Apple currently DNSSEC-signs `icloud.com` and `apple-dns.net`, and Apple toggles this over time. The runtime DS-probing workaround in `conftest.py` could not reliably model dnsmasq's behaviour (e.g. when Apple returns SERVFAIL on DS), so the suite went flaky again.

The fix here is to serve the `icloud.com` and `apple-dns.net` zones from the local authoritative PowerDNS server instead, so the chain resolves hermetically and the query counts are deterministic regardless of Apple's upstream DNSSEC posture. The DS-probing fixture is dropped and the expected counters become fixed constants again.

This reduces external dependence as Apple's domains have proven to be flaky.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.