### PR TITLE
Fix historical top item query totals

### DIFF
--- a/src/api/stats_database.c
+++ b/src/api/stats_database.c
@@ -247,11 +247,11 @@ int api_stats_database_top_items(struct ftl_conn *api)
 		}
 
 		// Count total number of queries for domains
-		count_total_str = "SELECT COUNT(DISTINCT domain) FROM query_storage "
+		count_total_str = "SELECT COUNT(*) FROM query_storage "
 		                  "WHERE timestamp >= :from AND timestamp <= :until";
 
 		// Count total number of blocked queries for domains
-		count_blocked_str = "SELECT COUNT(DISTINCT domain) FROM query_storage "
+		count_blocked_str = "SELECT COUNT(*) FROM query_storage "
 		                    "WHERE timestamp >= :from AND timestamp <= :until "
 			            "AND " FILTER_STATUS_BLOCKED;
 	}
@@ -277,11 +277,11 @@ int api_stats_database_top_items(struct ftl_conn *api)
 		}
 
 		// Count total number of queries for clients
-		count_total_str = "SELECT COUNT(DISTINCT client) FROM query_storage "
+		count_total_str = "SELECT COUNT(*) FROM query_storage "
 		                  "WHERE timestamp >= :from AND timestamp <= :until";
 
 		// Count number of blocked queries for clients
-		count_blocked_str = "SELECT COUNT(DISTINCT client) FROM query_storage "
+		count_blocked_str = "SELECT COUNT(*) FROM query_storage "
 		                    "WHERE timestamp >= :from AND timestamp <= :until "
 			            "AND " FILTER_STATUS_BLOCKED;
 	}

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -737,17 +737,25 @@ class TestStatsDatabase:
         data = _j(api_session.get(
             f"{FTL_URL}/api/stats/database/top_domains?from=1&until=9999999999",
             timeout=5))
+        summary = _j(api_session.get(
+            f"{FTL_URL}/api/stats/database/summary?from=1&until=9999999999",
+            timeout=5))
         assert "domains" in data
         assert isinstance(data["domains"], list)
-        assert "total_queries" in data
+        assert data["total_queries"] == summary["sum_queries"]
+        assert data["blocked_queries"] == summary["sum_blocked"]
 
     def test_database_top_clients_with_range(self, api_session):
         data = _j(api_session.get(
             f"{FTL_URL}/api/stats/database/top_clients?from=1&until=9999999999",
             timeout=5))
+        summary = _j(api_session.get(
+            f"{FTL_URL}/api/stats/database/summary?from=1&until=9999999999",
+            timeout=5))
         assert "clients" in data
         assert isinstance(data["clients"], list)
-        assert "total_queries" in data
+        assert data["total_queries"] == summary["sum_queries"]
+        assert data["blocked_queries"] == summary["sum_blocked"]
 
     def test_database_upstreams_with_range(self, api_session):
         data = _j(api_session.get(


### PR DESCRIPTION
Closes #2949.

**What does this PR aim to accomplish?:**

Restore the documented aggregate-query contract for:

- `GET /api/stats/database/top_clients`
- `GET /api/stats/database/top_domains`

Both endpoints currently return correctly ranked item rows, but serialize
distinct client/domain counts as `total_queries` and `blocked_queries`. API
consumers can therefore receive valid-looking but false totals and calculate
incorrect blocking rates.

In a live FTL v6.7 24-hour response, for example:

```text
database summary:     374,813 total / 86,248 blocked (23.01%)
database top clients:       5 total /      5 blocked (100%)
```

The five values represented distinct clients, not DNS queries. DNS resolution,
blocking decisions, and ranked item counts are unaffected; this is a reporting
and API-contract bug.

**How does this PR accomplish the above?:**

- Replace four `COUNT(DISTINCT domain|client)` aggregate queries with
  `COUNT(*)`, retaining the existing time-range and blocked-status filters.
- Preserve the top-item grouping, sorting, `count` limit, and response schema.
- Strengthen both historical top-item integration tests so
  `total_queries`/`blocked_queries` must match `sum_queries`/`sum_blocked` from
  `/api/stats/database/summary` for the identical interval.

The regression uses the summary endpoint as the oracle rather than hardcoded
fixture totals. This catches the original defect whenever query volume differs
from the number of distinct clients or domains.

### Root cause

The historical top-item implementation used distinct-entity aggregates:

```sql
SELECT COUNT(DISTINCT domain) FROM query_storage ...
SELECT COUNT(DISTINCT client) FROM query_storage ...
```

but returned those values under fields that the OpenAPI schema defines as total
and blocked query counts. The in-memory top endpoints already use actual query
counters.

### Evidence and validation

Before the fix:

- reproduced on two FTL v6.7 nodes using identical 24-hour intervals;
- `/stats/database/summary` returned 374,813 total and 86,248 blocked queries;
- `/stats/database/top_clients` returned 5 and 5;
- `/stats/database/top_domains` returned 3,865 and 481, the distinct domain
  counts;
- changing `count=5` to `count=20` did not alter the client aggregates.

Local patch checks:

```text
python3 -m py_compile test/api/test_api.py  # passed
git diff --check                            # passed
```

The old and repaired aggregate SQL was also executed read-only against the same
live 24-hour query database using FTL's blocked-status predicate:

```text
COUNT(DISTINCT client): 5 total / 5 blocked
COUNT(DISTINCT domain): 4,066 total / 528 blocked
COUNT(*):               378,100 total / 86,140 blocked
```

This demonstrates that the replacement queries produce query totals while the
existing expressions produce unique-entity totals.

The full FTL integration suite is Linux/container-based. The repository queued
its multi-architecture build, CodeQL, and Codespell workflows for this fork PR,
but GitHub currently reports `action_required`: a Pi-hole maintainer must approve
first-time-contributor workflow execution before those jobs can start. DCO has
passed and the commit is GitHub-verified.

**Link documentation PRs if any are needed to support this PR:**

None. The existing OpenAPI field descriptions already specify total queries and
blocked queries; this patch makes the implementation conform to that published
contract.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my code and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2).
5. I have squashed any insignificant commits.
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.
