### PR TITLE
Send CORS headers on 204 and error responses

### DIFF
--- a/patch/civetweb/0001-add-pihole-mods.patch
+++ b/patch/civetweb/0001-add-pihole-mods.patch
@@ -17,7 +17,7 @@ index 81f642be..ed360a76 100644
  }
  
  
-@@ -4530,6 +4538,48 @@ mg_send_http_error_impl(struct mg_connection *conn,
+@@ -4530,6 +4538,53 @@ mg_send_http_error_impl(struct mg_connection *conn,
  }
  
  
@@ -35,6 +35,11 @@ index 81f642be..ed360a76 100644
 +	mg_response_header_start(conn, status);
 +	send_no_cache_header(conn);
 +	send_additional_header(conn);
++	/* Pi-hole: also emit CORS headers here so that e.g. 204 No Content
++	 * responses (returned by DELETE endpoints) carry Access-Control-Allow-*
++	 * just like the 200 responses sent via mg_send_http_ok().
++	 * See https://github.com/pi-hole/FTL/issues/2261 */
++	send_cors_header(conn);
 +	mg_response_header_add(conn, "Content-Type", mime_type, -1);
 +	if (content_length < 0) {
 +		/* Size not known. Use chunked encoding (HTTP/1.x) */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -237,8 +237,7 @@ int api_handler(struct mg_connection *conn, void *ignored)
 	if(api.method == HTTP_OPTIONS)
 	{
 		// Build a comma-separated list of the methods allowed for this
-		// endpoint. It is used both for the RFC 7231 "Allow" header and for
-		// the CORS "Access-Control-Allow-Methods" header below.
+		// endpoint for the RFC 7231 "Allow" header.
 		char methods[256] = "";
 		unsigned int m = 0;
 		for(enum http_method j = HTTP_GET; j < HTTP_OPTIONS; j <<= 1)
@@ -256,48 +255,15 @@ int api_handler(struct mg_connection *conn, void *ignored)
 		mg_printf(conn, "HTTP/1.1 204 No Content\r\n"
 		                "Allow: %s\r\n", methods);
 
-		// CORS preflight headers. Browsers send a preflight OPTIONS request
-		// before "non-simple" cross-origin requests (e.g. DELETE, PUT, PATCH
-		// or any request carrying a JSON body or custom headers) and only
-		// send the actual request if the preflight is answered with the
-		// matching Access-Control-Allow-* headers. We mirror the same CORS
-		// configuration civetweb applies to ordinary responses (see
-		// send_cors_header()) so that all methods behave consistently.
-		//
-		// Like send_cors_header(), we only emit the CORS headers when the
-		// request actually carries an "Origin" header (every cross-origin
-		// preflight does) and otherwise answer with a plain 204. When the
-		// allowed origin is the "*" wildcard and the server is configured to
-		// replace it with the requesting origin (replace_asterisk_with_origin),
-		// we reflect the request's Origin instead of the literal "*".
+		// Note: we do not emit the CORS Access-Control-Allow-* preflight
+		// headers here. Civetweb's built-in CORS handler (step 4 of
+		// handle_request()) intercepts and answers valid cross-origin
+		// preflights - those carrying both an "Origin" and an
+		// "Access-Control-Request-Method" header - with a 200 response and the
+		// matching headers before the request is ever routed to this handler.
+		// We therefore only reach this branch for non-preflight OPTIONS
+		// requests, which just need the RFC 7231 "Allow" header.
 		// See https://github.com/pi-hole/FTL/issues/2261
-		const struct mg_context *ctx = mg_get_context(conn);
-		const char *allow_origin = mg_get_option(ctx, "access_control_allow_origin");
-		const char *origin = mg_get_header(conn, "Origin");
-		if(allow_origin != NULL && allow_origin[0] != '\0' &&
-		   origin != NULL && origin[0] != '\0')
-		{
-			const char *replace_asterisk = mg_get_option(ctx, "replace_asterisk_with_origin");
-			if(allow_origin[0] == '*' && replace_asterisk != NULL &&
-			   strcasecmp(replace_asterisk, "yes") == 0)
-				mg_printf(conn, "Access-Control-Allow-Origin: %s\r\n", origin);
-			else
-				mg_printf(conn, "Access-Control-Allow-Origin: %s\r\n", allow_origin);
-
-			mg_printf(conn, "Access-Control-Allow-Methods: %s\r\n", methods);
-
-			// Advertise the allowed request headers. When configured to
-			// allow any header ("*"), reflect the headers the browser asks
-			// for; otherwise return the explicitly configured list.
-			const char *allow_headers = mg_get_option(ctx, "access_control_allow_headers");
-			const char *req_headers = mg_get_header(conn, "Access-Control-Request-Headers");
-			if(allow_headers != NULL && allow_headers[0] == '*' && req_headers != NULL)
-				mg_printf(conn, "Access-Control-Allow-Headers: %s\r\n", req_headers);
-			else if(allow_headers != NULL && allow_headers[0] != '\0')
-				mg_printf(conn, "Access-Control-Allow-Headers: %s\r\n", allow_headers);
-
-			mg_printf(conn, "Access-Control-Max-Age: 60\r\n");
-		}
 
 		// Finish header and send empty body
 		mg_printf(conn, "Content-Length: 0\r\n"

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -261,14 +261,29 @@ int api_handler(struct mg_connection *conn, void *ignored)
 		// or any request carrying a JSON body or custom headers) and only
 		// send the actual request if the preflight is answered with the
 		// matching Access-Control-Allow-* headers. We mirror the same CORS
-		// configuration civetweb applies to ordinary responses so that all
-		// methods behave consistently.
+		// configuration civetweb applies to ordinary responses (see
+		// send_cors_header()) so that all methods behave consistently.
+		//
+		// Like send_cors_header(), we only emit the CORS headers when the
+		// request actually carries an "Origin" header (every cross-origin
+		// preflight does) and otherwise answer with a plain 204. When the
+		// allowed origin is the "*" wildcard and the server is configured to
+		// replace it with the requesting origin (replace_asterisk_with_origin),
+		// we reflect the request's Origin instead of the literal "*".
 		// See https://github.com/pi-hole/FTL/issues/2261
 		const struct mg_context *ctx = mg_get_context(conn);
 		const char *allow_origin = mg_get_option(ctx, "access_control_allow_origin");
-		if(allow_origin != NULL && allow_origin[0] != '\0')
+		const char *origin = mg_get_header(conn, "Origin");
+		if(allow_origin != NULL && allow_origin[0] != '\0' &&
+		   origin != NULL && origin[0] != '\0')
 		{
-			mg_printf(conn, "Access-Control-Allow-Origin: %s\r\n", allow_origin);
+			const char *replace_asterisk = mg_get_option(ctx, "replace_asterisk_with_origin");
+			if(allow_origin[0] == '*' && replace_asterisk != NULL &&
+			   strcasecmp(replace_asterisk, "yes") == 0)
+				mg_printf(conn, "Access-Control-Allow-Origin: %s\r\n", origin);
+			else
+				mg_printf(conn, "Access-Control-Allow-Origin: %s\r\n", allow_origin);
+
 			mg_printf(conn, "Access-Control-Allow-Methods: %s\r\n", methods);
 
 			// Advertise the allowed request headers. When configured to

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -230,28 +230,62 @@ int api_handler(struct mg_connection *conn, void *ignored)
 	}
 
 	// The HTTP OPTIONS method requests permitted communication options for
-	// a given URL or server. We no not implement the wildcard OPTIONS method
+	// a given URL or server. We do not implement the wildcard OPTIONS method
 	// but instead return the allowed methods for the requested endpoint
 	// in the Allow header.
 	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
 	if(api.method == HTTP_OPTIONS)
 	{
-		// Send Allow header
-		mg_printf(conn, "HTTP/1.1 204 No Content\r\n"
-		                "Allow: ");
-
-		// Loop over all possible methods
+		// Build a comma-separated list of the methods allowed for this
+		// endpoint. It is used both for the RFC 7231 "Allow" header and for
+		// the CORS "Access-Control-Allow-Methods" header below.
+		char methods[256] = "";
 		unsigned int m = 0;
 		for(enum http_method j = HTTP_GET; j < HTTP_OPTIONS; j <<= 1)
 		{
 			// Check if this method is allowed for this endpoint
-			if(allowed_methods & j)
-				mg_printf(conn, "%s%s", m++ > 0 ? ", " : "", get_http_method_str(j));
+			if(!(allowed_methods & j))
+				continue;
+
+			if(m++ > 0)
+				strncat(methods, ", ", sizeof(methods) - strlen(methods) - 1);
+			strncat(methods, get_http_method_str(j), sizeof(methods) - strlen(methods) - 1);
+		}
+
+		// Send Allow header
+		mg_printf(conn, "HTTP/1.1 204 No Content\r\n"
+		                "Allow: %s\r\n", methods);
+
+		// CORS preflight headers. Browsers send a preflight OPTIONS request
+		// before "non-simple" cross-origin requests (e.g. DELETE, PUT, PATCH
+		// or any request carrying a JSON body or custom headers) and only
+		// send the actual request if the preflight is answered with the
+		// matching Access-Control-Allow-* headers. We mirror the same CORS
+		// configuration civetweb applies to ordinary responses so that all
+		// methods behave consistently.
+		// See https://github.com/pi-hole/FTL/issues/2261
+		const struct mg_context *ctx = mg_get_context(conn);
+		const char *allow_origin = mg_get_option(ctx, "access_control_allow_origin");
+		if(allow_origin != NULL && allow_origin[0] != '\0')
+		{
+			mg_printf(conn, "Access-Control-Allow-Origin: %s\r\n", allow_origin);
+			mg_printf(conn, "Access-Control-Allow-Methods: %s\r\n", methods);
+
+			// Advertise the allowed request headers. When configured to
+			// allow any header ("*"), reflect the headers the browser asks
+			// for; otherwise return the explicitly configured list.
+			const char *allow_headers = mg_get_option(ctx, "access_control_allow_headers");
+			const char *req_headers = mg_get_header(conn, "Access-Control-Request-Headers");
+			if(allow_headers != NULL && allow_headers[0] == '*' && req_headers != NULL)
+				mg_printf(conn, "Access-Control-Allow-Headers: %s\r\n", req_headers);
+			else if(allow_headers != NULL && allow_headers[0] != '\0')
+				mg_printf(conn, "Access-Control-Allow-Headers: %s\r\n", allow_headers);
+
+			mg_printf(conn, "Access-Control-Max-Age: 60\r\n");
 		}
 
 		// Finish header and send empty body
-		mg_printf(conn, "\r\n"
-		                "Content-Length: 0\r\n"
+		mg_printf(conn, "Content-Length: 0\r\n"
 		                "Connection: close\r\n\r\n");
 		return 204;
 	}

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -4712,6 +4712,11 @@ my_send_http_error_headers(struct mg_connection *conn,
 	mg_response_header_start(conn, status);
 	send_no_cache_header(conn);
 	send_additional_header(conn);
+	/* Pi-hole: also emit CORS headers here so that e.g. 204 No Content
+	 * responses (returned by DELETE endpoints) carry Access-Control-Allow-*
+	 * just like the 200 responses sent via mg_send_http_ok().
+	 * See https://github.com/pi-hole/FTL/issues/2261 */
+	send_cors_header(conn);
 	mg_response_header_add(conn, "Content-Type", mime_type, -1);
 	if (content_length < 0) {
 		/* Size not known. Use chunked encoding (HTTP/1.x) */

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -116,7 +116,13 @@ class TestCORS:
     ORIGIN = "http://example.com"
 
     def test_preflight_returns_cors_headers(self, api_session):
-        """OPTIONS preflight advertises the allowed origin and methods."""
+        """OPTIONS preflight advertises the allowed origin and methods.
+
+        A valid cross-origin preflight (carrying both Origin and
+        Access-Control-Request-Method) is answered by civetweb's built-in CORS
+        handler with a 200 response and the matching Access-Control-Allow-*
+        headers, before the request reaches FTL's own OPTIONS branch.
+        """
         r = api_session.options(
             f"{FTL_URL}/api/auth",
             headers={
@@ -125,7 +131,7 @@ class TestCORS:
             },
             timeout=5,
         )
-        assert r.status_code == 204
+        assert r.status_code == 200
         assert "Access-Control-Allow-Origin" in r.headers
         assert "DELETE" in r.headers.get("Access-Control-Allow-Methods", "")
 

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -100,6 +100,51 @@ class TestHTTPErrors:
 
 
 # ---------------------------------------------------------------------------
+# CORS headers for cross-origin web apps
+# ---------------------------------------------------------------------------
+
+class TestCORS:
+    """Cross-origin requests must work for all methods.
+
+    Browsers send a preflight OPTIONS request before "non-simple" cross-origin
+    requests (DELETE, PUT, PATCH, JSON POST) and only send the real request if
+    the preflight is answered with the matching Access-Control-Allow-* headers.
+    The actual response must carry Access-Control-Allow-Origin as well.
+    Regression test for https://github.com/pi-hole/FTL/issues/2261.
+    """
+
+    ORIGIN = "http://example.com"
+
+    def test_preflight_returns_cors_headers(self, api_session):
+        """OPTIONS preflight advertises the allowed origin and methods."""
+        r = api_session.options(
+            f"{FTL_URL}/api/auth",
+            headers={
+                "Origin": self.ORIGIN,
+                "Access-Control-Request-Method": "DELETE",
+            },
+            timeout=5,
+        )
+        assert r.status_code == 204
+        assert "Access-Control-Allow-Origin" in r.headers
+        assert "DELETE" in r.headers.get("Access-Control-Allow-Methods", "")
+
+    def test_error_response_carries_cors_header(self, api_session):
+        """Non-200 responses include Access-Control-Allow-Origin too.
+
+        DELETE endpoints answer with 204 No Content, which - like this 404 - is
+        sent via the same code path that previously omitted the CORS header.
+        """
+        r = api_session.get(
+            f"{FTL_URL}/api/undefined",
+            headers={"Origin": self.ORIGIN},
+            timeout=5,
+        )
+        assert r.status_code == 404
+        assert "Access-Control-Allow-Origin" in r.headers
+
+
+# ---------------------------------------------------------------------------
 # Config validation via API (type-based)
 # ---------------------------------------------------------------------------
 

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -129,6 +129,18 @@ class TestCORS:
         assert "Access-Control-Allow-Origin" in r.headers
         assert "DELETE" in r.headers.get("Access-Control-Allow-Methods", "")
 
+    def test_preflight_without_origin_omits_cors_headers(self, api_session):
+        """A bare OPTIONS request (no Origin) is not a CORS preflight.
+
+        Like civetweb's send_cors_header(), we only emit Access-Control-Allow-*
+        when the request carries an Origin header, otherwise we answer with a
+        plain 204 and just the RFC 7231 Allow header.
+        """
+        r = api_session.options(f"{FTL_URL}/api/auth", timeout=5)
+        assert r.status_code == 204
+        assert "Allow" in r.headers
+        assert "Access-Control-Allow-Origin" not in r.headers
+
     def test_error_response_carries_cors_header(self, api_session):
         """Non-200 responses include Access-Control-Allow-Origin too.
 


### PR DESCRIPTION
# What does this implement/fix?

Cross-origin web apps could not use `DELETE` endpoints. The preflight is fine, CivetWeb answers it itself before it reaches `api_handler()`. The actual `204 No Content` answer, like every error response, goes through `my_send_http_error_headers()`, which did not call `send_cors_header()`, so the browser discarded it. `200` responses always carried `Access-Control-Allow-Origin`.

This adds the call, mirrored into `patch/civetweb/0001-add-pihole-mods.patch`. It does not widen anything: the header is already sent on every `200` API response, and we never send `Access-Control-Allow-Credentials`.

The `OPTIONS` changes this PR carried before are no longer needed, #3084 reworked that branch in the meantime.

## How to test the change during review

- `curl -si -X DELETE -H 'Origin: http://example.com' http://pi.hole/api/auth` now shows `Access-Control-Allow-Origin`.
- `TestCORS` in `test/api/test_api.py` covers the preflight, a bare `OPTIONS` and a `404` with `Origin`.

## Additional information

**Related issue or feature (if applicable):** Fixes #2261

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
