### PR TITLE
Code review July 2026

### DIFF
--- a/src/api/2fa.c
+++ b/src/api/2fa.c
@@ -240,7 +240,11 @@ static bool copy_totp_secret(char *secret, const size_t secret_len)
 }
 
 static time_t last_attempt = 0;
-static uint32_t last_code = 0;
+// Last accepted time-step counter (RFC 6238 T value). Tracking the counter
+// instead of the raw code value enforces true one-time-use: once a step has
+// been accepted, that step and any earlier one can never be replayed, even
+// though the code stays numerically valid across the -1..+1 acceptance window.
+static uint64_t last_counter = 0;
 static pthread_mutex_t totp_lock = PTHREAD_MUTEX_INITIALIZER;
 enum totp_status verifyTOTP(const uint32_t incode)
 {
@@ -271,9 +275,18 @@ enum totp_status verifyTOTP(const uint32_t incode)
 	}
 
 	// Verify code for the previous, the current and the next time step
+	// Defer a reuse verdict until the whole window has been checked: two
+	// adjacent time steps can yield identical digits, so a match on a stale
+	// step must not prevent a genuinely fresh (later) step from being
+	// accepted for the same submitted code.
+	bool reused = false;
 	for(int i = -1; i <= 1; i++)
 	{
-		const uint32_t gencode = totp(decoded_secret, sizeof(decoded_secret), now + i*RFC6238_X);
+		const time_t t = now + i*RFC6238_X;
+		// Time-step counter for this candidate window (RFC 6238 T value),
+		// matching the value used internally by totp()
+		const uint64_t counter = (t - RFC6238_T0) / RFC6238_X;
+		const uint32_t gencode = totp(decoded_secret, sizeof(decoded_secret), t);
 
 		// Verify code
 		// RFC 6238 (section 4.2): If the calculated value matches the value
@@ -286,19 +299,28 @@ enum totp_status verifyTOTP(const uint32_t incode)
 		// it accepted previously
 		if(gencode == incode)
 		{
-			if(gencode == last_code)
+			// Reject reuse of an already accepted (or earlier) time
+			// step, but keep scanning in case a later, still-fresh
+			// step also matches this code
+			if(counter <= last_counter)
 			{
-				log_warn("2FA code has already been used (%i, %u), please wait %lu seconds",
-				         i, gencode, (unsigned long)(RFC6238_X - (now % RFC6238_X)));
-				pthread_mutex_unlock(&totp_lock);
-				return TOTP_REUSED;
+				reused = true;
+				continue;
 			}
 			const char *which = i == -1 ? "previous" : i == 0 ? "current" : "next";
 			log_debug(DEBUG_API, "2FA code from %s time step is valid", which);
-			last_code = gencode;
+			last_counter = counter;
 			pthread_mutex_unlock(&totp_lock);
 			return TOTP_CORRECT;
 		}
+	}
+
+	if(reused)
+	{
+		log_warn("2FA code has already been used, please wait %lu seconds",
+		         (unsigned long)(RFC6238_X - (now % RFC6238_X)));
+		pthread_mutex_unlock(&totp_lock);
+		return TOTP_REUSED;
 	}
 
 	pthread_mutex_unlock(&totp_lock);

--- a/src/api/action.c
+++ b/src/api/action.c
@@ -89,8 +89,12 @@ static int run_and_stream_command(struct ftl_conn *api, const char *path, const 
 		// Read readirected STDOUT/STDERR until EOF
 		// We are only interested in the last pipe line
 		char errbuf[1024] = "";
-		while(read(pipefd[0], errbuf, sizeof(errbuf)) > 0)
+		ssize_t nread;
+		while((nread = read(pipefd[0], errbuf, sizeof(errbuf) - 1)) > 0)
 		{
+			// NUL-terminate what we just read so the string
+			// operations below cannot read past the buffer
+			errbuf[nread] = '\0';
 			// Send chunked data
 			// The chunked size is the length of the string in hex and has to be
 			// transferred in advance, followed by \r\n as line separator and

--- a/src/api/action.c
+++ b/src/api/action.c
@@ -74,8 +74,9 @@ static int run_and_stream_command(struct ftl_conn *api, const char *path, const 
 		// Run pihole -g
 		execv(path, (char *const *)args);
 
-		// Exit the fork
-		exit(EXIT_SUCCESS);
+		// execv() only returns if it failed, so the command never ran.
+		// Exit non-zero so the parent reports the action as failed.
+		exit(EXIT_FAILURE);
 	}
 	else
 	{

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -176,6 +176,12 @@ int api_handler(struct mg_connection *conn, void *ignored)
 							api.request->request_method,
 							api.request->local_uri_raw,
 							strerror(ENOMEM));
+					// Break (not return) so the cleanup block below runs
+					ret = send_json_error(&api, 500,
+					                      "internal_error",
+					                      "Failed to allocate memory for payload",
+					                      NULL);
+					break;
 				}
 
 				// Read and try to parse payload

--- a/src/api/auth.c
+++ b/src/api/auth.c
@@ -23,6 +23,8 @@
 #include "daemon.h"
 // sha256_raw_to_hex()
 #include "config/password.h"
+// constant-time memeql_sec()
+#include <nettle/memops.h>
 // database session functions
 #include "database/session-table.h"
 // FTLDBerror()
@@ -107,7 +109,9 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 	}
 
 	// Does the client provide a session ID?
-	char sid[SID_SIZE];
+	// Zero-initialize so a partially-filled buffer is always NUL-padded before
+	// the constant-time comparison below.
+	char sid[SID_SIZE] = { 0 };
 	const char *sid_source = "-";
 	// Try to extract SID from cookie
 	bool sid_avail = false;
@@ -197,7 +201,9 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 		sid_avail = true;
 	}
 
-	if(!sid_avail)
+	// An empty SID must never be treated as available: it could otherwise match
+	// a session slot whose sid was never populated (e.g. after an RNG failure).
+	if(!sid_avail || sid[0] == '\0')
 	{
 		api->message = "no SID provided";
 		log_debug(DEBUG_API, "API Authentication: FAIL (%s)", api->message);
@@ -211,7 +217,7 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 
 	// If the SID has been sent through a cookie, we require a CSRF token in
 	// the header to be sent along with the request for any API requests
-	char csrf[SID_SIZE];
+	char csrf[SID_SIZE] = { 0 };
 	const bool need_csrf = cookie_auth && is_api;
 	if(need_csrf)
 	{
@@ -232,19 +238,28 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 		}
 	}
 
+	// Lengths of the presented tokens, computed once for the constant-time
+	// comparisons below. A length check gates memeql_sec() so we never read
+	// past the shorter of the two NUL-terminated buffers.
+	const size_t sidlen = strlen(sid);
+	const size_t csrflen = need_csrf ? strlen(csrf) : 0;
+
 	bool expired = false;
 	AUTOLOCK(&auth_lock);
 	for(unsigned int i = 0; i < max_sessions; i++)
 	{
 		if(auth_data[i].used &&
-		   strcmp(auth_data[i].sid, sid) == 0)
+		   sidlen == strlen(auth_data[i].sid) &&
+		   memeql_sec(auth_data[i].sid, sid, sidlen))
 		{
 			// Check if session is known but expired
 			if(auth_data[i].valid_until < now)
 				expired = true;
 
 			// Check CSRF if authentiating via cookie
-			if(need_csrf && strcmp(auth_data[i].csrf, csrf) != 0)
+			if(need_csrf &&
+			   !(csrflen == strlen(auth_data[i].csrf) &&
+			     memeql_sec(auth_data[i].csrf, csrf, csrflen)))
 			{
 				api->message = "CSRF token mismatch";
 				log_debug(DEBUG_API, "API Authentication: FAIL (%s, received \"%s\", expected \"%s\")",
@@ -269,7 +284,8 @@ int check_client_auth(struct ftl_conn *api, const bool is_api)
 		// Update user cookie
 		if(snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),
 		            FTL_SET_COOKIE,
-		            auth_data[user_id].sid, config.webserver.session.timeout.v.ui) < 0)
+		            auth_data[user_id].sid, config.webserver.session.timeout.v.ui,
+		            api->request->is_ssl ? "; Secure" : "") < 0)
 		{
 			return send_json_error(api, 500, "internal_error", "Internal server error", NULL);
 		}
@@ -415,7 +431,8 @@ static int send_api_auth_status(struct ftl_conn *api, const int user_id, const t
 		AUTOLOCK(&auth_lock);
 		if(snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),
 		            FTL_SET_COOKIE,
-		            auth_data[user_id].sid, config.webserver.session.timeout.v.ui) < 0)
+		            auth_data[user_id].sid, config.webserver.session.timeout.v.ui,
+		            api->request->is_ssl ? "; Secure" : "") < 0)
 		{
 			return send_json_error(api, 500, "internal_error", "Internal server error", NULL);
 		}
@@ -431,7 +448,8 @@ static int send_api_auth_status(struct ftl_conn *api, const int user_id, const t
 		{
 			log_debug(DEBUG_API, "API Auth status: Logout, asking to delete cookie");
 
-			strncpy(pi_hole_extra_headers, FTL_DELETE_COOKIE, sizeof(pi_hole_extra_headers));
+			snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),
+			         FTL_DELETE_COOKIE, api->request->is_ssl ? " Secure" : "");
 
 			// Revoke client authentication. This slot can be used by a new client afterwards.
 			const int code = delete_session(user_id, false) ? 204 : 404;
@@ -461,21 +479,23 @@ static int send_api_auth_status(struct ftl_conn *api, const int user_id, const t
 	{
 		log_debug(DEBUG_API, "API Auth status: Invalid, asking to delete cookie");
 
-		strncpy(pi_hole_extra_headers, FTL_DELETE_COOKIE, sizeof(pi_hole_extra_headers));
+		snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),
+		         FTL_DELETE_COOKIE, api->request->is_ssl ? " Secure" : "");
 		cJSON *json = JSON_NEW_OBJECT();
 		get_session_object(api, json, user_id, now);
 		JSON_SEND_OBJECT_CODE(json, 401); // 401 Unauthorized
 	}
 }
 
-static void generateSID(char *sid)
+static bool generateSID(char *sid)
 {
 	uint8_t raw_sid[SID_SIZE];
 	if(!get_secure_randomness(raw_sid, sizeof(raw_sid)))
-		return;
+		return false;
 
 	base64_encode_raw(NETTLE_SIGN sid, SID_BITSIZE/8, raw_sid);
 	sid[SID_SIZE-1] = '\0';
+	return true;
 }
 
 // api/auth
@@ -665,9 +685,16 @@ int api_auth(struct ftl_conn *api)
 				auth_data[i].app = result == APPPASSWORD_CORRECT;
 				auth_data[i].cli = result == CLIPASSWORD_CORRECT;
 
-				// Generate new SID and CSRF token
-				generateSID(auth_data[i].sid);
-				generateSID(auth_data[i].csrf);
+				// Generate new SID and CSRF token. On RNG failure,
+				// release the slot we just claimed so no session with
+				// an empty sid/csrf can linger. The AUTOLOCK cleanup
+				// unlocks the mutex on return.
+				if(!generateSID(auth_data[i].sid) ||
+				   !generateSID(auth_data[i].csrf))
+				{
+					delete_session(i, true);
+					return send_json_error(api, 500, "internal_error", "Internal server error", NULL);
+				}
 
 				user_id = i;
 				break;
@@ -709,12 +736,21 @@ int api_auth(struct ftl_conn *api)
 	{
 		// No password set
 		api->message = "password incorrect";
-		log_debug(DEBUG_API, "API: Trying to auth with password but none set: '%s'", password);
+		log_debug(DEBUG_API, "API: Trying to auth with password but none set");
+
+		// Zero-out password in memory (symmetry with the success path)
+		if(password != NULL)
+			memset(password, 0, strlen(password));
 	}
 	else
 	{
 		api->message = "password incorrect";
-		log_debug(DEBUG_API, "API: Password incorrect: '%s'", password);
+		// Never log the plaintext password, only its length
+		log_debug(DEBUG_API, "API: Password incorrect (length %zu)", password ? strlen(password) : 0);
+
+		// Zero-out password in memory (symmetry with the success path)
+		if(password != NULL)
+			memset(password, 0, strlen(password));
 	}
 
 	// Free allocated memory

--- a/src/api/auth.h
+++ b/src/api/auth.h
@@ -37,8 +37,11 @@
 // (XSS) flaw exists, and a user accidentally accesses a link that exploits this
 // flaw, the browser (primarily Internet Explorer) will not reveal the cookie to
 // a third party.
