### PR TITLE
Re-resolve client groups event-driven, drop periodic recheck

### DIFF
--- a/src/FTL.h
+++ b/src/FTL.h
@@ -123,17 +123,6 @@
 // Default: 300 (five minutes)
 #define API_SESSION_EXPIRE 300u
 
-// After how many seconds do we check again if a client can be identified by other means?
-// (e.g., interface, MAC address, hostname)
-// Default: 60 (after one minutee)
-#define RECHECK_DELAY 60
-
-// How often should we check again if a client can be identified by other means?
-// (e.g., interface, MAC address, hostname)
-// Default: 3 (once after RECHECK_DELAY seconds, then again after 2*RECHECK_DELAY and 3*RECHECK_DELAY)
-// Important: This number has to be smaller than 256 for this mechanism to work
-#define NUM_RECHECKS 3
-
 // DELAY_STARTUP should only delay the startup of the resolver during a starting up system
 // This setting control how long after boot we consider a system to be in starting-up mode
 // Default: 180 [seconds]

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -224,10 +224,6 @@ void *DB_thread(void *val)
 				// Reload gravity
 				set_event(RELOAD_GRAVITY);
 			}
-
-			// Re-check client group membership for any client still
-			// inside its 3-minute identification window
-			TIMED_DB_OP(gravityDB_recheck_clients());
 		}
 
 		// Intermediate cancellation-point

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -724,17 +724,34 @@ static bool get_client_groupids(clientsData *client)
 	bool got_name = false;
 	if(chosen_match_id < 0)
 	{
-		log_debug(DEBUG_CLIENTS, "Querying gravity database for host name of %s...", ip);
-
-		// Do the lookup
-		got_name = getNameFromIP(NULL, hostname, ip);
-		if(!got_name)
-			log_debug(DEBUG_CLIENTS, "--> No result.");
-
-		if(got_name && hostname[0] == '\0')
+		// Prefer the host name resolved in-memory for this client. The
+		// resolver thread fills client->namepos asynchronously and clears
+		// found_group when it changes (see resolveClients()), so reading
+		// it here avoids the one-DBinterval lag of the network_addresses
+		// table and re-resolves against the new name on the next query.
+		const char *clientName = getstr(client->namepos);
+		if(clientName != NULL && clientName[0] != '\0')
 		{
-			log_debug(DEBUG_CLIENTS, "Skipping empty host name lookup");
-			got_name = false;
+			strncpy(hostname, clientName, sizeof(hostname) - 1);
+			hostname[sizeof(hostname) - 1] = '\0';
+			got_name = true;
+			log_debug(DEBUG_CLIENTS, "Using in-memory host name \"%s\" of %s", hostname, ip);
+		}
+		else
+		{
+			// Fall back to the network table for clients FTL only knows
+			// from imported history (no live query yet, so no name)
+			log_debug(DEBUG_CLIENTS, "Querying gravity database for host name of %s...", ip);
+
+			got_name = getNameFromIP(NULL, hostname, ip);
+			if(!got_name)
+				log_debug(DEBUG_CLIENTS, "--> No result.");
+
+			if(got_name && hostname[0] == '\0')
+			{
+				log_debug(DEBUG_CLIENTS, "Skipping empty host name lookup");
+				got_name = false;
+			}
 		}
 	}
 
@@ -802,16 +819,33 @@ static bool get_client_groupids(clientsData *client)
 	bool got_iface = false;
 	if(chosen_match_id < 0)
 	{
-		log_debug(DEBUG_CLIENTS, "Querying gravity database for interface of %s...", ip);
+		// Prefer the interface the client's queries actually arrive on.
+		// It is recorded in-memory on the client's very first query (see
+		// _FTL_new_query()), so it is already available here without the
+		// one-DBinterval lag of the network_addresses table and lets
+		// interface-based group assignment apply from the first query on.
+		const char *clientIface = getstr(client->ifacepos);
+		if(clientIface != NULL && clientIface[0] != '\0')
+		{
+			strncpy(interface, clientIface, sizeof(interface) - 1);
+			interface[sizeof(interface) - 1] = '\0';
+			got_iface = true;
+			log_debug(DEBUG_CLIENTS, "Using in-memory interface "INTERFACE_SEP"%s of %s", interface, ip);
+		}
+		else
+		{
+			// Fall back to the network table for clients FTL only knows
+			// from imported history (no live query yet, so no interface)
+			log_debug(DEBUG_CLIENTS, "Querying gravity database for interface of %s...", ip);
 
-		// Do the lookup
-		got_iface = getIfaceFromIP(NULL, interface, ip);
+			got_iface = getIfaceFromIP(NULL, interface, ip);
 
-		if(!got_iface)
-			log_debug(DEBUG_CLIENTS, "--> No result.");
+			if(!got_iface)
+				log_debug(DEBUG_CLIENTS, "--> No result.");
 
-		if(got_iface && interface[0] == '\0')
-			log_debug(DEBUG_CLIENTS, "Skipping empty interface lookup");
+			if(got_iface && interface[0] == '\0')
+				log_debug(DEBUG_CLIENTS, "Skipping empty interface lookup");
+		}
 	}
 
 	// Check if we received a valid interface
