### PR TITLE
fix build error from leftover variable

### DIFF
--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -650,8 +650,7 @@ void sanitize_dns_hosts(union conf_value *val)
 	// Walk the linked list directly: cJSON_GetArrayItem() is O(index) and
 	// cJSON_GetArraySize() in the loop condition re-walks the whole list
 	// every iteration, which made this loop O(n^2). item->next is O(1).
-	int i = 0;
-	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next)
 	{
 
 		// Check if it's a string


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Building FTL exits with an errror:
```bash
[100%] Built target dnsmasq
[100%] Built target lua
/home/shared/Projects/fleet/pi-hole-FTL/src/config/validator.c: In function ‘sanitize_dns_hosts’:
/home/shared/Projects/fleet/pi-hole-FTL/src/config/validator.c:653:13: error: variable ‘i’ set but not used [-Werror=unused-but-set-variable=]
  653 |         int i = 0;
      |             ^
cc1: all warnings being treated as errors
gmake[2]: *** [src/config/CMakeFiles/config.dir/build.make:247: src/config/CMakeFiles/config.dir/validator.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1098: src/config/CMakeFiles/config.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```
**How does this PR accomplish the above?:**

remove the variable leftover from https://github.com/pi-hole/FTL/pull/2935

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
