### PR TITLE
Tests: make local root zone hermetic and fix a dnsmasq config-test busy-loop

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -136,7 +136,7 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 			// Check if the child exited too quickly for waitpid to
 			// catch it. We cannot get the return code in this case
 			// and have to check the pipe content instead
-			if(errno == ECHILD)
+			if(err == ECHILD)
 			{
 				log_debug(DEBUG_CONFIG, "dnsmasq test exited too quickly for waitpid");
 				code = strstr(errbuf, "syntax check OK") != NULL ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/test/01-pihole-tests.conf
+++ b/test/01-pihole-tests.conf
@@ -9,3 +9,13 @@ server=/ftl/127.0.0.1#5555
 # server and recursor is not encrypted)
 server=/https.ftl/127.0.0.1#5554
 server=/svcb.ftl/127.0.0.1#5554
+# The zones below are served by the local authoritative PowerDNS instance but
+# are *unsigned*. Mark them as local domains (same mechanism as .ftl above) so
+# dnsmasq performs no DNSSEC validation for them - otherwise validating the
+# unsigned mask.icloud.com CNAME chain and the reverse zones issues internal
+# DS/DNSKEY queries that walk up to the real ICANN root, whose key set drifts
+# with rollovers and made the query counters flaky.
+server=/icloud.com/127.0.0.1#5555
+server=/apple-dns.net/127.0.0.1#5555
+server=/in-addr.arpa/127.0.0.1#5555
+server=/ip6.arpa/127.0.0.1#5555

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -19,19 +19,18 @@ FTL_URL = "http://127.0.0.1"
 # ---------------------------------------------------------------------------
 # Expected query counters
 # ---------------------------------------------------------------------------
-# The bats test suite queries mask.icloud.com via an allowlisted client, which
-# forwards the query upstream.  The mask.icloud.com -> mask.apple-dns.net CNAME
-# chain is served by the local (unsigned) PowerDNS authoritative server (see
-# test/pdns/setup.sh and recursor.conf) instead of being recursed to the public
-# internet.  This keeps the resolution hermetic and the query counts below
-# deterministic — previously they drifted by +2 whenever Apple toggled DNSSEC
-# signing on these zones, which made the suite flaky (see issue #2908 / PR
-# #2845).  If you add or remove queries in test_suite.bats, update these.
+# These counters must stay hermetic: every query the bats suite fires is served
+# by the local PowerDNS instance, including a locally-signed root zone (see
+# test/pdns/setup.sh and recursor.conf).  DNSSEC validation therefore never
+# recurses to the public ICANN root, whose DNSKEY set drifts with key-signing-key
+# rollovers - that used to change the number of root DNSKEY lookups and made the
+# DNSSEC-dependent counters below flaky.  If you add or remove queries in
+# test_suite.bats, update these.
 
-TOTAL       = 137
-FORWARDED   = 47
-DNSKEY      = 9
-TOP_DOMAIN  = "."
+TOTAL       = 131
+FORWARDED   = 41
+DNSKEY      = 4
+TOP_DOMAIN  = "localhost"
 
 
 # ---------------------------------------------------------------------------
@@ -691,7 +690,7 @@ class TestStatsQueryTypes:
         data = _j(api_session.get(f"{FTL_URL}/api/stats/query_types", timeout=5), dump="query_types")
         assert data["types"] == {
             "A": 69, "AAAA": 19, "ANY": 3, "SRV": 1, "SOA": 0,
-            "PTR": 8, "TXT": 10, "NAPTR": 1, "MX": 1, "DS": 7,
+            "PTR": 8, "TXT": 10, "NAPTR": 1, "MX": 1, "DS": 6,
             "RRSIG": 0, "DNSKEY": DNSKEY, "NS": 0, "SVCB": 3, "HTTPS": 3,
             "OTHER": 1,
         }, json.dumps(data, indent=2)

--- a/test/pdns/recursor.conf
+++ b/test/pdns/recursor.conf
@@ -45,4 +45,11 @@ recursor:
     recurse: false
     forwarders:
     - 127.0.0.1:5554
+  # Serve the root zone from the local authoritative server too, so DNSSEC
+  # validation never recurses to the public ICANN root (whose DNSKEY set drifts
+  # with key rollovers and made the query counts flaky).
+  - zone: .
+    recurse: false
+    forwarders:
+    - 127.0.0.1:5554
   lua_dns_script: /etc/pdns/luadns.lua

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -158,6 +158,14 @@ pdnsutil zone secure dnssec
 #   trust-anchor=dnssec.,42206,8,2,6d2007e292483fa061db37011676d9592649d1600e5b2ece1326f792ebedd412
 pdnsutil zone export-ds dnssec. | head -n1 | awk '{FS=" "; OFS=""; print "trust-anchor=",$1,",",$4,",",$5,",",$6,",",$7}' > /etc/dnsmasq.d/02-trust-anchor.conf
 
+# Create a locally-signed root zone so DNSSEC validation never leaves the test
+# environment. FTL ships the real ICANN root trust anchors, so without a local
+# root dnsmasq would fetch the live root DNSKEY (whose key set drifts with ICANN
+# rollovers). Serving a signed root here and trusting its key keeps it hermetic.
+pdnsutil zone create . ns1.
+pdnsutil zone secure .
+pdnsutil zone export-ds . | head -n1 | awk '{FS=" "; OFS=""; print "trust-anchor=",$1,",",$4,",",$5,",",$6,",",$7}' >> /etc/dnsmasq.d/02-trust-anchor.conf
+
 # Create intentionally broken DNSSEC (BOGUS) zone
 # The only difference to above is that this zone is signed with a key that is
 # not in the trust chain
@@ -167,6 +175,13 @@ pdnsutil zone create bogus ns1.ftl
 pdnsutil rrset add bogus. a.bogus. A 192.168.5.1
 pdnsutil rrset add bogus. aaaa.bogus. AAAA fe80::5c01
 pdnsutil zone secure bogus
+# Install a *deliberately mismatched* trust anchor for the bogus zone (same
+# keytag/algorithm/digest-type as the real key, but a corrupted digest). This
+# makes bogus validation fail as BOGUS *locally* instead of dnsmasq walking up
+# to the real ICANN root to learn the zone has no secure delegation.
+pdnsutil zone export-ds bogus. | head -n1 | \
+  awk '{OFS=""; d=$7; d=substr(d, 1, length(d) - 8) "deadbeef"; print "trust-anchor=", $1, ",", $4, ",", $5, ",", $6, ",", d}' \
+  >> /etc/dnsmasq.d/02-trust-anchor.conf
 
 # Create reverse lookup zone
 pdnsutil zone create arpa ns1.ftl

--- a/test/run.sh
+++ b/test/run.sh
@@ -104,14 +104,6 @@ echo "FTL verbose version (CLI): "
 echo -n "Contained dnsmasq version (DNS): "
 dig TXT CHAOS version.bind @127.0.0.1 +short
 
-# Pre-warm DNSSEC root key cache. dnsmasq's DNSSEC validation can
-# trigger internal DNSKEY queries for the root zone at unpredictable
-# times. By explicitly querying DNSKEY for "." first, we force the
-# root key into cache so all subsequent DNSSEC validation uses the
-# cached key. This makes the total query count deterministic.
-dig DNSKEY . @127.0.0.1 +dnssec > /dev/null 2>&1
-sleep 1
-
 RET=0
 
 # Prepare BATS

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -9,7 +9,7 @@ bats_load_library 'bats-assert'
 load 'bats_helper.bash'
 
 @test "No WARNING messages in FTL.log (besides known warnings)" {
-  run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|FTLCONF_|(negative DS reply without NS record received for ftl)|(nameserver 127.0.0.1 refused to do a recursive query)|API: Config item is invalid|API: Config item validation failed|API: Not found|API: Config items set via environment variables|API: Rate-limiting login attempts|API: You need to specify both|API: No request body data|API: Invalid request|API: Rate-limiting 2FA token requests|2FA code has already been used|API: Reused 2FA token"'
+  run bash -c 'grep "WARNING:" /var/log/pihole/FTL.log | grep -v -E "CAP_NET_ADMIN|CAP_NET_RAW|CAP_SYS_NICE|CAP_IPC_LOCK|CAP_CHOWN|CAP_NET_BIND_SERVICE|CAP_SYS_TIME|FTLCONF_|(negative DS reply without NS record received for )|(nameserver 127.0.0.1 refused to do a recursive query)|API: Config item is invalid|API: Config item validation failed|API: Not found|API: Config items set via environment variables|API: Rate-limiting login attempts|API: You need to specify both|API: No request body data|API: Invalid request|API: Rate-limiting 2FA token requests|2FA code has already been used|API: Reused 2FA token"'
   refute_output
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR carries two independent test-suite fixes.

## 1. Hermetic local root zone

The API test suite asserts exact DNS query counters. Several of them (`TOTAL`, `DNSKEY`, `DS`, `TOP_DOMAIN`) depend on how many DNSKEY/DS lookups dnsmasq issues while validating DNSSEC.

Until now those lookups recursed to the *live* ICANN root: FTL configures the real root trust anchors whenever `dns.dnssec` is enabled (`src/config/dnsmasq_config.c`), and the local PowerDNS recursor had no root zone of its own. The number of root DNSKEY queries therefore tracked ICANN's published root key set, so the ongoing key-signing-key rollover silently shifted the counters (`DNSKEY` 9 -> 7, `TOTAL` 137 -> 135, `TOP_DOMAIN` `.` -> `localhost`). That is why the suite started failing on completely unrelated PRs (e.g. the Dependabot bump in #2945) without any code change on our side.

The suite is now fully hermetic - no query leaves for the real root:

1. Serve a locally-signed root zone from PowerDNS, forward `.` to it and trust its key, so root DNSKEY validation resolves inside the test environment.
2. Mark the locally-served *unsigned* zones (`icloud.com`, `apple-dns.net`, `in-addr.arpa`, `ip6.arpa`) as local domains, so dnsmasq no longer proves them unsigned by walking up to the real root.
3. Give the `bogus` zone a deliberately mismatched local trust anchor, so it fails validation locally instead of by failing to find a secure delegation at the root.
4. Drop the root-key pre-warm `dig`, an internet round-trip that no longer serves any purpose.

The query counters no longer depend on ICANN key rollovers, so they are recalibrated once. Marking the extra zones as local emits the same `negative DS reply without NS record` warning already whitelisted for `ftl`, so the `test_final` whitelist is broadened to match it for any zone.

## 2. dnsmasq config-test `ECHILD` busy-loop

The Teleporter test could hang with `DEBUG_CONFIG: Waiting for dnsmasq test returned: No child process`. In `test_dnsmasq_config()` the `log_debug()` call between `waitpid()` and the `ECHILD` check clobbers `errno`, so the check read the live `errno` instead of the cached `err`. When the child had already been reaped, the `ECHILD` branch was skipped and the wait loop spun forever (only observable with `DEBUG_CONFIG` enabled). The check now uses the cached `err`.

>[!NOTE]
> This fixes the currently failing tests on branch `development`

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
