### PR TITLE
fix: avoid segfault in dnsmasq-test on unreadable config file

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -836,6 +836,14 @@ void parse_args(int argc, char *argv[])
 			arg[0] = "";
 			arg[1] = "--test";
 			log_ctrl(false, true);
+			// Signal dnsmasq's die() to exit() instead of trying to
+			// jump back into FTL's main() via longjmp(exit_jmp, ...).
+			// exit_jmp is only initialized (setjmp) once we reach
+			// main(), which never happens on this early-exit path, so
+			// a config read error (e.g., permission denied) would
+			// otherwise longjmp through an uninitialized jmp_buf and
+			// crash (see https://github.com/pi-hole/FTL/issues/2924).
+			only_testing = true;
 			exit(main_dnsmasq(2, (char**)arg));
 		}
 
@@ -851,6 +859,9 @@ void parse_args(int argc, char *argv[])
 			arg[1] = filename;
 			arg[2] = "--test";
 			log_ctrl(false, true);
+			// See note above: ensure die() exit()s cleanly instead of
+			// longjmp()ing through an uninitialized exit_jmp.
+			only_testing = true;
 			exit(main_dnsmasq(3, (char**)arg));
 		}
 


### PR DESCRIPTION
## What does this PR aim to accomplish?

`pihole-FTL dnsmasq-test` (and `pihole-FTL dnsmasq-test-file`) crash with a segmentation fault whenever the config file cannot be read - for example a "Permission denied" on `/etc/pihole/dnsmasq.conf`, which is what happens when the command is run without enough privileges to read that file. Reported in #2924, where the user saw:

```
dnsmasq: cannot read /etc/pihole/dnsmasq.conf: Permission denied
Segmentation fault
```

## How does this PR accomplish the above?

The `dnsmasq-test` / `dnsmasq-test-file` argument handlers in `src/args.c` exit very early: `main()` calls `parse_args()` before it reaches the `setjmp(exit_jmp)` landing pad. When dnsmasq fails to read the config file it calls `die()`, which `longjmp()`s back to `exit_jmp` so `main()` can shut down gracefully. On these early-exit paths `exit_jmp` was never initialized, so the `longjmp()` jumped through an uninitialized buffer and crashed with SIGSEGV.

(The `print_log = false` set by `log_ctrl(false, true)` means the FTL fatal-message helper returns immediately, so the database is never touched - the crash is purely the unguarded `longjmp()`.)

The fix sets `only_testing = true` before invoking the test, the same flag the internal config self-test (`test_dnsmasq_options()`) already sets. With it, `die()` takes its clean `exit(exit_code)` branch instead of attempting the `longjmp()`.

Changes:
- `src/args.c`: set `only_testing = true` in the `dnsmasq-test`/`--test` and `dnsmasq-test-file` handlers before calling `main_dnsmasq()`.

## How can this actually be tested?

Run the test command against a config file that cannot be read (e.g. `chmod 000` on a file, invoked as a non-root user):

```
pihole-FTL dnsmasq-test-file /path/to/unreadable.conf
```

| | Before | After |
|----------------------------------|---------------------------------|------------------------------------|
| Unreadable config file | `Segmentation fault`, exit 139 | error printed, exit 3, no crash |
| Valid config file | syntax check OK | syntax check OK (unchanged) |

After the fix the same command prints `dnsmasq: cannot read <file>: Permission denied` and exits with code 3 instead of crashing.

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/issues/2924

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