@@ -1046,8 +1080,23 @@ bool gravityDB_prepare_client_statements(clientsData *client)
 	log_debug(DEBUG_DATABASE, "Initializing gravity statements for %s", clientip);
 
 	// Get associated groups for this client (if defined)
-	if(!client->flags.found_group && !get_client_groupids(client))
-		return false;
+	if(!client->flags.found_group)
+	{
+		if(!get_client_groupids(client))
+			return false;
+
+		// The client's groups were just (re-)resolved. The per-client
+		// regex enable/disable state is cached separately (match_regex()
+		// reads a cached row) and must be rebuilt for the new groups,
+		// otherwise regex allow/deny decisions would keep using the
+		// previous groups after an identity change cleared found_group.
+		// This runs on the DNS query thread and, in check_domain_blocked(),
+		// before the in_regex() checks (in_denylist()/in_allowlist() call
+		// this first). It does not recurse: found_group is set now, so
+		// gravityDB_get_regex_client_groups() will not re-enter
+		// get_client_groupids().
+		reload_per_client_regex(client);
+	}
 
 	return true;
 }
@@ -1353,60 +1402,12 @@ static enum db_result domain_in_list(const char *domain, sqlite3_stmt *stmt, con
 
 void gravityDB_reload_groups(clientsData *client)
 {
-	// Rebuild client table statements (possibly from a different group set)
+	// Re-resolve the client's groups and rebuild its per-client regex
+	// state. finalize clears found_group so prepare re-runs
+	// get_client_groupids() and reload_per_client_regex() for the
+	// (possibly different) group set.
 	gravityDB_finalize_client_statements(client);
 	gravityDB_prepare_client_statements(client);
-
-	// Reload regex for this client (possibly from a different group set)
-	reload_per_client_regex(client);
-}
-
-// Re-check group membership for every client still within its initial 3-minute
-// identification window.
-//
-// A client may be identified by something that wasn't there on its first query
-// (hostname, MAC address, interface): FTL discovers those asynchronously —
-// parse_neighbor_cache() fills in ARP/MAC data from /proc/net/arp, and the
-// resolver thread fills in reverse-DNS hostnames. The 60/120/180-second
-// rechecks give those async sources time to arrive, then re-run
-// get_client_groupids() so the client lands in the correct group once its
-// identity is complete.
-//
-// Rechecking is periodic maintenance, not per-query work. The DB thread
-// iterates all clients once per second and does the check itself; any client
-// whose firstSeen clock has just crossed a 60/120/180-second mark gets reloaded
-// here, on the DB thread, rather than on whichever DNS query happens to land in
-// the boundary. Mature clients (reread_groups >= NUM_RECHECKS) short-circuit to
-// a single conditional per scan. Runs under the SHM lock because
-// gravityDB_reload_groups() mutates per-client state the DNS thread also reads.
-void gravityDB_recheck_clients(void)
-{
-	lock_shm();
-	const time_t now = time(NULL);
-	for(unsigned int clientID = 0; clientID < counters->clients; clientID++)
-	{
-		clientsData *client = getClient(clientID, true);
-		// Skip recycled client and mature clients (reread_groups >=
-		// NUM_RECHECKS) which have already been rechecked the maximum
-		// number of times. Also skip alias clients. They are meta-clients,
-		// only, and never issue queries themselves, so they also don't
-		// need to be rechecked.
-		if(client == NULL ||
-		   client->reread_groups >= NUM_RECHECKS ||
-		   client->flags.aliasclient)
-			continue;
-
-		const time_t diff = now - (time_t)client->firstSeen;
-		const unsigned char check_count = client->reread_groups + 1u;
-		if(diff > check_count * RECHECK_DELAY)
-		{
-			log_debug(DEBUG_CLIENTS, "Reloading client groups after %u seconds (%u%s check)",
-			          (unsigned int)diff, check_count, get_ordinal_suffix(check_count));
-			client->reread_groups++;
-			gravityDB_reload_groups(client);
-		}
-	}
-	unlock_shm();
 }
 
 enum db_result in_allowlist(const char *domain, DNSCacheData *dns_cache, clientsData *client)

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -656,6 +656,13 @@ static bool get_client_groupids(clientsData *client)
 			         client->hwaddr[0], client->hwaddr[1], client->hwaddr[2],
 			         client->hwaddr[3], client->hwaddr[4], client->hwaddr[5]);
 