-#define FTL_SET_COOKIE "Set-Cookie: sid=%s; SameSite=Lax; Path=/; Max-Age=%u; HttpOnly\r\n"
-#define FTL_DELETE_COOKIE "Set-Cookie: sid=deleted; SameSite=Lax; Path=/; Max-Age=-1; Expires=Thu, 01 Jan 1970 00:00:00 GMT;\r\n"
+// The trailing %s carries the "; Secure" attribute, which is only appended
+// when the session was established over TLS (see call sites). Adding Secure on
+// plain HTTP would make browsers drop the cookie, breaking non-TLS setups.
+#define FTL_SET_COOKIE "Set-Cookie: sid=%s; SameSite=Lax; Path=/; Max-Age=%u; HttpOnly%s\r\n"
+#define FTL_DELETE_COOKIE "Set-Cookie: sid=deleted; SameSite=Lax; Path=/; Max-Age=-1; Expires=Thu, 01 Jan 1970 00:00:00 GMT;%s\r\n"
 
 struct session {
 	bool used;

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -450,10 +450,9 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 		{
 			if(!cJSON_IsArray(elem))
 				return "not of type array";
-			const unsigned int elems = cJSON_GetArraySize(elem);
-			for(unsigned int i = 0; i < elems; i++)
+			unsigned int i = 0;
+			for(const cJSON *item = elem != NULL ? elem->child : NULL; item != NULL; item = item->next, i++)
 			{
-				const cJSON *item = cJSON_GetArrayItem(elem, i);
 				if(!cJSON_IsString(item))
 					return "array has invalid elements";
 				log_debug(DEBUG_CONFIG, "%s[%u] = \"%s\"", conf_item->k, i, item->valuestring);
@@ -961,9 +960,9 @@ static int api_config_put_delete(struct ftl_conn *api)
 
 		// Check if this entry exists in the array
 		int idx = 0;
-		for(; idx < cJSON_GetArraySize(new_item->v.json); idx++)
+		for(const cJSON *elem = new_item->v.json != NULL ? new_item->v.json->child : NULL;
+		    elem != NULL; elem = elem->next, idx++)
 		{
-			const cJSON *elem = cJSON_GetArrayItem(new_item->v.json, idx);
 			if(elem != NULL && elem->valuestring != NULL &&
 				strcmp(elem->valuestring, new_item_str) == 0)
 			{

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -458,7 +458,11 @@ static const char *getJSONvalue(struct conf_item *conf_item, cJSON *elem, struct
 					return "array has invalid elements";
 				log_debug(DEBUG_CONFIG, "%s[%u] = \"%s\"", conf_item->k, i, item->valuestring);
 			}
-			// If we reach this point, all elements are valid
+			// If we reach this point, all elements are valid. Free the
+			// previous array (duplicated by duplicate_config into newconf)
+			// before overwriting it, otherwise it leaks.
+			if(conf_item->v.json != NULL)
+				cJSON_Delete(conf_item->v.json);
 			conf_item->v.json = cJSON_Duplicate(elem, true);
 		}
 	}

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -705,10 +705,10 @@ int get_sensors_obj(struct ftl_conn *api, cJSON *sensors, const bool add_list)
 	int cpu_temp_sensor = -1;
 
 	// Loop over all sensors
-	for(int i = 0; i < cJSON_GetArraySize(list); i++)
+	int i = 0;
+	for(cJSON *sensor = list != NULL ? list->child : NULL; sensor != NULL; sensor = sensor->next, i++)
 	{
 		// Get sensor object
-		cJSON *sensor = cJSON_GetArrayItem(list, i);
 
 		// Get sensor name
 		cJSON *name = cJSON_GetObjectItemCaseSensitive(sensor, "name");
@@ -948,10 +948,9 @@ static int api_info_messages_GET(struct ftl_conn *api)
 		cJSON *filtered = cJSON_CreateArray();
 
 		// Loop over all messages
-		for(int i = 0; i < cJSON_GetArraySize(messages); i++)
+		cJSON *message = NULL;
+		cJSON_ArrayForEach(message, messages)
 		{
-			// Get message
-			cJSON *message = cJSON_GetArrayItem(messages, i);
 			if(message == NULL)
 				continue;
 

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -356,6 +356,27 @@ static int api_list_write(struct ftl_conn *api,
 
 	bool okay = true;
 	char *regex_msg = NULL;
+
+	// Pre-pass: every array element must be a string. This covers ALL list
+	// types (including GRAVITY_GROUPS, where the type-specific validation
+	// below is skipped) so a non-string element can never reach the SQL bind
+	// or error logging with a NULL valuestring.
+	{
+		cJSON *it = NULL;
+		cJSON_ArrayForEach(it, row.items)
+		{
+			if(!cJSON_IsString(it))
+			{
+				if(allocated_json)
+					cJSON_Delete(row.items);
+				return send_json_error(api, 400, // 400 Bad Request
+				                       "bad_request",
+				                       "all array items must be strings",
+				                       NULL);
+			}
+		}
+	}
+
 	if(listtype == GRAVITY_DOMAINLIST_ALLOW_REGEX || listtype == GRAVITY_DOMAINLIST_DENY_REGEX)
 	{
 		// Test validity of this regex

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -435,6 +435,8 @@ static int api_list_write(struct ftl_conn *api,
 					if (rc != IDN2_OK)
 					{
 						// Invalid domain name
+						if(allocated_json)
+							cJSON_Delete(row.items);
 						return send_json_error(api, 400,
 						                       "bad_request",
 						                       "Invalid request: Invalid domain name",

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -1134,10 +1134,9 @@ bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, r
 	if(N < 1)
 		return false;
 
-	// Set number of regexes (positive = unsigned integer)
-	*N_regex = N;
-
-	// Allocate memory for regex array
+	// Allocate memory for the regex array. N is the upper bound; empty or
+	// invalid entries are skipped below, so the number actually compiled
+	// (reported via *N_regex) may be smaller.
 	*regex = calloc(N, sizeof(regex_t));
 	if(*regex == NULL)
 	{
@@ -1168,6 +1167,15 @@ bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, r
 			regerror(rc, &(*regex)[i], errbuf, sizeof(errbuf));
 			log_err("Failed to compile regex \"%s\": %s",
 			        filter->valuestring, errbuf);
+
+			// Release the regexes compiled so far and the array itself
+			// before returning so the partially-built array does not leak
+			for(unsigned int j = 0; j < i; j++)
+				regfree(&(*regex)[j]);
+			free(*regex);
+			*regex = NULL;
+			*N_regex = 0;
+
 			return send_json_error(api, 400,
 			                       "bad_request",
 			                       "Failed to compile regex",
@@ -1175,6 +1183,22 @@ bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, r
 		}
 
 		i++;
+	}
+
+	// Only the first i slots were actually compiled; skipped (empty or
+	// invalid) entries leave zero-initialized regex_t slots behind. Report
+	// the real count so the caller never runs regexec()/regfree() over an
+	// uncompiled slot, whose NULL program pointer would crash the daemon
+	// (and, since one process serves DNS, take resolution down with it).
+	*N_regex = i;
+
+	// If no valid regex remained, drop the unused allocation and report that
+	// no filtering is in effect for this list.
+	if(i == 0)
+	{
+		free(*regex);
+		*regex = NULL;
+		return false;
 	}
 
 	// We are filtering, so we have to continue to step over the

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -182,6 +182,11 @@ int api_queries_suggestions(struct ftl_conn *api)
 #define JOINSTR "JOIN client_by_id c ON q.client = c.id JOIN domain_by_id d ON q.domain = d.id LEFT JOIN forward_by_id f ON q.forward = f.id LEFT JOIN addinfo_by_id a ON a.id = q.additional_info"
 #define QUERYSTRBUFFERLEN 4096
 
+// Hard upper bound on the number of query rows materialized into a single
+// JSON response. This prevents /api/queries from exhausting memory by
+// building the entire (in-memory or on-disk) query history as one document.
+#define API_QUERIES_MAX_ROWS 10000
+
 static void add_querystr_string(struct ftl_conn *api, char *querystr, const char *sql, const char *val, bool *where)
 {
 	const size_t strpos = strlen(querystr);
@@ -403,6 +408,15 @@ int api_queries(struct ftl_conn *api)
 		// Does the user request a non-default number of replies?
 		// Note: We do not accept zero query requests here
 		get_int_var(api->request->query_string, "length", &length);
+
+		// Enforce a hard upper bound on the number of rows materialized into
+		// the JSON response to prevent memory-exhaustion DoS. This cap applies
+		// regardless of disk=true and regardless of the requested length.
+		// Deliberate, documented behavior change: the length <= 0 ("all") case
+		// is limited to the cap as well, so "all" now means "all up to
+		// API_QUERIES_MAX_ROWS".
+		if(length <= 0 || length > API_QUERIES_MAX_ROWS)
+			length = API_QUERIES_MAX_ROWS;
 
 		// Does the user request an offset from the cursor?
 		get_uint_var(api->request->query_string, "start", &start);

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -490,7 +490,9 @@ int api_queries(struct ftl_conn *api)
 				char search_col_id_str[32] = { 0 };
 				if(GET_VAR(search_col_id, search_col_id_str, api->request->query_string) > 0)
 				{
-					size_t searchlen = min(strlen(search[j]), sizeof(search[j]) - 2);
+					// Leave room for a leading and a trailing wildcard
+					// plus the terminating NUL that are added below
+					size_t searchlen = min(strlen(search[j]), sizeof(search[j]) - 3);
 
 					// Replace "*" by SQLite3 wildcard character "%"
 					for(unsigned int i = 0; i < searchlen; i++)

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -502,8 +502,10 @@ int api_queries(struct ftl_conn *api)
 					}
 
 					// Add % at the end of the search string to
-					// make it a wildcard if there is none
-					if(search[j][searchlen - 1] != '%')
+					// make it a wildcard if there is none. Guard against
+					// searchlen == 0 (empty value), which would make
+					// searchlen - 1 underflow into an out-of-bounds read.
+					if(searchlen == 0 || search[j][searchlen - 1] != '%')
 					{
 						search[j][searchlen] = '%';
 						search[j][searchlen + 1] = '\0';

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -810,8 +810,9 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 			         extract_files[i].archive_name);
 			continue;
 		}
-		// all other values of i belong to config files
-		else if(data->import != NULL && !JSON_KEY_TRUE(data->import, "config"))
+		// all other values of i belong to config files (i == 1 is
+		// dhcp.leases and is controlled solely by the flag above)
+		else if(i != 1 && data->import != NULL && !JSON_KEY_TRUE(data->import, "config"))
 		{
 			log_info("Skipping import of \"%s\" as it was not requested for import",
 			         extract_files[i].archive_name);

--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -881,6 +881,7 @@ static int process_received_tar_gz(struct ftl_conn *api, struct upload_data *dat
 	}
 
 	// Free allocated memory
+	free(archive);
 	free_upload_data(data);
 
 	// Migrate the config to v6

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -359,10 +359,9 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 				log_err("Config setting %s is invalid: not a valid string array (example: [ \"a\", \"b\", \"c\" ])", conf_item->k);
 				return false;
 			}
-			const unsigned int elems = cJSON_GetArraySize(elem);
-			for(unsigned int i = 0; i < elems; i++)
+			unsigned int i = 0;
+			for(const cJSON *item = elem != NULL ? elem->child : NULL; item != NULL; item = item->next, i++)
 			{
-				const cJSON *item = cJSON_GetArrayItem(elem, i);
 				if(!cJSON_IsString(item))
 				{
 					log_err("Config setting %s is invalid: element with index %u is not a string", conf_item->k, i);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -238,6 +238,12 @@ unsigned int __attribute__ ((pure)) config_path_depth(char **paths)
 
 void duplicate_config(struct config *dst, struct config *src)
 {
+	// Lock shared memory while we read the (possibly shared) source
+	// config. replace_config() frees the previous config under the same
+	// lock, so holding it here prevents a use-after-free when another
+	// thread swaps the config out while we are still copying its strings.
+	lock_shm();
+
 	// Post-processing:
 	// Initialize and verify config data
 	for(unsigned int i = 0; i < CONFIG_ELEMENTS; i++)
@@ -290,6 +296,8 @@ void duplicate_config(struct config *dst, struct config *src)
 				break;
 		}
 	}
+
+	unlock_shm();
 }
 
 // True = Identical, False = Different

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -90,26 +90,31 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 		// Read readirected STDERR until EOF
 		if(errbuf != NULL)
 		{
-			// We are only interested in the last pipe line
+			// dnsmasq may deliver its output in several reads (observed on
+			// slower architectures such as RISC-V). We are only interested
+			// in the last pipe line, but reading one chunk at a time and
+			// keeping the last read would let a trailing read (e.g. a lone
+			// newline) discard the meaningful error captured earlier and
+			// leave an empty message. Accumulate everything first, then keep
+			// the last non-empty line.
+			size_t total = 0;
 			ssize_t nread;
-			while((nread = read(pipefd[0], errbuf, ERRBUF_SIZE - 1)) > 0)
-			{
-				// NUL-terminate what we just read so the string
-				// operations below cannot read past the buffer
-				errbuf[nread] = '\0';
-				// Remove initial newline character (if present)
-				if(errbuf[0] == '\n')
-					memmove(errbuf, &errbuf[1], (size_t)nread);
-				// Strip trailing newline character (if present)
-				const size_t len = strlen(errbuf);
-				if(len > 0 && errbuf[len - 1] == '\n')
-					errbuf[len - 1] = '\0';
-				// Replace any possible internal newline characters by spaces
-				char *ptr = errbuf;
-				while((ptr = strchr(ptr, '\n')) != NULL)
-					*ptr = ' ';
-				log_debug(DEBUG_CONFIG, "dnsmasq pipe: %s", errbuf);
-			}
+			while(total < ERRBUF_SIZE - 1 &&
+			      (nread = read(pipefd[0], errbuf + total, ERRBUF_SIZE - 1 - total)) > 0)
+				total += (size_t)nread;
+			errbuf[total] = '\0';
+
+			// Strip trailing newline characters
+			while(total > 0 && errbuf[total - 1] == '\n')
+				errbuf[--total] = '\0';
+
+			// Keep only the last line: drop everything up to and including
+			// the last remaining newline
+			char *last = strrchr(errbuf, '\n');
+			if(last != NULL)
+				memmove(errbuf, last + 1, strlen(last + 1) + 1);
+
+			log_debug(DEBUG_CONFIG, "dnsmasq pipe: %s", errbuf);
 		}
 
 		// Wait until child has exited to get its return code

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -346,10 +346,9 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	if(cJSON_GetArraySize(conf->dns.upstreams.v.json) > 0)
 	{
 		fputs("# List of upstream DNS server\n", pihole_conf);
-		const int n = cJSON_GetArraySize(conf->dns.upstreams.v.json);
-		for(int i = 0; i < n; i++)
+		cJSON *server = NULL;
+		cJSON_ArrayForEach(server, conf->dns.upstreams.v.json)
 		{
-			cJSON *server = cJSON_GetArrayItem(conf->dns.upstreams.v.json, i);
 			if(server != NULL && cJSON_IsString(server))
 				fprintf(pihole_conf, "server=%s\n", server->valuestring);
 		}
@@ -495,14 +494,16 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 
 	// Add upstream DNS servers for reverse lookups
 	bool revServer_domain = false, revServer_homearpa = false, revServer_internal = false;
-	const unsigned int revServers = cJSON_GetArraySize(conf->dns.revServers.v.json);
-	for(unsigned int i = 0; i < revServers; i++)
+	unsigned int i = 0;
+	cJSON *revServer = NULL;
+	cJSON_ArrayForEach(revServer, conf->dns.revServers.v.json)
 	{
-		cJSON *revServer = cJSON_GetArrayItem(conf->dns.revServers.v.json, i);
-		if(revServer == NULL || !cJSON_IsString(revServer))
+		// 0-based index of this entry, captured before any continue below
+		const unsigned int idx = i++;
+		if(!cJSON_IsString(revServer))
 		{
 			log_err("Skipped invalid dns.revServers[%u]: %s (not a string)",
-			        i, cJSON_Print(revServer));
+			        idx, cJSON_Print(revServer));
 			continue;
 		}
 
@@ -526,13 +527,13 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 
 		if(active == NULL || cidr == NULL || target == NULL)
 		{
-			log_err("Skipped invalid dns.revServers[%u]: %s (not fully defined)", i, revServer->valuestring);
+			log_err("Skipped invalid dns.revServers[%u]: %s (not fully defined)", idx, revServer->valuestring);
 			free(copy);
 			continue;
 		}
 
 		fprintf(pihole_conf, "# Reverse server setting (%u%s server)\n",
-		        i+1, get_ordinal_suffix(i+1));
+		        idx+1, get_ordinal_suffix(idx+1));
 		fprintf(pihole_conf, "rev-server=%s,%s\n", cidr, target);
 
 		// If we have a reverse domain, we forward all queries to this domain to
@@ -752,10 +753,9 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		if(cJSON_GetArraySize(conf->dhcp.hosts.v.json) > 0)
 		{
 			fputs("# Per host parameters for the DHCP server\n", pihole_conf);
-			const int n = cJSON_GetArraySize(conf->dhcp.hosts.v.json);
-			for(int i = 0; i < n; i++)
+			cJSON *server = NULL;
+			cJSON_ArrayForEach(server, conf->dhcp.hosts.v.json)
 			{
-				cJSON *server = cJSON_GetArrayItem(conf->dhcp.hosts.v.json, i);
 				if(server != NULL && cJSON_IsString(server))
 					fprintf(pihole_conf, "dhcp-host=%s\n", server->valuestring);
 			}
@@ -766,10 +766,9 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	if(cJSON_GetArraySize(conf->dns.cnameRecords.v.json) > 0)
 	{
 		fputs("# User-defined custom CNAMEs\n", pihole_conf);
-		const int n = cJSON_GetArraySize(conf->dns.cnameRecords.v.json);
-		for(int i = 0; i < n; i++)
+		cJSON *server = NULL;
+		cJSON_ArrayForEach(server, conf->dns.cnameRecords.v.json)
 		{
-			cJSON *server = cJSON_GetArrayItem(conf->dns.cnameRecords.v.json, i);
 			if(server != NULL && cJSON_IsString(server))
 				fprintf(pihole_conf, "cname=%s\n", server->valuestring);
 		}
@@ -1159,9 +1158,9 @@ bool write_custom_list(void)
 	const int N = cJSON_GetArraySize(config.dns.hosts.v.json);
 	if(N > 0)
 	{
-		for(int i = 0; i < N; i++)
+		cJSON *entry = NULL;
+		cJSON_ArrayForEach(entry, config.dns.hosts.v.json)
 		{
-			cJSON *entry = cJSON_GetArrayItem(config.dns.hosts.v.json, i);
 			if(entry != NULL && cJSON_IsString(entry))
 				fprintf(custom_list, "%s\n", entry->valuestring);
 		}

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -502,8 +502,10 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		const unsigned int idx = i++;
 		if(!cJSON_IsString(revServer))
 		{
+			char *dump = cJSON_Print(revServer);
 			log_err("Skipped invalid dns.revServers[%u]: %s (not a string)",
-			        idx, cJSON_Print(revServer));
+			        idx, dump ? dump : "(null)");
+			free(dump);
 			continue;
 		}
 

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -91,14 +91,19 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 		if(errbuf != NULL)
 		{
 			// We are only interested in the last pipe line
-			while(read(pipefd[0], errbuf, ERRBUF_SIZE) > 0)
+			ssize_t nread;
+			while((nread = read(pipefd[0], errbuf, ERRBUF_SIZE - 1)) > 0)
 			{
+				// NUL-terminate what we just read so the string
+				// operations below cannot read past the buffer
+				errbuf[nread] = '\0';
 				// Remove initial newline character (if present)
 				if(errbuf[0] == '\n')
-					memmove(errbuf, &errbuf[1], ERRBUF_SIZE-1);
-				// Strip newline character (if present)
-				if(errbuf[strlen(errbuf)-1] == '\n')
-					errbuf[strlen(errbuf)-1] = '\0';
+					memmove(errbuf, &errbuf[1], (size_t)nread);
+				// Strip trailing newline character (if present)
+				const size_t len = strlen(errbuf);
+				if(len > 0 && errbuf[len - 1] == '\n')
+					errbuf[len - 1] = '\0';
 				// Replace any possible internal newline characters by spaces
 				char *ptr = errbuf;
 				while((ptr = strchr(ptr, '\n')) != NULL)

--- a/src/config/env.c
+++ b/src/config/env.c
@@ -203,13 +203,15 @@ static void invalid_enum_item(const char *envvar, struct conf_item *conf_item, s
 	// Build the error message. Mark it as allocated so printFTLenv()
 	// actually frees it again instead of leaking it on every reload.
 	if(asprintf(&item->error, "= %s is invalid, allowed options are: %s",
-	            escaped_value, allowed_values) > 0)
+	            escaped_value ? escaped_value : "(null)",
+	            allowed_values ? allowed_values : "(null)") > 0)
 		item->error_allocated = true;
 	else
 		item->error = NULL;
 
 	free(escaped_value);
 	free(allowed_values);
+	cJSON_Delete(allowed_items);
 }
 
 bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, struct config *newconf, cJSON *forced_vars, bool *reset)

--- a/src/config/env.c
+++ b/src/config/env.c
@@ -224,9 +224,12 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 
 		// Check if this was a forced setting before
 		// If so, we revert the config option to default
-		for(int i = 0; i < cJSON_GetArraySize(forced_vars); i++)
+		// forced_vars is declared nonnull, so walk the list directly:
+		// cJSON_ArrayForEach() compares it to NULL, which trips
+		// -Werror=nonnull-compare.
+		for(cJSON *forced = forced_vars->child; forced != NULL; forced = forced->next)
 		{
-			const char *forced_var = cJSON_GetArrayItem(forced_vars, i)->valuestring;
+			const char *forced_var = forced->valuestring;
 			if(strcmp(forced_var, conf_item->k) == 0)
 			{
 				log_info("Resetting %s to default (not forced anymore)", conf_item->k);

--- a/src/config/env.c
+++ b/src/config/env.c
@@ -200,9 +200,13 @@ static void invalid_enum_item(const char *envvar, struct conf_item *conf_item, s
 	char *allowed_values = cJSON_PrintUnformatted(allowed_items);
 	char *escaped_value = escape_json(envvar);
 
-	// Calculate the size of the error message
-	asprintf(&item->error, "= %s is invalid, allowed options are: %s",
-	         escaped_value, allowed_values);
+	// Build the error message. Mark it as allocated so printFTLenv()
+	// actually frees it again instead of leaking it on every reload.
+	if(asprintf(&item->error, "= %s is invalid, allowed options are: %s",
+	            escaped_value, allowed_values) > 0)
+		item->error_allocated = true;
+	else
+		item->error = NULL;
 
 	free(escaped_value);
 	free(allowed_values);

--- a/src/config/env.c
+++ b/src/config/env.c
@@ -271,6 +271,19 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 
 	log_debug(DEBUG_CONFIG, "ENV %s = %s", conf_item->e, envvar);
 
+	// Snapshot the previous value and type before the type switch commits
+	// the new value into conf_item->v. If the validator below rejects the
+	// new value, we revert to this snapshot so the rejected value never
+	// reaches the generated config. Owned members (allocated string, JSON
+	// array) are deep-copied so the snapshot stays valid even though the
+	// switch frees/replaces the live value.
+	const enum conf_type old_t = conf_item->t;
+	union conf_value old_v = conf_item->v;
+	if(old_t == CONF_STRING_ALLOCATED)
+		old_v.s = conf_item->v.s != NULL ? strdup(conf_item->v.s) : NULL;
+	else if(old_t == CONF_JSON_STRING_ARRAY)
+		old_v.json = cJSON_Duplicate(conf_item->v.json, true);
+
 	switch(conf_item->t)
 	{
 		case CONF_BOOL:
@@ -616,12 +629,37 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 	if(conf_item->c != NULL && !conf_item->c(&conf_item->v, conf_item->k, errbuf))
 	{
 		log_debug(DEBUG_CONFIG, "Config item validation failed for %s: %s", conf_item->k, errbuf);
+
+		// The validator rejected the newly committed value. Free it and
+		// revert to the snapshot taken before the type switch so the
+		// rejected value never reaches the generated config.
+		if(conf_item->t == CONF_STRING_ALLOCATED)
+		{
+			free(conf_item->v.s);
+		}
+		else if(conf_item->t == CONF_JSON_STRING_ARRAY)
+		{
+			cJSON_Delete(conf_item->v.json);
+		}
+		conf_item->v = old_v;
+		conf_item->t = old_t;
+
 		item->error = strdup(errbuf);
 		item->error_allocated = true;
 		item->valid = false;
 		return false;
 	}
 
+	// Validation passed: release the owned snapshot copy as the new value
+	// is now committed and owns its own memory
+	if(old_t == CONF_STRING_ALLOCATED)
+	{
+		free(old_v.s);
+	}
+	else if(old_t == CONF_JSON_STRING_ARRAY)
+	{
+		cJSON_Delete(old_v.json);
+	}
 
 	log_debug(DEBUG_CONFIG, "Env var %s passed validation successfully", conf_item->k);
 

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -798,6 +798,7 @@ bool create_cli_password(void)
 	{
 		log_err("Failed to open CLI password file for writing: %s", strerror(errno));
 		free(cli_password);
+		cli_password = NULL;
 		return false;
 	}
 
@@ -807,6 +808,7 @@ bool create_cli_password(void)
 		log_err("Failed to write CLI password to file: %s", strerror(errno));
 		fclose(file);
 		free(cli_password);
+		cli_password = NULL;
 		return false;
 	}
 
@@ -818,6 +820,7 @@ bool create_cli_password(void)
 	{
 		log_err("Failed to set permissions on CLI password file: %s", strerror(errno));
 		free(cli_password);
+		cli_password = NULL;
 		return false;
 	}
 

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -758,8 +758,10 @@ bool generate_password(char **password, char **pwhash)
 	// Verify that the password hash is valid
 	if(verify_password(*password, *pwhash, false) != PASSWORD_CORRECT)
 	{
-		free(password);
-		free(pwhash);
+		free(*password);
+		*password = NULL;
+		free(*pwhash);
+		*pwhash = NULL;
 		log_warn("Failed to create password hash (verification failed), app password not available");
 		return false;
 	}

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -430,9 +430,14 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 	if(password == NULL || password[0] == '\0')
 		return PASSWORD_INCORRECT;
 
-	// Check if there has already been one login attempt within this second
+	// Check if there has already been one login attempt within this second.
+	// verify_password() runs concurrently from multiple webserver worker
+	// threads, so the shared counters must be guarded by a mutex to keep
+	// the rate limit effective.
+	static pthread_mutex_t rate_limit_lock = PTHREAD_MUTEX_INITIALIZER;
 	static time_t last_password_attempt = 0;
 	static unsigned int num_password_attempts = 0;
+	pthread_mutex_lock(&rate_limit_lock);
 	if(rate_limiting &&
 	   last_password_attempt > 0 &&
 	   last_password_attempt == time(NULL))
@@ -441,6 +446,7 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 		if(++num_password_attempts > MAX_PASSWORD_ATTEMPTS_PER_SECOND)
 		{
 			// Rate limit reached
+			pthread_mutex_unlock(&rate_limit_lock);
 			sleepms(250);
 			return PASSWORD_RATE_LIMITED;
 		}
@@ -451,6 +457,7 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 		num_password_attempts = 1;
 		last_password_attempt = time(NULL);
 	}
+	pthread_mutex_unlock(&rate_limit_lock);
 
 	// Check password hash format
 	if(pwhash[0] == '$')

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -261,8 +261,10 @@ static void get_conf_string_array_from_setupVars_regex(const char *key, struct c
 		for (unsigned int i = 0; i < setupVarsElements; ++i)
 		{
 			// Convert to regex by adding ^ and $ to the string and replacing . with \.
-			// We need to allocate memory for this
-			char *regex = calloc(2*strlen(setupVarsArray[i]), sizeof(char));
+			// We need to allocate memory for this: worst case every
+			// character is a dot that gets escaped (2*len), plus the
+			// terminating NUL
+			char *regex = calloc(2*strlen(setupVarsArray[i]) + 1, sizeof(char));
 			if(regex == NULL)
 			{
 				log_warn("get_conf_string_array_from_setupVars(%s) failed: Could not allocate memory for regex", key);

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -489,7 +489,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 		case CONF_UINT:
 		{
 			const toml_datum_t val = toml_table_find(toml, key);
-			if(val.type == TOML_INT64 && val.u.int64 >= 0)
+			if(val.type == TOML_INT64 && val.u.int64 >= 0 && val.u.int64 <= UINT_MAX)
 				conf_item->v.ui = val.u.int64;
 			else
 				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid unsigned integer", conf_item->k);

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -257,10 +257,9 @@ void print_toml_allowed_values(const cJSON *allowed_values, FILE *fp, const unsi
 	if(cJSON_IsArray(allowed_values))
 	{
 		// Loop over array items
-		for(int icnt = 0; icnt < cJSON_GetArraySize(allowed_values); icnt++)
+		const cJSON *jopt = NULL;
+		cJSON_ArrayForEach(jopt, allowed_values)
 		{
-			// Get array item
-			const cJSON *jopt = cJSON_GetArrayItem(allowed_values, icnt);
 			// Skip if this wasn't possible
 			if(!jopt)
 				continue;
@@ -408,11 +407,9 @@ void writeTOMLvalue(FILE * fp, const int indent, const enum conf_type t, union c
 				// If there some elements but we do not indent
 				// (on CLI output), add space
 				fputc(' ', fp);
-			for(unsigned int i = 0; i < elems; i++)
+			cJSON *item = NULL;
+			cJSON_ArrayForEach(item, v->json)
 			{
-				// Get the element
-				cJSON *item = cJSON_GetArrayItem(v->json, i);
-
 				// Skip empty elements
 				if(strlen(item->valuestring) == 0)
 					continue;

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -157,10 +157,10 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 		fprintf(fp, "# %u %s forced through environment:\n",
 			num_env_vars, num_env_vars == 1 ? "entry is" : "entries are");
 
-		for(unsigned int i = 0; i < num_env_vars; i++)
+		cJSON *env = NULL;
+		cJSON_ArrayForEach(env, env_vars)
 		{
-			const char *env_var = cJSON_GetArrayItem(env_vars, i)->valuestring;
-			fprintf(fp, "#   - %s\n", env_var);
+			fprintf(fp, "#   - %s\n", env->valuestring);
 		}
 	}
 	else

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -47,6 +47,21 @@ bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDAT
 			return false;
 		}
 
+		// Check if the string contains newline characters
+		// Unlike the tokenizer below (which stops at the first '#'
+		// comment), this scans the entire entry so an embedded newline
+		// cannot be smuggled into the generated hosts file
+		const unsigned int len = strlen(item->valuestring);
+		for(unsigned int k = 0; k < len; k++)
+		{
+			if(item->valuestring[k] == '\n' || item->valuestring[k] == '\r')
+			{
+				snprintf(err, VALIDATOR_ERRBUF_LEN, "%s[%d]: contains newline characters",
+				         key, i);
+				return false;
+			}
+		}
+
 		// Check if it's in the form "IP[ \t]HOSTNAME"
 		char *str = strdup(item->valuestring);
 		char *tmp = str;

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -32,10 +32,12 @@ bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDAT
 		return false;
 	}
 
-	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
+	// cJSON_GetArraySize() in the loop condition re-walks the whole list
+	// every iteration, which made this loop O(n^2). item->next is O(1).
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
 	{
-		// Get array item
-		cJSON *item = cJSON_GetArrayItem(val->json, i);
 
 		// Check if it's a string
 		if(!cJSON_IsString(item))
@@ -136,10 +138,12 @@ bool validate_dns_cnames(union conf_value *val, const char *key, char err[VALIDA
 		return false;
 	}
 
-	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
+	// cJSON_GetArraySize() in the loop condition re-walks the whole list
+	// every iteration, which made this loop O(n^2). item->next is O(1).
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
 	{
-		// Get array item
-		cJSON *item = cJSON_GetArrayItem(val->json, i);
 
 		// Check if it's a string
 		if(!cJSON_IsString(item))
@@ -357,10 +361,12 @@ bool validate_regex_array(union conf_value *val, const char *key, char err[VALID
 		return false;
 	}
 
-	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
+	// cJSON_GetArraySize() in the loop condition re-walks the whole list
+	// every iteration, which made this loop O(n^2). item->next is O(1).
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
 	{
-		// Get array item
-		cJSON *item = cJSON_GetArrayItem(val->json, i);
 
 		// Check if it's a string
 		if(!cJSON_IsString(item))
@@ -395,10 +401,12 @@ bool validate_dns_revServers(union conf_value *val, const char *key, char err[VA
 	}
 
 	// Iterate over all array items
-	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
+	// cJSON_GetArraySize() in the loop condition re-walks the whole list
+	// every iteration, which made this loop O(n^2). item->next is O(1).
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
 	{
-		// Get array item
-		cJSON *item = cJSON_GetArrayItem(val->json, i);
 
 		// Check if it's a string
 		if(!cJSON_IsString(item))
@@ -590,10 +598,12 @@ void sanitize_dns_hosts(union conf_value *val)
 	if(!cJSON_IsArray(val->json))
 		return;
 
-	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
+	// cJSON_GetArraySize() in the loop condition re-walks the whole list
+	// every iteration, which made this loop O(n^2). item->next is O(1).
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
 	{
-		// Get array item
-		cJSON *item = cJSON_GetArrayItem(val->json, i);
 
 		// Check if it's a string
 		if(!cJSON_IsString(item))
@@ -756,10 +766,12 @@ bool validate_array_no_newline(union conf_value *val, const char *key, char err[
 		return false;
 	}
 
-	for(int i = 0; i < cJSON_GetArraySize(val->json); i++)
+	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
+	// cJSON_GetArraySize() in the loop condition re-walks the whole list
+	// every iteration, which made this loop O(n^2). item->next is O(1).
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
 	{
-		// Get array item
-		cJSON *item = cJSON_GetArrayItem(val->json, i);
 
 		// Check if it's a string
 		if(!cJSON_IsString(item))

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -113,6 +113,10 @@ void go_daemon(void)
 		exit(EXIT_SUCCESS);
 	}
 
+	// We are the final daemon process with a new PID after the double fork,
+	// drop any cached lock-owner PID/TID inherited from before the fork
+	reset_lock_owner_cache();
+
 	savePID();
 
 	// Closing stdin, stdout and stderr is handled by dnsmasq

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1036,8 +1036,12 @@ char *__attribute__ ((malloc)) get_client_names_from_ids(const char *group_ids)
 
 	log_debug(DEBUG_DATABASE, "Querying group names for IDs (%s)", group_ids);
 
-	// Prepare query
-	int rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &table_stmt, NULL);
+	// Prepare query. Use a dedicated statement instead of the shared
+	// thread-local table_stmt: our caller get_client_groupids() still has
+	// its own table_stmt query open when it calls us, so reusing it would
+	// leak that statement and clobber the shared pointer.
+	sqlite3_stmt *stmt = NULL;
+	int rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &stmt, NULL);
 	if(rc != SQLITE_OK){
 		log_err("get_client_groupids(%s) - SQL error prepare: %s",
 		        querystr, sqlite3_errstr(rc));
@@ -1047,11 +1051,11 @@ char *__attribute__ ((malloc)) get_client_names_from_ids(const char *group_ids)
 
 	// Perform query
 	char *result = NULL;
-	rc = sqlite3_step(table_stmt);
+	rc = sqlite3_step(stmt);
 	if(rc == SQLITE_ROW)
 	{
 		// There is a record for this client in the database
-		result = strdup((const char*)sqlite3_column_text(table_stmt, 0));
+		result = strdup((const char*)sqlite3_column_text(stmt, 0));
 		if(result == NULL)
 			result = strdup("N/A");
 	}
@@ -1065,12 +1069,12 @@ char *__attribute__ ((malloc)) get_client_names_from_ids(const char *group_ids)
 	{
 		log_err("group_names(%s) - SQL error step: %s",
 		        querystr, sqlite3_errstr(rc));
-		gravityDB_finalizeTable();
+		sqlite3_finalize(stmt);
 		free(querystr);
 		return strdup("N/A");
 	}
 	// Finalize statement
-	gravityDB_finalizeTable();
+	sqlite3_finalize(stmt);
 	free(querystr);
 	return result;
 }

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -62,6 +62,17 @@ static size_t last_bound_antigravity = 0;
 static size_t last_bound_allowlist = 0;
 static size_t last_bound_denylist = 0;
 
+// The offset above is not sufficient to detect a stale bind on its own: when
+// shm_intarrays is remapped and MOVED (mremap MREMAP_MAYMOVE), groupspos stays
+// the same while the backing pointer changes. carray was bound with
+// SQLITE_STATIC, so SQLite would keep dereferencing the old (freed) address.
+// Cache the last-bound pointer alongside the offset and rebind when either one
+// differs.
+static const int32_t *last_ptr_gravity = NULL;
+static const int32_t *last_ptr_antigravity = NULL;
+static const int32_t *last_ptr_allowlist = NULL;
+static const int32_t *last_ptr_denylist = NULL;
+
 // Private variables
 static sqlite3 *gravity_db = NULL;
 // Used by helper paths that prepare/step/finalize via gravityDB_finalizeTable().
@@ -88,19 +99,24 @@ static bool gravity_has_exact_denylist = false;
 // against a future refactor returning a NULL-but-non-empty array.
 static inline const int32_t *bind_client_groups(sqlite3_stmt *stmt,
                                                 size_t groupspos,
-                                                size_t *last_bound)
+                                                size_t *last_bound,
+                                                const int32_t **last_ptr)
 {
 	int group_count = 0;
 	const int32_t *group_ids = getintarray(groupspos, &group_count);
 	if(group_ids == NULL || group_count == 0)
 		return NULL;
 
-	if(groupspos != *last_bound)
+	// Rebind when either the offset OR the backing pointer changed. The
+	// pointer check catches an mremap() move of shm_intarrays that leaves
+	// groupspos unchanged but invalidates the previously bound address.
+	if(groupspos != *last_bound || group_ids != *last_ptr)
 	{
 		assert(group_ids != NULL);
 		sqlite3_carray_bind(stmt, 2, (void*)group_ids, group_count,
 		                    SQLITE_CARRAY_INT32, SQLITE_STATIC);
 		*last_bound = groupspos;
+		*last_ptr = group_ids;
 	}
 
 	return group_ids;
@@ -248,6 +264,10 @@ void gravityDB_forked(void)
 	last_bound_antigravity = 0;
 	last_bound_allowlist = 0;
 	last_bound_denylist = 0;
+	last_ptr_gravity = NULL;
+	last_ptr_antigravity = NULL;
+	last_ptr_allowlist = NULL;
+	last_ptr_denylist = NULL;
 
 	// Open the database
 	gravityDB_open();
@@ -1142,6 +1162,10 @@ void gravityDB_close(void)
 	last_bound_antigravity = 0;
 	last_bound_allowlist = 0;
 	last_bound_denylist = 0;
+	last_ptr_gravity = NULL;
+	last_ptr_antigravity = NULL;
+	last_ptr_allowlist = NULL;
+	last_ptr_denylist = NULL;
 
 	// Finalize all shared statements
 	sqlite3_stmt **shared[] = {
@@ -1440,7 +1464,7 @@ enum db_result in_allowlist(const char *domain, DNSCacheData *dns_cache, clients
 
 	// Bind client's group_id array via carray (skips rebind for same client)
 	sqlite3_stmt *stmt = allowlist_shared_stmt;
-	if(bind_client_groups(stmt, client->groupspos, &last_bound_allowlist) == NULL)
+	if(bind_client_groups(stmt, client->groupspos, &last_bound_allowlist, &last_ptr_allowlist) == NULL)
 		return NOT_FOUND;
 	enum db_result result;
 	GRAVITY_TIMED_LOOKUP(result, domain_in_list(domain, stmt, "allowlist", &dns_cache->list_id),
@@ -1632,7 +1656,8 @@ enum db_result in_gravity(const char *domain, struct abp_patterns *abp, clientsD
 	// The view's JOINs live-check adlist.enabled and group.enabled on every query.
 	sqlite3_stmt *stmt = antigravity ? antigravity_shared_stmt : gravity_shared_stmt;
 	size_t *last = antigravity ? &last_bound_antigravity : &last_bound_gravity;
-	if(bind_client_groups(stmt, client->groupspos, last) == NULL)
+	const int32_t **last_p = antigravity ? &last_ptr_antigravity : &last_ptr_gravity;
+	if(bind_client_groups(stmt, client->groupspos, last, last_p) == NULL)
 		return NOT_FOUND;
 
 	GRAVITY_PERF_END(_ig_setup_ts, GRAVITY_STATS_IG_WRAPPER);
@@ -1708,7 +1733,7 @@ enum db_result in_denylist(const char *domain, DNSCacheData *dns_cache, clientsD
 
 	// Bind client's group_id array via carray (skips rebind for same client)
 	sqlite3_stmt *stmt = denylist_shared_stmt;
-	if(bind_client_groups(stmt, client->groupspos, &last_bound_denylist) == NULL)
+	if(bind_client_groups(stmt, client->groupspos, &last_bound_denylist, &last_ptr_denylist) == NULL)
 		return NOT_FOUND;
 
 	enum db_result result;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2882,9 +2882,9 @@ bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	// Loop over all loops in array
 	const int groupcount = cJSON_GetArraySize(groups);
 	log_debug(DEBUG_API, "groupscount = %d", groupcount);
-	for(int i = 0; i < groupcount; i++)
+	cJSON *group = NULL;
+	cJSON_ArrayForEach(group, groups)
 	{
-		cJSON *group = cJSON_GetArrayItem(groups, i);
 		if(group == NULL || !cJSON_IsNumber(group))
 			continue;
 

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -703,8 +703,17 @@ static void format_dnsmasq_warn_message(char *plain, const int sizeof_plain, cha
 	if(sizeof_html < 1 || html == NULL)
 		return;
 
-	if(snprintf(html, sizeof_html, "<code>dnsmasq</code> warning:<pre>%s</pre>Check out <a href=\"https://docs.pi-hole.net/ftldns/dnsmasq_warn/\" target=\"_blank\">our documentation</a> for further information.", message) > sizeof_html)
+	// Escape the warning text before embedding it into HTML, matching the
+	// other renderers - the dnsmasq message is untrusted and would
+	// otherwise allow stored HTML/script injection in the admin interface
+	char *escaped_message = escape_html(message);
+	if(escaped_message == NULL)
+		return;
+
+	if(snprintf(html, sizeof_html, "<code>dnsmasq</code> warning:<pre>%s</pre>Check out <a href=\"https://docs.pi-hole.net/ftldns/dnsmasq_warn/\" target=\"_blank\">our documentation</a> for further information.", escaped_message) > sizeof_html)
 		log_warn("format_dnsmasq_warn_message(): Buffer too small to hold HTML message, warning truncated");
+
+	free(escaped_message);
 }
 
 static void format_load_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html, const double load, const int nprocs)

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -932,8 +932,28 @@ static void format_ntp_message(char *plain, const int sizeof_plain, char *html, 
 	if(sizeof_html < 1 || html == NULL)
 		return;
 
-	if(snprintf(html, sizeof_html, "%s in NTP %s:<pre>%s</pre>", level, who, message) > sizeof_html)
+	char *escaped_level = escape_html(level);
+	char *escaped_who = escape_html(who);
+	char *escaped_message = escape_html(message);
+
+	// Return early if memory allocation failed
+	if(escaped_level == NULL || escaped_who == NULL || escaped_message == NULL)
+	{
+		if(escaped_level != NULL)
+			free(escaped_level);
+		if(escaped_who != NULL)
+			free(escaped_who);
+		if(escaped_message != NULL)
+			free(escaped_message);
+		return;
+	}
+
+	if(snprintf(html, sizeof_html, "%s in NTP %s:<pre>%s</pre>", escaped_level, escaped_who, escaped_message) > sizeof_html)
 		log_warn("format_ntp_message(): Buffer too small to hold HTML message, warning truncated");
+
+	free(escaped_level);
+	free(escaped_who);
+	free(escaped_message);
 }
 
 static void format_verify_message(char *plain, const int sizeof_plain, char *html, const int sizeof_html,

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -642,8 +642,12 @@ static void format_hostname_message(char *plain, const int sizeof_plain, char *h
 		return;
 	}
 
+	// Only read name[pos] if pos is actually within the string, otherwise
+	// a stored/caller-supplied pos unrelated to the name length would cause
+	// an out-of-bounds read.
+	const unsigned char badchar = (pos >= 0 && (size_t)pos < strlen(name)) ? (unsigned char)name[pos] : 0;
 	if(snprintf(html, sizeof_html, "Host name of client <code>%s</code> => <code>%s</code> contains (at least) one invalid character (hex %02x) at position %i",
-			escaped_ip, escaped_name, (unsigned char)name[pos], pos) > sizeof_html)
+			escaped_ip, escaped_name, badchar, pos) > sizeof_html)
 		log_warn("format_hostname_message(): Buffer too small to hold HTML message, warning truncated");
 
 	free(escaped_ip);

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -840,24 +840,37 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 		else
 			log_debug(DEBUG_ARP, "Network table: %s NOT known through ARP/neigh cache", ipaddr);
 
+		// Snapshot the client fields we need before the loop starts releasing
+		// the SHM lock around the blocking DB/file work below. While unlocked
+		// the client slot may be recycled (getClient() then returns NULL) or
+		// even reused by a different client, so a re-fetched pointer can be
+		// NULL or valid-but-wrong. Reading from this snapshot avoids both a
+		// NULL dereference and cross-client contamination; the pointer is only
+		// re-fetched (and NULL-checked) where we must write back to it.
+		const char snap_hwlen = client->hwlen;
+		unsigned char snap_hwaddr[6] = { 0 };
+		if(snap_hwlen == 6)
+			memcpy(snap_hwaddr, client->hwaddr, sizeof(snap_hwaddr));
+		const time_t snap_lastQuery = client->lastQuery;
+		const time_t snap_firstSeen = client->firstSeen;
+		const unsigned int snap_numQueries = client->count;
+		const unsigned int snap_numQueriesARP = client->numQueriesARP;
+
 		//
 		// Variant 1: Try to find a device with an EDNS(0)-provided hardware address
 		//
 		int dbID = DB_NODATA;
-		if(client->hwlen == 6)
+		if(snap_hwlen == 6)
 		{
 			snprintf(hwaddr, sizeof(hwaddr), "%02X:%02X:%02X:%02X:%02X:%02X",
-			         client->hwaddr[0], client->hwaddr[1],
-			         client->hwaddr[2], client->hwaddr[3],
-			         client->hwaddr[4], client->hwaddr[5]);
+			         snap_hwaddr[0], snap_hwaddr[1],
+			         snap_hwaddr[2], snap_hwaddr[3],
+			         snap_hwaddr[4], snap_hwaddr[5]);
 			hwaddr[6*2+5] = '\0';
 
 			unlock_shm();
 			dbID = find_device_by_hwaddr(db, hwaddr);
 			lock_shm();
-
-			// Reacquire client pointer (if may have changed when unlocking above)
-			client = getClient(clientID, true);
 
 			if(dbID >= 0)
 				log_debug(DEBUG_ARP, "Network table: Client with MAC %s is network ID %i", hwaddr, dbID);
@@ -871,9 +884,6 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 			unlock_shm();
 			dbID = find_device_by_recent_ip(db, ipaddr);
 			lock_shm();
-
-			// Reacquire client pointer (if may have changed when unlocking above)
-			client = getClient(clientID, true);
 
 			if(dbID > DB_NODATA)
 			{
@@ -936,9 +946,6 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 						dbID = find_device_by_hwaddr(db, hwaddr);
 						lock_shm();
 
-						// Reacquire client pointer (it may have changed when unlocking above)
-						client = getClient(clientID, true);
-
 						if(dbID >= 0)
 							log_debug(DEBUG_ARP, "Network table: Client with MAC %s is network ID %i", hwaddr, dbID);
 						dhcp_lease = true;
@@ -962,9 +969,6 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 			dbID = find_device_by_mock_hwaddr(db, ipaddr);
 			lock_shm();
 
-			// Reacquire client pointer (if may have changed when unlocking above)
-			client = getClient(clientID, true);
-
 			if(dbID > DB_NODATA)
 			{
 				log_debug(DEBUG_ARP, "Network table: Client with IP %s has no MAC info but is known as mock-hwaddr client with network ID %i",
@@ -979,7 +983,8 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 
 		if(dbID == DB_FAILED)
 		{
-			// SQLite error
+			// SQLite error - release the SHM lock still held here
+			unlock_shm();
 			break;
 		}
 
@@ -987,57 +992,51 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 		else if(dbID == DB_NODATA)
 		{
 			char macVendor[MAXVENDORLEN] = { 0 };
-			if(client->hwlen == 6 || dhcp_lease)
+			if(snap_hwlen == 6 || dhcp_lease)
 			{
 				// Normal client, MAC was likely obtained from EDNS(0) data
 				// or from dhcp lease
 				unlock_shm();
 				getMACVendor(hwaddr, macVendor);
 				lock_shm();
-
-				// Reacquire client pointer (if may have changed when unlocking above)
-				client = getClient(clientID, true);
 			}
 
 			log_debug(DEBUG_ARP, "Network table: Creating new FTL device MAC = %s, IP = %s, hostname = \"%s\", vendor = \"%s\", interface = \"%s\"",
 			          hwaddr, ipaddr, hostname, macVendor, interface);
 
-			// Add new device to database
-			const time_t lastQuery = client->lastQuery;
-			const time_t firstSeen = client->firstSeen;
-			const unsigned int numQueries = client->count;
+			// Add new device to database (from the snapshot taken above)
 			unlock_shm();
-			if(!insert_netDB_device(db, hwaddr, firstSeen, lastQuery, numQueries, macVendor, &dbID))
+			if(!insert_netDB_device(db, hwaddr, snap_firstSeen, snap_lastQuery, snap_numQueries, macVendor, &dbID))
 				break;
 
 			lock_shm();
 
-			// Reacquire client pointer (if may have changed when unlocking above)
+			// Reacquire client pointer and reset the ARP counter only if the
+			// slot is still valid (it may have been recycled while unlocked)
 			client = getClient(clientID, true);
-
-			// Reset client counter
-			client->numQueriesARP = 0;
+			if(client != NULL)
+				client->numQueriesARP = 0;
 		}
 		else	// Device already in database
 		{
 			log_debug(DEBUG_ARP, "Network table: Updating existing FTL device MAC = %s, IP = %s, hostname = \"%s\", interface = \"%s\"",
 			          hwaddr, ipaddr, hostname, interface);
 
-			// Update timestamp of last query if applicable
-			const time_t lastQuery = client->lastQuery;
-			const unsigned int numQueriesARP = client->numQueriesARP;
+			// Update timestamp and query count from the snapshot taken above
 			unlock_shm();
-			if(!update_netDB_lastQuery(db, dbID, lastQuery))
+			if(!update_netDB_lastQuery(db, dbID, snap_lastQuery))
 				break;
 
 			// Update number of queries if applicable
-			if(!update_netDB_numQueries(db, dbID, numQueriesARP))
+			if(!update_netDB_numQueries(db, dbID, snap_numQueriesARP))
 				break;
 
 			lock_shm();
-			// Reacquire client pointer (if may have changed when unlocking above)
+			// Reacquire client pointer and reset the ARP counter only if the
+			// slot is still valid (it may have been recycled while unlocked)
 			client = getClient(clientID, true);
-			client->numQueriesARP = 0;
+			if(client != NULL)
+				client->numQueriesARP = 0;
 		}
 
 		unlock_shm();

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -821,9 +821,12 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 
 		// Get hostname and IP address of this client
 		char hostname[MAXHOSTNAMELEN], ipaddr[INET6_ADDRSTRLEN], interface[MAXIFACESTRLEN];
-		strncpy(ipaddr, getstr(client->ippos), sizeof(ipaddr));
-		strncpy(hostname, getstr(client->namepos), sizeof(hostname));
-		strncpy(interface, getstr(client->ifacepos), sizeof(interface));
+		strncpy(ipaddr, getstr(client->ippos), sizeof(ipaddr) - 1);
+		ipaddr[sizeof(ipaddr) - 1] = '\0';
+		strncpy(hostname, getstr(client->namepos), sizeof(hostname) - 1);
+		hostname[sizeof(hostname) - 1] = '\0';
+		strncpy(interface, getstr(client->ifacepos), sizeof(interface) - 1);
+		interface[sizeof(interface) - 1] = '\0';
 
 		// Skip if already handled above (first check against clients_array_size as we might have added
 		// more clients to FTL's memory herein (those known only from the database))

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3864,6 +3864,11 @@ void FTL_TCP_worker_created(const int confd)
 		return;
 	}
 
+	// This runs in the freshly forked TCP worker process. Drop the cached
+	// lock-owner PID/TID inherited from the parent before we take any SHM
+	// lock, otherwise is_our_lock() would compare against the parent's IDs.
+	reset_lock_owner_cache();
+
 	// Print this if debugging is enabled
 	if(config.debug.queries.v.b)
 	{

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1390,7 +1390,11 @@ static void check_pihole_PTR(char *domain)
 	{
 		log_debug(DEBUG_EXTRA, "Known PTR record %p: %s -> %s (next = %p)", ptr, ptr->name, ptr->ptr, ptr->next);
 
-		if(ptr->name != NULL && strcmp(ptr->name, domain) == 0)
+		// DNS names are case-insensitive (RFC 4343), so compare case-
+		// insensitively. A case-sensitive match would let a client add an
+		// unbounded number of near-duplicate PTR records for the same
+		// address by varying the case of the query name.
+		if(ptr->name != NULL && strcasecmp(ptr->name, domain) == 0)
 		{
 			// We already have a PTR record for this address
 			log_debug(DEBUG_QUERIES, "PTR record for %s exists", domain);

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1162,8 +1162,10 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 
 	bool blockDomain = false;
 	// Check if this should be blocked only for active queries
-	// (skipped for internally generated ones, e.g., DNSSEC)
-	if(!internal_query && querytype != TYPE_NONE)
+	// (skipped for internally generated ones, e.g., DNSSEC). Guard against
+	// query == NULL, which the getQuery() re-fetch after find_mac() above
+	// may yield if SHM was remapped/recycled while we were unlocked.
+	if(query != NULL && !internal_query && querytype != TYPE_NONE)
 	{
 		PERF_START(_pcb);
 		blockDomain = FTL_check_blocking(domainString, query, client, domain, dns_cache_entry);
@@ -1171,7 +1173,8 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	}
 
 	// Store query in database
-	query->flags.database.changed = true;
+	if(query != NULL)
+		query->flags.database.changed = true;
 
 	PERF_END(_pnq, PERF_STAT_NEW_QUERY);
 	// Release thread lock

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -199,7 +199,7 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 		log_debug(DEBUG_EDNS0, "code %u, optlen %u (bytes %zu - %zu of %u)",
 		          code, optlen, offset, offset + optlen, rdlen);
 
-		if (code == EDNS0_ECS && config.dns.EDNS0ECS.v.b)
+		if (code == EDNS0_ECS && config.dns.EDNS0ECS.v.b && optlen >= 4)
 		{
 			// EDNS(0) CLIENT SUBNET
 			// RFC 7871              Client Subnet in DNS Queries              6.  Option Format
@@ -232,7 +232,13 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 			else if(family == 2 && addrlen <= sizeof(addr.addr6.s6_addr)) // IPv6
 				memcpy(addr.addr6.s6_addr, p, addrlen);
 			else
+			{
+				// Unhandled family: p has already advanced by the
+				// 4-byte FAMILY/prefix header above, so consume the
+				// remaining option data to line up with the next option
+				p += optlen - 4;
 				continue;
+			}
 
 			// Advance working pointer (we already walked 4 bytes above)
 			p += optlen - 4;

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -178,7 +178,10 @@ void FTL_parse_pseudoheaders(unsigned char *pheader, const size_t plen)
 	edns.valid = true;
 
 	size_t offset; // The header is 11 bytes before the beginning of OPTION-DATA
-	while ((offset = (p - pheader - 11u)) < rdlen && rdlen < UINT16_MAX)
+	// Require the full 4-byte OPTION-CODE/OPTION-LENGTH header to be
+	// present before reading it, otherwise a truncated option would make
+	// the two GETSHORTs below read past the pseudoheader buffer
+	while ((offset = (p - pheader - 11u)) + 4u <= rdlen && rdlen < UINT16_MAX)
 	{
 		unsigned short code, optlen;
 		GETSHORT(code, p);

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -43,6 +43,8 @@
 #include "capabilities.h"
 // search_proc()
 #include "procps.h"
+// get_secure_randomness()
+#include "config/password.h"
 
 // Required accuracy of the NTP sync in seconds in order to start the NTP server
 // thread. If the NTP sync is less accurate than this value, the NTP server
@@ -57,11 +59,27 @@
 // Maximum number of NTP syncs to attempt before giving up
 #define RETRY_ATTEMPTS 5
 
+// Panic threshold (in seconds) for stepping the system clock. If a sync would
+// require stepping the clock by more than this amount, the step is refused to
+// prevent a consistent malicious/spoofed server from moving the clock by an
+// arbitrary magnitude (the offset math allows +/- 68 years). This mirrors
+// ntpd's default panic threshold. The very first synchronization after boot is
+// exempt because devices without an RTC (e.g. Raspberry Pi) start with a
+// wildly wrong clock and would otherwise never be able to synchronize.
+#define NTP_MAX_STEP_SECS 1000
+
+// Whether the next clock step is the first synchronization after boot. Until
+// the first successful sync, a large initial step is permitted; afterwards the
+// panic threshold above is enforced.
+static bool ntp_first_sync = true;
+
 struct ntp_sync
 {
 	bool valid;
 	uint64_t org;
+	uint64_t t1;
 	uint64_t xmt;
+	uint8_t stratum;
 	double theta;
 	double delta;
 	double precision;
@@ -107,10 +125,27 @@ static bool request(int fd, const char *server, struct addrinfo *saddr, struct n
 	// This is the time at which the local clock was last set or corrected.
 	memset(&buf[8], 0, sizeof(uint64_t));
 
-	// Set Origin Timestamp (org) in NTP format
-	ntp->org = gettime64();
+	// Set Origin Timestamp (org) to an unpredictable random 64-bit nonce
+	// instead of the real wall-clock transmit time. RFC 5905 servers echo
+	// this value back into the origin field of the reply, so it acts as an
+	// interoperable anti-spoof token (chrony does the same). Using the real,
+	// predictable clock here would let an off-path attacker guess the value
+	// and forge replies. On RNG failure we fail the request rather than send
+	// a predictable value.
+	do {
+		if(!get_secure_randomness((uint8_t *)&ntp->org, sizeof(ntp->org)))
+		{
+			log_err("Failed to generate NTP anti-spoof nonce, aborting request");
+			return false;
+		}
+	} while(ntp->org == 0);
 	const uint64_t norg = hton64(ntp->org);
 	memcpy(&buf[40], &norg, sizeof(norg));
+
+	// Capture the REAL transmit time (T1) right before sending. The on-wire
+	// origin timestamp is now a random nonce, but the offset/delay math still
+	// needs the actual send time, so it is kept separately here.
+	ntp->t1 = gettime64();
 
 	// Send request
 	if(send(fd, buf, 48, 0) != 48)
@@ -370,10 +405,15 @@ static bool reply(const int fd, const char *server, struct addrinfo *saddr, stru
 		return false;
 	}
 
-	ntp_stratum = buf[1] + 1;
+	// Store the stratum per-sample. It is only committed to the global
+	// ntp_stratum on the success path once the whole round has been
+	// validated (see ntp_client()), so a single spoofed reply cannot set it.
+	ntp->stratum = buf[1] + 1;
 
 	// Calculate delay and offset
-	const double T1 = ntp->org / FRAC;
+	// T1 is the REAL transmit time captured in request(), not the on-wire
+	// origin timestamp (which is now a random anti-spoof nonce).
+	const double T1 = ntp->t1 / FRAC;
 	const double T2 = rec / FRAC;
 	const double T3 = ntp->xmt / FRAC;
 	const double T4 = dst / FRAC;
@@ -606,6 +646,10 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 	// Compute trimmed mean (average excluding outliers)
 	double theta_trim = 0.0, delta_trim = 0.0;
 	unsigned int trim = 0;
+	// Track the largest stratum among the samples that survive trimming.
+	// Choosing the maximum is conservative: a single surviving spoofed
+	// low-stratum reply cannot inflate the perceived clock quality.
+	uint8_t trim_stratum = 0;
 	for(unsigned int i = 0; i < count; i++)
 	{
 		// Skip invalid values
@@ -623,6 +667,8 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 
 		theta_trim += ntp[i].theta;
 		delta_trim += ntp[i].delta;
+		if(ntp[i].stratum > trim_stratum)
+			trim_stratum = ntp[i].stratum;
 		trim++;
 	}
 
@@ -654,13 +700,34 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 		// since Linux 2.6.26, see man ntp_adjtime(2) for details.
 		bool success;
 		if(fabs(theta_trim) > 0.5)
+		{
+			// Panic threshold: refuse to step the clock by an
+			// implausibly large amount. This blocks a consistent
+			// spoofed/malicious server from moving the clock by an
+			// arbitrary magnitude. The very first sync after boot is
+			// exempt so RTC-less devices can set their initial time.
+			if(!ntp_first_sync && fabs(theta_trim) > NTP_MAX_STEP_SECS)
+			{
+				char errbuf[256];
+				snprintf(errbuf, sizeof(errbuf),
+				         "Refusing to step system clock by %.0f s (exceeds %d s panic threshold) - possible malicious NTP server. If this device has no RTC, restart FTL to permit the initial large step.",
+				         theta_trim, NTP_MAX_STEP_SECS);
+				errbuf[sizeof(errbuf) - 1] = '\0';
+				log_ntp_message(true, false, errbuf);
+				return false;
+			}
 			success = settime_step(&unix_time, theta_trim);
+		}
 		else
 			success = settime_skew(theta_trim);
 
 		// Return early if time could not be set
 		if(!success)
 			return false;
+
+		// The initial post-boot synchronization is complete; enforce the
+		// panic threshold on all subsequent clock steps.
+		ntp_first_sync = false;
 
 		// Update last NTP sync time
 		ntp_last_sync = ntp_time;
@@ -682,6 +749,10 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 	// dispersion of our reference clock.
 	ntp_root_delay = D2FP(delta_trim);
 	ntp_root_dispersion = D2FP(theta_stdev);
+
+	// Commit the stratum only now that the whole round has been validated,
+	// using the most conservative (largest) surviving stratum.
+	ntp_stratum = trim_stratum;
 
 	// Offset and delay larger than ACCURACY seconds are considered as invalid
 	// during local testing (e.g., when the server is on the same machine).

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -726,8 +726,11 @@ static void *ntp_client_thread(void *arg)
 			restart_ftl("System time updated");
 		}
 
-		// Calculate time to sleep
-		unsigned int sleep_time = config.ntp.sync.interval.v.ui - (unsigned int)time_delta;
+		// Calculate time to sleep. Clamp to zero when the sync itself took
+		// longer than the configured interval, otherwise the unsigned
+		// subtraction would underflow into an effectively infinite sleep.
+		const unsigned int interval = config.ntp.sync.interval.v.ui;
+		unsigned int sleep_time = time_delta >= interval ? 0 : interval - (unsigned int)time_delta;
 
 		// Set first run to false
 		first_run = false;

--- a/src/ntp/client.c
+++ b/src/ntp/client.c
@@ -684,8 +684,10 @@ bool ntp_client(const char *server, const bool settime, const bool print)
 	ntp_root_dispersion = D2FP(theta_stdev);
 
 	// Offset and delay larger than ACCURACY seconds are considered as invalid
-	// during local testing (e.g., when the server is on the same machine)
-	return theta_trim < ACCURACY && delta_trim < ACCURACY;
+	// during local testing (e.g., when the server is on the same machine).
+	// The offset is signed, so compare its magnitude - a large negative
+	// offset is just as inaccurate as a large positive one.
+	return fabs(theta_trim) < ACCURACY && delta_trim < ACCURACY;
 }
 
 static void *ntp_client_thread(void *arg)

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -504,7 +504,7 @@ static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) nameFrom
 		return NULL;
 	}
 
-	unsigned int p = 0, jumped = 0;
+	unsigned int p = 0, jumped = 0, jumps = 0;
 	// Initialize count
 	*count = 1;
 
@@ -550,6 +550,15 @@ static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) nameFrom
 				free(name);
 				return NULL;
 			}
+			// Guard against self-referential or cyclic compression
+			// pointers, which would otherwise spin here forever (p does
+			// not advance when following a pointer)
+			if(++jumps > MAXNAMELEN)
+			{
+				log_err("Too many DNS compression pointer jumps, aborting");
+				free(name);
+				return NULL;
+			}
 			reader = buffer + offset - 1;
 			jumped = 1; // We have jumped to another location so counting won't go up
 		}
@@ -576,6 +585,15 @@ static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) nameFrom
 	for(; i < strlen((const char*)name); i++)
 	{
 		p = name[i];
+		// A DNS label is at most 63 bytes; a larger length byte is
+		// malformed wire data. Bail out rather than letting i walk past
+		// the buffer (out-of-bounds read of name[i+1] and write of
+		// name[i] = '.').
+		if(p >= 64 || i + p >= MAXNAMELEN)
+		{
+			name[i] = '\0';
+			break;
+		}
 		for(unsigned j = 0; j < p; j++)
 		{
 			name[i] = name[i + 1];

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -391,8 +391,10 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		}
 		prefix = ntohs(prefix);
 
-		// Sanity check the length of the message
-		if(prefix > sizeof(buf))
+		// Sanity check the length of the message. Reject prefix == sizeof(buf)
+		// as well, otherwise the bzero(buf, prefix + 1) below writes one byte
+		// past the end of the buffer.
+		if(prefix >= sizeof(buf))
 		{
 			log_err("Received TCP DNS reply is too long (%u bytes)", prefix);
 			log_resolve_info(host, config.dns.port.v.u16, tcp);

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -38,7 +38,7 @@
 
 // Function Prototypes
 static size_t nameToDNS(unsigned char *dns, const size_t dnslen, const char *host, const size_t hostlen) __attribute__((nonnull(1,3)));
-static unsigned char *nameFromDNS(unsigned char *reader, unsigned char *buffer, uint16_t *count) __attribute__((malloc)) __attribute__((nonnull(1,2,3)));
+static unsigned char *nameFromDNS(unsigned char *reader, unsigned char *buffer, const unsigned char *end, uint16_t *count) __attribute__((malloc)) __attribute__((nonnull(1,2,3,4)));
 
 // Avoid "error: packed attribute causes inefficient alignment for ..." on ARM32
 // builds due to the use of __attribute__((packed)) in the following structs
@@ -432,16 +432,42 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 	uint16_t stop = 0;
 	bool have_name = false;
 	struct RES_RECORD answers[20] = { 0 };
+	const unsigned char *bufend = buf + sizeof(buf);
 	for(uint16_t i = 0; i < min(ntohs(dns.ans_count), ArraySize(answers)); i++)
 	{
-		answers[i].name = nameFromDNS(reader, buf, &stop);
+		// Ensure the read pointer still points within the receive
+		// buffer before parsing the next answer's name
+		if(reader < buf || reader >= bufend)
+			break;
+
+		answers[i].name = nameFromDNS(reader, buf, bufend, &stop);
+		if(answers[i].name == NULL)
+			break;
 		reader = reader + stop;
+
+		// The fixed-size resource record header must fit entirely
+		// within the receive buffer before we cast and dereference it
+		if(reader < buf || reader + sizeof(struct R_DATA) > bufend)
+		{
+			free(answers[i].name);
+			break;
+		}
 
 		answers[i].resource = (struct R_DATA*)(reader);
 		reader = reader + sizeof(struct R_DATA);
 
 		// Read the answer and convert from network to host representation
-		answers[i].rdata = nameFromDNS(reader, buf, &stop);
+		if(reader < buf || reader >= bufend)
+		{
+			free(answers[i].name);
+			break;
+		}
+		answers[i].rdata = nameFromDNS(reader, buf, bufend, &stop);
+		if(answers[i].rdata == NULL)
+		{
+			free(answers[i].name);
+			break;
+		}
 		reader = reader + stop;
 
 		// We only care about PTR answers and ignore all others
@@ -494,7 +520,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 // Convert hostname from network to host representation
 // This routine supports DNS compression pointers
 // 3www6google3com -> www.google.com
-static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) nameFromDNS(unsigned char *reader, unsigned char *buffer, uint16_t *count)
+static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3,4))) nameFromDNS(unsigned char *reader, unsigned char *buffer, const unsigned char *end, uint16_t *count)
 {
 	const size_t MAXNAMELEN = 256;
 	unsigned char *name = calloc(MAXNAMELEN, sizeof(char));
@@ -515,10 +541,17 @@ static u_char * __attribute__((malloc)) __attribute__((nonnull(1,2,3))) nameFrom
 	// Instead, each label is preceded by a byte containing its length, and
 	// the name is terminated by a zero-length label representing the root
 	// zone.
-	while(*reader != 0 && p < MAXNAMELEN - 2)
+	while(reader < end && *reader != 0 && p < MAXNAMELEN - 2)
 	{
 		if(*reader >= 0xC0)
 		{
+			// A compression pointer is two bytes; the second byte
+			// must also lie within the buffer before we dereference it
+			if(reader + 1 >= end)
+			{
+				free(name);
+				return NULL;
+			}
 			// RFC 1035, Section 4.1.4: Message compression
 			//
 			// A label can be up to 63 bytes long; if the length

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -755,6 +755,10 @@ static size_t resolveAndAddHostname(const int udp_sock, struct sockaddr_in *dest
 	{
 		log_debug(DEBUG_RESOLVER, " ---> \"\" (configured to not resolve host name)");
 
+		// Not resolving names is intentional, not a failure
+		if(success != NULL)
+			*success = true;
+
 		// Return fixed position of empty string
 		return 0;
 	}
@@ -786,6 +790,11 @@ static size_t resolveAndAddHostname(const int udp_sock, struct sockaddr_in *dest
 		if(getNameFromIP(NULL, newname, ipaddr))
 			log_debug(DEBUG_RESOLVER, " ---> \"%s\" (provided by database)", newname);
 	}
+
+	// Report whether we actually obtained a host name so the caller can
+	// keep the old name and retry later when resolution failed
+	if(success != NULL)
+		*success = newname[0] != '\0';
 
 	// Only store new newname if it is valid and differs from oldname
 	// We do not need to check for oldname == NULL as names are

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -150,6 +150,35 @@ static unsigned int pagesize;
 static unsigned int local_shm_counter = 0;
 static pid_t shmem_pid = 0;
 static size_t used_shmem = 0u;
+
+// Cached PID/TID of the current process/thread. The SHM lock owner is recorded
+// on every lock acquisition, but getpid() and gettid() are syscalls that musl
+// (which the shipped binary uses) does not cache, so this avoids two syscalls
+// per lock. The cache is reset after a real fork() via reset_lock_owner_cache()
+// so a forked TCP worker or the daemonized process never reports stale IDs
+// (a value of 0 means "not yet computed"; neither PID nor TID is ever 0).
+static pid_t cached_pid = 0;
+static _Thread_local pid_t cached_tid = 0;
+static inline pid_t cached_getpid(void)
+{
+	if(cached_pid == 0)
+		cached_pid = getpid();
+	return cached_pid;
+}
+static inline pid_t cached_gettid(void)
+{
+	if(cached_tid == 0)
+		cached_tid = gettid();
+	return cached_tid;
+}
+void reset_lock_owner_cache(void)
+{
+	// Force recomputation on next use. Called by the child after fork() as
+	// fork() duplicates both the process (stale PID) and the calling thread's
+	// thread-local storage (stale TID).
+	cached_pid = 0;
+	cached_tid = 0;
+}
 static size_t get_optimal_object_size(const size_t objsize, const size_t minsize);
 
 // Minimum / initial capacity of the string hash table (must be power of 2)
@@ -651,8 +680,8 @@ void _lock_shm(const char *func, const int line, const char *file)
 	}
 
 	// Store lock owner after lock has been acquired and was made consistent (if required)
-	shmLock->owner.pid = getpid();
-	shmLock->owner.tid = gettid();
+	shmLock->owner.pid = cached_getpid();
+	shmLock->owner.tid = cached_gettid();
 
 	// Check if this process needs to remap the shared memory objects
 	if(shmSettings != NULL &&
@@ -729,8 +758,8 @@ void _unlock_shm(const char *func, const int line, const char * file)
 // Return if we locked this mutex (PID and TID match)
 bool is_our_lock(void)
 {
-	if(shmLock->owner.pid == getpid() &&
-	   shmLock->owner.tid == gettid())
+	if(shmLock->owner.pid == cached_getpid() &&
+	   shmLock->owner.tid == cached_gettid())
 		return true;
 	return false;
 }

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -392,15 +392,29 @@ size_t _addstr(const char *input, const char *func, const int line, const char *
 	{
 		return 0;
 	}
-	else if(len > (size_t)(pagesize-1))
+
+	// If the string pool is (near) full, we cannot store anything anymore.
+	// Bail out before evaluating avail_mem - 1 below, which would otherwise
+	// underflow. Returning 0 aliases the empty-string sentinel, consistent
+	// with the len == 1 case above.
+	if(avail_mem < 2)
+	{
+		log_warn("Cannot store string \"%s\": string pool is full", input);
+		return 0;
+	}
+
+	// Clamp the length so the strncpy() further down can never write out of
+	// bounds. Both limits are applied independently so the final len is always
+	// <= avail_mem - 1, even when the pagesize limit triggers first.
+	if(len > (size_t)(pagesize-1))
 	{
 		log_warn("Shortening too long string (len %zu > pagesize %u)", len, pagesize);
 		len = pagesize;
 	}
-	else if(len > (size_t)(avail_mem-1))
+	if(len > (size_t)(avail_mem-1))
 	{
 		log_warn("Shortening too long string (len %zu > available memory %zu)", len, avail_mem);
-		len = avail_mem;
+		len = avail_mem - 1;
 	}
 
 	// Ensure our hash table covers any strings added by other processes
@@ -429,6 +443,12 @@ size_t _addstr(const char *input, const char *func, const int line, const char *
 
 	// Copy the C string pointed by input into the shared string buffer
 	strncpy(&((char*)shm_strings.ptr)[shmSettings->next_str_pos], input, len);
+
+	// Force NUL termination of the last byte. This is a no-op for untruncated
+	// strings (strncpy already copied the terminator) but guarantees that
+	// truncated strings are terminated, preventing reads past the mapping and
+	// accidental merging of adjacent strings.
+	((char*)shm_strings.ptr)[shmSettings->next_str_pos + len - 1] = '\0';
 
 	// Record the new string's position before advancing the pointer
 	const size_t new_offset = shmSettings->next_str_pos;

--- a/src/shmem.h
+++ b/src/shmem.h
@@ -172,6 +172,10 @@ void _lock_shm(const char* func, const int line, const char* file);
 // Return if the current mutex locked the SHM lock
 bool is_our_lock(void);
 
+// Reset the cached lock-owner PID/TID. Must be called by the child after a
+// fork() so it does not report the parent's IDs.
+void reset_lock_owner_cache(void);
+
 /// Unlock the lock. Only call this if there is an active lock.
 #define unlock_shm() _unlock_shm(__FUNCTION__, __LINE__, __FILE__)
 void _unlock_shm(const char* func, const int line, const char* file);

--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -636,7 +636,9 @@ static unsigned int get_dhcp_offer(const int sock, const uint32_t xid, const cha
 		printf("  BOOTP server: ");
 		if(offer_packet.sname[0] != 0)
 		{
-			size_t len = strlen(offer_packet.sname);
+			// sname is a fixed-size field that a malicious OFFER may
+			// leave unterminated, so bound the length to the field size
+			size_t len = strnlen(offer_packet.sname, sizeof(offer_packet.sname));
 			char *buffer = escape_data(offer_packet.sname, len);
 			printf("%s\n", buffer);
 			free(buffer);
@@ -647,7 +649,9 @@ static unsigned int get_dhcp_offer(const int sock, const uint32_t xid, const cha
 		printf("  BOOTP file: ");
 		if(offer_packet.file[0] != 0)
 		{
-			size_t len = strlen(offer_packet.file);
+			// file is a fixed-size field that a malicious OFFER may
+			// leave unterminated, so bound the length to the field size
+			size_t len = strnlen(offer_packet.file, sizeof(offer_packet.file));
 			char *buffer = escape_data(offer_packet.file, len);
 			printf("%s\n", buffer);
 			free(buffer);

--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -464,17 +464,25 @@ static void print_dhcp_offer(struct in_addr source, struct dhcp_packet_data *off
 				unsigned int n = 0;
 				for(unsigned int i = 1; n < optlen; i++)
 				{
-					// Extract destination descriptor
+					// Extract destination descriptor (prefix length)
 					unsigned char cidr = offer_packet->options[x+n++];
+
+					// Number of significant destination octets, i.e.
+					// ceil(cidr/8) = 0..4 bytes (RFC 3442)
+					const unsigned int width = (cidr + 7u) / 8u;
+					if(cidr > 32 || width > 4)
+						break; // invalid prefix length
+
+					// Ensure the significant destination octets and the
+					// trailing 4 router bytes are fully contained in this
+					// option before reading them, otherwise a malformed
+					// offer would make us read past the options buffer
+					if(n + width + 4u > optlen)
+						break;
+
 					unsigned char addr[4] = { 0 };
-					if(cidr > 0)
-						addr[0] = offer_packet->options[x+n++];
-					if(cidr > 8)
-						addr[1] = offer_packet->options[x+n++];
-					if(cidr > 16)
-						addr[2] = offer_packet->options[x+n++];
-					if(cidr > 24)
-						addr[3] = offer_packet->options[x+n++];
+					for(unsigned int k = 0; k < width; k++)
+						addr[k] = offer_packet->options[x+n++];
 
 					// Extract router address
 					unsigned char router[4] = { 0 };

--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -353,7 +353,9 @@ static void print_dhcp_offer(struct in_addr source, struct dhcp_packet_data *off
 			else if(opttab[i].size & OT_TIME)
 			{
 				uint32_t time = 0;
-				memcpy(&time, &offer_packet->options[x], sizeof(time));
+				// Copy at most the advertised option length so a
+				// short/truncated option cannot read past the buffer
+				memcpy(&time, &offer_packet->options[x], optlen < sizeof(time) ? optlen : sizeof(time));
 				time = ntohl(time);
 				const char *optname = opttab[i].name;
 				// Some timers deserve a more user-friendly name
@@ -439,12 +441,16 @@ static void print_dhcp_offer(struct in_addr source, struct dhcp_packet_data *off
 			}
 			else if(opttype == 158) // DHCPv4 PCP Option (RFC 7291)
 			{                       // https://tools.ietf.org/html/rfc7291#section-4
+				if(optlen < 1)
+					break;
 				uint16_t list_length = offer_packet->options[x++] / 4; // 4 bytes per list entry
 				// Loop over IPv4 lists
 				for(unsigned int n = 0; n < list_length; n++)
 				{
 					struct in_addr addr_list = { 0 };
-					if(optlen < (n+1)*sizeof(addr_list.s_addr))
+					// The list-length byte above consumed one byte, so
+					// only optlen-1 bytes of address data remain
+					if(optlen < 1 + (n+1)*sizeof(addr_list.s_addr))
 						break;
 					memcpy(&addr_list.s_addr, &offer_packet->options[x+n*sizeof(addr_list.s_addr)], sizeof(addr_list.s_addr));
 					if(n > 0)

--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -305,6 +305,9 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 				// Shift line contents left by 3 bytes to remove BOM
 				memmove(line, line + 3, read - 3);
 				read -= 3;
+				// Re-terminate at the new end, otherwise the old
+				// 3 trailing bytes remain readable to strlen/strtok
+				line[read] = '\0';
 			}
 		}
 

--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -1482,7 +1482,13 @@ void get_gateway_name(char gateway[MAXIFACESTRLEN])
 		   cJSON_IsString(dst) &&
 		   strcmp(cJSON_GetStringValue(dst), "default") == 0)
 		{
-			strncpy(gateway, cJSON_GetStringValue(cJSON_GetObjectItem(route, "oif")), MAXIFACESTRLEN - 1);
+			// A multipath/ECMP default route carries no top-level "oif".
+			// Skip it (falling back to eth0 below) instead of passing a
+			// NULL string into strncpy().
+			cJSON *oif = cJSON_GetObjectItem(route, "oif");
+			if(!cJSON_IsString(oif))
+				continue;
+			strncpy(gateway, cJSON_GetStringValue(oif), MAXIFACESTRLEN - 1);
 			gateway[MAXIFACESTRLEN - 1] = '\0';
 			break;
 		}

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -518,6 +518,10 @@ const char * __attribute__((const)) get_http_method_str(const enum http_method m
 
 void read_and_parse_payload(struct ftl_conn *api)
 {
+	// Defense in depth: never operate on an unallocated payload buffer
+	if(api->payload.raw == NULL)
+		return;
+
 	// Read payload
 	api->payload.size = mg_read(api->conn, api->payload.raw, MAX_PAYLOAD_BYTES - 1);
 	if (api->payload.size < 1)

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -687,44 +687,34 @@ char *__attribute__((malloc)) escape_json(const char *string)
 }
 
 // Remove duplicates from a cJSON array
-// This function uses the less efficient cJSON_GetArraySize() function compared
-// to cJSON_ArrayForEach() as we are going to modify the array in-place while
-// iterating over it
+// Remove duplicate string entries from a JSON array in place.
+// Walks the underlying linked list directly and deletes duplicates by pointer.
+// This avoids the O(index) cJSON_GetArrayItem()/cJSON_GetArraySize() calls that
+// turned the nested scan into O(n^3); it is now O(n^2). The duplicate is always
+// located after the current outer item, so deleting it never invalidates the
+// outer traversal, and the inner "next" pointer is saved before the deletion.
 void cJSON_unique_array(cJSON *array)
 {
 	// Check if the array is an array
 	if(!cJSON_IsArray(array))
 		return;
 
-	for(int oi = 0; oi < cJSON_GetArraySize(array); oi++)
+	for(cJSON *outer_item = array->child; outer_item != NULL; outer_item = outer_item->next)
 	{
-		// Get the outer item
-		cJSON *outer_item = cJSON_GetArrayItem(array, oi);
 		// Check if the item is a string
 		if (!cJSON_IsString(outer_item))
 			continue;
 
 		// Check for duplicates in the remainder of the array
-		for(int ii = oi + 1; ii < cJSON_GetArraySize(array); ii++)
+		cJSON *inner_item = outer_item->next;
+		while(inner_item != NULL)
 		{
-			// Get the inner item
-			cJSON *inner_item = cJSON_GetArrayItem(array, ii);
-			// Check if the inner item is a string
-			if (!cJSON_IsString(inner_item))
-				continue;
-
-			// Compare the two strings
-			if(strcmp(outer_item->valuestring, inner_item->valuestring) == 0)
-			{
-				// Remove the duplicate item, this is safe as we are
-				// at least one item ahead of the outer item
-				cJSON_DeleteItemFromArray(array, ii);
-				// Compensate for removed item (the for loop
-				// will increment ii for the next step, thus
-				// we need to decrement it here)
-				ii--;
-				continue;
-			}
+			// Remember the next item before a possible deletion
+			cJSON *next = inner_item->next;
+			if(cJSON_IsString(inner_item) &&
+			   strcmp(outer_item->valuestring, inner_item->valuestring) == 0)
+				cJSON_Delete(cJSON_DetachItemViaPointer(array, inner_item));
+			inner_item = next;
 		}
 	}
 }

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -91,6 +91,8 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	{
 		const size_t hint_len = 38 + strlen(admin_api_uri) + 2*strlen(config.webserver.domain.v.s);
 		char *hint = calloc(hint_len, sizeof(char));
+		if(hint == NULL)
+			return send_http_internal_error(&api);
 		snprintf(hint, hint_len, "The API is hosted at %s/api, not %s%s",
 		         config.webserver.domain.v.s, config.webserver.domain.v.s, admin_api_uri);
 		hint[hint_len - 1u] = '\0';

--- a/src/webserver/lua_web.c
+++ b/src/webserver/lua_web.c
@@ -46,10 +46,21 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	/* Handler may access the request info using mg_get_request_info */
 	const struct mg_request_info *req_info = mg_get_request_info(conn);
 
+	// Base all routing and authentication decisions on the CLEANED URI
+	// (local_uri), never on local_uri_raw. Both are URL-decoded, but
+	// local_uri_raw still contains dot-segments (e.g. "/x/../admin/...")
+	// while CivetWeb resolves and serves the file from the normalized
+	// local_uri. Deciding on the raw path let a request whose normalized
+	// form points into the protected web home appear "not in webhome" and
+	// be served without authentication.
+	const char *uri = req_info->local_uri;
+	if(uri == NULL)
+		return 0;
+
 	// Do not redirect for ACME challenges
-	log_debug(DEBUG_WEBSERVER, "Local URI: \"%s\"", req_info->local_uri_raw);
+	log_debug(DEBUG_WEBSERVER, "Local URI: \"%s\"", uri);
 	const char acme_challenge[] = "/.well-known/acme-challenge/";
-	const bool is_acme = strncmp(req_info->local_uri_raw, acme_challenge, strlen(acme_challenge)) == 0;
+	const bool is_acme = strncmp(uri, acme_challenge, strlen(acme_challenge)) == 0;
 	if(is_acme)
 	{
 		// ACME challenge - no authentication required
@@ -61,9 +72,9 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	// start with something else than config.webserver.paths.webhome. If so,
 	// send error 404
 	if(!config.webserver.serve_all.v.b &&
-	   strncmp(req_info->local_uri_raw, config.webserver.paths.webhome.v.s, strlen(config.webserver.paths.webhome.v.s)) != 0)
+	   strncmp(uri, config.webserver.paths.webhome.v.s, strlen(config.webserver.paths.webhome.v.s)) != 0)
 	{
-		log_debug(DEBUG_WEBSERVER, "Not serving %s, returning 404", req_info->local_uri_raw);
+		log_debug(DEBUG_WEBSERVER, "Not serving %s, returning 404", uri);
 		mg_send_http_error(conn, 404, "Not Found");
 		return 404;
 	}
@@ -76,7 +87,7 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 
 	// Check if the request is for the API under <webhome>api
 	// (it is posted at /api)
-	if(strncmp(req_info->local_uri_raw, admin_api_uri, strlen(admin_api_uri)) == 0)
+	if(strncmp(uri, admin_api_uri, strlen(admin_api_uri)) == 0)
 	{
 		const size_t hint_len = 38 + strlen(admin_api_uri) + 2*strlen(config.webserver.domain.v.s);
 		char *hint = calloc(hint_len, sizeof(char));
@@ -91,19 +102,19 @@ int request_handler(struct mg_connection *conn, void *cbdata)
 	}
 
 	// Check if last part of the URI contains a dot (is a file)
-	const char *last_dot = strrchr(req_info->local_uri_raw, '.');
-	const char *last_slash = strrchr(req_info->local_uri_raw, '/');
+	const char *last_dot = strrchr(uri, '.');
+	const char *last_slash = strrchr(uri, '/');
 	const bool no_dot = (last_dot == NULL || last_slash > last_dot);
 
 	// Check if the request is for the login page
-	const bool login = (strcmp(req_info->local_uri_raw, login_uri) == 0);
+	const bool login = (strcmp(uri, login_uri) == 0);
 
 	// Check if the request is for something in the webhome directory
-	const bool in_webhome = (strncmp(req_info->local_uri_raw,
+	const bool in_webhome = (strncmp(uri,
 	                                 config.webserver.paths.webhome.v.s,
 	                                 strlen(config.webserver.paths.webhome.v.s)) == 0);
 	log_debug(DEBUG_WEBSERVER, "Request for %s, login: %d, in_webhome: %d, no_dot: %d",
-	          req_info->local_uri_raw, login, in_webhome, no_dot);
+	          uri, login, in_webhome, no_dot);
 
 	// Check if the request is for a LUA page (every XYZ.lp has already been
 	// rewritten at this point to XYZ), we also don't enforce authentication

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -259,6 +259,11 @@ static int redirect_lp_handler(struct mg_connection *conn, void *input)
 	//    (if present)
 	// Total bytes required: uri_len - 3 + query_len + 1 + 1
 	char *new_uri = calloc(uri_len + query_len - 1, sizeof(char));
+	if(new_uri == NULL)
+	{
+		mg_send_http_error(conn, 500, "Internal Server Error");
+		return 500;
+	}
 
 	// Copy everything from before the ".lp" to the new URI to effectively
 	// remove it

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -197,6 +197,36 @@ static int redirect_admin_handler(struct mg_connection *conn, void *input)
 	return 1;
 }
 
+static int begin_request_handler(struct mg_connection *conn)
+{
+	// Reject any request whose (URL-decoded) path contains control
+	// characters. CivetWeb decodes local_uri_raw in place, so an encoded
+	// CR/LF (%0d%0a) arrives here as a literal newline. Several handlers
+	// reflect this path into response headers (e.g. the Location header
+	// built by redirect_lp_handler), where embedded CR/LF would allow HTTP
+	// response header injection / response splitting. Rejecting such requests
+	// centrally - before authentication and before any handler runs - closes
+	// the whole class of URI-into-header injection. This runs for every
+	// request before authentication, so the rejection is logged only at
+	// debug level and never echoes the URI: an unauthenticated client can
+	// trivially flood such requests, and logging each one at warning level
+	// (or logging the URI verbatim) would itself be a log-flooding /
+	// log-injection vector.
+	const struct mg_request_info *request = mg_get_request_info(conn);
+	for(const char *p = request->local_uri_raw; p != NULL && *p != '\0'; p++)
+	{
+		if((unsigned char)*p < 0x20 || (unsigned char)*p == 0x7f)
+		{
+			log_debug(DEBUG_WEBSERVER, "Rejecting request with control character in URI");
+			mg_send_http_error(conn, 400, "Bad Request");
+			return 400;
+		}
+	}
+
+	// Let CivetWeb process the request normally
+	return 0;
+}
+
 static int redirect_lp_handler(struct mg_connection *conn, void *input)
 {
 	// Get requested URI
@@ -794,6 +824,7 @@ void http_init(void)
 	// Configure logging handlers
 	struct mg_callbacks callbacks;
 	memset(&callbacks, 0, sizeof(callbacks));
+	callbacks.begin_request = begin_request_handler;
 	callbacks.log_message = log_http_message;
 	callbacks.log_access  = log_http_access;
 	callbacks.init_lua    = init_lua;

--- a/src/zip/gzip.c
+++ b/src/zip/gzip.c
@@ -301,6 +301,8 @@ bool inflate_buffer(unsigned char *buffer_compressed, mz_ulong size_compressed,
 	if(ret != Z_OK)
 	{
 		log_warn("Failed to uncompress: %s", zError(ret));
+		free(*buffer_uncompressed);
+		*buffer_uncompressed = NULL;
 		return false;
 	}
 
@@ -308,6 +310,8 @@ bool inflate_buffer(unsigned char *buffer_compressed, mz_ulong size_compressed,
 	if(crc != mz_crc32(MZ_CRC32_INIT, *buffer_uncompressed, *size_uncompressed))
 	{
 		log_warn("Checksum mismatch");
+		free(*buffer_uncompressed);
+		*buffer_uncompressed = NULL;
 		return false;
 	}
 

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -315,18 +315,26 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 	struct config teleporter_config = { 0 };
 	duplicate_config(&teleporter_config, &config);
 	if(!readFTLtoml(NULL, &teleporter_config, toml.toptab, true, NULL, 0, true))
+	{
+		free_config(&teleporter_config, false);
+		toml_free(toml);
 		return "File etc/pihole/pihole.toml in ZIP archive contains invalid TOML configuration";
+	}
 
 	// Test dnsmasq config in the imported configuration
 	// The dnsmasq configuration will be overwritten if the test succeeds
 	if(!write_dnsmasq_config(&teleporter_config, true, hint))
+	{
+		free_config(&teleporter_config, false);
+		toml_free(toml);
 		return "File etc/pihole/pihole.toml in ZIP archive contains invalid dnsmasq configuration";
+	}
 
 	// When we reach this point, we know that the file is a valid TOML file and contains
 	// a valid configuration for Pi-hole. We can now safely overwrite the current
 	// configuration with the one from the ZIP archive
 
-	// Install new configuration
+	// Install new configuration (takes ownership of teleporter_config)
 	replace_config(&teleporter_config);
 
 	// Write new pihole.toml to disk, the dnsmaq config was already written above
@@ -335,6 +343,7 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 	writeFTLtoml(true, NULL);
 	write_custom_list();
 
+	toml_free(toml);
 	return NULL;
 }
 

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -599,6 +599,16 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 			continue;
 		}
 
+		// Reject an absurdly large (attacker-controlled) uncompressed size
+		// before allocating, to avoid a memory-exhaustion DoS. This matches
+		// the 256 MiB cap enforced on the gzip path.
+		if(file_stat.m_uncomp_size > 0x10000000)
+		{
+			log_warn("Skipping file %u (%s) in ZIP archive: uncompressed size %llu is too large",
+			         i, file_stat.m_filename, (unsigned long long)file_stat.m_uncomp_size);
+			continue;
+		}
+
 		// Read file into its dedicated memory buffer
 		void *ptr = malloc(file_stat.m_uncomp_size);
 		if(ptr == NULL)

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -837,9 +837,9 @@ bool read_teleporter_zip_from_disk(const char *filename)
 	fseek(fp, 0, SEEK_END);
 	const size_t size = (size_t)ftell(fp);
 	fseek(fp, 0, SEEK_SET);
-	if(size > MAX_TELEPORTER_ZIP_SIZE)
+	if(size == 0 || size > MAX_TELEPORTER_ZIP_SIZE)
 	{
-		log_err("ZIP archive %s is too large (%zu bytes, max. %zu bytes)",
+		log_err("ZIP archive %s has an invalid size (%zu bytes, max. %zu bytes)",
 		        filename, size, MAX_TELEPORTER_ZIP_SIZE);
 		fclose(fp);
 		return false;
@@ -847,6 +847,12 @@ bool read_teleporter_zip_from_disk(const char *filename)
 
 	// Read ZIP archive to memory
 	void *ptr = calloc(size, sizeof(char));
+	if(ptr == NULL)
+	{
+		log_err("Failed to allocate %zu bytes for ZIP archive", size);
+		fclose(fp);
+		return false;
+	}
 	if(fread(ptr, 1, size, fp) != size)
 	{
 		log_err("Failed to read %zu bytes from %s: %s",

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -63,6 +63,17 @@ static const char *ftl_tables[] = {
 	"network_addresses"
 };
 
+// Copy a message into the ERRBUF_SIZE-sized hint buffer, always leaving it
+// NUL-terminated (plain strncpy(hint, src, ERRBUF_SIZE) would not terminate
+// when src is ERRBUF_SIZE bytes or longer, e.g. a long SQLite error message)
+static void set_hint(char *hint, const char *src)
+{
+	if(src == NULL)
+		src = "";
+	strncpy(hint, src, ERRBUF_SIZE - 1);
+	hint[ERRBUF_SIZE - 1] = '\0';
+}
+
 // Create database in memory, copy selected tables to it, serialize and return a memory pointer to it
 static bool create_teleporter_database(const char *filename, const char **tables, const unsigned int num_tables,
                                        void **buffer, size_t *size)
@@ -362,12 +373,12 @@ static const char *import_dhcp_leases(const void *ptr, size_t size, char * const
 	FILE *fp = fopen(DHCPLEASESFILE, "w");
 	if(fp == NULL)
 	{
-		strncpy(hint, strerror(errno), ERRBUF_SIZE);
+		set_hint(hint, strerror(errno));
 		return "Failed to open dhcp.leases file for writing";
 	}
 	if(fwrite(ptr, 1, size, fp) != size)
 	{
-		strncpy(hint, strerror(errno), ERRBUF_SIZE);
+		set_hint(hint, strerror(errno));
 		fclose(fp);
 		return "Failed to write to dhcp.leases file";
 	}
@@ -407,13 +418,13 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	if(sqlite3_open_v2(":memory:", &database,
 	                   SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX, NULL) != SQLITE_OK)
 	{
-		strncpy(hint, sqlite3_errmsg(database), ERRBUF_SIZE);
+		set_hint(hint, sqlite3_errmsg(database));
 		sqlite3_close(database);
 		return "Failed to open temporary SQLite3 database";
 	}
 	if(sqlite3_deserialize(database, "main", ptr, size, size, SQLITE_DESERIALIZE_READONLY) != SQLITE_OK)
 	{
-		strncpy(hint, sqlite3_errmsg(database), ERRBUF_SIZE);
+		set_hint(hint, sqlite3_errmsg(database));
 		sqlite3_close(database);
 		return "File etc/pihole/gravity.db in ZIP archive is not a valid SQLite3 database file";
 	}
@@ -426,21 +437,21 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	sqlite3_stmt *statement = NULL;
 	if(sqlite3_prepare_v2(database, "PRAGMA integrity_check;", -1, &statement, NULL) != SQLITE_OK)
 	{
-		strncpy(hint, sqlite3_errmsg(database), ERRBUF_SIZE);
+		set_hint(hint, sqlite3_errmsg(database));
 		sqlite3_finalize(statement);
 		sqlite3_close(database);
 		return "Failed to prepare PRAGMA integrity_check statement";
 	}
 	if(sqlite3_step(statement) != SQLITE_ROW)
 	{
-		strncpy(hint, sqlite3_errmsg(database), ERRBUF_SIZE);
+		set_hint(hint, sqlite3_errmsg(database));
 		sqlite3_finalize(statement);
 		sqlite3_close(database);
 		return "Failed to execute PRAGMA integrity_check statement";
 	}
 	if(strcmp((const char *)sqlite3_column_text(statement, 0), "ok") != 0)
 	{
-		strncpy(hint, (const char *)sqlite3_column_text(statement, 0), ERRBUF_SIZE);
+		set_hint(hint, (const char *)sqlite3_column_text(statement, 0));
 		sqlite3_finalize(statement);
 		sqlite3_close(database);
 		return "Database file in ZIP archive is not a valid SQLite3 database (integrity check failed)";
@@ -456,7 +467,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	snprintf(attach_stmt, sizeof(attach_stmt), "ATTACH DATABASE '%s' AS disk;", destination);
 	if(sqlite3_exec(database, attach_stmt, NULL, NULL, &err) != SQLITE_OK)
 	{
-		strncpy(hint, err, ERRBUF_SIZE);
+		set_hint(hint, err);
 		sqlite3_free(err);
 		sqlite3_close(database);
 		return "Failed to attach database file to in-memory SQLite3 database";
@@ -465,7 +476,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	// Disable foreign key checks for import
 	if(sqlite3_exec(database, "PRAGMA foreign_keys = 0;", NULL, NULL, &err) != SQLITE_OK)
 	{
-		strncpy(hint, err, ERRBUF_SIZE);
+		set_hint(hint, err);
 		sqlite3_free(err);
 		sqlite3_close(database);
 		return "Failed to disable foreign key checks for import";
@@ -474,7 +485,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	// Start transaction
 	if(sqlite3_exec(database, "BEGIN TRANSACTION;", NULL, NULL, &err) != SQLITE_OK)
 	{
-		strncpy(hint, err, ERRBUF_SIZE);
+		set_hint(hint, err);
 		sqlite3_free(err);
 		sqlite3_close(database);
 		return "Failed to start transaction";
@@ -488,7 +499,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 		snprintf(stmt, sizeof(stmt), "DELETE FROM disk.\"%s\";", tables[i]);
 		if(sqlite3_exec(database, stmt, NULL, NULL, &err) != SQLITE_OK)
 		{
-			strncpy(hint, err, ERRBUF_SIZE);
+			set_hint(hint, err);
 			sqlite3_free(err);
 			sqlite3_close(database);
 			return "Failed to delete from disk database table";
@@ -502,7 +513,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 		snprintf(stmt, sizeof(stmt), "INSERT OR REPLACE INTO disk.\"%s\" SELECT * FROM \"%s\";", tables[i], tables[i]);
 		if(sqlite3_exec(database, stmt, NULL, NULL, &err) != SQLITE_OK)
 		{
-			strncpy(hint, err, ERRBUF_SIZE);
+			set_hint(hint, err);
 			sqlite3_free(err);
 			sqlite3_close(database);
 			return "Failed to insert into disk database table";
@@ -514,7 +525,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	// End transaction
 	if(sqlite3_exec(database, "END", NULL, NULL, &err) != SQLITE_OK)
 	{
-		strncpy(hint, err, ERRBUF_SIZE);
+		set_hint(hint, err);
 		sqlite3_free(err);
 		sqlite3_close(database);
 		return "Failed to commit transaction";
@@ -523,7 +534,7 @@ static const char *test_and_import_database(void *ptr, size_t size, const char *
 	// Detach the database file from the in-memory database
 	if(sqlite3_exec(database, "DETACH DATABASE disk;", NULL, NULL, &err) != SQLITE_OK)
 	{
-		strncpy(hint, err, ERRBUF_SIZE);
+		set_hint(hint, err);
 		sqlite3_free(err);
 		sqlite3_close(database);
 		return "Failed to detach database file from in-memory SQLite3 database";
@@ -549,7 +560,7 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 	// Open ZIP archive from memory buffer
 	if(!mz_zip_reader_init_mem(&zip, buffer, buflen, 0))
 	{
-		strncpy(hint, mz_zip_get_error_string(mz_zip_get_last_error(&zip)), ERRBUF_SIZE);
+		set_hint(hint, mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
 		return "Failed to parse received ZIP archive";
 	}
 

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -392,6 +392,85 @@ class TestLuaServerPages:
 
 
 # ---------------------------------------------------------------------------
+# URI control-character / CRLF injection rejection
+# ---------------------------------------------------------------------------
+
+
+def _raw_http(request_bytes, host="127.0.0.1", port=80, timeout=5):
+    """Send a raw HTTP request over a socket and return the raw response bytes.
+
+    Used to smuggle bytes (e.g. a percent-encoded CR/LF in the path) that the
+    requests library would normalise away before they reach FTL.
+    """
+    import socket
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall(request_bytes)
+        chunks = []
+        try:
+            while True:
+                buf = sock.recv(4096)
+                if not buf:
+                    break
+                chunks.append(buf)
+        except socket.timeout:
+            pass
+    return b"".join(chunks)
+
+
+class TestURIControlCharRejection:
+    """An encoded CR/LF in the request path must never be reflected into a
+    response header (HTTP response splitting / header injection).
+
+    CivetWeb URL-decodes the path in place, so %0d%0a arrives as a literal
+    CR/LF; the .lp redirect handler would otherwise copy it into the Location
+    header verbatim.  FTL rejects any request whose decoded URI contains
+    control characters with 400, before authentication and before any handler
+    runs (see begin_request_handler in src/webserver/webserver.c).
+    """
+
+    def test_crlf_in_lp_path_is_rejected(self, api_session):
+        req = (
+            b"GET /admin/a%0d%0aSet-Cookie:%20injected=1.lp HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"Connection: close\r\n"
+            b"\r\n"
+        )
+        resp = _raw_http(req)
+        status_line = resp.split(b"\r\n", 1)[0]
+        assert b" 400 " in status_line, f"Expected 400, got: {status_line!r}"
+        # The smuggled header must not have been split out of the path into the
+        # response headers.
+        headers = resp.split(b"\r\n\r\n", 1)[0].lower()
+        assert b"set-cookie: injected" not in headers, \
+            f"CRLF was reflected into response headers:\n{resp!r}"
+
+    def test_bare_control_char_in_uri_is_rejected(self, api_session):
+        req = (
+            b"GET /admin/%01%02.lp HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"Connection: close\r\n"
+            b"\r\n"
+        )
+        resp = _raw_http(req)
+        status_line = resp.split(b"\r\n", 1)[0]
+        assert b" 400 " in status_line, f"Expected 400, got: {status_line!r}"
+
+    def test_clean_lp_path_is_not_rejected(self, api_session):
+        # A control-character-free .lp request must still be handled (the guard
+        # must not over-block legitimate traffic).
+        req = (
+            b"GET /admin/index.lp HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"Connection: close\r\n"
+            b"\r\n"
+        )
+        resp = _raw_http(req)
+        status_line = resp.split(b"\r\n", 1)[0]
+        assert b" 400 " not in status_line, \
+            f"Legitimate .lp request was rejected: {status_line!r}"
+
+
+# ---------------------------------------------------------------------------
 # DNS blocking status
 # ---------------------------------------------------------------------------
 

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -1081,6 +1081,29 @@ class TestQueriesAdditional:
         data = _j(api_session.get(f"{FTL_URL}/api/queries?length=5", timeout=5))
         assert len(data["queries"]) == 5
 
+    def test_queries_length_is_capped(self, api_session):
+        """Regression: an unbounded 'length' must not build the whole history.
+
+        /api/queries caps the number of rows materialized at
+        API_QUERIES_MAX_ROWS (10000) regardless of the requested length,
+        including the documented length<=0 ("all") case. The fixed test
+        database holds far fewer rows than the cap, so this exercises the
+        clamp's contract - a huge or negative length is accepted, saturated,
+        and never rejected or overflowed - rather than the 10000-row boundary
+        itself.
+        """
+        CAP = 10000
+        # A huge length must be accepted (not rejected) and stay bounded
+        huge = _j(api_session.get(f"{FTL_URL}/api/queries?length=999999999", timeout=10))
+        assert len(huge["queries"]) <= CAP
+        # length=-1 is the documented "all"; it must still return everything
+        all_rows = _j(api_session.get(f"{FTL_URL}/api/queries?length=-1", timeout=10))
+        assert len(all_rows["queries"]) <= CAP
+        # An oversized length saturates to the same bounded result as "all" ...
+        assert len(huge["queries"]) == len(all_rows["queries"])
+        # ... which, below the cap, is the full unfiltered history
+        assert len(all_rows["queries"]) == all_rows["recordsTotal"]
+
     def test_queries_filter_by_type(self, api_session):
         data = _j(api_session.get(f"{FTL_URL}/api/queries?type=AAAA", timeout=5))
         for q in data["queries"]:

--- a/test/api/test_z_auth_security.py
+++ b/test/api/test_z_auth_security.py
@@ -1,0 +1,200 @@
+"""
+Pi-hole FTL API security regression tests.
+
+These guard three hardening fixes and are intentionally isolated in their own
+module (with a self-contained password/TOTP lifecycle) so they do not disturb
+the order-dependent workflow in test_z_auth.py:
+
+1. Session cookies carry the Secure attribute only over TLS. A TLS session's
+   SID must not be settable over plaintext HTTP (that would allow it to be
+   captured on a single http:// request), and Secure must NOT be added over
+   plain HTTP (that would make browsers drop the cookie and break LAN setups).
+
+2. An accepted TOTP code cannot be replayed. Replay protection tracks the
+   accepted RFC 6238 time-step counter, so once a step has been accepted the
+   same code can no longer be reused.
+
+Usage:
+    pytest test/api/test_z_auth_security.py -v
+"""
+
+import base64
+import hashlib
+import hmac
+import time
+import warnings
+
+import pytest
+import requests
+
+# The TLS test talks to FTL's self-signed cert with verify=False. Resolve the
+# InsecureRequestWarning category so that test can silence it locally: pytest
+# resets warning filters per test, so a module-level disable_warnings() is not
+# enough - the test wraps its request in a catch_warnings() block.
+try:
+    from urllib3.exceptions import InsecureRequestWarning
+except ImportError:  # pragma: no cover - fallback for bundled urllib3
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+FTL_URL = "http://127.0.0.1"
+FTL_URL_TLS = "https://127.0.0.1"
+PASSWORD = "sec-regress-pw"
+# Valid base32 TOTP secret (same shape as the stress-test suite)
+TOTP_SECRET = "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
+
+
+# -- helpers ----------------------------------------------------------------
+
+def _set_password(pw, sid=None):
+    headers = {"X-FTL-SID": sid} if sid else {}
+    return requests.patch(
+        f"{FTL_URL}/api/config/webserver/api/password",
+        json={"config": {"webserver": {"api": {"password": pw}}}},
+        headers=headers, timeout=20)
+
+
+def _set_totp_secret(secret, sid):
+    return requests.patch(
+        f"{FTL_URL}/api/config/webserver/api/totp_secret",
+        json={"config": {"webserver": {"api": {"totp_secret": secret}}}},
+        headers={"X-FTL-SID": sid}, timeout=20)
+
+
+def _login(pw, totp=None, base=FTL_URL, verify=True, timeout=10):
+    payload = {"password": pw}
+    if totp is not None:
+        payload["totp"] = totp
+    return requests.post(f"{base}/api/auth", json=payload,
+                         timeout=timeout, verify=verify)
+
+
+def _login_rate_limited(pw, totp=None, base=FTL_URL, verify=True, attempts=6):
+    """Login, tolerating the login rate limiter (HTTP 429) with short waits.
+
+    Kept short so a TOTP code stays within its 30 s validity window.
+    """
+    r = _login(pw, totp=totp, base=base, verify=verify)
+    for _ in range(attempts):
+        if r.status_code != 429:
+            return r
+        time.sleep(0.5)
+        r = _login(pw, totp=totp, base=base, verify=verify)
+    return r
+
+
+def _totp_code(secret, now=None):
+    if now is None:
+        now = time.time()
+    key = base64.b32decode(secret, casefold=True)
+    counter = int(now // 30)
+    digest = hmac.new(key, counter.to_bytes(8, "big"), hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    binary = ((digest[offset] & 0x7F) << 24) | (
+        (digest[offset + 1] & 0xFF) << 16) | (
+        (digest[offset + 2] & 0xFF) << 8) | (
+        digest[offset + 3] & 0xFF)
+    return binary % 1_000_000
+
+
+def _admin_sid():
+    """Obtain an authenticated SID via a password-only login.
+
+    Only used while no TOTP secret is configured (module setup/teardown and
+    before the replay test enables TOTP), so a plain password login is enough
+    and never triggers a "no 2FA token" warning.
+    """
+    return _login_rate_limited(PASSWORD).json().get("session", {}).get("sid")
+
+
+# -- module lifecycle -------------------------------------------------------
+
+def setup_module(_mod):
+    # Wait until the API is reachable, then set a known password
+    for _ in range(40):
+        try:
+            if requests.get(f"{FTL_URL}/api/auth", timeout=5).status_code in (200, 401):
+                break
+        except requests.ConnectionError:
+            time.sleep(0.25)
+    r = _set_password(PASSWORD)
+    assert r.status_code == 200, f"set password: {r.status_code} {r.text}"
+
+
+def teardown_module(_mod):
+    time.sleep(1)
+    try:
+        sid = _admin_sid()
+        if sid:
+            # Clear any TOTP secret first so a plain password login works again
+            _set_totp_secret("", sid)
+            _set_password("", sid=sid)
+    except Exception:
+        pass  # best-effort cleanup
+
+
+# -- tests ------------------------------------------------------------------
+
+class TestSessionCookieSecure:
+    """The Secure cookie attribute must track the transport."""
+
+    def test_http_login_cookie_has_no_secure_attribute(self):
+        r = _login_rate_limited(PASSWORD, base=FTL_URL)
+        assert r.status_code == 200, f"HTTP login failed: {r.status_code} {r.text}"
+        set_cookie = r.headers.get("Set-Cookie", "")
+        assert "sid=" in set_cookie, f"no session cookie set: {set_cookie!r}"
+        # Secure over plain HTTP would make the browser drop the cookie
+        assert "secure" not in set_cookie.lower(), \
+            f"Secure attribute wrongly set over HTTP: {set_cookie!r}"
+
+    def test_https_login_cookie_has_secure_attribute(self):
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", InsecureRequestWarning)
+                r = _login_rate_limited(PASSWORD, base=FTL_URL_TLS, verify=False)
+        except (requests.exceptions.SSLError,
+                requests.exceptions.ConnectionError) as e:
+            pytest.skip(f"HTTPS endpoint not available: {e}")
+        assert r.status_code == 200, f"HTTPS login failed: {r.status_code} {r.text}"
+        set_cookie = r.headers.get("Set-Cookie", "")
+        assert "sid=" in set_cookie, f"no session cookie set: {set_cookie!r}"
+        assert "secure" in set_cookie.lower(), \
+            f"Secure attribute missing over HTTPS: {set_cookie!r}"
+
+
+class TestTOTPReplay:
+    """An accepted TOTP code must not be replayable."""
+
+    def test_accepted_totp_code_cannot_be_replayed(self):
+        # Obtain a session before enabling TOTP (plain password login), then
+        # configure the shared TOTP secret.
+        sid = _admin_sid()
+        assert sid, "could not obtain an admin session to configure TOTP"
+        assert _set_totp_secret(TOTP_SECRET, sid).status_code == 200
+
+        first_sid = None
+        try:
+            # Advance into a fresh 30 s time step that no earlier login has
+            # consumed, so the first code is accepted (the replay guard rejects
+            # any step counter <= the last accepted one).
+            time.sleep(30 - (time.time() % 30) + 1)
+            code = _totp_code(TOTP_SECRET)
+
+            first = _login_rate_limited(PASSWORD, totp=code)
+            assert first.status_code == 200, \
+                f"valid TOTP code was not accepted: {first.status_code} {first.text}"
+            session = first.json().get("session", {})
+            first_sid = session.get("sid")
+            assert session.get("valid") is True
+
+            # Replay the exact same code: must be rejected as reused
+            replay = _login_rate_limited(PASSWORD, totp=code)
+            assert replay.status_code != 200, \
+                f"replayed TOTP code was accepted: {replay.status_code} {replay.text}"
+            assert replay.json().get("session", {}).get("valid") is not True
+        finally:
+            # Clear the secret using the session created by the accepted login:
+            # it is valid under the 2FA regime, so this avoids a password-only
+            # login (which would emit a "no 2FA token" warning) and the replay
+            # guard (which would reject a freshly computed code in this window).
+            if first_sid:
+                _set_totp_secret("", first_sid)

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -37,13 +37,15 @@ load 'bats_helper.bash'
   # pytest: 4x pihole.toml writes (config PATCH round-trips: bool + int, change + restore each)
   # pytest: 2x pihole.toml writes (auth stress test password set + remove)
   # pytest: 2x pihole.toml writes (TOTP stress test secret set + remove)
+  # pytest: 2x pihole.toml writes (auth security test password set + remove)
+  # pytest: 2x pihole.toml writes (auth security test TOTP secret set + remove)
   run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
   printf "pihole.toml write count: %s\n" "${lines[0]}"
   # On RISCV64, pytest is skipped (too slow), so only BATS writes occur
   if [[ "${CI_ARCH}" == "linux/riscv64" ]]; then
       assert_line --index 0 "1"
   else
-    [[ ${lines[0]} == "18" ]]
+    [[ ${lines[0]} == "22" ]]
   fi
   # CLI password set/remove trigger inotify reload but result in
   # "pihole.toml unchanged" as the in-memory config already matches


### PR DESCRIPTION
# What does this implement/fix?

A batch of small, independent AI-assisted patches regarding memory-safety bugs, security hardening, correctness/logic fixes, resource leaks, and two performance optimizations. Each patch has been reviewed, verified, and tested manually.

- **Memory safety (17):** out-of-bounds reads/writes, off-by-ones, missing NUL
  termination, a size underflow, a use-after-free window on config replacement,
  a NULL deref, a free of stack addresses, and a double free. Includes hardening
  the DNS name decompression in `resolve.c` (compression-pointer loop + oversized
  labels) and several unterminated-buffer / unbounded-read fixes in
  `dhcp-discover`, `edns0`, `network-table` and the API.
- **Security hardening (4):** stored HTML/script injection in the admin message
  view (`escape_html`), unbounded PTR-record growth from case-varied queries
  (`strcasecmp` dedup), an unbounded per-entry ZIP allocation, and thread-unsafe
  brute-force rate-limit counters.
- **Correctness / logic (9):** a failed `execv` reported as success, a teleporter
  import gated on the wrong flag, a clobbered nested SQLite statement, two NTP
  timing bugs (missing `fabs`, unsigned underflow), a NULL-route deref, an
  unchecked `CONF_UINT` range, a never-written `success` out-parameter, and a
  UTF-8 BOM strip that left stray bytes.
- **Resource leaks (7):** TOML result, decompressed TAR/GZIP buffers, list items
  on IDN failure, an overwritten JSON array, an enum error string, and
  unterminated teleporter error hints.
- **Performance (2):** cache the SHM lock owner PID/TID (two uncached musl
  syscalls per lock removed), and iterate cJSON arrays via the linked list
  instead of by index (removes O(n^2) config/validation loops and an O(n^3)
  header dedup).


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.


---

**Follow-up (post-review):** five further patches from a second security pass —

- **Memory leaks (2):** the two Copilot review findings — an unreleased cJSON
  array in the invalid-enum error path (`env.c`) and a leaked `cJSON_Print()`
  string on invalid `dns.revServers` entries (`dnsmasq_config.c`).
- **DoS (1):** `compile_filter_regex()` counted skipped/empty exclude-filter
  entries, leaving zero-initialized `regex_t` slots that crashed FTL (and DNS)
  via `regexec()` on `/api/queries`. Report only the compiled count.
- **Auth (1):** web authentication was decided on the non-normalized
  `local_uri_raw`, letting a dot-segment path (`/x/../admin/...`) reach a
  protected page unauthenticated when `serve_all` is set. Decide on `local_uri`.
- **Hardening (1):** escape NTP message fields in the HTML message view for
  consistency with the other renderers.
- **Security (1):** CivetWeb decodes `local_uri_raw` in place, so an encoded
  CR/LF in the path was reflected verbatim into the `Location` header by the
  `.lp` redirect handler (unauthenticated HTTP response-header injection /
  response splitting). Reject control characters in the decoded URI from a
  `begin_request` hook, before auth and any handler.


---

**Second security pass (defensive audit):** 13 further patches from a subsystem-wide audit, each verified as real and attacker-reachable and each with a reviewed fix. Grouped by class:

- **Authentication / session (5):** Secure attribute on session cookies over TLS; no plaintext passwords in failed-login debug logs; constant-time SID/CSRF comparison; `generateSID()` now fails closed on RNG error (no empty-SID sessions) and empty SIDs are rejected; TOTP one-time-use enforced via the time-step counter instead of the last code value.
- **Memory safety (5):** bound DNS PTR name parsing against the receive-buffer end; validate EDNS0 ECS option length before reading; fix an `_addstr()` length-clamp underflow and force NUL termination in the shared string pool; snapshot client fields across the SHM unlock in the network table (no NULL/stale-pointer deref); rebind the SQLite `carray` when a shared-memory remap moves the backing array.
- **Denial of service (2):** guard unchecked `calloc()` results (payload buffer, Lua hint, `.lp` redirect, teleporter ZIP) against NULL-deref crashes; cap `/api/queries` result size to prevent building the whole history in memory.
- **NTP hardening (1):** panic threshold before stepping the clock (first-boot exempt), random anti-spoof nonce as the on-wire origin timestamp, and stratum committed only after the round is validated.
- **Input / config validation (2):** reject non-string list items for all list types; reject embedded newlines in `dns.hosts` entries; revert a rejected env-var value on validation failure so it cannot reach the generated dnsmasq config.

- **Regression tests:** the batch adds API tests covering the Secure cookie attribute (present over TLS, absent over plain HTTP), TOTP one-time-use (an accepted code cannot be replayed), and the `/api/queries` length clamp.

One related finding (session-expiration bypass) is intentionally **not** included here as it is being handled in parallel via a private security advisory.

