### PR TITLE
Add native DoT/DoH support for encrypted upstreams (part 1/2)

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -25,7 +25,7 @@ RUN sed -i '/buffer_with_truncation /d' /bats/bats-core/libexec/bats-core/bats-f
 # Remove possible old build files
 RUN rm -rf cmake && \
 # Build and test FTL
-    bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON" ${BUILD_OPTS} && \
+    bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON" ${BUILD_OPTS} && \
 # Copy FTL binary to root directory
     cd / &&\
     cp /app/pihole-FTL . && \

--- a/build.sh
+++ b/build.sh
@@ -109,9 +109,9 @@ fi
 # They are gated behind CMake options so ordinary builds do not produce them.
 if [[ -n "${test}" ]]; then
     if [[ -n "${cmake_args}" ]]; then
-        cmake_args="${cmake_args} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON"
+        cmake_args="${cmake_args} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON"
     else
-        cmake_args="-DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON"
+        cmake_args="-DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON"
     fi
 fi
 
@@ -210,7 +210,7 @@ else
     cp pihole-FTL ../
     # Copy the regression test binaries alongside it so the bats tests can run
     # them from the repo root.
-    for regression_bin in tar_regression gzip_regression; do
+    for regression_bin in tar_regression gzip_regression dotdoh_regression; do
         if [[ -f "${regression_bin}" ]]; then
             cp "${regression_bin}" ../
         fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,6 +303,7 @@ add_executable(pihole-FTL
         $<TARGET_OBJECTS:config>
         $<TARGET_OBJECTS:tools>
         $<TARGET_OBJECTS:ntp>
+        $<TARGET_OBJECTS:dotdoh>
         )
 if(STATIC)
     set_target_properties(pihole-FTL PROPERTIES LINK_SEARCH_START_STATIC ON)
@@ -373,6 +374,7 @@ add_subdirectory(syscalls)
 add_subdirectory(config)
 add_subdirectory(tools)
 add_subdirectory(ntp)
+add_subdirectory(dotdoh)
 
 # Standalone regression harness for the in-memory tar parser (zip/tar.c).
 # It #includes tar.c directly to reach the file-internal helpers, stubs the
