### PR TITLE
fix(cli): warn when --config cannot read pihole.toml (#2849)

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -383,10 +383,17 @@ void parse_args(int argc, char *argv[])
 		if(querying && file_exists(GLOBALTOMLPATH))
 		{
 			if(access(GLOBALTOMLPATH, R_OK) != 0)
+			{
+				const int err = errno;
 				fprintf(stderr, "Warning: %s exists but cannot be read (%s).\n"
-				                "         The value shown below may not reflect the current configuration.\n"
-				                "         Try running this command with sudo.\n",
-				        GLOBALTOMLPATH, strerror(errno));
+				                "         The value shown below may not reflect the current configuration.\n",
+				        GLOBALTOMLPATH, strerror(err));
+				// Only suggest sudo for permission-related errors; other
+				// failures (e.g. I/O errors) are not fixed by elevated
+				// privileges.
+				if(err == EACCES || err == EPERM)
+					fprintf(stderr, "         Try running this command with sudo.\n");
+			}
 			else if(!conf_read)
 				fprintf(stderr, "Warning: %s could not be parsed.\n"
 				                "         The value shown below may not reflect the current configuration.\n",

--- a/src/args.c
+++ b/src/args.c
@@ -364,9 +364,34 @@ void parse_args(int argc, char *argv[])
 		// Enable stdout printing
 		cli_mode = true;
 		log_ctrl(false, false);
-		readFTLconf(&config, false);
+		const bool conf_read = readFTLconf(&config, false);
 		log_ctrl(false, true);
 		clear_debug_flags(); // No debug printing wanted
+
+		// When querying (not setting) a config value, warn the user if the
+		// value we are about to print may not reflect the current
+		// configuration. This happens when the primary config file exists
+		// but cannot be read - most commonly because the command is run
+		// without sudo as a user that is not allowed to read pihole.toml
+		// (which is installed mode 0640 owned by pihole:pihole). In that
+		// case, FTL silently falls back to a config backup or, if none can
+		// be read either, to the compiled-in defaults. We warn on stderr so
+		// the (possibly stale or default) value can still be consumed on
+		// stdout (see GitHub issue #2849).
+		const bool querying = argc == 2 || argc == 3 ||
+		                      (argc == 4 && strcmp(argv[2], "-q") == 0);
+		if(querying && file_exists(GLOBALTOMLPATH))
+		{
+			if(access(GLOBALTOMLPATH, R_OK) != 0)
+				fprintf(stderr, "Warning: %s exists but cannot be read (%s).\n"
+				                "         The value shown below may not reflect the current configuration.\n"
+				                "         Try running this command with sudo.\n",
+				        GLOBALTOMLPATH, strerror(errno));
+			else if(!conf_read)
+				fprintf(stderr, "Warning: %s could not be parsed.\n"
+				                "         The value shown below may not reflect the current configuration.\n",
+				        GLOBALTOMLPATH);
+		}
 		if(argc == 2)
 			exit(get_config_from_CLI(NULL, false));
 		else if(argc == 3)


### PR DESCRIPTION
## What this does

Closes #2849.

`pihole-FTL --config <key>` sometimes returns a default value instead of the configured one when run without `sudo`. This happens because the invoking user cannot read `/etc/pihole/pihole.toml` (installed mode `0640`, owned by `pihole:pihole`). FTL then silently falls back to a config backup or, if none is readable either, to the compiled-in defaults. The user gets a value with no indication it does not reflect the live configuration. Running the same command with `sudo` bypasses the permission check and returns the correct value.

## Root cause

- The `--config` CLI branch in `src/args.c` discarded the return value of `readFTLconf()`.
- On a read failure (`EACCES`), `openFTLtoml()` returns `NULL` and FTL loops through the backups in `/etc/pihole/config_backups`; the only diagnostic is a `log_info()` that is suppressed in CLI mode.
- Checking only `readFTLconf()`'s return value is insufficient: it reports success whenever any backup is readable, so a stale backup value can still be served while the live config could not be read.

## Fix

When *querying* a config value, warn on **stderr** if the primary config file exists but cannot be read, so the (possibly stale or default) value can still be consumed on **stdout** and the exit code is unchanged. The condition keys off the readability of the primary file rather than `readFTLconf()`'s return value. The set path is untouched, as it already emits its own permission error.

Example:

```
$ pihole-FTL --config webserver.port
Warning: /etc/pihole/pihole.toml exists but cannot be read (Permission denied).
         The value shown below may not reflect the current configuration.
         Try running this command with sudo.
80o,443os,[::]:80o,[::]:443os
```

## Testing

Built and exercised the real permission scenario (primary config made unreadable to the invoking user):

| Scenario | stdout | stderr | exit |
| --- | --- | --- | --- |
| Readable config | value | (none) | 0 |
| Unreadable primary, query | value | warning | 0 |
| Unreadable primary, quiet `-q` query | value (clean) | warning | 0 |
| Set without permission | (none) | existing permission error | non-zero |

stdout stays clean for scripts (including `-q`); the warning is informational on stderr only.

## Notes

There is an open question for reviewers: whether running as root should `chown`/relax the permissions, or whether the CLI should instead exit non-zero in this case. This PR keeps the value printable and the exit code unchanged, matching the behavior discussed in the issue.