+			// Mark the MAC as obtained so the gravity client table is
+			// actually queried for it below. Without this, the synthesized
+			// address is logged but never used, and a client whose new IP
+			// is not yet in the network_addresses table falls back to the
+			// default group despite its MAC being known in-memory (#2912).
+			got_hwaddr = true;
+
 			log_debug(DEBUG_CLIENTS, "--> Obtained %s from internal ARP cache", hwaddr);
 		}
 	}

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -44,7 +44,6 @@ typedef struct {
 bool gravityDB_reopen(void);
 void gravityDB_forked(void);
 void gravityDB_reload_groups(clientsData *client);
-void gravityDB_recheck_clients(void);
 bool gravityDB_prepare_client_statements(clientsData *client);
 void gravityDB_close(void);
 bool gravityDB_getTable(unsigned char list);

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1446,6 +1446,46 @@ void parse_neighbor_cache(sqlite3 *db)
 				numQueries = client->numQueriesARP;
 				totalQueries = client->count;
 				client_status[clientID] = CLIENT_ARP_COMPLETE;
+
+				// If the MAC the kernel reports for this IP
+				// just appeared or changed since we last
+				// resolved this client's group membership, the
+				// client may be stuck in the wrong (often
+				// default) group. FTL keys clients by IP, so an
+				// external DHCP server handing the same device a
+				// new IP creates a fresh client whose MAC is
+				// only learned here - after the client's first
+				// query already resolved it (to the default
+				// group). Nothing would otherwise re-trigger
+				// MAC-based group resolution (#2912).
+				//
+				// Detect that case by comparing the freshly
+				// learned MAC against the one stored on the
+				// client. If it differs, adopt the new MAC (so
+				// get_client_groupids() matches it from the
+				// in-memory ARP cache even before the
+				// network_addresses table catches up) and clear
+				// found_group so the client's next query
+				// re-resolves its groups and picks up any
+				// MAC-based group.
+				unsigned char newhw[6] = { 0 };
+				if(sscanf(hwaddr, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+				          &newhw[0], &newhw[1], &newhw[2],
+				          &newhw[3], &newhw[4], &newhw[5]) == 6 &&
+				   (client->hwlen != 6 ||
+				    memcmp(client->hwaddr, newhw, sizeof(newhw)) != 0))
+				{
+					log_debug(DEBUG_CLIENTS, "Network table: MAC behind %s changed to %s, re-resolving client groups",
+					          ip, hwaddr);
+
+					memcpy(client->hwaddr, newhw, sizeof(newhw));
+					client->hwlen = sizeof(newhw);
+
+					// Clearing found_group makes the next query
+					// for this client re-resolve its groups via
+					// get_client_groupids() (lazy re-resolution).
+					client->flags.found_group = false;
+				}
 			}
 			// else
 			// {

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -422,10 +422,6 @@ int _findClientID(const char *clientIP, const bool count, const bool aliasclient
 	// Configured groups are yet unknown
 	client->flags.found_group = false;
 	client->groupspos = 0u;
-	// Store time this client was added, we re-read group settings
-	// some time after adding a client to ensure we pick up possible
-	// group configuration though hostname, MAC address or interface
-	client->reread_groups = 0u;
 	client->firstSeen = now;
 	// Interface is not yet known
 	client->ifacepos = 0;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -94,7 +94,6 @@ typedef struct {
 	// at offset 60 and straddle the cache line boundary (bytes 60–67),
 	// causing a split load on every client IP comparison.
 	unsigned char magic;
-	unsigned char reread_groups;
 	char hwlen;
 	unsigned char hwaddr[16]; // See DHCP_CHADDR_MAX in dnsmasq/dhcp-protocol.h
 	struct client_flags {

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1085,6 +1085,10 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 					          clientIP, clientName, oldiface, interface);
 				}
 
+				// Adopt the new interface so the in-memory
+				// interface match in get_client_groupids()
+				// re-resolves against it
+				client->ifacepos = addstr(interface);
 				gravityDB_reload_groups(client);
 			}
 		}