@@ -400,6 +402,29 @@ if(BUILD_TAR_REGRESSION)
     if(TAR_REGRESSION_SANITIZE)
         target_compile_options(tar_regression PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
         target_link_options(tar_regression PRIVATE -fsanitize=address,undefined)
+    endif()
+endif()
+
+# Standalone regression harness for the dotdoh leaf units (URI parser and
+# DoT/DoH framing). It #includes the self-contained implementation .c files
+# directly; no object dependencies are needed. The "dotdoh regression
+# harness" bats test runs the resulting binary. Deliberately NOT given the
+# strict EXTRAWARN/-Werror flags applied to FTL code.
+#
+# Only built on request: `./build.sh test` enables it for local runs and the
+# CI Dockerfile passes -DBUILD_DOTDOH_REGRESSION=ON at build time.
+option(BUILD_DOTDOH_REGRESSION "Build the dotdoh regression test harness" OFF)
+if(BUILD_DOTDOH_REGRESSION)
+    add_executable(dotdoh_regression
+            ${PROJECT_SOURCE_DIR}/test/dotdoh_regression.c)
+    target_include_directories(dotdoh_regression PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+    # Optional ASan/UBSan instrumentation for local runs:
+    #   ./build.sh "-DDOTDOH_REGRESSION_SANITIZE=ON" test
+    option(DOTDOH_REGRESSION_SANITIZE "Build the dotdoh regression test with ASan/UBSan" OFF)
+    if(DOTDOH_REGRESSION_SANITIZE)
+        target_compile_options(dotdoh_regression PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(dotdoh_regression PRIVATE -fsanitize=address,undefined)
     endif()
 endif()
 
@@ -520,6 +545,7 @@ if(LIBMBEDCRYPTO AND LIBMBEDX509 AND LIBMBEDTLS AND USE_MBED_TLS)
     target_compile_definitions(core PRIVATE HAVE_MBEDTLS)
     target_compile_definitions(civetweb PRIVATE USE_MBEDTLS)
     target_compile_definitions(webserver PRIVATE HAVE_MBEDTLS)
+    target_compile_definitions(dotdoh PRIVATE HAVE_MBEDTLS)
     # Link against the mbedTLS libraries, the order is important (!)
     target_link_libraries(pihole-FTL ${LIBMBEDTLS} ${LIBMBEDX509} ${LIBMBEDCRYPTO})
 else()

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -56,16 +56,74 @@ static struct {
 		const char *addr1;
 		const char *addr2;
 	} v6;
+	// DoT/DoH URIs pinned to the primary v4 and v6 address, so no untrusted
+	// lookup of the resolver hostname is needed before switching to it.
+	struct {
+		const char *v4;
+		const char *v6;
+	} dot;
+	struct {
+		const char *v4;
+		const char *v6;
+	} doh;
 } dns_server[] =
 {
-	{ "Google (ECS, DNSSEC)", { "8.8.8.8", "8.8.4.4" }, { "2001:4860:4860:0:0:0:0:8888", "2001:4860:4860:0:0:0:0:8844" } },
-	{ "OpenDNS (ECS, DNSSEC)", { "208.67.222.222", "208.67.220.220" }, {"2620:119:35::35", "2620:119:53::53"} },
-	{ "Level3", { "4.2.2.1", "4.2.2.2" }, { NULL, NULL } },
-	{ "Comodo", { "8.26.56.26", "8.20.247.20" }, { NULL, NULL} },
-	{ "Quad9 (filtered, DNSSEC)", {"9.9.9.9", "149.112.112.112" }, { "2620:fe::fe", "2620:fe::9" } },
-	{ "Quad9 (unfiltered, no DNSSEC)", { "9.9.9.10", "149.112.112.10" }, { "2620:fe::10", "2620:fe::fe:10" } },
-	{ "Quad9 (filtered, ECS, DNSSEC)", { "9.9.9.11", "149.112.112.11" }, { "2620:fe::11", "2620:fe::fe:11" } },
-	{ "Cloudflare (DNSSEC)", { "1.1.1.1", "1.0.0.1" }, { "2606:4700:4700::1111", "2606:4700:4700::1001" } }
+	{
+		.name = "Google (ECS, DNSSEC)",
+		.v4 = { "8.8.8.8", "8.8.4.4" },
+		.v6 = {	"2001:4860:4860:0:0:0:0:8888", "2001:4860:4860:0:0:0:0:8844" },
+		.dot = { "tls://dns.google@8.8.8.8", "tls://dns.google@[2001:4860:4860:0:0:0:0:8888]" },
+		.doh = { "https://dns.google@8.8.8.8/dns-query", "https://dns.google@[2001:4860:4860:0:0:0:0:8888]/dns-query" }
+	},
+	{
+		.name = "OpenDNS (ECS, DNSSEC)",
+		.v4 = { "208.67.222.222", "208.67.220.220" },
+		.v6 = {	"2620:119:35::35", "2620:119:53::53" },
+		.dot = { "tls://dns.opendns.com@208.67.222.222", "tls://dns.opendns.com@[2620:119:35::35]" },
+		.doh = { "https://doh.opendns.com@208.67.222.222/dns-query", "https://doh.opendns.com@[2620:119:35::35]/dns-query" }
+	},
+	{
+		.name = "Level3",
+		.v4 = { "4.2.2.1", "4.2.2.2" },
+		.v6 = {	"2001:4:112::1", "2001:4:112::2" },
+		.dot = { NULL, NULL },
+		.doh = { NULL, NULL }
+	},
+	{
+		.name = "Comodo",
+		.v4 = { "8.26.56.26", "8.20.247.20" },
+		.v6 = {	"2001:5a60::ad1:0ff", "2001:5a60::ad2:0ff" },
+		.dot = { NULL, NULL },
+		.doh = { NULL, NULL }
+	},
+	{
+		.name = "Quad9 (filtered, DNSSEC)",
+		.v4 = { "9.9.9.9", "149.112.112.112" },
+		.v6 = {	"2620:fe::fe", "2620:fe::9" },
+		.dot = { "tls://dns.quad9.net@9.9.9.9", "tls://dns.quad9.net@[2620:fe::fe]" },
+		.doh = { "https://dns.quad9.net@9.9.9.9/dns-query", "https://dns.quad9.net@[2620:fe::fe]/dns-query" }
+	},
+	{
+		.name = "Quad9 (unfiltered, no DNSSEC)",
+		.v4 = { "9.9.9.10", "149.112.112.10" },
+		.v6 = {	"2620:fe::10", "2620:fe::fe:10" },
+		.dot = { "tls://dns10.quad9.net@9.9.9.10", "tls://dns10.quad9.net@[2620:fe::10]" },
+		.doh = { "https://dns10.quad9.net@9.9.9.10/dns-query", "https://dns10.quad9.net@[2620:fe::10]/dns-query" }
+	},
+	{
+		.name = "Quad9 (filtered, ECS, DNSSEC)",
+		.v4 = { "9.9.9.11", "149.112.112.11" },
+		.v6 = {	"2620:fe::11", "2620:fe::fe:11" },
+		.dot = { "tls://dns11.quad9.net@9.9.9.11", "tls://dns11.quad9.net@[2620:fe::11]" },
+		.doh = { "https://dns11.quad9.net@9.9.9.11/dns-query", "https://dns11.quad9.net@[2620:fe::11]/dns-query" }
+	},
+	{
+		.name = "Cloudflare (DNSSEC)",
+		.v4 = { "1.1.1.1", "1.0.0.1" },
+		.v6 = {	"2606:4700:4700::1111", "2606:4700:4700::1001" },
+		.dot = { "tls://one.one.one.one@1.1.1.1", "tls://one.one.one.one@[2606:4700:4700::1111]" },
+		.doh = { "https://cloudflare-dns.com@1.1.1.1/dns-query", "https://cloudflare-dns.com@[2606:4700:4700::1111]/dns-query" }
+	}
 };
 
 // The following functions are used to create the JSON output
@@ -636,6 +694,24 @@ int get_json_config(struct ftl_conn *api, cJSON *json, const bool detailed)
 			if(dns_server[i].v6.addr2 != NULL)
 				JSON_REF_STR_IN_ARRAY(v6, dns_server[i].v6.addr2);
 			JSON_ADD_ITEM_TO_OBJECT(server, "v6", v6);
+
+			// DoT/DoH endpoints pinned to the v4/v6 address. The object is
+			// always present; the v4/v6 keys appear only for the families the
+			// resolver actually offers, so it is empty for resolvers without
+			// any encrypted endpoint.
+			cJSON *dot = JSON_NEW_OBJECT();
+			if(dns_server[i].dot.v4 != NULL)
+				JSON_REF_STR_IN_OBJECT(dot, "v4", dns_server[i].dot.v4);
+			if(dns_server[i].dot.v6 != NULL)
+				JSON_REF_STR_IN_OBJECT(dot, "v6", dns_server[i].dot.v6);
+			JSON_ADD_ITEM_TO_OBJECT(server, "dot", dot);
+
+			cJSON *doh = JSON_NEW_OBJECT();
+			if(dns_server[i].doh.v4 != NULL)
+				JSON_REF_STR_IN_OBJECT(doh, "v4", dns_server[i].doh.v4);
+			if(dns_server[i].doh.v6 != NULL)
+				JSON_REF_STR_IN_OBJECT(doh, "v6", dns_server[i].doh.v6);
+			JSON_ADD_ITEM_TO_OBJECT(server, "doh", doh);
 
 			JSON_ADD_ITEM_TO_ARRAY(servers, server);
 		}

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -718,6 +718,26 @@ components:
                 description: Array of IPv6 addresses (if any)
                 items:
                   type: string
+              dot:
+                type: object
+                description: DoT (DNS-over-TLS) endpoints, pinned to the resolver's IPv4/IPv6 address so no untrusted hostname lookup is needed before switching. Always present; the v4/v6 keys appear only for the families offered, so the object is empty if the resolver has no DoT endpoint.
+                properties:
+                  v4:
+                    type: string
+                    description: "tls:// URI pinned to the primary IPv4 address"
+                  v6:
+                    type: string
+                    description: "tls:// URI pinned to the primary IPv6 address"
+              doh:
+                type: object
+                description: DoH (DNS-over-HTTPS) endpoints, pinned to the resolver's IPv4/IPv6 address. Always present; the v4/v6 keys appear only for the families offered, so the object is empty if the resolver has no DoH endpoint.
+                properties:
+                  v4:
+                    type: string
+                    description: "https:// URI pinned to the primary IPv4 address"
+                  v6:
+                    type: string
+                    description: "https:// URI pinned to the primary IPv6 address"
     props:
       type: object
       properties:

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -295,6 +295,8 @@ components:
                   type: array
                   items:
                     type: string
+                upstreamCA:
+                  type: string
                 blocking:
                   type: object
                   properties:
@@ -744,6 +746,7 @@ components:
         config:
           dns:
             upstreams: [ "127.0.0.1#5353", "8.8.8.8" ]
+            upstreamCA: ""
             CNAMEdeepInspect: true
             blockESNI: true
             EDNS0ECS: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -418,7 +418,7 @@ void initConfig(struct config *conf)
 	conf->dns.upstreams.t = CONF_JSON_STRING_ARRAY;
 	conf->dns.upstreams.d.json = cJSON_CreateArray();
 	conf->dns.upstreams.f = FLAG_RESTART_FTL;
-	conf->dns.upstreams.c = validate_array_no_newline;
+	conf->dns.upstreams.c = validate_upstreams;
 
 	conf->dns.CNAMEdeepInspect.k = "dns.CNAMEdeepInspect";
 	conf->dns.CNAMEdeepInspect.h = "Use this option to control deep CNAME inspection. Disabling it might be beneficial for very low-end devices";
@@ -602,6 +602,14 @@ void initConfig(struct config *conf)
 	conf->dns.revServers.d.json = cJSON_CreateArray();
 	conf->dns.revServers.c = validate_dns_revServers;
 	conf->dns.revServers.f = FLAG_RESTART_FTL;
+
+	conf->dns.upstreamCA.k = "dns.upstreamCA";
+	conf->dns.upstreamCA.h = "Path to a CA certificate bundle used to verify encrypted upstream servers (DoT/DoH). If left empty, the system default trust store is used. Only relevant when at least one dns.upstreams entry uses the tls:// or https:// scheme.";
+	conf->dns.upstreamCA.a = cJSON_CreateStringReference("A path to a PEM CA bundle, or empty for the system default trust store");
+	conf->dns.upstreamCA.t = CONF_STRING;
+	conf->dns.upstreamCA.d.s = (char*)"";
+	conf->dns.upstreamCA.f = FLAG_RESTART_FTL;
+	conf->dns.upstreamCA.c = validate_filepath_empty;
 
 	// sub-struct dns.cache
 	conf->dns.domain.name.k = "dns.domain.name";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -155,6 +155,7 @@ struct config {
 		struct conf_item port;
 		struct conf_item localise;
 		struct conf_item revServers;
+		struct conf_item upstreamCA;
 		struct {
 			struct conf_item name;
 			struct conf_item local;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -139,7 +139,7 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 			// Check if the child exited too quickly for waitpid to
 			// catch it. We cannot get the return code in this case
 			// and have to check the pipe content instead
-			if(errno == ECHILD)
+			if(err == ECHILD)
 			{
 				log_debug(DEBUG_CONFIG, "dnsmasq test exited too quickly for waitpid");
 				code = strstr(errbuf, "syntax check OK") != NULL ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -18,6 +18,9 @@
 #include "config/config.h"
 // JSON array functions
 #include "webserver/cJSON/cJSON.h"
+// encrypted upstreams: parse_upstream_uri() + the deterministic loopback tuple
+#include "dotdoh/upstream_uri.h"
+#include "dotdoh/registry.h"
 // directory_exists()
 #include "files.h"
 // trim_whitespace()
@@ -351,10 +354,39 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	if(cJSON_GetArraySize(conf->dns.upstreams.v.json) > 0)
 	{
 		fputs("# List of upstream DNS server\n", pihole_conf);
+
+		// Encrypted upstreams (tls:// / https://) are not handed to dnsmasq
+		// directly: dnsmasq forwards their plaintext queries to a deterministic
+		// loopback tuple in 127.47.11.0/24 that FTL's DoT/DoH proxy binds later
+		// (in FTL_fork_and_bind_sockets, after dnsmasq's startup has closed stray
+		// fds). The proxy derives the tuple from the same formula, so the two
+		// agree without anything being bound here.
+		int enc = 0;
 		cJSON *server = NULL;
 		cJSON_ArrayForEach(server, conf->dns.upstreams.v.json)
 		{
-			if(server != NULL && cJSON_IsString(server))
+			if(server == NULL || !cJSON_IsString(server) || server->valuestring == NULL)
+				continue;
+
+			struct upstream_uri u;
+			const bool encrypted = parse_upstream_uri(server->valuestring, &u) && u.type != UST_PLAIN;
+			if(encrypted)
+			{
+				// The proxy binds at most DOTDOH_MAX_UPSTREAMS loopback tuples
+				// (proxy.c walks the same list with the same index). Never point
+				// dnsmasq at a tuple beyond that range - it would be bound by
+				// nothing and only add failover delay.
+				if(enc >= DOTDOH_MAX_UPSTREAMS)
+				{
+					log_warn("Ignoring encrypted upstream '%s': at most %d are supported",
+					         server->valuestring, DOTDOH_MAX_UPSTREAMS);
+					continue;
+				}
+				fprintf(pihole_conf, "server=%s%d#%d\n",
+				        DOTDOH_NET_PREFIX, enc + 1, DOTDOH_PORT_BASE + enc + 1);
+				enc++;
+			}
+			else
 				fprintf(pihole_conf, "server=%s\n", server->valuestring);
 		}
 		fputs("\n", pihole_conf);

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -14,6 +14,8 @@
 #include "tools/gravity-parseList.h"
 // regex
 #include "regex_r.h"
+// parse_upstream_uri()
+#include "dotdoh/upstream_uri.h"
 
 // Stub validator for config types that need to dedicated validation as they can
 // be tested by their type only (e.g., integers, strings, booleans, enums, etc.)
@@ -801,6 +803,43 @@ bool validate_str_no_newline(union conf_value *val, const char *key, char err[VA
 		{
 			snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: contains newline characters", key);
 			return false;
+		}
+	}
+
+	return true;
+}
+
+// Validator for dns.upstreams. Enforces the same array/string/newline rules as
+// validate_array_no_newline() and, in addition, requires every encrypted entry
+// (tls:// or https://) to parse as a valid encrypted-upstream URI. Plaintext
+// entries are left untouched - dnsmasq validates those itself.
+bool validate_upstreams(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	if(!validate_array_no_newline(val, key, err))
+		return false;
+
+	int i = 0;
+	for(cJSON *item = val->json != NULL ? val->json->child : NULL; item != NULL; item = item->next, i++)
+	{
+		const char *s = item->valuestring;
+		if(s == NULL)
+			continue;
+
+		// Anything carrying a URI scheme ("://") must be a supported encrypted
+		// upstream (tls:// or https://) that parses cleanly. A plaintext server
+		// specification handled downstream by dnsmasq never contains "://", so
+		// an entry that does but is not a valid encrypted URI (e.g. http://,
+		// ftp:// or a malformed tls://) is rejected here rather than being
+		// written into dnsmasq.conf and breaking DNS startup.
+		if(strstr(s, "://") != NULL)
+		{
+			struct upstream_uri u;
+			if(!parse_upstream_uri(s, &u) || u.type == UST_PLAIN)
+			{
+				snprintf(err, VALIDATOR_ERRBUF_LEN,
+				         "%s[%d]: invalid encrypted upstream URI", key, i);
+				return false;
+			}
 		}
 	}
 

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -32,5 +32,6 @@ void sanitize_dns_hosts(union conf_value *val);
 bool validate_dns_domain_or_ip(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_str_no_newline(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_array_no_newline(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+bool validate_upstreams(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 
 #endif // CONFIG_VALIDATOR_H

--- a/src/datastructure.c
+++ b/src/datastructure.c
@@ -22,6 +22,8 @@
 #include "database/aliasclients.h"
 // config struct
 #include "config/config.h"
+// dotdoh_uri_for_listener()
+#include "dotdoh/proxy.h"
 // set_event(RESOLVE_NEW_HOSTNAMES)
 #include "events.h"
 // overTime array
@@ -193,6 +195,20 @@ int findQueryID(const int id)
 
 int _findUpstreamID(const char *upstreamString, const in_port_t port, int line, const char *func, const char *file)
 {
+	// Encrypted upstreams are forwarded to an internal loopback proxy tuple
+	// (127.47.11.N#port). Record the real configured upstream instead, so every
+	// consumer (all API endpoints, PADD, the query database, ...) sees it and
+	// not the internal address. Cheap for plaintext upstreams: the prefix check
+	// inside short-circuits before any config walk.
+	in_port_t eff_port = port;
+	char dotdoh_uri[512];
+	int dotdoh_port = 0;
+	if(dotdoh_uri_for_listener(upstreamString, port, dotdoh_uri, sizeof(dotdoh_uri), &dotdoh_port))
+	{
+		upstreamString = dotdoh_uri;
+		eff_port = (in_port_t)dotdoh_port;
+	}
+
 	// Go through already knows upstream servers and see if we used one of those
 	for(unsigned int upstreamID = 0; upstreamID < counters->upstreams; upstreamID++)
 	{
@@ -203,13 +219,13 @@ int _findUpstreamID(const char *upstreamString, const in_port_t port, int line, 
 		if(upstream == NULL)
 			continue;
 
-		if(strcmp(getstr(upstream->ippos), upstreamString) == 0 && upstream->port == port)
+		if(strcmp(getstr(upstream->ippos), upstreamString) == 0 && upstream->port == eff_port)
 			return upstreamID;
 	}
 	// This upstream server is not known
 	// Store ID
 	const unsigned int upstreamID = counters->upstreams;
-	log_debug(DEBUG_GC, "New upstream server: %s:%u (ID %u)", upstreamString, port, upstreamID);
+	log_debug(DEBUG_GC, "New upstream server: %s:%u (ID %u)", upstreamString, eff_port, upstreamID);
 
 	// Get upstream pointer
 	upstreamsData *upstream = _getUpstream(upstreamID, false, line, func, file);
@@ -238,7 +254,7 @@ int _findUpstreamID(const char *upstreamString, const in_port_t port, int line, 
 	set_event(RESOLVE_NEW_HOSTNAMES);
 	upstream->lastQuery = 0.0;
 	// Store port
-	upstream->port = port;
+	upstream->port = eff_port;
 	// Increase counter by one
 	counters->upstreams++;
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -14,6 +14,7 @@
 #include "FTL.h"
 #include "enums.h"
 #include "dnsmasq_interface.h"
+#include "dotdoh/proxy.h"
 #include "shmem.h"
 #include "overTime.h"
 #include "database/common.h"
@@ -3595,6 +3596,21 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 	// Initialize FTL HTTP server
 	http_init();
 #endif /* HAVE_MBEDTLS */
+
+	// Arm the encrypted-upstream (DoT/DoH) proxy and start its worker. This must
+	// happen here - after dnsmasq's own startup has closed stray fds - because
+	// binding the listeners any earlier would get their fds closed and their
+	// numbers reused by dnsmasq. Only relevant when dnsmasq is actually running.
+	if(dnsmasq_start)
+	{
+		dotdoh_init();
+		if(dotdoh_count() > 0 &&
+		   pthread_create( &threads[DOTDOH], &attr, dotdoh_thread, NULL ) != 0)
+		{
+			log_crit("Unable to create dotdoh thread. Exiting...");
+			exit(EXIT_FAILURE);
+		}
+	}
 
 	// Chown files if FTL started as user root but a dnsmasq config
 	// option states to run as a different user/group (e.g. "nobody")

--- a/src/dotdoh/CMakeLists.txt
+++ b/src/dotdoh/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# FTL Engine
+# /src/dotdoh/CMakeLists.txt
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+set(dotdoh_sources
+        upstream_uri.c
+        upstream_uri.h
+        framing.c
+        framing.h
+        registry.c
+        registry.h
+        tls_client.c
+        tls_client.h
+        proxy.c
+        proxy.h
+        )
+
+add_library(dotdoh OBJECT ${dotdoh_sources})
+target_compile_options(dotdoh PRIVATE "${EXTRAWARN}")
+target_include_directories(dotdoh PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/dotdoh/CMakeLists.txt
+++ b/src/dotdoh/CMakeLists.txt
@@ -13,6 +13,8 @@ set(dotdoh_sources
         upstream_uri.h
         framing.c
         framing.h
+        edns_pad.c
+        edns_pad.h
         registry.c
         registry.h
         tls_client.c

--- a/src/dotdoh/edns_pad.c
+++ b/src/dotdoh/edns_pad.c
@@ -1,0 +1,186 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  EDNS(0) query padding (RFC 7830 / RFC 8467)
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "edns_pad.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+// RFC 8467 recommends clients pad queries to a multiple of this many octets.
+#define EDNS_PAD_BLOCK 128
+// EDNS(0) OPT resource record type (RFC 6891) and Padding option (RFC 7830).
+#define DNS_TYPE_OPT   41
+#define EDNS_OPT_PAD   12
+// Requestor's UDP payload size advertised when we add an OPT ourselves. The
+// transport to the upstream is a reliable stream (DoT/DoH), so this does not
+// cap the answer; a conservative value keeps the record neutral.
+#define EDNS_UDP_SIZE  1232
+// The 2-byte DoT length prefix and DoH Content-Length bound the message to 64 KiB.
+#define DNS_MSG_LIMIT  65535
+
+// Advance *pos past a DNS name (RFC 1035 label sequence). Handles a trailing
+// compression pointer as the terminator (2 octets). Returns false on any
+// out-of-bounds or reserved label, leaving *pos undefined.
+static bool skip_name(const uint8_t *buf, size_t len, size_t *pos)
+{
+	size_t p = *pos;
+	for(;;)
+	{
+		if(p >= len)
+			return false;
+		const uint8_t c = buf[p];
+		if(c == 0)               // root label: name ends here
+		{
+			p += 1;
+			break;
+		}
+		if((c & 0xC0) == 0xC0)   // compression pointer: 2 octets, ends the name
+		{
+			if(p + 2 > len)
+				return false;
+			p += 2;
+			break;
+		}
+		if((c & 0xC0) != 0)      // 0x40/0x80 are reserved label types
+			return false;
+		p += 1 + c;              // normal label
+		if(p > len)
+			return false;
+	}
+	*pos = p;
+	return true;
+}
+
+size_t edns_pad_query(uint8_t *buf, size_t len, size_t bufsz)
+{
+	// Need at least a fixed 12-byte header to look at.
+	if(len < 12)
+		return len;
+
+	const uint16_t qdcount = (uint16_t)((buf[4] << 8) | buf[5]);
+	const uint16_t ancount = (uint16_t)((buf[6] << 8) | buf[7]);
+	const uint16_t nscount = (uint16_t)((buf[8] << 8) | buf[9]);
+	const uint16_t arcount = (uint16_t)((buf[10] << 8) | buf[11]);
+
+	size_t pos = 12;
+
+	// Question section: a name followed by QTYPE and QCLASS.
+	for(uint16_t i = 0; i < qdcount; i++)
+	{
+		if(!skip_name(buf, len, &pos))
+			return len;
+		if(pos + 4 > len)
+			return len;
+		pos += 4;
+	}
+
+	// Walk every resource record, locating the OPT record if present. We need to
+	// know it exists, where its RDLENGTH is, and that it is the last RR (so its
+	// RDATA ends exactly at the message tail and we can append there).
+	bool found_opt = false;
+	size_t opt_rdlen_off = 0, opt_rdata_off = 0, opt_rdlen = 0;
+	const unsigned long total_rr = (unsigned long)ancount + nscount + arcount;
+	for(unsigned long i = 0; i < total_rr; i++)
+	{
+		if(!skip_name(buf, len, &pos))
+			return len;
+		if(pos + 10 > len) // TYPE(2) CLASS(2) TTL(4) RDLENGTH(2)
+			return len;
+		const uint16_t type = (uint16_t)((buf[pos] << 8) | buf[pos + 1]);
+		const size_t rdlen_off = pos + 8;
+		const size_t rdlen = (size_t)((buf[rdlen_off] << 8) | buf[rdlen_off + 1]);
+		const size_t rdata_off = pos + 10;
+		if(rdata_off + rdlen > len)
+			return len;
+
+		if(type == DNS_TYPE_OPT)
+		{
+			if(found_opt) // a second OPT is malformed
+				return len;
+			found_opt = true;
+			opt_rdlen_off = rdlen_off;
+			opt_rdata_off = rdata_off;
+			opt_rdlen = rdlen;
+
+			// Scan existing options: if a Padding option is already present, leave
+			// the message untouched (idempotent). A ragged option list that does
+			// not tile the RDATA exactly is malformed -> fail open.
+			size_t o = rdata_off;
+			while(o + 4 <= rdata_off + rdlen)
+			{
+				const uint16_t oc = (uint16_t)((buf[o] << 8) | buf[o + 1]);
+				const size_t ol = (size_t)((buf[o + 2] << 8) | buf[o + 3]);
+				if(oc == EDNS_OPT_PAD)
+					return len;
+				o += 4 + ol;
+			}
+			if(o != rdata_off + rdlen)
+				return len;
+		}
+
+		pos = rdata_off + rdlen;
+	}
+
+	// A clean parse consumes the whole message; trailing bytes mean malformed.
+	if(pos != len)
+		return len;
+
+	// Fixed overhead added before the pad octets: the 4-byte Padding option
+	// header, plus an 11-byte OPT RR (root name, TYPE, CLASS, TTL, RDLENGTH) when
+	// the query has no OPT record yet.
+	if(found_opt && opt_rdata_off + opt_rdlen != len)
+		return len; // OPT is not the last RR -> cannot append at the tail
+	const size_t overhead = found_opt ? 4 : (11 + 4);
+
+	// Round the message up to the next EDNS_PAD_BLOCK boundary. The pad count is
+	// always < EDNS_PAD_BLOCK, so it fits an option length comfortably.
+	const size_t provisional = len + overhead;
+	const size_t new_len = ((provisional + EDNS_PAD_BLOCK - 1) / EDNS_PAD_BLOCK) * EDNS_PAD_BLOCK;
+	const size_t pad = new_len - provisional;
+	if(new_len > bufsz || new_len > DNS_MSG_LIMIT)
+		return len; // would not fit -> send unpadded
+
+	if(found_opt)
+	{
+		// Append the Padding option to the existing OPT RDATA and grow RDLENGTH.
+		size_t w = len;
+		buf[w++] = 0x00;
+		buf[w++] = EDNS_OPT_PAD;
+		buf[w++] = (uint8_t)(pad >> 8);
+		buf[w++] = (uint8_t)(pad & 0xff);
+		memset(buf + w, 0, pad);
+		const size_t new_rdlen = opt_rdlen + 4 + pad;
+		buf[opt_rdlen_off]     = (uint8_t)(new_rdlen >> 8);
+		buf[opt_rdlen_off + 1] = (uint8_t)(new_rdlen & 0xff);
+	}
+	else
+	{
+		// Append a fresh OPT RR carrying the Padding option, and bump ARCOUNT.
+		size_t w = len;
+		buf[w++] = 0x00;                              // root name
+		buf[w++] = 0x00; buf[w++] = DNS_TYPE_OPT;     // TYPE = OPT (41)
+		buf[w++] = (uint8_t)(EDNS_UDP_SIZE >> 8);     // CLASS = UDP payload size
+		buf[w++] = (uint8_t)(EDNS_UDP_SIZE & 0xff);
+		buf[w++] = 0x00; buf[w++] = 0x00;             // TTL: ext-rcode, version,
+		buf[w++] = 0x00; buf[w++] = 0x00;             //      flags (DO=0) all zero
+		const size_t rdlen = 4 + pad;
+		buf[w++] = (uint8_t)(rdlen >> 8);             // RDLENGTH
+		buf[w++] = (uint8_t)(rdlen & 0xff);
+		buf[w++] = 0x00; buf[w++] = EDNS_OPT_PAD;     // Padding option code (12)
+		buf[w++] = (uint8_t)(pad >> 8);               // Padding option length
+		buf[w++] = (uint8_t)(pad & 0xff);
+		memset(buf + w, 0, pad);
+		const uint16_t new_ar = (uint16_t)(arcount + 1);
+		buf[10] = (uint8_t)(new_ar >> 8);
+		buf[11] = (uint8_t)(new_ar & 0xff);
+	}
+
+	return new_len;
+}

--- a/src/dotdoh/edns_pad.h
+++ b/src/dotdoh/edns_pad.h
@@ -1,0 +1,35 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  EDNS(0) query padding (RFC 7830 / RFC 8467)
+*
+*  Public interface of the query padding helper: rounds an outbound encrypted
+*  query up to a block boundary by adding an EDNS(0) Padding option, so the size
+*  of the ciphertext no longer leaks the query. Self-contained (no DNS library),
+*  so the regression harness can use it directly.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_EDNS_PAD_H
+#define DOTDOH_EDNS_PAD_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// Pad a DNS query in place to the next multiple of EDNS_PAD_BLOCK octets by
+// adding (or extending) an EDNS(0) Padding option (RFC 7830, option code 12)
+// following the recommended query policy of RFC 8467. buf holds the len-byte
+// message and has capacity bufsz.
+//
+// Returns the new message length, or len unchanged (fail-open) when padding is
+// not safely possible: a truncated/malformed message, an OPT record that is not
+// the last RR, a query that already carries a Padding option, or a result that
+// would not fit in bufsz (or the 64 KiB DNS limit). Padding is best-effort
+// privacy hardening, so a query we cannot pad is still sent as-is rather than
+// dropped.
+size_t edns_pad_query(uint8_t *buf, size_t len, size_t bufsz);
+
+#endif // DOTDOH_EDNS_PAD_H

--- a/src/dotdoh/framing.c
+++ b/src/dotdoh/framing.c
@@ -1,0 +1,224 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  DoT/DoH wire framing
+*
+*  Frames/deframes bytes only; DNS message contents are never parsed here. All
+*  lengths are bounds-checked; no read or write ever crosses the caller-provided
+*  buffer bounds.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "framing.h"
+
+#include <string.h>
+#include <stdio.h>
+
+// DoT: write a 2-byte big-endian length prefix followed by msg into out.
+// Returns len+2 on success, -1 on empty/oversized msg or insufficient out.
+ssize_t dot_frame(const uint8_t *msg, size_t len, uint8_t *out, size_t out_sz)
+{
+	// DoT frames each message with a 2-octet big-endian length prefix - RFC
+	// 7858 Sec. 3.3: messages "MUST use the two-octet length field
+	// described in Section 4.2.2 of [RFC1035]". Refuse a length we cannot
+	// represent or fit.
+	if(len == 0 || len > DNS_MSG_MAX)
+		return -1;
+	if(out_sz < len + 2)
+		return -1;
+	out[0] = (uint8_t)((len >> 8) & 0xff);
+	out[1] = (uint8_t)(len & 0xff);
+	memcpy(out + 2, msg, len);
+	return (ssize_t)(len + 2);
+}
+
+// DoT: inspect an accumulated receive buffer. Returns the DNS message length and
+// sets *msg_off to the offset of the message body once a full length-prefixed
+// message is present, 0 if more bytes are needed, -1 on a zero-length
+// (protocol error) frame.
+ssize_t dot_deframe(const uint8_t *buf, size_t buflen, size_t *msg_off)
+{
+	// We cannot know the message size until the 2-byte prefix has arrived.
+	if(buflen < 2)
+		return 0;
+	const size_t l = ((size_t)buf[0] << 8) | (size_t)buf[1];
+	if(l == 0)
+		return -1; // a zero-length DNS message is a protocol error
+	if(buflen < l + 2)
+		return 0;  // the body has not fully arrived yet
+	if(msg_off != NULL)
+		*msg_off = 2;
+	return (ssize_t)l;
+}
+
+// Reject control characters that could break out of an HTTP header.
+static bool __attribute__((pure)) clean_header_value(const char *s)
+{
+	for(const char *p = s; *p != '\0'; p++)
+	{
+		const unsigned char c = (unsigned char)*p;
+		// Reject controls, DEL and spaces: a space would also split the
+		// HTTP request line ("POST /a b HTTP/1.1"), not just inject a
+		// header.
+		if(c < 0x20 || c == 0x7f || c == ' ')
+			return false;
+	}
+	return true;
+}
+
+// DoH: build an HTTP/1.1 POST request carrying the DNS message. host and path
+// must be free of control characters. Returns request length or -1.
+ssize_t doh_build_request(const char *host, const char *path,
+                          const uint8_t *msg, size_t len, uint8_t *out, size_t out_sz)
+{
+	if(host == NULL || path == NULL || msg == NULL)
+		return -1;
+	if(len == 0 || len > DNS_MSG_MAX)
+		return -1;
+	if(!clean_header_value(host) || !clean_header_value(path))
+		return -1;
+
+	// An IPv6 literal in the Host header must be bracketed (RFC 7230 Sec. 5.4);
+	// a hostname never contains ':', so a colon reliably marks an IPv6 literal.
+	char hostbuf[256];
+	const char *hosthdr = host;
+	if(strchr(host, ':') != NULL)
+	{
+		if((size_t)snprintf(hostbuf, sizeof(hostbuf), "[%s]", host) >= sizeof(hostbuf))
+			return -1;
+		hosthdr = hostbuf;
+	}
+
+	// RFC 8484: the DNS wire message is the POST body with media type
+	// application/dns-message (Sec. 4.1 and Sec. 6).
+	const int hlen = snprintf((char *)out, out_sz,
+	                          "POST %s HTTP/1.1\r\n"
+	                          "Host: %s\r\n"
+	                          "Accept: application/dns-message\r\n"
+	                          "Content-Type: application/dns-message\r\n"
+	                          "Content-Length: %zu\r\n"
+	                          "\r\n",
+	                          path, hosthdr, len);
+	if(hlen < 0 || (size_t)hlen >= out_sz)
+		return -1;
+	if((size_t)hlen + len > out_sz)
+		return -1;
+	memcpy(out + hlen, msg, len);
+	return (ssize_t)((size_t)hlen + len);
+}
+
+// Case-insensitive search for needle (already lowercase) in hay[hn].
+static const uint8_t *__attribute__((pure)) mem_findci(const uint8_t *hay, size_t hn, const char *needle)
+{
+	const size_t nn = strlen(needle);
+	if(nn == 0 || nn > hn)
+		return NULL;
+	for(size_t i = 0; i + nn <= hn; i++)
+	{
+		size_t j = 0;
+		for(; j < nn; j++)
+		{
+			unsigned char a = hay[i + j];
+			if(a >= 'A' && a <= 'Z')
+				a = (unsigned char)(a + 32);
+			if(a != (unsigned char)needle[j])
+				break;
+		}
+		if(j == nn)
+			return hay + i;
+	}
+	return NULL;
+}
+
+// DoH: parse an accumulated HTTP/1.1 response. On a complete 200 response sets
+// body_off and body_len to the DNS answer within buf and returns total bytes
+// consumed; 0 if more bytes are needed; -1 on a non-200 status, a missing or
+// oversized Content-Length, or a malformed/oversized header block.
+ssize_t doh_parse_response(const uint8_t *buf, size_t buflen,
+                           size_t *body_off, size_t *body_len)
+{
+	// Locate the end of the header block.
+	const uint8_t *hdr_end = NULL;
+	for(size_t i = 0; i + 4 <= buflen; i++)
+		if(memcmp(buf + i, "\r\n\r\n", 4) == 0)
+		{
+			hdr_end = buf + i + 4;
+			break;
+		}
+	if(hdr_end == NULL)
+		return (buflen > DOH_HEADER_MAX) ? -1 : 0;
+
+	const size_t hlen = (size_t)(hdr_end - buf);
+
+	// A header block that only reaches the terminator past DOH_HEADER_MAX is
+	// still oversized (the pre-terminator check above cannot catch this case).
+	if(hlen > DOH_HEADER_MAX)
+		return -1;
+
+	// Require an HTTP/1.x status line, so a non-HTTP response is rejected
+	// outright rather than misclassified (which could leave stray bytes in and
+	// desync the pooled connection).
+	if(hlen < 8 || memcmp(buf, "HTTP/1.", 7) != 0)
+		return -1;
+
+	// Status line must be exactly "HTTP/x.y 200 " - require the 3-digit code to
+	// be followed by a space or CR so a malformed "2000" is rejected.
+	const uint8_t *sp = memchr(buf, ' ', hlen);
+	if(sp == NULL || sp + 5 > buf + hlen)
+		return -1;
+	if(!(sp[1] == '2' && sp[2] == '0' && sp[3] == '0' &&
+	     (sp[4] == ' ' || sp[4] == '\r')))
+		return -1;
+
+	// Content-Length is required. Anchor the match to the start of a header
+	// line (headers are always preceded by CRLF) so that a header such as
+	// "X-Content-Length:" cannot be mistaken for it.
+	const uint8_t *cl = mem_findci(buf, hlen, "\r\ncontent-length:");
+	if(cl == NULL)
+		return -1;
+	// Reject a second Content-Length (RFC 7230 Sec. 3.3.3 message smuggling)
+	// and any Transfer-Encoding: either lets the real body length differ from
+	// the parsed one, leaving unconsumed bytes that desync the pooled
+	// connection for the following queries.
+	const size_t after_cl = (size_t)(cl + 2 - buf); // just past the leading CRLF
+	if(mem_findci(buf + after_cl, hlen - after_cl, "\r\ncontent-length:") != NULL)
+		return -1;
+	if(mem_findci(buf, hlen, "\r\ntransfer-encoding:") != NULL)
+		return -1;
+	const uint8_t *v = cl + strlen("\r\ncontent-length:");
+	while(v < buf + hlen && (*v == ' ' || *v == '\t'))
+		v++;
+	size_t content_len = 0;
+	bool anydigit = false;
+	while(v < buf + hlen && *v >= '0' && *v <= '9')
+	{
+		content_len = content_len * 10 + (size_t)(*v - '0');
+		anydigit = true;
+		if(content_len > DNS_MSG_MAX)
+			return -1;
+		v++;
+	}
+	// A DNS wire message cannot be empty, so Content-Length: 0 is a protocol
+	// error (fail closed), not a valid zero-length answer.
+	if(!anydigit || content_len == 0)
+		return -1;
+	// The value must be properly terminated: only optional whitespace and then
+	// the end-of-line CR may follow. Rejecting trailing junk ("2x") prevents a
+	// mismatched body length from desyncing the persistent connection.
+	while(v < buf + hlen && (*v == ' ' || *v == '\t'))
+		v++;
+	if(v >= buf + hlen || *v != '\r')
+		return -1;
+
+	if(buflen < hlen + content_len)
+		return 0; // need more body
+
+	if(body_off != NULL)
+		*body_off = hlen;
+	if(body_len != NULL)
+		*body_len = content_len;
+	return (ssize_t)(hlen + content_len);
+}

--- a/src/dotdoh/framing.h
+++ b/src/dotdoh/framing.h
@@ -1,0 +1,50 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  DoT/DoH wire framing
+*
+*  Public interface of the framing helpers (frame/deframe bytes only, no DNS
+*  parsing). Self-contained so the regression harness can use it directly.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_FRAMING_H
+#define DOTDOH_FRAMING_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#define DNS_MSG_MAX 65535
+
+// Largest HTTP/1.1 response header block a DoH response may carry before we
+ // give up (guards the accumulation buffer against an endless header stream).
+#define DOH_HEADER_MAX 8192
+
+// DoT: write a 2-byte big-endian length prefix followed by msg into out.
+ // Returns len+2 on success, -1 on empty/oversized msg or insufficient out.
+ssize_t dot_frame(const uint8_t *msg, size_t len, uint8_t *out, size_t out_sz);
+
+// DoT: inspect an accumulated receive buffer. Returns the DNS message length
+ // and sets *msg_off to the offset of the message body once a full length-
+ // prefixed message is present, 0 if more bytes are needed, -1 on a zero-length
+ // (protocol error) frame.
+ssize_t dot_deframe(const uint8_t *buf, size_t buflen, size_t *msg_off);
+
+// DoH: build an HTTP/1.1 POST request carrying the DNS message. host and path
+ // must be free of control characters. Returns request length or -1.
+ssize_t doh_build_request(const char *host, const char *path,
+                          const uint8_t *msg, size_t len, uint8_t *out, size_t out_sz);
+
+// DoH: parse an accumulated HTTP/1.1 response. On a complete 200 response sets
+ // body_off and body_len to the DNS answer within buf and returns total bytes
+ // consumed; 0 if more bytes are needed; -1 on a non-200 status, a missing or
+ // oversized Content-Length, or a malformed/oversized header block.
+ssize_t doh_parse_response(const uint8_t *buf, size_t buflen,
+                           size_t *body_off, size_t *body_len);
+
+#endif // DOTDOH_FRAMING_H

--- a/src/dotdoh/proxy.c
+++ b/src/dotdoh/proxy.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 #include <time.h>
 
 // Per-upstream state, one entry per encrypted upstream. Plaintext entries are
@@ -52,6 +53,13 @@ static struct proxy_up g_ups[DOTDOH_MAX_UPSTREAMS];
 static int g_nups = 0;       // number of encrypted upstreams recorded
 static int g_nactive = 0;    // number of those successfully armed
 static bool g_armed = false; // init runs once per process
+
+// Tuple -> upstream lookup, precomputed once at arm time so the per-query hot
+// path (findUpstreamID) is an O(1) array access, not a config walk + URI parse.
+// Index enc holds the upstream that owns tuple 127.47.11.(enc+1)#(5300+enc+1).
+static char g_uri_map[DOTDOH_MAX_UPSTREAMS][256];
+static int  g_uri_port[DOTDOH_MAX_UPSTREAMS];
+static int  g_uri_count = 0;
 
 // Arm one loopback listener pair per encrypted upstream and record the
 // per-upstream proxy state. Runs exactly once per process, after dnsmasq
@@ -101,6 +109,13 @@ void dotdoh_init(void)
 		if(g_nups >= DOTDOH_MAX_UPSTREAMS)
 			break;
 
+		// Record the tuple->upstream mapping (tuple 127.47.11.(enc+1)) so the
+		// API can resolve it without re-walking the config per query.
+		strncpy(g_uri_map[enc], it->valuestring, sizeof(g_uri_map[enc]) - 1);
+		g_uri_map[enc][sizeof(g_uri_map[enc]) - 1] = '\0';
+		g_uri_port[enc] = u.port;
+		g_uri_count = enc + 1;
+
 		struct proxy_up *up = &g_ups[g_nups++];
 		memset(up, 0, sizeof(*up));
 		up->uri = u;
@@ -134,6 +149,31 @@ void dotdoh_init(void)
 int dotdoh_count(void)
 {
 	return g_nactive;
+}
+
+bool dotdoh_uri_for_listener(const char *ip, int port, char *out, size_t outlen, int *real_port)
+{
+	if(ip == NULL || out == NULL || outlen == 0)
+		return false;
+
+	// Cheap prefix check first, so plaintext upstreams (the common case) cost
+	// almost nothing on the per-query hot path.
+	const size_t plen = strlen(DOTDOH_NET_PREFIX);
+	if(strncmp(ip, DOTDOH_NET_PREFIX, plen) != 0)
+		return false;
+	char *end = NULL;
+	const long n = strtol(ip + plen, &end, 10);
+	if(end == NULL || *end != '\0' || n < 1 || n > g_uri_count ||
+	   port != DOTDOH_PORT_BASE + (int)n)
+		return false;
+
+	// O(1) lookup in the table dotdoh_init() precomputed - tuple N maps to the
+	// N-th encrypted upstream, the same numbering the dnsmasq.conf emission uses.
+	strncpy(out, g_uri_map[n - 1], outlen - 1);
+	out[outlen - 1] = '\0';
+	if(real_port != NULL)
+		*real_port = g_uri_port[n - 1];
+	return true;
 }
 
 // True for an IPv4 loopback source (127.0.0.0/8). Everything else is rejected:
@@ -348,5 +388,6 @@ void dotdoh_cleanup(void)
 	g_nups = 0;
 	g_nactive = 0;
 	g_armed = false;
+	g_uri_count = 0;
 	tls_client_global_free();
 }

--- a/src/dotdoh/proxy.c
+++ b/src/dotdoh/proxy.c
@@ -1,0 +1,352 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Encrypted-upstream forward proxy
+*
+*  FTL forwards plaintext DNS to a loopback address in 127.47.11.0/24; this
+*  module re-encrypts it to the real resolver over DoT/DoH and hands the answer
+*  back. A single worker thread poll()s every armed listener. On any TLS failure
+*  the query is dropped, not answered, so FTL fails over to the next server
+*  instead of ever downgrading to plaintext.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "log.h"
+// killed, thread_names
+#include "signals.h"
+
+#include "proxy.h"
+#include "registry.h"
+#include "tls_client.h"
+#include "framing.h"
+// global config
+#include "config/config.h"
+// upstream list iteration
+#include "webserver/cJSON/cJSON.h"
+
+#include <poll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+// Per-upstream state, one entry per encrypted upstream. Plaintext entries are
+// not tracked here - dnsmasq talks to those directly.
+struct proxy_up {
+	bool active;                    // armed: listener bound and connection ready
+	struct upstream_uri uri;        // parsed descriptor
+	struct proxy_listener listener; // bound UDP+TCP pair
+	struct tls_conn *conn;          // pooled TLS connection
+	char target[INET_ADDRSTRLEN + 8]; // "127.47.11.N#P", for logging
+};
+
+static struct proxy_up g_ups[DOTDOH_MAX_UPSTREAMS];
+static int g_nups = 0;       // number of encrypted upstreams recorded
+static int g_nactive = 0;    // number of those successfully armed
+static bool g_armed = false; // init runs once per process
+
+// Arm one loopback listener pair per encrypted upstream and record the
+// per-upstream proxy state. Runs exactly once per process, after dnsmasq
+// startup so the freshly bound listener fds cannot collide with dnsmasq's.
+void dotdoh_init(void)
+{
+	// Arm exactly once per process (upstreams are RESTART_FTL, so the set
+	// cannot change without a full restart).
+	if(g_armed)
+		return;
+	g_armed = true;
+
+	cJSON *ups = config.dns.upstreams.v.json;
+	if(ups == NULL || cJSON_GetArraySize(ups) <= 0)
+		return;
+
+	// Bring the TLS stack up only if at least one upstream is encrypted; if
+	// it fails, every encrypted upstream stays disabled (fail-closed)
+	// rather than silently falling back to plaintext.
+	bool any_encrypted = false;
+	cJSON *it = NULL;
+	cJSON_ArrayForEach(it, ups)
+		if(it != NULL && cJSON_IsString(it) && it->valuestring != NULL &&
+		   (strncmp(it->valuestring, "tls://", 6) == 0 || strncmp(it->valuestring, "https://", 8) == 0))
+			any_encrypted = true;
+	if(!any_encrypted)
+		return;
+
+	const bool tls_ok = tls_client_global_init(config.dns.upstreamCA.v.s);
+	if(!tls_ok)
+		log_err("dotdoh: TLS init failed - encrypted upstreams are disabled");
+
+	// Walk the upstreams in order. Each encrypted entry consumes one slot
+	// in the 127.47.11.N addressing (enc), matching the deterministic tuple
+	// the config layer already emitted for it - so a disabled entry still
+	// keeps subsequent ones aligned.
+	int enc = 0;
+	cJSON_ArrayForEach(it, ups)
+	{
+		if(it == NULL || !cJSON_IsString(it) || it->valuestring == NULL)
+			continue;
+
+		struct upstream_uri u;
+		if(!parse_upstream_uri(it->valuestring, &u) || u.type == UST_PLAIN)
+			continue; // plaintext -> dnsmasq handles it directly
+
+		if(g_nups >= DOTDOH_MAX_UPSTREAMS)
+			break;
+
+		struct proxy_up *up = &g_ups[g_nups++];
+		memset(up, 0, sizeof(*up));
+		up->uri = u;
+
+		// Deterministic tuple; no iteration, since dnsmasq is already
+		// pointed at exactly this address. If we cannot own it, the
+		// upstream is left disabled and queries to it fail closed
+		// (dnsmasq fails over).
+		if(tls_ok && proxy_listener_bind(enc, &up->listener))
+		{
+			up->conn = tls_conn_new();
+			if(up->conn != NULL)
+			{
+				snprintf(up->target, sizeof(up->target), "%s#%d",
+				         up->listener.ip, up->listener.port);
+				up->active = true;
+				g_nactive++;
+				log_info("dotdoh: %s upstream %s armed on %s",
+				         u.type == UST_DOT ? "DoT" : "DoH", u.verify_name, up->target);
+			}
+			else
+				proxy_listener_close(&up->listener);
+		}
+		if(!up->active)
+			log_warn("dotdoh: encrypted upstream %s could not be armed (127.47.11.%d#%d)",
+			         u.verify_name, enc + 1, DOTDOH_PORT_BASE + enc + 1);
+		enc++;
+	}
+}
+
+int dotdoh_count(void)
+{
+	return g_nactive;
+}
+
+// True for an IPv4 loopback source (127.0.0.0/8). Everything else is rejected:
+// only dnsmasq on this host is a legitimate client, and this also closes any
+// exposure via net.ipv4.conf.*.route_localnet.
+static bool is_loopback_v4(const struct sockaddr_in *sa)
+{
+	return sa->sin_family == AF_INET &&
+	       (ntohl(sa->sin_addr.s_addr) >> 24) == 127;
+}
+
+// Overall budget (ms) for one TCP request cycle (read query + write answer).
+// The socket's per-op SO_RCVTIMEO/SO_SNDTIMEO bound a fully idle peer, but not
+// one that trickles a byte just before each timeout; this deadline does, so a
+// local peer cannot pin the single worker thread across every other upstream.
+#define PROXY_REQUEST_TIMEOUT_MS 10000
+
+// Per-connection caps so a single accepted TCP connection cannot monopolize the
+// sole worker thread (the loopback listener is reachable by any local process,
+// not just dnsmasq). Generous enough for dnsmasq's pipelining; on hitting either
+// the connection is closed and dnsmasq reconnects.
+#define PROXY_CONN_MAX_QUERIES 64
+#define PROXY_CONN_TIMEOUT_MS  60000
+
+// Monotonic clock in milliseconds, for the per-request deadline.
+static uint64_t now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+// Read exactly len bytes (or fail), giving up once deadline passes. Returns
+// true on success.
+static bool read_full(int fd, uint8_t *buf, size_t len, uint64_t deadline)
+{
+	size_t off = 0;
+	while(off < len)
+	{
+		if(now_ms() >= deadline)
+			return false;
+		const ssize_t r = read(fd, buf + off, len - off);
+		if(r < 0 && errno == EINTR)
+			continue;
+		if(r <= 0)
+			return false;
+		off += (size_t)r;
+	}
+	return true;
+}
+
+// Write exactly len bytes (or fail), giving up once deadline passes. Returns
+// true on success.
+static bool write_full(int fd, const uint8_t *buf, size_t len, uint64_t deadline)
+{
+	size_t off = 0;
+	while(off < len)
+	{
+		if(now_ms() >= deadline)
+			return false;
+		const ssize_t w = write(fd, buf + off, len - off);
+		if(w < 0 && errno == EINTR)
+			continue;
+		if(w <= 0)
+			return false;
+		off += (size_t)w;
+	}
+	return true;
+}
+
+// A single UDP query from dnsmasq: receive, forward over TLS, send the answer
+// back to the same source. On failure we drop it (see the file header).
+static void handle_udp(struct proxy_up *up)
+{
+	// 64 KiB each - too large for the worker's thread stack,
+	// declared thread-local instead
+	static _Thread_local uint8_t query[DNS_MSG_MAX];
+	static _Thread_local uint8_t answer[DNS_MSG_MAX];
+	struct sockaddr_in src;
+	socklen_t sl = sizeof(src);
+	const ssize_t n = recvfrom(up->listener.udp_fd, query, sizeof(query), 0,
+	                           (struct sockaddr *)&src, &sl);
+	if(n <= 0)
+		return;
+	if(!is_loopback_v4(&src))
+		return;
+
+	const ssize_t a = tls_exchange(up->conn, &up->uri, query, (size_t)n, answer, sizeof(answer));
+	if(a < 0)
+		return; // drop -> dnsmasq times out and fails over
+
+	sendto(up->listener.udp_fd, answer, (size_t)a, 0, (struct sockaddr *)&src, sl);
+}
+
+// A TCP connection from dnsmasq: length-prefixed queries in, length-prefixed
+// answers out, until the peer closes or something fails.
+static void handle_tcp(struct proxy_up *up)
+{
+	struct sockaddr_in peer;
+	socklen_t pl = sizeof(peer);
+	// accept4() with SOCK_CLOEXEC: the flag is not inherited from the listening
+	// socket, so without it the accepted fd would leak across FTL's execvp()
+	// self-restart and keep the client connection alive in the new process.
+	const int cfd = accept4(up->listener.tcp_fd, (struct sockaddr *)&peer, &pl, SOCK_CLOEXEC);
+	if(cfd < 0)
+		return;
+	if(!is_loopback_v4(&peer))
+	{
+		close(cfd);
+		return;
+	}
+
+	// Bound how long we wait on this connection so a stalled peer cannot pin
+	// the single worker thread. Both directions are bounded: without
+	// SO_SNDTIMEO a peer that stops reading would block write_full() forever.
+	const struct timeval tv = { .tv_sec = 5, .tv_usec = 0 };
+	setsockopt(cfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	setsockopt(cfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+	// See handle_udp(): keep these 64 KiB buffers off the thread stack.
+	static _Thread_local uint8_t query[DNS_MSG_MAX];
+	static _Thread_local uint8_t answer[DNS_MSG_MAX];
+	static _Thread_local uint8_t out[2 + DNS_MSG_MAX];
+	// Bound one connection's hold on the sole worker thread: any local process
+	// can reach the loopback listener, so without this a peer could stream
+	// valid queries forever and starve every other upstream. Cap both the total
+	// lifetime and the query count; dnsmasq simply reconnects.
+	const uint64_t conn_deadline = now_ms() + PROXY_CONN_TIMEOUT_MS;
+	int served = 0;
+	for(;;)
+	{
+		if(served >= PROXY_CONN_MAX_QUERIES || now_ms() >= conn_deadline)
+			break;
+
+		// Separate read and write budgets, each fresh: the upstream exchange
+		// between them has its own deadline, so sharing one budget could let a
+		// slow-but-valid exchange expire it before the answer is even written.
+		const uint64_t rdeadline = now_ms() + PROXY_REQUEST_TIMEOUT_MS;
+
+		uint8_t lenbuf[2];
+		if(!read_full(cfd, lenbuf, 2, rdeadline))
+			break;
+		const size_t qlen = ((size_t)lenbuf[0] << 8) | (size_t)lenbuf[1];
+		if(qlen == 0 || qlen > DNS_MSG_MAX)
+			break;
+
+		if(!read_full(cfd, query, qlen, rdeadline))
+			break;
+
+		const ssize_t a = tls_exchange(up->conn, &up->uri, query, qlen, answer, sizeof(answer));
+		if(a < 0)
+			break; // drop: closing the connection makes dnsmasq retry/fail over
+
+		out[0] = (uint8_t)(((size_t)a >> 8) & 0xff);
+		out[1] = (uint8_t)((size_t)a & 0xff);
+		memcpy(out + 2, answer, (size_t)a);
+		const uint64_t wdeadline = now_ms() + PROXY_REQUEST_TIMEOUT_MS;
+		if(!write_full(cfd, out, (size_t)a + 2, wdeadline))
+			break;
+		served++;
+	}
+	close(cfd);
+}
+
+void *dotdoh_thread(void *val)
+{
+	(void)val;
+	prctl(PR_SET_NAME, thread_names[DOTDOH], 0, 0, 0);
+
+	// The armed listeners never change after init, so build the poll set
+	// once.
+	struct pollfd fds[2 * DOTDOH_MAX_UPSTREAMS];
+	struct proxy_up *owner[2 * DOTDOH_MAX_UPSTREAMS];
+	bool is_tcp[2 * DOTDOH_MAX_UPSTREAMS];
+	nfds_t n = 0;
+	for(int i = 0; i < g_nups; i++)
+	{
+		if(!g_ups[i].active)
+			continue;
+		fds[n].fd = g_ups[i].listener.udp_fd; fds[n].events = POLLIN; owner[n] = &g_ups[i]; is_tcp[n] = false; n++;
+		fds[n].fd = g_ups[i].listener.tcp_fd; fds[n].events = POLLIN; owner[n] = &g_ups[i]; is_tcp[n] = true;  n++;
+	}
+
+	while(!killed)
+	{
+		const int r = poll(fds, n, 1000);
+		if(r <= 0)
+			continue; // timeout or interrupted; re-check killed
+		for(nfds_t k = 0; k < n; k++)
+		{
+			if(!(fds[k].revents & POLLIN))
+				continue;
+			if(is_tcp[k])
+				handle_tcp(owner[k]);
+			else
+				handle_udp(owner[k]);
+		}
+	}
+	return NULL;
+}
+
+void dotdoh_cleanup(void)
+{
+	for(int i = 0; i < g_nups; i++)
+	{
+		if(g_ups[i].conn != NULL)
+			tls_conn_free(g_ups[i].conn);
+		if(g_ups[i].active)
+			proxy_listener_close(&g_ups[i].listener);
+		memset(&g_ups[i], 0, sizeof(g_ups[i]));
+	}
+	g_nups = 0;
+	g_nactive = 0;
+	g_armed = false;
+	tls_client_global_free();
+}

--- a/src/dotdoh/proxy.c
+++ b/src/dotdoh/proxy.c
@@ -23,6 +23,7 @@
 #include "registry.h"
 #include "tls_client.h"
 #include "framing.h"
+#include "edns_pad.h"
 // global config
 #include "config/config.h"
 // upstream list iteration
@@ -261,7 +262,11 @@ static void handle_udp(struct proxy_up *up)
 	if(!is_loopback_v4(&src))
 		return;
 
-	const ssize_t a = tls_exchange(up->conn, &up->uri, query, (size_t)n, answer, sizeof(answer));
+	// Pad the query to a block boundary (RFC 8467) before it is encrypted, so the
+	// ciphertext size no longer leaks the query. Only this encrypted leg is
+	// padded; the plaintext dnsmasq spoke to us over loopback is left untouched.
+	const size_t qlen = edns_pad_query(query, (size_t)n, sizeof(query));
+	const ssize_t a = tls_exchange(up->conn, &up->uri, query, qlen, answer, sizeof(answer));
 	if(a < 0)
 		return; // drop -> dnsmasq times out and fails over
 
@@ -323,7 +328,9 @@ static void handle_tcp(struct proxy_up *up)
 		if(!read_full(cfd, query, qlen, rdeadline))
 			break;
 
-		const ssize_t a = tls_exchange(up->conn, &up->uri, query, qlen, answer, sizeof(answer));
+		// Pad before encrypting (see handle_udp()); the loopback leg stays plain.
+		const size_t plen = edns_pad_query(query, qlen, sizeof(query));
+		const ssize_t a = tls_exchange(up->conn, &up->uri, query, plen, answer, sizeof(answer));
 		if(a < 0)
 			break; // drop: closing the connection makes dnsmasq retry/fail over
 

--- a/src/dotdoh/proxy.h
+++ b/src/dotdoh/proxy.h
@@ -15,6 +15,7 @@
 #define DOTDOH_PROXY_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include "upstream_uri.h"
 
 // Arm the proxy from the global config: for every encrypted dns.upstreams entry
@@ -36,5 +37,13 @@ void *dotdoh_thread(void *val);
 
 // Release listeners, connections and the CA store.
 void dotdoh_cleanup(void);
+
+// Map a loopback proxy tuple (127.47.11.N#(5300+N)) back to the encrypted
+// upstream it represents, so it is recorded/displayed as the real upstream
+// rather than the internal address dnsmasq forwards to. Returns false if
+// (ip, port) is not a dotdoh proxy tuple; otherwise copies the URI
+// (NUL-terminated) into out and, if real_port is non-NULL, stores the upstream's
+// actual port (853/443 or an explicit one) there.
+bool dotdoh_uri_for_listener(const char *ip, int port, char *out, size_t outlen, int *real_port);
 
 #endif // DOTDOH_PROXY_H

--- a/src/dotdoh/proxy.h
+++ b/src/dotdoh/proxy.h
@@ -1,0 +1,40 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Encrypted-upstream forward proxy
+*
+*  Public interface of the forward proxy: arms the encrypted upstreams and runs
+*  the worker thread that re-encrypts dnsmasq's plaintext DNS over DoT/DoH.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_PROXY_H
+#define DOTDOH_PROXY_H
+
+#include <stdbool.h>
+#include "upstream_uri.h"
+
+// Arm the proxy from the global config: for every encrypted dns.upstreams entry
+ // bind its deterministic loopback listener (127.47.11.N#(5300+N)) and prepare a
+ // connection. Plaintext entries are ignored (dnsmasq talks to them directly).
+ //
+ // This MUST run late - from FTL_fork_and_bind_sockets(), after dnsmasq's own
+ // startup has finished closing stray fds - otherwise the listener fds would be
+ // closed and their numbers reused by dnsmasq. The dnsmasq server= list is
+ // emitted earlier using the same deterministic tuples, so the two agree without
+ // needing the sockets to be bound at emission time.
+void dotdoh_init(void);
+
+// Number of encrypted upstreams that are armed and being served.
+int dotdoh_count(void) __attribute__((pure));
+
+// FTL worker thread entry: services every armed listener until shutdown.
+void *dotdoh_thread(void *val);
+
+// Release listeners, connections and the CA store.
+void dotdoh_cleanup(void);
+
+#endif // DOTDOH_PROXY_H

--- a/src/dotdoh/registry.c
+++ b/src/dotdoh/registry.c
@@ -1,0 +1,106 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Encrypted-upstream proxy listener registry
+*
+*  Binds one UDP+TCP listener pair per encrypted upstream in 127.47.11.0/24 and
+*  enforces the bind-first invariant: a pair is only reported active once BOTH
+*  sockets are owned exclusively. No SO_REUSEADDR / SO_REUSEPORT is ever set, so
+*  a local squatter can neither co-bind our tuple nor be silently forwarded to
+*  (dnsmasq only ever learns a tuple we own).
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "registry.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+// Bind a single socket of the given type to ip:port. Deliberately does NOT set
+ // SO_REUSEADDR/SO_REUSEPORT. Returns fd or -1.
+static int bind_one(const char *ip, int port, int socktype)
+{
+	// SOCK_CLOEXEC so the listener fd is not inherited across FTL's execvp()
+	// self-restart, where it would keep the loopback tuple busy and make the
+	// new process fail to re-bind it.
+	const int fd = socket(AF_INET, socktype | SOCK_CLOEXEC, 0);
+	if(fd < 0)
+		return -1;
+
+	struct sockaddr_in sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons((uint16_t)port);
+	if(inet_pton(AF_INET, ip, &sa.sin_addr) != 1)
+	{
+		close(fd);
+		return -1;
+	}
+	if(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+	{
+		close(fd);
+		return -1;
+	}
+	if(socktype == SOCK_STREAM && listen(fd, SOMAXCONN) != 0)
+	{
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+bool proxy_listener_bind(int index, struct proxy_listener *l)
+{
+	if(l == NULL || index < 0 || index >= DOTDOH_MAX_UPSTREAMS)
+		return false;
+
+	memset(l, 0, sizeof(*l));
+	l->udp_fd = -1;
+	l->tcp_fd = -1;
+
+	char ip[INET_ADDRSTRLEN];
+	snprintf(ip, sizeof(ip), DOTDOH_NET_PREFIX "%d", index + 1);
+
+	const int port = DOTDOH_PORT_BASE + index + 1;
+
+	// The port is deterministic: dnsmasq has already been pointed at
+	// exactly this tuple, so we do NOT iterate. Either we own both
+	// transports or the upstream stays disabled. No SO_REUSEADDR, so a
+	// squatter cannot co-bind.
+	const int ufd = bind_one(ip, port, SOCK_DGRAM);
+	if(ufd < 0)
+		return false;
+	const int tfd = bind_one(ip, port, SOCK_STREAM);
+	if(tfd < 0)
+	{
+		close(ufd);
+		return false;
+	}
+
+	l->udp_fd = ufd;
+	l->tcp_fd = tfd;
+	snprintf(l->ip, sizeof(l->ip), "%s", ip);
+	l->port = port;
+	l->active = true;
+	return true;
+}
+
+void proxy_listener_close(struct proxy_listener *l)
+{
+	if(l == NULL)
+		return;
+	if(l->udp_fd >= 0)
+		close(l->udp_fd);
+	if(l->tcp_fd >= 0)
+		close(l->tcp_fd);
+	l->udp_fd = -1;
+	l->tcp_fd = -1;
+	l->active = false;
+}

--- a/src/dotdoh/registry.h
+++ b/src/dotdoh/registry.h
@@ -1,0 +1,47 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Encrypted-upstream proxy listener registry
+*
+*  Public interface for binding the loopback listeners in 127.47.11.0/24 that
+*  dnsmasq forwards plaintext DNS to, one pair per encrypted upstream.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_REGISTRY_H
+#define DOTDOH_REGISTRY_H
+
+#include <stdbool.h>
+#include <arpa/inet.h>
+
+// Deterministic tuple for upstream slot i (0-based):
+ // 127.47.11.(i+1)#(5300+i+1). Both the address and the port are deliberately !=
+ // 53 so a dnsmasq wildcard bind on :53 cannot collide. The tuple is fixed (not
+ // iterated) because the dnsmasq config is emitted with the very same formula
+ // before the sockets are bound.
+#define DOTDOH_NET_PREFIX  "127.47.11."
+#define DOTDOH_PORT_BASE   5300
+#define DOTDOH_MAX_UPSTREAMS 32
+
+struct proxy_listener {
+	int  udp_fd;
+	int  tcp_fd;
+	char ip[INET_ADDRSTRLEN]; // 127.47.11.N
+	int  port; // the port actually bound
+	bool active;
+};
+
+// Atomically bind the UDP+TCP listener pair for upstream slot `index` on its
+ // fixed deterministic tuple. On success fills *l and returns true (l->active ==
+ // true). If the tuple cannot be fully owned it returns false and l is inactive
+ // (the upstream is left disabled). Never sets SO_REUSEADDR/SO_REUSEPORT, so a
+ // squatter cannot co-bind.
+bool proxy_listener_bind(int index, struct proxy_listener *l);
+
+// Close both sockets and mark the listener inactive.
+void proxy_listener_close(struct proxy_listener *l);
+
+#endif // DOTDOH_REGISTRY_H

--- a/src/dotdoh/tls_client.c
+++ b/src/dotdoh/tls_client.c
@@ -1,0 +1,508 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Outbound TLS client for encrypted upstreams (DoT/DoH)
+*
+*  Talks TLS to the real upstream resolver. Verification is REQUIRED (chain +
+*  hostname): a failed check aborts the handshake, so the path is fail-closed by
+*  construction. The caller then gets -1 and drops the query, and FTL fails over
+*  to the next server - we never downgrade to plaintext.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "log.h"
+#include "tls_client.h"
+
+#ifdef HAVE_MBEDTLS
+
+#include "framing.h"
+#include <mbedtls/build_info.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/x509_crt.h>
+// For the bounded, non-blocking connect and the socket-level send timeout below.
+#include <sys/socket.h>
+#include <netdb.h>
+#include <poll.h>
+#include <fcntl.h>
+#include <time.h>
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+// Before Mbed TLS 4.0 the RNG was wired up by hand from a CTR_DRBG seeded off
+// an entropy source; 4.0+ draws randomness from PSA and needs neither header.
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#endif
+#ifdef MBEDTLS_PSA_CRYPTO_C
+#include <psa/crypto.h>
+#endif
+
+// Read timeout (ms) applied to the handshake and to reading the answer. Keeps a
+// dead or slow upstream from stalling the query indefinitely; on timeout the
+// exchange fails and dnsmasq fails over.
+#define TLS_READ_TIMEOUT_MS 5000
+
+// Timeout (ms) for the TCP connect to the upstream, plus an overall wall-clock
+// budget for the whole exchange (connect + handshake + write + read). The
+// per-op read timeout above only bounds an idle peer; it does not bound a
+// black-holed connect(), a blocking write to a peer whose receive window is
+// full, or a peer that trickles one byte before each idle timeout. These hard
+// deadlines do, so a single unreachable or misbehaving upstream cannot pin the
+// single worker thread and stall every other encrypted upstream with it.
+#define TLS_CONNECT_TIMEOUT_MS 5000
+#define TLS_EXCHANGE_TIMEOUT_MS 10000
+
+// Where to look for trust anchors when no explicit CA path is configured.
+// Distributions place the system bundle differently, so try the common
+// single-file locations in turn and finally the hashed directory. FTL ships as
+// a musl binary that can run on any of these, so this is deliberately not
+// Debian-only.
+static const char *const TLS_DEFAULT_CA_FILES[] = {
+	"/etc/ssl/certs/ca-certificates.crt", // Debian, Ubuntu, Alpine, Gentoo
+	"/etc/pki/tls/certs/ca-bundle.crt",   // RHEL, Fedora, CentOS
+	"/etc/ssl/ca-bundle.pem",             // openSUSE
+	"/etc/ssl/cert.pem",                  // Alpine, *BSD, macOS
+};
+#define TLS_DEFAULT_CA_DIR  "/etc/ssl/certs"
+
+// Shared, read-only-after-init crypto state. One trust store and (pre-4.0) one
+// DRBG are enough for all upstreams; each connection gets its own SSL context.
+static bool g_ready = false;
+static mbedtls_x509_crt g_cacert;
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+static mbedtls_entropy_context g_entropy;
+static mbedtls_ctr_drbg_context g_ctr;
+#endif
+
+// One pooled connection per upstream. The scratch buffers live here (not on the
+// stack and not shared) so that concurrent exchanges on different connections
+// never clobber each other.
+struct tls_conn {
+	bool connected;
+	mbedtls_net_context net;
+	mbedtls_ssl_context ssl;
+	mbedtls_ssl_config conf;
+	uint8_t req[DNS_MSG_MAX + 512];                 // framed request we send
+	uint8_t rbuf[DNS_MSG_MAX + DOH_HEADER_MAX];     // response accumulation buffer
+};
+
+bool tls_client_global_init(const char *ca_file)
+{
+	// Idempotent: the proxy may be (re)started, but the trust store only
+	// needs to be built once.
+	if(g_ready)
+		return true;
+
+#ifdef MBEDTLS_PSA_CRYPTO_C
+	// PSA must be up before any TLS work. On 4.0+ it is also the RNG
+	// source, which is why no explicit DRBG is wired below on that branch.
+	if(psa_crypto_init() != PSA_SUCCESS)
+	{
+		log_err("dotdoh: psa_crypto_init() failed");
+		return false;
+	}
+#endif
+
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+	// Pre-4.0: seed the DRBG handed to mbedtls_ssl_conf_rng() at connect
+	// time.
+	mbedtls_entropy_init(&g_entropy);
+	mbedtls_ctr_drbg_init(&g_ctr);
+	if(mbedtls_ctr_drbg_seed(&g_ctr, mbedtls_entropy_func, &g_entropy,
+	                         (const unsigned char *)"pihole-dotdoh", 15) != 0)
+	{
+		log_err("dotdoh: CTR_DRBG seeding failed");
+		mbedtls_ctr_drbg_free(&g_ctr);
+		mbedtls_entropy_free(&g_entropy);
+		return false;
+	}
+#endif
+
+	// Load the trust anchors. An explicit path (dns.upstreamCA, or the test CA
+	// during E2E) always wins. Otherwise try each well-known system bundle and
+	// finally the hashed directory. mbedtls_x509_crt_parse_file() returns the
+	// number of certs it could not parse (>= 0) or a negative error, so only a
+	// negative result means nothing at all was loaded.
+	mbedtls_x509_crt_init(&g_cacert);
+	int rc = -1;
+	if(ca_file != NULL && ca_file[0] != '\0')
+		rc = mbedtls_x509_crt_parse_file(&g_cacert, ca_file);
+	else
+	{
+		for(size_t i = 0; rc < 0 && i < sizeof(TLS_DEFAULT_CA_FILES) / sizeof(*TLS_DEFAULT_CA_FILES); i++)
+			rc = mbedtls_x509_crt_parse_file(&g_cacert, TLS_DEFAULT_CA_FILES[i]);
+		if(rc < 0)
+			rc = mbedtls_x509_crt_parse_path(&g_cacert, TLS_DEFAULT_CA_DIR);
+	}
+	if(rc < 0)
+	{
+		log_err("dotdoh: could not load a CA trust store "
+		        "(set dns.upstreamCA or install a system CA bundle)");
+		mbedtls_x509_crt_free(&g_cacert);
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+		mbedtls_ctr_drbg_free(&g_ctr);
+		mbedtls_entropy_free(&g_entropy);
+#endif
+		return false;
+	}
+
+	g_ready = true;
+	return true;
+}
+
+void tls_client_global_free(void)
+{
+	if(!g_ready)
+		return;
+	mbedtls_x509_crt_free(&g_cacert);
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+	mbedtls_ctr_drbg_free(&g_ctr);
+	mbedtls_entropy_free(&g_entropy);
+#endif
+	g_ready = false;
+}
+
+struct tls_conn *tls_conn_new(void)
+{
+	return calloc(1, sizeof(struct tls_conn));
+}
+
+// Tear down an established connection so the next exchange reconnects cleanly.
+static void conn_close(struct tls_conn *c)
+{
+	if(!c->connected)
+		return;
+	// Best-effort notify; we do not care whether the peer sees it.
+	mbedtls_ssl_close_notify(&c->ssl);
+	mbedtls_ssl_free(&c->ssl);
+	mbedtls_ssl_config_free(&c->conf);
+	mbedtls_net_free(&c->net);
+	c->connected = false;
+}
+
+void tls_conn_free(struct tls_conn *c)
+{
+	if(c == NULL)
+		return;
+	conn_close(c);
+	free(c);
+}
+
+// Monotonic clock in milliseconds, for the exchange deadline.
+static uint64_t now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+// Milliseconds left until deadline, clamped to [0, cap].
+static int ms_left(uint64_t deadline, int cap)
+{
+	const uint64_t n = now_ms();
+	if(n >= deadline)
+		return 0;
+	const uint64_t left = deadline - n;
+	return left < (uint64_t)cap ? (int)left : cap;
+}
+
+// Bounded, non-blocking TCP connect. mbedtls_net_connect() does a blocking
+// connect() with no timeout, so a black-holed upstream (dropped SYN) would pin
+// the single worker thread for the kernel's full SYN timeout (~2 min) and stall
+// every other encrypted upstream with it. Connect non-blocking and poll() for
+// the deadline instead, then hand the ready socket to mbedTLS.
+static int net_connect_timeout(mbedtls_net_context *net, const char *host,
+                               const char *port, int timeout_ms)
+{
+	struct addrinfo hints = { 0 };
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	struct addrinfo *res = NULL;
+	if(getaddrinfo(host, port, &hints, &res) != 0)
+		return MBEDTLS_ERR_NET_UNKNOWN_HOST;
+
+	// timeout_ms is the budget for the whole connect, not per address: share
+	// the remaining time across every A/AAAA record rather than restarting the
+	// full timeout for each, so a multi-homed host cannot blow the deadline.
+	const uint64_t deadline = now_ms() + (uint64_t)timeout_ms;
+
+	int ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
+	for(struct addrinfo *cur = res; cur != NULL; cur = cur->ai_next)
+	{
+		// SOCK_CLOEXEC so a connected upstream socket is not inherited across
+		// FTL's execvp() self-restart.
+		const int fd = socket(cur->ai_family, cur->ai_socktype | SOCK_CLOEXEC, cur->ai_protocol);
+		if(fd < 0)
+			continue;
+
+		// Non-blocking connect, then wait for writability within the deadline.
+		const int flags = fcntl(fd, F_GETFL, 0);
+		if(flags < 0)
+		{
+			close(fd);
+			continue;
+		}
+		fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+		struct pollfd pfd = { .fd = fd, .events = POLLOUT };
+		int soerr = 0;
+		socklen_t sl = sizeof(soerr);
+		if((connect(fd, cur->ai_addr, cur->ai_addrlen) == 0 || errno == EINPROGRESS) &&
+		   poll(&pfd, 1, ms_left(deadline, timeout_ms)) == 1 && (pfd.revents & POLLOUT) &&
+		   getsockopt(fd, SOL_SOCKET, SO_ERROR, &soerr, &sl) == 0 && soerr == 0)
+		{
+			fcntl(fd, F_SETFL, flags); // restore blocking mode for mbedTLS I/O
+			net->fd = fd;
+			ret = 0;
+			break;
+		}
+		close(fd);
+	}
+
+	freeaddrinfo(res);
+	return ret;
+}
+
+// Open a TCP connection and drive the TLS handshake to the upstream described
+// by u. Returns true only once the connection is verified and ready. deadline
+// bounds the connect and handshake so a stalled peer cannot pin the worker.
+static bool conn_connect(struct tls_conn *c, const struct upstream_uri *u, uint64_t deadline)
+{
+	mbedtls_net_init(&c->net);
+	mbedtls_ssl_init(&c->ssl);
+	mbedtls_ssl_config_init(&c->conf);
+
+	// net_connect_timeout() wants the port as a string.
+	char portstr[8];
+	snprintf(portstr, sizeof(portstr), "%d", u->port);
+
+	int rc;
+	if((rc = net_connect_timeout(&c->net, u->connect_host, portstr,
+	                             ms_left(deadline, TLS_CONNECT_TIMEOUT_MS))) != 0)
+	{
+		log_warn("dotdoh: connect to %s#%d failed (mbedtls -0x%04x)",
+		         u->connect_host, u->port, (unsigned)-rc);
+		goto fail;
+	}
+
+	// Bound blocking sends too: the write BIO (mbedtls_net_send) has no timeout
+	// of its own, so without this a peer that stops reading would block
+	// ssl_write_all() forever once its receive window fills.
+	const struct timeval sndto = { .tv_sec = TLS_READ_TIMEOUT_MS / 1000, .tv_usec = 0 };
+	setsockopt(c->net.fd, SOL_SOCKET, SO_SNDTIMEO, &sndto, sizeof(sndto));
+
+	if(mbedtls_ssl_config_defaults(&c->conf, MBEDTLS_SSL_IS_CLIENT,
+	                               MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT) != 0)
+		goto fail;
+
+	// This is the fail-closed heart of the client: REQUIRED means a bad
+	// chain or hostname mismatch aborts the handshake instead of merely
+	// being reported after the fact.
+	mbedtls_ssl_conf_authmode(&c->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+	mbedtls_ssl_conf_ca_chain(&c->conf, &g_cacert, NULL);
+	mbedtls_ssl_conf_read_timeout(&c->conf, TLS_READ_TIMEOUT_MS);
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
+	// 4.0+ pulls randomness from PSA automatically; only older versions need
+	// the DRBG wired in explicitly.
+	mbedtls_ssl_conf_rng(&c->conf, mbedtls_ctr_drbg_random, &g_ctr);
+#endif
+
+	if(mbedtls_ssl_setup(&c->ssl, &c->conf) != 0)
+		goto fail;
+
+	// verify_name is the hostname the certificate is checked against and
+	// the SNI sent to the server. For a pinned "sni-host@ip" upstream this
+	// is the hostname, not the IP, so verification still matches the real
+	// cert.
+	if(mbedtls_ssl_set_hostname(&c->ssl, u->verify_name) != 0)
+		goto fail;
+
+	// Use the timeout-aware receive callback so the read timeout above
+	// applies.
+	mbedtls_ssl_set_bio(&c->ssl, &c->net, mbedtls_net_send, NULL, mbedtls_net_recv_timeout);
+
+	// Blocking sockets should not normally yield WANT_READ/WANT_WRITE, but
+	// the read timeout can surface them; loop until the handshake resolves.
+	while((rc = mbedtls_ssl_handshake(&c->ssl)) != 0)
+	{
+		if(rc != MBEDTLS_ERR_SSL_WANT_READ && rc != MBEDTLS_ERR_SSL_WANT_WRITE)
+		{
+			log_warn("dotdoh: TLS handshake with %s (%s#%d) failed (mbedtls -0x%04x)",
+			         u->verify_name, u->connect_host, u->port, (unsigned)-rc);
+			goto fail;
+		}
+		if(now_ms() >= deadline)
+		{
+			log_warn("dotdoh: TLS handshake with %s (%s#%d) timed out",
+			         u->verify_name, u->connect_host, u->port);
+			goto fail;
+		}
+	}
+
+	c->connected = true;
+	return true;
+
+fail:
+	// We never reached the "connected" state, so free the half-initialised
+	// contexts directly rather than via conn_close().
+	mbedtls_ssl_free(&c->ssl);
+	mbedtls_ssl_config_free(&c->conf);
+	mbedtls_net_free(&c->net);
+	c->connected = false;
+	return false;
+}
+
+// Write the whole buffer, tolerating short writes and the transient
+// WANT_READ/WANT_WRITE conditions. Returns true once everything is sent.
+static bool ssl_write_all(struct tls_conn *c, const uint8_t *buf, size_t len, uint64_t deadline)
+{
+	size_t off = 0;
+	while(off < len)
+	{
+		int w = mbedtls_ssl_write(&c->ssl, buf + off, len - off);
+		if(w == MBEDTLS_ERR_SSL_WANT_READ || w == MBEDTLS_ERR_SSL_WANT_WRITE)
+		{
+			if(now_ms() >= deadline)
+				return false;
+			continue;
+		}
+		if(w <= 0)
+			return false;
+		off += (size_t)w;
+	}
+	return true;
+}
+
+// Send one query and read back the framed answer over the established
+// connection. Returns the answer length, or -1 on any protocol/transport error
+// (which makes the caller drop and, once, rebuild the connection).
+static ssize_t conn_do(struct tls_conn *c, const struct upstream_uri *u,
+                       const uint8_t *query, size_t qlen,
+                       uint8_t *answer, size_t answer_sz, uint64_t deadline)
+{
+	// Frame the request: DoT prepends a 2-byte length, DoH wraps it in a
+	// POST.
+	ssize_t reqlen;
+	if(u->type == UST_DOT)
+		reqlen = dot_frame(query, qlen, c->req, sizeof(c->req));
+	else
+		reqlen = doh_build_request(u->verify_name, u->doh_path, query, qlen, c->req, sizeof(c->req));
+	if(reqlen < 0)
+		return -1;
+
+	if(!ssl_write_all(c, c->req, (size_t)reqlen, deadline))
+		return -1;
+
+	// Accumulate the response until the framer says a full message is
+	// present. The buffer is bounded, so a misbehaving upstream cannot make
+	// us grow it.
+	uint8_t *buf = c->rbuf;
+	const size_t bufcap = sizeof(c->rbuf);
+	size_t have = 0;
+	for(;;)
+	{
+		// Bounds both a full buffer and a peer that trickles a byte at a time:
+		// such reads return r > 0 and would otherwise loop until the buffer
+		// fills (many hours) without ever hitting the WANT_READ deadline below.
+		if(have >= bufcap || now_ms() >= deadline)
+			return -1;
+		int r = mbedtls_ssl_read(&c->ssl, buf + have, bufcap - have);
+		// TLS 1.3 delivers post-handshake messages to the application
+		// as these non-fatal returns: a NewSessionTicket arrives right
+		// after the handshake (which the upstream sends before our
+		// answer). They are not errors - just read again for the actual
+		// response.
+		if(r == MBEDTLS_ERR_SSL_WANT_READ || r == MBEDTLS_ERR_SSL_WANT_WRITE
+#ifdef MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET
+		   // Only present on mbedTLS builds with TLS 1.3 post-handshake tickets;
+		   // guarded so older versions still compile (they never return it).
+		   || r == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET
+#endif
+		   )
+			continue; // deadline is enforced at the top of the loop
+		if(r <= 0)
+			return -1; // timeout, close_notify or hard error
+		have += (size_t)r;
+
+		size_t off = 0, blen = 0;
+		if(u->type == UST_DOT)
+		{
+			const ssize_t m = dot_deframe(buf, have, &off);
+			if(m < 0)
+				return -1;
+			if(m > 0)
+			{
+				if((size_t)m > answer_sz)
+					return -1;
+				memcpy(answer, buf + off, (size_t)m);
+				return m;
+			}
+		}
+		else
+		{
+			const ssize_t consumed = doh_parse_response(buf, have, &off, &blen);
+			if(consumed < 0)
+				return -1;
+			if(consumed > 0)
+			{
+				if(blen > answer_sz)
+					return -1;
+				memcpy(answer, buf + off, blen);
+				return (ssize_t)blen;
+			}
+		}
+		// Otherwise we need more bytes; loop and read again.
+	}
+}
+
+ssize_t tls_exchange(struct tls_conn *c, const struct upstream_uri *u,
+                     const uint8_t *query, size_t qlen,
+                     uint8_t *answer, size_t answer_sz)
+{
+	if(!g_ready || c == NULL || u == NULL)
+		return -1;
+
+	// Two attempts at most: a pooled keep-alive connection the upstream
+	// closed while idle is transparently rebuilt once. A second failure is
+	// real and we give up (fail-closed) rather than retry forever.
+	// One overall budget for the whole exchange (both attempts share it) so a
+	// stalled connect, handshake, read or write cannot pin the single worker
+	// thread and starve every other encrypted upstream.
+	const uint64_t deadline = now_ms() + TLS_EXCHANGE_TIMEOUT_MS;
+
+	for(int attempt = 0; attempt < 2; attempt++)
+	{
+		if(!c->connected && !conn_connect(c, u, deadline))
+			continue;
+
+		const ssize_t r = conn_do(c, u, query, qlen, answer, answer_sz, deadline);
+		if(r >= 0)
+			return r;
+
+		conn_close(c);
+	}
+	return -1;
+}
+
+#else // !HAVE_MBEDTLS
+
+// Without mbedTLS there is no TLS client; encrypted upstreams are unavailable
+// and every exchange fails closed. The config layer refuses to enable them.
+bool tls_client_global_init(const char *ca_file) { (void)ca_file; return false; }
+void tls_client_global_free(void) { }
+struct tls_conn *tls_conn_new(void) { return NULL; }
+void tls_conn_free(struct tls_conn *c) { (void)c; }
+ssize_t tls_exchange(struct tls_conn *c, const struct upstream_uri *u,
+                     const uint8_t *query, size_t qlen,
+                     uint8_t *answer, size_t answer_sz)
+{
+	(void)c; (void)u; (void)query; (void)qlen; (void)answer; (void)answer_sz;
+	return -1;
+}
+
+#endif // HAVE_MBEDTLS

--- a/src/dotdoh/tls_client.h
+++ b/src/dotdoh/tls_client.h
@@ -1,0 +1,43 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Outbound TLS client for encrypted upstreams (DoT/DoH)
+*
+*  Public interface of the strict, fail-closed mbedTLS client that talks to the
+*  real upstream resolver and never falls back to plaintext.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_TLS_CLIENT_H
+#define DOTDOH_TLS_CLIENT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#include "upstream_uri.h"
+
+struct tls_conn; // opaque per-upstream connection state
+
+// Load the CA bundle and seed the RNG. ca_file NULL selects the system default
+ // bundle. Returns true on success.
+bool tls_client_global_init(const char *ca_file);
+void tls_client_global_free(void);
+
+// Allocate / free a reusable per-upstream connection handle.
+struct tls_conn *tls_conn_new(void) __attribute__((malloc));
+void tls_conn_free(struct tls_conn *c);
+
+// Perform one DNS exchange over TLS for upstream u, (re)establishing the pooled
+ // connection as needed. query/qlen is the DNS wire message; the answer is
+ // written into answer[answer_sz]. Returns the answer length, or -1 on any
+ // failure (the caller returns SERVFAIL so dnsmasq fails over). Fail-closed.
+ssize_t tls_exchange(struct tls_conn *c, const struct upstream_uri *u,
+                     const uint8_t *query, size_t qlen,
+                     uint8_t *answer, size_t answer_sz);
+
+#endif // DOTDOH_TLS_CLIENT_H

--- a/src/dotdoh/upstream_uri.c
+++ b/src/dotdoh/upstream_uri.c
@@ -1,0 +1,224 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Encrypted upstream URI parser
+*
+*  Parses one dns.upstreams entry; plaintext entries are only classified
+*  (dnsmasq validates them), encrypted entries are strictly validated.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "upstream_uri.h"
+
+#include <string.h>
+#include <stddef.h>
+
+// Bounded copy of src[len] into dst[cap] including the terminating NUL. Returns
+ // false (no write past cap) if it would not fit.
+static bool bcopy_str(char *dst, size_t cap, const char *src, size_t len)
+{
+	if(len >= cap)
+		return false;
+	memcpy(dst, src, len);
+	dst[len] = '\0';
+	return true;
+}
+
+// Only characters valid in hostnames and IP literals (IPv6 brackets are
+ // stripped before this is called); rejecting the rest also blocks header/URI
+ // injection via the SNI/Host value.
+// allow_colon permits ':' for a bracketed IPv6 literal only; a plain hostname
+// or a bare (unbracketed) host must not contain one - ':' is never a port
+// separator here (we use '#'), so an unbracketed ':' is a malformed entry.
+static bool __attribute__((pure)) valid_host(const char *h, bool allow_colon)
+{
+	if(h[0] == '\0')
+		return false;
+	for(const char *p = h; *p != '\0'; p++)
+	{
+		const unsigned char c = (unsigned char)*p;
+		if(!(( c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		     ( c >= '0' && c <= '9') || c == '.' || c == '-' ||
+		     (allow_colon && c == ':')))
+			return false;
+	}
+	return true;
+}
+
+// Parse a decimal port in [1, 65535]; returns -1 on any error.
+static int __attribute__((pure)) parse_port(const char *s)
+{
+	if(s[0] == '\0')
+		return -1;
+	long v = 0;
+	for(const char *p = s; *p != '\0'; p++)
+	{
+		if(*p < '0' || *p > '9')
+			return -1;
+		v = v * 10 + (*p - '0');
+		if(v > 65535)
+			return -1;
+	}
+	return (v < 1) ? -1 : (int)v;
+}
+
+// Parse one dns.upstreams entry
+//
+// Returns true on success. For UST_PLAIN only .type and .connect_host are
+// meaningful (plaintext entries are handled by dnsmasq, not the proxy).
+//
+// Encrypted forms (strictly validated):
+// tls://<host>[#<port>]                 DoT, default port 853
+// tls://<verify>@<ip>[#<port>]          DoT, pinned IP + SNI/verify name
+// tls://[<ipv6>][#<port>]               DoT to a bracketed IPv6 literal
+// https://<host>[#<port>][/<path>]      DoH, default port 443, path /dns-query
+// https://<verify>@<ip>[#<port>][/<path>]
+//
+// Rejects control characters (incl. CR/LF), empty host, invalid/oversized
+// fields, and unknown schemes.
+bool parse_upstream_uri(const char *in, struct upstream_uri *out)
+{
+	if(in == NULL || out == NULL)
+		return false;
+
+	const size_t inlen = strlen(in);
+	if(inlen == 0 || inlen >= 512)
+		return false;
+
+	// Reject any control character (incl. CR/LF/TAB and DEL) up front.
+	for(size_t i = 0; i < inlen; i++)
+	{
+		const unsigned char c = (unsigned char)in[i];
+		if(c < 0x20 || c == 0x7f)
+			return false;
+	}
+
+	memset(out, 0, sizeof(*out));
+
+	// Scheme detection. No "://" means a plaintext entry: only classify it,
+	// dnsmasq validates the actual syntax.
+	const char *sep = strstr(in, "://");
+	if(sep == NULL)
+	{
+		out->type = UST_PLAIN;
+		return bcopy_str(out->connect_host, sizeof(out->connect_host), in, inlen);
+	}
+
+	const size_t schemelen = (size_t)(sep - in);
+	if(schemelen == 3 && strncmp(in, "tls", 3) == 0)
+		out->type = UST_DOT;
+	else if(schemelen == 5 && strncmp(in, "https", 5) == 0)
+		out->type = UST_DOH;
+	else
+		return false; // unknown scheme
+
+	const char *rest = sep + 3;
+	// 853 is the DoT default port (RFC 7858 Sec. 3.1); 443 is HTTPS for
+	// DoH.
+	const int default_port = (out->type == UST_DOT) ? 853 : 443;
+
+	// For DoH, split off the path at the first '/'.
+	const char *authority_end = rest + strlen(rest);
+	if(out->type == UST_DOH)
+	{
+		const char *slash = strchr(rest, '/');
+		if(slash != NULL)
+		{
+			authority_end = slash;
+			if(!bcopy_str(out->doh_path, sizeof(out->doh_path), slash, strlen(slash)))
+				return false;
+			// The path goes verbatim into the HTTP request-target, so it must
+			// not contain whitespace or control characters. doh_build_request()
+			// rejects those at runtime; reject them here so a bad path fails
+			// config validation instead of silently disabling the upstream.
+			for(const char *p = out->doh_path; *p != '\0'; p++)
+				if((unsigned char)*p <= 0x20 || *p == 0x7f)
+					return false;
+		}
+		else
+			// RFC 8484 (Sec. 4.1.1) defines the path via a URI
+			// Template rather than mandating one; "/dns-query" is
+			// the widely used convention we default to.
+			strcpy(out->doh_path, "/dns-query");
+	}
+
+	// authority = [<verify>@]<host>[#<port>], possibly [ipv6].
+	const size_t authlen = (size_t)(authority_end - rest);
+	char auth[UURI_HOST_MAX * 2];
+	if(authlen >= sizeof(auth))
+		return false;
+	memcpy(auth, rest, authlen);
+	auth[authlen] = '\0';
+
+	char *host = auth;
+	const char *verify = NULL;
+	char *at = strchr(auth, '@');
+	if(at != NULL)
+	{
+		*at = '\0';
+		verify = auth; // left of '@' is the SNI/verify name
+		host = at + 1; // right of '@' is the connect host
+		if(verify[0] == '\0')
+			return false;
+	}
+
+	char hostbuf[UURI_HOST_MAX];
+	const char *portstr = NULL;
+	const bool bracketed = (host[0] == '[');
+	if(bracketed)
+	{
+		char *close = strchr(host, ']');
+		if(close == NULL)
+			return false;
+		if(!bcopy_str(hostbuf, sizeof(hostbuf), host + 1, (size_t)(close - (host + 1))))
+			return false;
+		char *after = close + 1;
+		if(*after == '#')
+			portstr = after + 1;
+		else if(*after != '\0')
+			return false;
+	}
+	else
+	{
+		char *hash = strchr(host, '#');
+		if(hash != NULL)
+		{
+			*hash = '\0';
+			portstr = hash + 1;
+		}
+		if(!bcopy_str(hostbuf, sizeof(hostbuf), host, strlen(host)))
+			return false;
+	}
+
+	// ':' is only legitimate inside the bracketed IPv6 form.
+	if(!valid_host(hostbuf, bracketed))
+		return false;
+
+	int port = default_port;
+	if(portstr != NULL)
+	{
+		port = parse_port(portstr);
+		if(port < 0)
+			return false;
+	}
+
+	// SNI/verify name: the explicit one from '@', else the host (already
+	// validated above), so only the explicit name needs re-checking.
+	const char *vn = hostbuf;
+	if(verify != NULL)
+	{
+		if(!valid_host(verify, false))
+			return false;
+		vn = verify;
+	}
+
+	if(!bcopy_str(out->connect_host, sizeof(out->connect_host), hostbuf, strlen(hostbuf)))
+		return false;
+	if(!bcopy_str(out->verify_name, sizeof(out->verify_name), vn, strlen(vn)))
+		return false;
+	out->port = port;
+	return true;
+}

--- a/src/dotdoh/upstream_uri.h
+++ b/src/dotdoh/upstream_uri.h
@@ -1,0 +1,35 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Encrypted upstream URI parser
+*
+*  Public interface of the dns.upstreams entry parser. Self-contained (standard
+*  headers only, no FTL.h) so the standalone regression harness can use it.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_UPSTREAM_URI_H
+#define DOTDOH_UPSTREAM_URI_H
+
+#include <stdbool.h>
+
+enum ustype { UST_PLAIN = 0, UST_DOT, UST_DOH };
+
+#define UURI_HOST_MAX 256
+#define UURI_PATH_MAX 256
+
+struct upstream_uri {
+	enum ustype type;
+	char connect_host[UURI_HOST_MAX]; // TCP connect target: IP literal or hostname
+	char verify_name[UURI_HOST_MAX]; // SNI + certificate verification name
+	int  port; // 53 (plain) / 853 (DoT) / 443 (DoH) default
+	char doh_path[UURI_PATH_MAX]; // DoH only, default "/dns-query"
+};
+
+// Parse one dns.upstreams entry.
+bool parse_upstream_uri(const char *in, struct upstream_uri *out);
+
+#endif /* DOTDOH_UPSTREAM_URI_H */

--- a/src/enums.h
+++ b/src/enums.h
@@ -252,6 +252,7 @@ enum thread_types {
 	NTP_SERVER4,
 	NTP_SERVER6,
 	WEBSERVER,
+	DOTDOH,
 	THREADS_MAX
 } __attribute__ ((packed));
 

--- a/src/signals.c
+++ b/src/signals.c
@@ -857,6 +857,7 @@ const char * const thread_names[THREADS_MAX] = {
 	"ntp-server4",
 	"ntp-server6",
 	"webserver",
+	"dotdoh",
 };
 
 // Private prototypes

--- a/test/dotdoh.bats
+++ b/test/dotdoh.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# Encrypted-upstream (DoT/DoH) end-to-end tests.
+#
+# Prerequisites, provided by test/run.sh:
+#   - pdns_recursor serving the .ftl test zone on 127.0.0.1:5555
+#   - test/dotdoh_shim.py running (DoT on :8853, DoH on :8443), terminating
+#     TLS with test/test.pem (CN/SAN "pi.hole", signed by test/test_ca.crt)
+#
+# dns.upstreams and dns.upstreamCA are RESTART_FTL settings. We switch both to
+# the encrypted test upstream in ONE atomic API request, so FTL restarts exactly
+# once and comes up with a consistent state (dotdoh armed AND the generated
+# dnsmasq.conf pointing at the proxy). Doing it as two separate CLI changes would
+# race the two restarts against each other.
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+bats_load_library 'bats-file'
+load 'bats_helper.bash'
+
+FTL_URL="http://127.0.0.1"
+
+# PATCH the given dns config object ($1) in one atomic request and block until
+# the self-restart it triggers has produced the readiness marker ($2) past the
+# pre-change log offset, using pihole-FTL wait-for as the rest of the suite does.
+api_patch_dns() {  # $1 = JSON object for "dns", $2 = readiness log marker
+  local before
+  before=$(stat -c%s /var/log/pihole/FTL.log)
+  # --max-time: the config change restarts FTL mid-request, so the connection is
+  # dropped and curl must not hang waiting on the reply. wait-for below is what
+  # actually blocks until the restart has completed.
+  curl -s -o /dev/null --max-time 10 -X PATCH "${FTL_URL}/api/config" \
+       -H "Content-Type: application/json" \
+       -d "{\"config\":{\"dns\":$1}}" || true
+  ./pihole-FTL wait-for "$2" /var/log/pihole/FTL.log 30 "$before"
+}
+
+ensure_shim() {
+  if ! pgrep -f dotdoh_shim.py >/dev/null 2>&1; then
+    python3 test/dotdoh_shim.py &
+  fi
+  # pgrep only proves the process exists, not that it is accepting yet. Wait
+  # until both TLS ports actually accept a connection so setup_file cannot race
+  # a still-starting shim, which otherwise made the E2E test flaky. Fail loudly
+  # if a port never comes up instead of letting it surface as a later, harder
+  # to diagnose DNS failure.
+  local port i ready
+  for port in 8853 8443; do
+    ready=""
+    for i in $(seq 1 50); do
+      if (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+        exec 3>&-
+        ready=1
+        break
+      fi
+      sleep 0.2
+    done
+    if [ -z "$ready" ]; then
+      echo "dotdoh shim TLS port ${port} never became ready" >&2
+      return 1
+    fi
+  done
+}
+
+setup_file() {
+  ensure_shim || return 1
+  # The DoH upstream is armed last, so waiting for it means both listeners are up.
+  api_patch_dns "{\"upstreamCA\":\"$(pwd)/test/test_ca.crt\",\"upstreams\":[\"tls://pi.hole@127.0.0.1#8853\",\"https://pi.hole@127.0.0.1#8443/dns-query\"]}" \
+                "dotdoh: DoH upstream pi.hole armed"
+}
+
+teardown_file() {
+  # Restore the plaintext upstream. It arms no proxy, so wait instead for the
+  # regex recompile that every (re)start logs to know FTL is back up.
+  api_patch_dns "{\"upstreamCA\":\"\",\"upstreams\":[\"127.0.0.1#5555\"]}" \
+                "deny regex for"
+}
+
+@test "dotdoh-client: a malformed tls:// upstream is rejected by the validator" {
+  run bash -c './pihole-FTL --config dns.upstreams "[\"tls://\"]"'
+  assert_failure
+}
+
+@test "dotdoh-client: both the DoT and DoH upstreams were armed" {
+  run bash -c 'grep -E "dotdoh: (DoT|DoH) upstream .* armed" /var/log/pihole/FTL.log'
+  assert_output --partial "DoT upstream"
+  assert_output --partial "DoH upstream"
+}
+
+# Query the proxy listeners directly. This is the meaningful end-to-end unit: the
+# proxy re-encrypts the plaintext DNS it receives to the shim over TLS and hands
+# back the answer. Going via dnsmasq instead would only add a trivial plaintext
+# UDP hop and, worse, .ftl is pinned to the plaintext recursor by a server=/ftl/
+# rule in 01-pihole-tests.conf, so it would never traverse the proxy at all.
+@test "dotdoh-client: a query resolves through the DoT proxy path" {
+  run bash -c "dig +short +tries=1 +time=5 @127.47.11.1 -p 5301 a.ftl"
+  assert_output --partial "192.168.1.1"
+}
+
+@test "dotdoh-client: a query resolves through the DoH proxy path" {
+  run bash -c "dig +short +tries=1 +time=5 @127.47.11.2 -p 5302 a.ftl"
+  assert_output --partial "192.168.1.1"
+}

--- a/test/dotdoh.bats
+++ b/test/dotdoh.bats
@@ -19,6 +19,11 @@ load 'bats_helper.bash'
 
 FTL_URL="http://127.0.0.1"
 
+# The shim (started by run.sh, or ensure_shim below) appends every decrypted
+# query length here; used to confirm FTL padded the encrypted query. Default so
+# a standalone bats run works too; run.sh exports the same path.
+export SHIM_PAD_LOG="${SHIM_PAD_LOG:-/tmp/dotdoh_pad.log}"
+
 # PATCH the given dns config object ($1) in one atomic request and block until
 # the self-restart it triggers has produced the readiness marker ($2) past the
 # pre-change log offset, using pihole-FTL wait-for as the rest of the suite does.
@@ -61,6 +66,21 @@ ensure_shim() {
   done
 }
 
+# Succeed if the shim recorded at least one query of the given transport whose
+# length is a positive multiple of 128 - i.e. FTL padded it (RFC 8467). An
+# unpadded query for the test name is well under 128 octets.
+assert_padded() {  # $1 = transport (dot|doh)
+  local t len
+  while read -r t len; do
+    if [ "$t" = "$1" ] && [ "$len" -ge 128 ] && [ $((len % 128)) -eq 0 ]; then
+      return 0
+    fi
+  done < "$SHIM_PAD_LOG"
+  echo "no padded $1 query (multiple of 128) in $SHIM_PAD_LOG:" >&2
+  cat "$SHIM_PAD_LOG" >&2 2>/dev/null || true
+  return 1
+}
+
 setup_file() {
   ensure_shim || return 1
   # The DoH upstream is armed last, so waiting for it means both listeners are up.
@@ -99,4 +119,18 @@ teardown_file() {
 @test "dotdoh-client: a query resolves through the DoH proxy path" {
   run bash -c "dig +short +tries=1 +time=5 @127.47.11.2 -p 5302 a.ftl"
   assert_output --partial "192.168.1.1"
+}
+
+@test "dotdoh-client: the DoT-forwarded query is padded (RFC 8467)" {
+  run bash -c "dig +short +tries=1 +time=5 @127.47.11.1 -p 5301 a.ftl"
+  assert_output --partial "192.168.1.1"
+  run assert_padded dot
+  assert_success
+}
+
+@test "dotdoh-client: the DoH-forwarded query is padded (RFC 8467)" {
+  run bash -c "dig +short +tries=1 +time=5 @127.47.11.2 -p 5302 a.ftl"
+  assert_output --partial "192.168.1.1"
+  run assert_padded doh
+  assert_success
 }

--- a/test/dotdoh_regression.c
+++ b/test/dotdoh_regression.c
@@ -1,0 +1,274 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Standalone regression harness for the dotdoh leaf units
+*
+*  #includes the self-contained implementation .c files directly (URI parser,
+*  DoT/DoH framing). Built only on request via -DBUILD_DOTDOH_REGRESSION=ON.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include "dotdoh/upstream_uri.c"
+#include "dotdoh/framing.c"
+#include "dotdoh/registry.c"
+
+static int failures = 0;
+
+// Does haystack[hn] contain the C-string needle?
+static bool contains(const uint8_t *hay, size_t hn, const char *needle)
+{
+	size_t nn = strlen(needle);
+	if(nn == 0 || nn > hn) return false;
+	for(size_t i = 0; i + nn <= hn; i++)
+		if(memcmp(hay + i, needle, nn) == 0) return true;
+	return false;
+}
+
+#define EXPECT(cond, ...) do { \
+	if(!(cond)) { \
+		failures++; \
+		fprintf(stderr, "  FAIL: "); \
+		fprintf(stderr, __VA_ARGS__); \
+		fprintf(stderr, " (%s:%d)\n", __FILE__, __LINE__); \
+	} \
+} while(0)
+
+// Assert a URI parses to the expected fields.
+static void ok(const char *in, enum ustype type, const char *connect,
+               const char *verify, int port, const char *path)
+{
+	struct upstream_uri u;
+	memset(&u, 0xAA, sizeof(u));
+	bool r = parse_upstream_uri(in, &u);
+	EXPECT(r, "\"%s\" expected to parse", in);
+	if(!r) return;
+	EXPECT(u.type == type, "\"%s\" type %d != %d", in, u.type, type);
+	EXPECT(strcmp(u.connect_host, connect) == 0,
+	       "\"%s\" connect_host \"%s\" != \"%s\"", in, u.connect_host, connect);
+	if(type != UST_PLAIN)
+	{
+		EXPECT(strcmp(u.verify_name, verify) == 0,
+		       "\"%s\" verify_name \"%s\" != \"%s\"", in, u.verify_name, verify);
+		EXPECT(u.port == port, "\"%s\" port %d != %d", in, u.port, port);
+	}
+	if(type == UST_DOH)
+		EXPECT(strcmp(u.doh_path, path) == 0,
+		       "\"%s\" doh_path \"%s\" != \"%s\"", in, u.doh_path, path);
+}
+
+// Assert a URI is rejected.
+static void bad(const char *in)
+{
+	struct upstream_uri u;
+	bool r = parse_upstream_uri(in, &u);
+	EXPECT(!r, "\"%s\" expected to be rejected", in);
+}
+
+static void test_plain(void)
+{
+	ok("9.9.9.9",       UST_PLAIN, "9.9.9.9",  "", 0, "");
+	ok("9.9.9.9#5335",  UST_PLAIN, "9.9.9.9#5335", "", 0, "");
+	ok("docker-resolver", UST_PLAIN, "docker-resolver", "", 0, "");
+}
+
+static void test_dot(void)
+{
+	ok("tls://one.one.one.one",        UST_DOT, "one.one.one.one", "one.one.one.one", 853, "");
+	ok("tls://dns.quad9.net#853",      UST_DOT, "dns.quad9.net",   "dns.quad9.net",   853, "");
+	ok("tls://dns.quad9.net#8853",     UST_DOT, "dns.quad9.net",   "dns.quad9.net",   8853, "");
+	ok("tls://one.one.one.one@1.1.1.1", UST_DOT, "1.1.1.1",        "one.one.one.one", 853, "");
+	ok("tls://1.1.1.1",                UST_DOT, "1.1.1.1",         "1.1.1.1",         853, "");
+	ok("tls://[2606:4700:4700::1111]#853", UST_DOT, "2606:4700:4700::1111", "2606:4700:4700::1111", 853, "");
+	// sni@[ipv6] pinning, as emitted for the suggested DoT servers
+	ok("tls://dns.google@[2001:4860:4860::8888]", UST_DOT, "2001:4860:4860::8888", "dns.google", 853, "");
+}
+
+static void test_doh(void)
+{
+	ok("https://cloudflare-dns.com/dns-query", UST_DOH, "cloudflare-dns.com", "cloudflare-dns.com", 443, "/dns-query");
+	ok("https://cloudflare-dns.com",           UST_DOH, "cloudflare-dns.com", "cloudflare-dns.com", 443, "/dns-query");
+	ok("https://one.one.one.one@1.1.1.1/dns-query", UST_DOH, "1.1.1.1", "one.one.one.one", 443, "/dns-query");
+	// sni@[ipv6] pinning, as emitted for the suggested DoH servers
+	ok("https://dns.google@[2001:4860:4860::8888]/dns-query", UST_DOH, "2001:4860:4860::8888", "dns.google", 443, "/dns-query");
+	ok("https://doh.example#8443/q",           UST_DOH, "doh.example", "doh.example", 8443, "/q");
+}
+
+static void test_reject(void)
+{
+	bad("tls://"); // empty host
+	bad("https://"); // empty host
+	bad("tls://host\r\nx"); // CRLF injection
+	bad("tls://ho st"); // space
+	bad("tls://host#0"); // port 0
+	bad("tls://host#99999"); // port out of range
+	bad("tls://host#abc"); // non-numeric port
+	bad("http://x"); // unknown scheme (not https)
+	bad("ftp://x"); // unknown scheme
+	bad("tls://@1.1.1.1"); // empty verify name
+	bad("tls://name@"); // empty connect host
+	bad(NULL); // NULL input
+	bad(""); // empty input
+}
+
+static void test_dot_framing(void)
+{
+	uint8_t out[16];
+	ssize_t n = dot_frame((const uint8_t *)"abc", 3, out, sizeof(out));
+	EXPECT(n == 5, "dot_frame len");
+	EXPECT(out[0] == 0 && out[1] == 3, "dot_frame prefix");
+	EXPECT(memcmp(out + 2, "abc", 3) == 0, "dot_frame body");
+	EXPECT(dot_frame((const uint8_t *)"abc", 3, out, 4) == -1, "dot_frame out too small");
+	EXPECT(dot_frame((const uint8_t *)"x", 65536, out, sizeof(out)) == -1, "dot_frame oversized");
+	EXPECT(dot_frame((const uint8_t *)"", 0, out, sizeof(out)) == -1, "dot_frame empty");
+
+	uint8_t b[8] = { 0, 3, 'a', 'b', 'c' };
+	size_t off = 0;
+	EXPECT(dot_deframe(b, 5, &off) == 3 && off == 2, "dot_deframe full");
+	EXPECT(dot_deframe(b, 4, &off) == 0, "dot_deframe partial body");
+	EXPECT(dot_deframe(b, 1, &off) == 0, "dot_deframe partial prefix");
+	uint8_t z[4] = { 0, 0, 9, 9 };
+	EXPECT(dot_deframe(z, 4, &off) == -1, "dot_deframe zero length");
+}
+
+static void test_doh_request(void)
+{
+	uint8_t req[512];
+	ssize_t n = doh_build_request("cloudflare-dns.com", "/dns-query",
+	                              (const uint8_t *)"xy", 2, req, sizeof(req));
+	EXPECT(n > 0, "doh_build_request ok");
+	if(n > 0)
+	{
+		EXPECT(contains(req, (size_t)n, "POST /dns-query HTTP/1.1\r\n"), "doh request line");
+		EXPECT(contains(req, (size_t)n, "Host: cloudflare-dns.com\r\n"), "doh host header");
+		EXPECT(contains(req, (size_t)n, "Content-Type: application/dns-message\r\n"), "doh content-type");
+		EXPECT(contains(req, (size_t)n, "Content-Length: 2\r\n"), "doh content-length");
+		EXPECT((size_t)n >= 6 && memcmp(req + n - 6, "\r\n\r\nxy", 6) == 0, "doh body appended");
+	}
+	EXPECT(doh_build_request("h", "/p", (const uint8_t *)"xy", 2, req, 10) == -1, "doh out too small");
+	EXPECT(doh_build_request("h\r\nX", "/p", (const uint8_t *)"xy", 2, req, sizeof(req)) == -1, "doh CRLF host rejected");
+	EXPECT(doh_build_request("h", "/p\r\nx", (const uint8_t *)"xy", 2, req, sizeof(req)) == -1, "doh CRLF path rejected");
+	EXPECT(doh_build_request("h", "/dns query", (const uint8_t *)"xy", 2, req, sizeof(req)) == -1, "doh space in path rejected");
+}
+
+static void test_doh_response(void)
+{
+	size_t bo = 0, bl = 0;
+	const char *r1 = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nAB";
+	ssize_t c = doh_parse_response((const uint8_t *)r1, strlen(r1), &bo, &bl);
+	EXPECT(c == (ssize_t)strlen(r1), "doh resp consumed");
+	EXPECT(bl == 2 && memcmp(r1 + bo, "AB", 2) == 0, "doh resp body");
+
+	EXPECT(doh_parse_response((const uint8_t *)"HTTP/1.1 200 OK\r\n", 17, &bo, &bl) == 0, "doh resp partial headers");
+	const char *r2 = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r2, strlen(r2), &bo, &bl) == 0, "doh resp partial body");
+	const char *r3 = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+	EXPECT(doh_parse_response((const uint8_t *)r3, strlen(r3), &bo, &bl) == -1, "doh resp non-200");
+	const char *r4 = "HTTP/1.1 200 OK\r\nFoo: bar\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r4, strlen(r4), &bo, &bl) == -1, "doh resp missing content-length");
+	const char *r5 = "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r5, strlen(r5), &bo, &bl) == (ssize_t)strlen(r5), "doh resp case-insensitive");
+	const char *r6 = "HTTP/1.1 200 OK\r\nContent-Length: 70000\r\n\r\n";
+	EXPECT(doh_parse_response((const uint8_t *)r6, strlen(r6), &bo, &bl) == -1, "doh resp oversized");
+	const char *r7 = "HTTP/1.1 200 OK\r\nX-Content-Length: 9\r\nContent-Length: 2\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r7, strlen(r7), &bo, &bl) == (ssize_t)strlen(r7) && bl == 2, "doh resp ignores X-Content-Length prefix");
+	const char *r8 = "HTTP/1.1 200 OK\r\nX-Content-Length: 2\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r8, strlen(r8), &bo, &bl) == -1, "doh resp X-Content-Length is not Content-Length");
+	// Stricter status-line and Content-Length parsing (locked in against regressions).
+	const char *r9 = "HTTP/1.1 2000 OK\r\nContent-Length: 2\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r9, strlen(r9), &bo, &bl) == -1, "doh resp rejects 4-digit status code");
+	const char *r10 = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+	EXPECT(doh_parse_response((const uint8_t *)r10, strlen(r10), &bo, &bl) == -1, "doh resp rejects zero Content-Length");
+	const char *r11 = "HTTP/1.1 200 OK\r\nContent-Length: 2x\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r11, strlen(r11), &bo, &bl) == -1, "doh resp rejects trailing junk in Content-Length");
+	const char *r12 = "220 smtp ready\r\nContent-Length: 2\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r12, strlen(r12), &bo, &bl) == -1, "doh resp rejects non-HTTP status line");
+	const char *r13 = "HTTP/1.1 200 OK\r\nContent-Length: 2 \r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r13, strlen(r13), &bo, &bl) == (ssize_t)strlen(r13), "doh resp tolerates trailing OWS in Content-Length");
+	// Message-smuggling shapes must be rejected so leftover bytes cannot desync
+	// the pooled connection for later queries.
+	const char *r14 = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Length: 300\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r14, strlen(r14), &bo, &bl) == -1, "doh resp rejects duplicate Content-Length");
+	const char *r15 = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 2\r\n\r\nAB";
+	EXPECT(doh_parse_response((const uint8_t *)r15, strlen(r15), &bo, &bl) == -1, "doh resp rejects Transfer-Encoding");
+}
+
+// Occupy ip:port with a socket of the given type; returns fd or -1.
+static int occupy(const char *ip, int port, int socktype)
+{
+	int fd = socket(AF_INET, socktype, 0);
+	if(fd < 0) return -1;
+	struct sockaddr_in sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons((uint16_t)port);
+	inet_pton(AF_INET, ip, &sa.sin_addr);
+	if(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+	{
+		close(fd);
+		return -1;
+	}
+	if(socktype == SOCK_STREAM)
+		listen(fd, 1);
+	return fd;
+}
+
+static void test_registry(void)
+{
+	struct proxy_listener l0, l1, l2;
+
+	EXPECT(proxy_listener_bind(0, &l0), "bind slot 0");
+	EXPECT(strcmp(l0.ip, "127.47.11.1") == 0, "slot 0 ip %s", l0.ip);
+	EXPECT(l0.port == DOTDOH_PORT_BASE + 1, "slot 0 preferred port %d", l0.port);
+	EXPECT(l0.udp_fd >= 0 && l0.tcp_fd >= 0, "slot 0 fds");
+
+	EXPECT(proxy_listener_bind(1, &l1), "bind slot 1");
+	EXPECT(strcmp(l1.ip, "127.47.11.2") == 0, "slot 1 ip %s", l1.ip);
+
+	// Squat the deterministic TCP tuple of slot 2 -> bind must now FAIL (the port
+	// is fixed, so there is no iteration); the upstream is left disabled.
+	int occ = occupy("127.47.11.3", DOTDOH_PORT_BASE + 3, SOCK_STREAM);
+	EXPECT(occ >= 0, "occupy deterministic tuple of slot 2");
+	EXPECT(!proxy_listener_bind(2, &l2), "bind slot 2 fails when its tuple is squatted");
+
+	// Bind-first / exclusivity: our owned tuple cannot be co-bound.
+	int again = occupy(l0.ip, l0.port, SOCK_STREAM);
+	EXPECT(again < 0, "owned tuple is exclusive (no SO_REUSEADDR)");
+	if(again >= 0) close(again);
+
+	proxy_listener_close(&l0);
+	proxy_listener_close(&l1);
+	proxy_listener_close(&l2);
+	if(occ >= 0) close(occ);
+}
+
+int main(void)
+{
+	test_plain();
+	test_dot();
+	test_doh();
+	test_reject();
+	test_dot_framing();
+	test_doh_request();
+	test_doh_response();
+	test_registry();
+
+	if(failures == 0)
+		printf("dotdoh_regression: all tests passed\n");
+	else
+		printf("dotdoh_regression: %d failure(s)\n", failures);
+	return failures ? 1 : 0;
+}

--- a/test/dotdoh_regression.c
+++ b/test/dotdoh_regression.c
@@ -25,6 +25,7 @@
 #include "dotdoh/upstream_uri.c"
 #include "dotdoh/framing.c"
 #include "dotdoh/registry.c"
+#include "dotdoh/edns_pad.c"
 
 static int failures = 0;
 
@@ -255,6 +256,129 @@ static void test_registry(void)
 	if(occ >= 0) close(occ);
 }
 
+// "example.com" IN A: a 17-byte question section (13-byte QNAME + QTYPE + QCLASS).
+static const uint8_t QUESTION[] = {
+	0x07, 'e','x','a','m','p','l','e', 0x03, 'c','o','m', 0x00, // QNAME
+	0x00, 0x01, // QTYPE  A
+	0x00, 0x01, // QCLASS IN
+};
+
+// Write a 12-byte DNS header into buf with the given section counts.
+static void put_header(uint8_t *buf, uint16_t qd, uint16_t an, uint16_t ns, uint16_t ar)
+{
+	buf[0] = 0x12; buf[1] = 0x34;   // ID
+	buf[2] = 0x01; buf[3] = 0x00;   // flags: standard query, RD
+	buf[4] = (uint8_t)(qd >> 8); buf[5] = (uint8_t)qd;
+	buf[6] = (uint8_t)(an >> 8); buf[7] = (uint8_t)an;
+	buf[8] = (uint8_t)(ns >> 8); buf[9] = (uint8_t)ns;
+	buf[10] = (uint8_t)(ar >> 8); buf[11] = (uint8_t)ar;
+}
+
+// Assert every byte in buf[from..to) is zero (the padding octets).
+static void expect_zeros(const uint8_t *buf, size_t from, size_t to, const char *what)
+{
+	for(size_t i = from; i < to; i++)
+		if(buf[i] != 0)
+		{
+			EXPECT(false, "%s: buf[%zu]=0x%02x != 0", what, i, buf[i]);
+			return;
+		}
+}
+
+static void test_edns_pad(void)
+{
+	// 1) Query with no OPT record: a fresh OPT RR carrying the Padding option is
+	//    appended and ARCOUNT is bumped, rounding the message up to 128 octets.
+	{
+		uint8_t buf[512];
+		memset(buf, 0, sizeof(buf));
+		put_header(buf, 1, 0, 0, 0);
+		memcpy(buf + 12, QUESTION, sizeof(QUESTION));
+		const size_t len = 12 + sizeof(QUESTION); // 29
+
+		const size_t out = edns_pad_query(buf, len, sizeof(buf));
+		EXPECT(out == 128, "no-OPT padded length %zu != 128", out);
+		EXPECT(out % 128 == 0, "no-OPT length not a multiple of 128");
+		EXPECT(buf[10] == 0x00 && buf[11] == 0x01, "no-OPT ARCOUNT not bumped to 1");
+		EXPECT(memcmp(buf + 12, QUESTION, sizeof(QUESTION)) == 0, "no-OPT question corrupted");
+		// OPT RR at offset 29
+		EXPECT(buf[29] == 0x00, "OPT name not root");
+		EXPECT(buf[30] == 0x00 && buf[31] == 0x29, "OPT type != 41");
+		EXPECT(buf[32] == 0x04 && buf[33] == 0xD0, "OPT UDP size != 1232");
+		EXPECT(buf[34] == 0 && buf[35] == 0 && buf[36] == 0 && buf[37] == 0, "OPT TTL not zero");
+		EXPECT(buf[38] == 0x00 && buf[39] == 0x58, "OPT RDLEN != 88");
+		// Padding option (code 12, length 84) + 84 zero octets
+		EXPECT(buf[40] == 0x00 && buf[41] == 0x0C, "padding option code != 12");
+		EXPECT(buf[42] == 0x00 && buf[43] == 0x54, "padding option length != 84");
+		expect_zeros(buf, 44, 128, "no-OPT padding octets");
+	}
+
+	// 2) Query that already has an OPT record (no options): the Padding option is
+	//    appended to its RDATA and ARCOUNT stays 1.
+	{
+		uint8_t buf[512];
+		memset(buf, 0, sizeof(buf));
+		put_header(buf, 1, 0, 0, 1);
+		memcpy(buf + 12, QUESTION, sizeof(QUESTION));
+		size_t p = 12 + sizeof(QUESTION); // 29
+		buf[p++] = 0x00;                       // root name
+		buf[p++] = 0x00; buf[p++] = 0x29;      // type OPT
+		buf[p++] = 0x10; buf[p++] = 0x00;      // UDP size 4096
+		buf[p++] = 0x00; buf[p++] = 0x00; buf[p++] = 0x00; buf[p++] = 0x00; // TTL
+		buf[p++] = 0x00; buf[p++] = 0x00;      // RDLEN 0
+		const size_t len = p; // 40
+
+		const size_t out = edns_pad_query(buf, len, sizeof(buf));
+		EXPECT(out == 128, "with-OPT padded length %zu != 128", out);
+		EXPECT(buf[10] == 0x00 && buf[11] == 0x01, "with-OPT ARCOUNT changed");
+		EXPECT(buf[32] == 0x10 && buf[33] == 0x00, "with-OPT existing UDP size clobbered");
+		EXPECT(buf[38] == 0x00 && buf[39] == 0x58, "with-OPT RDLEN not grown to 88");
+		EXPECT(buf[40] == 0x00 && buf[41] == 0x0C, "with-OPT padding option code != 12");
+		EXPECT(buf[42] == 0x00 && buf[43] == 0x54, "with-OPT padding option length != 84");
+		expect_zeros(buf, 44, 128, "with-OPT padding octets");
+	}
+
+	// 3) Idempotent: a query that already carries a Padding option is left as-is.
+	{
+		uint8_t buf[512];
+		memset(buf, 0, sizeof(buf));
+		put_header(buf, 1, 0, 0, 1);
+		memcpy(buf + 12, QUESTION, sizeof(QUESTION));
+		size_t p = 12 + sizeof(QUESTION);
+		buf[p++] = 0x00;                       // root name
+		buf[p++] = 0x00; buf[p++] = 0x29;      // type OPT
+		buf[p++] = 0x10; buf[p++] = 0x00;      // UDP size
+		buf[p++] = 0x00; buf[p++] = 0x00; buf[p++] = 0x00; buf[p++] = 0x00; // TTL
+		buf[p++] = 0x00; buf[p++] = 0x04;      // RDLEN 4
+		buf[p++] = 0x00; buf[p++] = 0x0C;      // Padding option code
+		buf[p++] = 0x00; buf[p++] = 0x00;      // Padding option length 0
+		const size_t len = p; // 44
+
+		const size_t out = edns_pad_query(buf, len, sizeof(buf));
+		EXPECT(out == len, "already-padded query changed (%zu != %zu)", out, len);
+	}
+
+	// 4) Fail-open: the padded message would not fit in the caller's buffer.
+	{
+		uint8_t buf[512];
+		memset(buf, 0, sizeof(buf));
+		put_header(buf, 1, 0, 0, 0);
+		memcpy(buf + 12, QUESTION, sizeof(QUESTION));
+		const size_t len = 12 + sizeof(QUESTION); // 29, needs 128
+		const size_t out = edns_pad_query(buf, len, 100);
+		EXPECT(out == len, "oversized should fail open (%zu != %zu)", out, len);
+	}
+
+	// 5) Fail-open: truncated / malformed messages are returned unchanged.
+	{
+		uint8_t buf[512];
+		memset(buf, 0, sizeof(buf));
+		EXPECT(edns_pad_query(buf, 5, sizeof(buf)) == 5, "short-header should fail open");
+		put_header(buf, 1, 0, 0, 0); // claims a question that isn't present
+		EXPECT(edns_pad_query(buf, 12, sizeof(buf)) == 12, "missing question should fail open");
+	}
+}
+
 int main(void)
 {
 	test_plain();
@@ -265,6 +389,7 @@ int main(void)
 	test_doh_request();
 	test_doh_response();
 	test_registry();
+	test_edns_pad();
 
 	if(failures == 0)
 		printf("dotdoh_regression: all tests passed\n");

--- a/test/dotdoh_shim.py
+++ b/test/dotdoh_shim.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# FTL Engine
+# Encrypted-upstream DoT/DoH test shim
+#
+# A tiny, self-contained DoT + DoH server used only by the encrypted-upstream
+# E2E tests. It terminates TLS with the repository test certificate (CN/SAN
+# "pi.hole", signed by test/test_ca.crt) and forwards the decrypted DNS wire
+# message to the local plaintext PowerDNS recursor, returning its answer. Using
+# a shim keeps the recursor config untouched and also covers DoH, which the CI
+# recursor is not built with.
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+#
+#   DoT  : TLS  on 127.0.0.1:8853 (2-byte length-prefixed DNS)
+#   DoH  : HTTPS on 127.0.0.1:8443 (HTTP/1.1 POST /dns-query)
+#   backend: 127.0.0.1:5555 (pdns_recursor, UDP)
+
+import os
+import socket
+import ssl
+import struct
+import sys
+import threading
+import time
+
+BACKEND = ("127.0.0.1", 5555)
+CERT = os.environ.get("SHIM_CERT", "test/test.pem")
+DOT_ADDR = ("127.0.0.1", 8853)
+DOH_ADDR = ("127.0.0.1", 8443)
+
+
+def resolve(wire):
+    """Forward a DNS wire message to the plaintext backend and return the reply."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(5)
+    try:
+        s.sendto(wire, BACKEND)
+        data, _ = s.recvfrom(65535)
+        return data
+    finally:
+        s.close()
+
+
+def tls_context():
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(CERT)
+    return ctx
+
+
+def recvall(sock, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def dot_handle(ctx, raw):
+    try:
+        conn = ctx.wrap_socket(raw, server_side=True)
+    except Exception:
+        raw.close()
+        return
+    try:
+        while True:
+            hdr = recvall(conn, 2)
+            if not hdr:
+                break
+            (qlen,) = struct.unpack("!H", hdr)
+            query = recvall(conn, qlen)
+            if query is None:
+                break
+            answer = resolve(query)
+            conn.sendall(struct.pack("!H", len(answer)) + answer)
+    except Exception:
+        pass
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def doh_handle(ctx, raw):
+    try:
+        conn = ctx.wrap_socket(raw, server_side=True)
+    except Exception:
+        raw.close()
+        return
+    try:
+        # Read up to the end of the request headers.
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                return
+            data += chunk
+            if len(data) > 65536:
+                return
+        head, _, body = data.partition(b"\r\n\r\n")
+
+        # Require a valid, positive Content-Length and read exactly that many
+        # body bytes. A malformed client request then fails closed (the
+        # connection is dropped with no answer) instead of being resolved with
+        # an empty or partial body, which could mask a broken client.
+        content_len = None
+        for line in head.split(b"\r\n")[1:]:
+            if line.lower().startswith(b"content-length:"):
+                try:
+                    content_len = int(line.split(b":", 1)[1].strip())
+                except ValueError:
+                    return
+        if content_len is None or content_len <= 0:
+            return
+        while len(body) < content_len:
+            chunk = conn.recv(content_len - len(body))
+            if not chunk:
+                return  # connection closed before the full body arrived
+            body += chunk
+        body = body[:content_len]
+
+        answer = resolve(body)
+        resp = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/dns-message\r\n"
+            b"Content-Length: " + str(len(answer)).encode() + b"\r\n"
+            b"Connection: close\r\n\r\n" + answer
+        )
+        conn.sendall(resp)
+    except Exception:
+        pass
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def make_listener(addr):
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(addr)
+    srv.listen(16)
+    return srv
+
+
+def accept_loop(srv, ctx, handler):
+    while True:
+        raw, _ = srv.accept()
+        threading.Thread(target=handler, args=(ctx, raw), daemon=True).start()
+
+
+if __name__ == "__main__":
+    ctx = tls_context()
+    # Bind both listeners up front so a port clash (e.g. a stale shim from an
+    # interrupted run) makes us exit immediately instead of lingering half-alive.
+    try:
+        dot_srv = make_listener(DOT_ADDR)
+        doh_srv = make_listener(DOH_ADDR)
+    except OSError as exc:
+        print("dotdoh_shim: could not bind (%s); is another shim running?" % exc,
+              file=sys.stderr)
+        sys.exit(1)
+    threading.Thread(target=accept_loop, args=(dot_srv, ctx, dot_handle), daemon=True).start()
+    threading.Thread(target=accept_loop, args=(doh_srv, ctx, doh_handle), daemon=True).start()
+    while True:
+        time.sleep(3600)

--- a/test/dotdoh_shim.py
+++ b/test/dotdoh_shim.py
@@ -32,6 +32,19 @@ BACKEND = ("127.0.0.1", 5555)
 CERT = os.environ.get("SHIM_CERT", "test/test.pem")
 DOT_ADDR = ("127.0.0.1", 8853)
 DOH_ADDR = ("127.0.0.1", 8443)
+# When set, append the on-the-wire length of every decrypted query here so the
+# padding E2E test can confirm FTL padded it. FTL pads encrypted queries to a
+# 128-octet boundary (RFC 8467), so a padded query arrives as a multiple of 128.
+PAD_LOG = os.environ.get("SHIM_PAD_LOG", "")
+_pad_lock = threading.Lock()
+
+
+def note_query(transport, query):
+    if not PAD_LOG:
+        return
+    with _pad_lock:
+        with open(PAD_LOG, "a") as fh:
+            fh.write("%s %d\n" % (transport, len(query)))
 
 
 def resolve(wire):
@@ -77,6 +90,7 @@ def dot_handle(ctx, raw):
             query = recvall(conn, qlen)
             if query is None:
                 break
+            note_query("dot", query)
             answer = resolve(query)
             conn.sendall(struct.pack("!H", len(answer)) + answer)
     except Exception:
@@ -126,6 +140,7 @@ def doh_handle(ctx, raw):
             body += chunk
         body = body[:content_len]
 
+        note_query("doh", body)
         answer = resolve(body)
         resp = (
             b"HTTP/1.1 200 OK\r\n"

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -279,6 +279,14 @@
   #     Example: "fritz.box"
   revServers = []
 
+  # Path to a CA certificate bundle used to verify encrypted upstream servers (DoT/DoH).
+  # If left empty, the system default trust store is used. Only relevant when at least
+  # one dns.upstreams entry uses the tls:// or https:// scheme.
+  #
+  # Allowed values are:
+  #     A path to a PEM CA bundle, or empty for the system default trust store
+  upstreamCA = ""
+
   [dns.domain]
     # The DNS domain used by your Pi-hole.
     #
@@ -1746,7 +1754,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 167 total entries out of which 112 entries are default
+# 168 total entries out of which 113 entries are default
 # --> 55 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/run.sh
+++ b/test/run.sh
@@ -70,6 +70,19 @@ cp test/broken_lua_2.lp /var/www/html/broken_lua_2.lp
 # Prepare local powerDNS resolver
 bash test/pdns/setup.sh
 
+# Start the DoT/DoH encrypted-upstream test shim (terminates TLS with the repo
+# test certificate and forwards to the local recursor). See test/dotdoh.bats.
+# Match the exact shim invocation so pkill cannot hit an unrelated process
+# (e.g. an editor) that merely has "dotdoh_shim.py" somewhere in its argv.
+SHIM_PATTERN="python3 test/dotdoh_shim.py"
+# Kill any stale instance first so its ports (8853/8443) are free.
+pkill -f "${SHIM_PATTERN}" 2>/dev/null || true
+python3 test/dotdoh_shim.py &
+DOTDOH_SHIM_PID=$!
+# Stop the shim even if the script exits early (e.g. FTL fails to start below),
+# so a leftover process cannot hold ports 8853/8443 and make the next run flaky.
+trap 'kill "${DOTDOH_SHIM_PID}" 2>/dev/null; pkill -f "${SHIM_PATTERN}" 2>/dev/null' EXIT
+
 # Set restrictive umask
 OLDUMASK=$(umask)
 umask 0022
@@ -152,6 +165,15 @@ else
   echo "Skipping pytest API tests (too slow on ${CI_ARCH})"
 fi
 
+# Encrypted-upstream (DoT/DoH) end-to-end tests. Run after pytest: switching the
+# upstream restarts FTL, which would otherwise perturb the query statistics the
+# API tests assert on. test_final still counts this file's config writes below.
+$BATS -p "test/dotdoh.bats"
+DOTDOH_RET=$?
+if [ $DOTDOH_RET != 0 ]; then
+  RET=$DOTDOH_RET
+fi
+
 # Run final BATS suite — log validation and FTL termination
 # This runs after both test_suite.bats and pytest to catch any
 # unexpected log messages from the entire run, then terminates FTL.
@@ -201,6 +223,10 @@ rm /home/pihole/pihole-FTL
 # Stop local powerDNS resolver
 killall pdns_server
 killall pdns_recursor
+
+# Stop the DoT/DoH test shim (same narrow pattern as at startup)
+[ -n "${DOTDOH_SHIM_PID}" ] && kill "${DOTDOH_SHIM_PID}" 2>/dev/null
+pkill -f "${SHIM_PATTERN}" 2>/dev/null || true
 
 # Exit with return code of bats tests
 exit $RET

--- a/test/run.sh
+++ b/test/run.sh
@@ -77,6 +77,9 @@ bash test/pdns/setup.sh
 SHIM_PATTERN="python3 test/dotdoh_shim.py"
 # Kill any stale instance first so its ports (8853/8443) are free.
 pkill -f "${SHIM_PATTERN}" 2>/dev/null || true
+# Record decrypted query lengths so dotdoh.bats can confirm FTL padded them.
+export SHIM_PAD_LOG="/tmp/dotdoh_pad.log"
+rm -f "${SHIM_PAD_LOG}"
 python3 test/dotdoh_shim.py &
 DOTDOH_SHIM_PID=$!
 # Stop the shim even if the script exits early (e.g. FTL fails to start below),

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -39,13 +39,14 @@ load 'bats_helper.bash'
   # pytest: 2x pihole.toml writes (TOTP stress test secret set + remove)
   # pytest: 2x pihole.toml writes (auth security test password set + remove)
   # pytest: 2x pihole.toml writes (auth security test TOTP secret set + remove)
+  # dotdoh.bats: 2x pihole.toml writes (encrypted setup + plaintext teardown)
   run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
   printf "pihole.toml write count: %s\n" "${lines[0]}"
   # On RISCV64, pytest is skipped (too slow), so only BATS writes occur
   if [[ "${CI_ARCH}" == "linux/riscv64" ]]; then
-      assert_line --index 0 "1"
+      assert_line --index 0 "3"
   else
-    [[ ${lines[0]} == "22" ]]
+    [[ ${lines[0]} == "24" ]]
   fi
   # CLI password set/remove trigger inotify reload but result in
   # "pihole.toml unchanged" as the in-memory config already matches
@@ -55,7 +56,7 @@ load 'bats_helper.bash'
   assert_success
   run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
   printf "dnsmasq.conf write count: %s\n" "${lines[0]}"
-  assert_line --index 0 "1"
+  assert_line --index 0 "3"
   run bash -c 'grep -c "DEBUG_CONFIG: HOSTS file written to /etc/pihole/hosts/custom.list" /var/log/pihole/FTL.log'
   printf "custom.list write count: %s\n" "${lines[0]}"
   # On RISCV64, pytest is skipped, so only BATS writes occur (3x)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1810,6 +1810,11 @@ setup() {
   assert_success
 }
 
+@test "DoT/DoH parser regression harness" {
+  run ./dotdoh_regression
+  assert_success
+}
+
 @test "SHA256 checksum working" {
   run bash -c './pihole-FTL sha256sum test/test.pem'
   assert_line --index 0 "ce4c01340ef46bf3bc26831f7c53763d57c863528826aa795f1da5e16d6e7b2d  test/test.pem"


### PR DESCRIPTION
# What does this implement/fix?

Native **DoT** (DNS-over-TLS, [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858.html)) and **DoH** (DNS-over-HTTPS, [RFC 8484](https://www.rfc-editor.org/rfc/rfc8484.html)) for FTL's **outbound** resolution - FTL talking to an encrypted upstream resolver - with **zero dnsmasq changes**.

**How it works.** dnsmasq cannot speak TLS to its upstreams, so FTL runs a small local forward-proxy. For every encrypted entry in `dns.upstreams`, FTL binds a loopback listener pair (UDP+TCP) in `127.47.11.0/24` and emits a `server=127.47.11.N#port` line into `dnsmasq.conf`. dnsmasq forwards the plaintext query to that listener as usual; a dedicated FTL worker thread then re-encrypts it, forwards it to the real resolver over DoT/DoH via mbedTLS, and hands the answer back. No query leaves the host in the clear.

**What is added** (new module `src/dotdoh/`, leaf units self-contained and unit-tested):
- `upstream_uri` - parser/classifier for `tls://`, `https://` and plaintext upstream entries.
- `framing` - DoT two-octet length prefix ([RFC 7858](https://www.rfc-editor.org/rfc/rfc7858.html)) and DoH HTTP/1.1 request/response ([RFC 8484](https://www.rfc-editor.org/rfc/rfc8484.html)). Bytes only; DNS message contents are never parsed here.
- `registry` - one loopback listener pair per upstream, bind-first (no `SO_REUSEADDR`, so nothing can co-bind).
- `tls_client` - fail-closed mbedTLS client: required chain + hostname verification, SNI, a pooled connection per upstream with a single reconnect. Never downgrades to plaintext.
- `edns_pad` - pads each outbound query to a 128-octet boundary with an EDNS(0) Padding option ([RFC 7830](https://www.rfc-editor.org/rfc/rfc7830.html) / [RFC 8467](https://www.rfc-editor.org/rfc/rfc8467.html)) so the ciphertext length no longer leaks the query size. Only the encrypted leg is padded. As a missing padding reduces obscuring the question length somewhat but does not weaken the integrity and/or encryption, this is implemented fail-open, so a query that cannot be padded is still sent rather than dropped.
- `proxy` - the forward-proxy worker thread, armed after dnsmasq startup so the listener fds are not reused.

**Config / API:**
- `dns.upstreams` now accepts `tls://` and `https://` URIs (validated by the parser).
- New `dns.upstreamCA` trust-anchor option (documented in the OpenAPI spec).
- The suggested-servers list gained v4/v6-**pinned** DoT/DoH URIs for the well-known resolvers (Google, Quad9, Cloudflare, OpenDNS), e.g. `tls://dns.google@8.8.8.8`. Pinning the address (`sni@ip`) avoids an untrusted bootstrap lookup of the resolver hostname before switching to it.

**Security posture:** encrypted upstreams are fail-closed - a failed certificate or hostname verification drops the answer rather than falling back to plaintext.

| Privacy feature | Shipped |
| --- | --- |
| CA trust-anchor chain verification - system trust store or a custom `dns.upstreamCA` bundle | :white_check_mark: |
| Server certificate hostname and SNI verification | :white_check_mark: |
| Strict privacy ([RFC 8310](https://www.rfc-editor.org/rfc/rfc8310.html)) - fail-closed, never downgrades to plaintext | :white_check_mark: |
| EDNS(0) query padding to a 128-octet boundary ([RFC 7830](https://www.rfc-editor.org/rfc/rfc7830.html) / [RFC 8467](https://www.rfc-editor.org/rfc/rfc8467.html)) | :white_check_mark: |

## How to test this locally

Set an encrypted upstream - via the web UI, a `PATCH /api/config`, or by editing `dns.upstreams` in `pihole.toml` - for example `tls://dns.google@8.8.8.8` (DoT) or `https://cloudflare-dns.com@1.1.1.1/dns-query` (DoH). FTL restarts, arms the proxy, and rewrites `dnsmasq.conf`. Then resolve normally; the query is carried to the upstream over TLS:

```
dig @127.0.0.1 example.com
```

FTL's log shows a `dotdoh: <DoT|DoH> upstream <name> armed` line for each encrypted upstream.

## How the CI tests this automatically

Two layers, both wired into the existing test job (`test/run.sh`):

1. **Unit / regression harness** - a standalone `dotdoh_regression` executable (same pattern as `tar_regression`/`gzip_regression`) exercises the URI parser and the DoT/DoH framing against a table of expected results. It is built in CI via `-DBUILD_DOTDOH_REGRESSION=ON` (`.github/Dockerfile` + `build.sh`) and run as a bats case in `test_suite.bats` ("DoT/DoH parser regression harness"). It can be built with ASan/UBSan locally via `./build.sh "-DDOTDOH_REGRESSION_SANITIZE=ON" test`.
2. **End-to-end** - `test/dotdoh.bats` configures a real encrypted upstream and resolves **real DoT and DoH** through a local TLS shim (`test/dotdoh_shim.py`, terminating TLS with the repo test certificate) into the recursor, asserting the decrypted answer. It runs **after** the pytest API suite on purpose: switching the upstream restarts FTL, which would otherwise perturb the query statistics those API tests assert on. `test_final.bats` still accounts for its config writes.

## Scope: part 1 of 2

This PR is **part 1 of 2** and deliberately covers **only the outbound direction** (FTL as a DoT/DoH *client* toward the upstream resolver).

**Part 2** - the **server** direction (FTL terminating inbound DoT/DoH from downstream clients and handing plaintext to dnsmasq) - will follow as a **separate** PR, submitted once this one is reviewed and merged, to keep each direction independently reviewable.

Much of the foundation laid here is deliberately reusable for part 2: the wire framing (`src/dotdoh/framing.c`), the URI/config plumbing, and the mbedTLS and test-shim scaffolding are shared between both directions - the module is named `dotdoh` (not `client`) for exactly this reason, so the server side can live beside it.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I signed off all commits (DCO).
- [x] I signed all my commits.
- [x] I have read the above and my PR is ready for review.