@@ -1093,6 +1097,11 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	// Set client MAC address from EDNS(0) information (if available)
 	if(config.dns.EDNS0ECS.v.b && edns && edns->mac_set)
 	{
+		// If the MAC just became known or changed, clear found_group so
+		// the next query re-resolves this client's groups - the MAC is
+		// one of the identities used for group assignment
+		if(client->hwlen != 6 || memcmp(client->hwaddr, edns->mac_byte, 6) != 0)
+			client->flags.found_group = false;
 		memcpy(client->hwaddr, edns->mac_byte, 6);
 		client->hwlen = 6;
 	}
@@ -1118,6 +1127,12 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		client = getClient(clientID, true);
 		if(client != NULL)
 		{
+			// If a MAC was just learned (this runs only while it was
+			// still unknown), clear found_group so the next query
+			// re-resolves this client's groups using it
+			if(hwlen == 6 &&
+			   (client->hwlen != 6 || memcmp(client->hwaddr, hwaddr, sizeof(hwaddr)) != 0))
+				client->flags.found_group = false;
 			memcpy(client->hwaddr, hwaddr, sizeof(hwaddr));
 			client->hwlen = hwlen;
 		}

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -974,6 +974,12 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 			// client_by_id on the next batch insertion of queries
 			client->flags.in_database = false;
 			client->db_id = 0;
+			// The host name is one of the identities a client can be
+			// matched on for group assignment. Now that it changed,
+			// clear found_group so the client's next query re-resolves
+			// its groups against the new name (lazy re-resolution via
+			// get_client_groupids()).
+			client->flags.found_group = false;
 		}
 		// Mark entry as not new
 		client->flags.new = false;


### PR DESCRIPTION
# What does this implement/fix?

A client assigned to a group by MAC address lost its group assignment after an external DHCP server handed its device a new IP (same MAC). FTL keys clients by IP, so the new IP became a fresh client that resolved its groups on the first query. If the network table did not yet know the new IP's MAC at that moment, the client fell back to the default group and stayed there: the only thing that re-evaluated group membership was a fixed 3-checks-in-3-minutes window keyed to when the IP was first seen, after which the client was never re-checked again until a gravity reload. When the MAC was learned after that window closed, the client was stuck in the default group forever (observation in #2912).

**This PR make group re-resolution event-driven instead.** `get_client_groupids()` is already re-run lazily on the next query whenever found_group is false, so it is enough to clear found_group when a client's identity becomes known or changes:

- MAC: clear found_group whenever the MAC is learned or changes, at every acquisition site - EDNS(0) data, `find_mac()` from the kernel, and `parse_neighbor_cache()` learning a new or changed MAC for a known client's IP. The in-memory MAC is adopted there so the next resolution matches it even before the network table catches up.
- Interface: match from the in-memory client interface (recorded on the first query) instead of the lagged network table lookup, so interface based assignment applies from the first query on. The network table lookup is kept as a fallback for history-only clients. When a client moves to another interface, the new interface is adopted before its groups are reloaded. While this is a drive-by fix, it actually the best strategy for interface-based lookups overall, not sure why we have overseen this in the past.
- Host name: match from the in-memory client name (network table lookup kept as fallback) and clear found_group in `resolveClients()` when the resolved name changes.

The per-client regex enable/disable state is cached separately from the group IDs (`match_regex()` reads a cached per-client row), so clearing found_group alone would leave regex allow/deny decisions on the previous groups. `gravityDB_prepare_client_statements()` now rebuilds that regex state whenever it re-resolves a client's groups; in `check_domain_blocked()` this runs (via `in_denylist()`/`in_allowlist()`) before the `in_regex()` checks, so the regex state is current when it is read.

With all three identity sources handled on change, the periodic poller `gravityDB_recheck_clients()` and the per-client `reread_groups` counter are no longer needed and are removed, along with the `RECHECK_DELAY` and `NUM_RECHECKS` constants. One hack less in FTL's codebase.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/2912

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
