### PR TITLE
Fix the Pi-hole PTR FQDN for conditional domains

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3659,73 +3659,57 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 
 static char *get_ptrname(const struct in_addr *addr)
 {
-	static char *ptrname = NULL;
-
-	// Return cached value if available
-	if(ptrname)
-		return ptrname;
-
-	// else: Determine name that should be replied to with on Pi-hole PTRs
+	// Determine the name Pi-hole should reply with to PTR queries for its own
+	// interface addresses.
+	//
+	// PTR_PIHOLE and PTR_HOSTNAME are independent of the queried address and
+	// return a stable string. PTR_HOSTNAMEFQDN, however, appends a domain
+	// suffix that may differ per address when conditional domains
+	// (domain=<domain>,<address range>) are configured. We must therefore not
+	// cache a single result across addresses: the caller stores the returned
+	// pointer in a persistent per-interface PTR record, so each address needs
+	// its own string. check_pihole_PTR() ensures we are called at most once
+	// per address, so the per-address allocation is bounded.
 	switch (config.dns.piholePTR.v.ptr_type)
 	{
 		default:
 		case PTR_MAX:
 		case PTR_NONE:
 		case PTR_PIHOLE:
-			ptrname = (char*)"pi.hole";
-			break;
+			return (char*)"pi.hole";
 
 		case PTR_HOSTNAME:
-			ptrname = (char*)hostname();
-			break;
+			return (char*)hostname();
 
 		case PTR_HOSTNAMEFQDN:
 		{
-			const char *suffix;
-			size_t ptrnamesize = 0;
 			// get_domain() will also check conditional domains configured like
 			// domain=<domain>[,<address range>[,local]]
-			if(addr)
-				suffix = get_domain(*addr);
-			else
-				suffix = daemon->domain_suffix;
+			const char *suffix = addr ? get_domain(*addr) : daemon->domain_suffix;
 
 			// If local suffix is not available, we try to obtain the domain from
 			// the kernel similar to how we do it for the hostname
 			if(!suffix)
 				suffix = (char*)domainname();
 
-			// If local suffix is not available, we substitute "no_fqdn_available"
-			// see the comment about PIHOLE_PTR=HOSTNAMEFQDN in the Pi-hole docs
-			// for further details on why this was chosen
+			// If local suffix is still not available, we substitute
+			// "no_fqdn_available", see the comment about PIHOLE_PTR=HOSTNAMEFQDN
+			// in the Pi-hole docs for further details on why this was chosen
 			if(!suffix || suffix[0] == '\0')
 				suffix = (char*)"no_fqdn_available";
 
-			// Get enough space for domain building
-			size_t needspace = strlen(hostname()) + strlen(suffix) + 2;
-			if(ptrnamesize < needspace)
-			{
-				ptrname = realloc(ptrname, needspace);
-				ptrnamesize = needspace;
-			}
-
-			if(ptrname)
-			{
-				// Build "<hostname>.<local suffix>" domain
-				strcpy(ptrname, hostname());
-				strcat(ptrname, ".");
-				strcat(ptrname, suffix);
-			}
-			else
-			{
+			// Build a fresh "<hostname>.<local suffix>" string for this address
+			char *ptrname = calloc(strlen(hostname()) + strlen(suffix) + 2, sizeof(char));
+			if(!ptrname)
 				// Fallback to "<hostname>" on memory error
-				ptrname = (char*)hostname();
-			}
-			break;
+				return (char*)hostname();
+
+			strcpy(ptrname, hostname());
+			strcat(ptrname, ".");
+			strcat(ptrname, suffix);
+			return ptrname;
 		}
 	}
-
-	return ptrname;
 }
 
 void FTL_forwarding_retried(struct frec *forward, const int newID, const bool dnssec)


### PR DESCRIPTION
# What does this implement/fix?

PTR replies for the Pi-hole's own interface addresses could be built with the wrong domain suffix when conditional domains (`domain=<domain>,<address range>`) are configured.

`get_ptrname()` memorized the first `<hostname>.<suffix>` string it built in a `static` variable and returned it for every subsequent address, ignoring the `addr` argument. However, for `PTR_HOSTNAMEFQDN` the suffix is address-dependent (`get_domain(*addr)`, which matches the address against the conditional-domain ranges), so whichever of the Pi-hole's own addresses received a PTR query first determined the suffix for all of them.

Example: with

```
domain=lan,192.168.0.0/24,local
domain=vpn,10.0.0.0/24,local
```

a reverse lookup of the Pi-hole's VPN address `10.0.0.1` would return `<hostname>.lan` (the suffix cached from an earlier LAN-side lookup) instead of `<hostname>.vpn`. Regular clients were unaffected because their PTRs are synthesized by dnsmasq's normal reverse path (`is_rev_synth()` -> `get_domain()`), which is not cached.

The fix builds a fresh `<hostname>.<get_domain(addr)>` string per address. `PTR_PIHOLE` and `PTR_HOSTNAME` are address-independent and keep returning their stable strings directly. **No caching is lost**: `check_pihole_PTR()` builds at most one PTR record per address and answers all later queries for that address straight from `daemon->ptr`, so `get_ptrname()` runs at most once per address regardless. The dead `ptrnamesize` local (a non-`static` size guard that reset on every call) is removed as well.

## Manual reproduction

A regression test is not included: reproducing the bug requires the Pi-hole to own two addresses in two different conditional-domain subnets, which the CI container cannot provide (it has a single usable interface address; loopback is excluded, and creating a second interface needs `NET_ADMIN`, which the CI `docker run` does not grant).

To reproduce manually on a host with two interfaces/subnets (or two dummy interfaces):

```
# Two interfaces in two subnets
ip link add lan0 type dummy && ip addr add 192.168.50.1/24 dev lan0 && ip link set lan0 up
ip link add vpn0 type dummy && ip addr add 10.50.0.1/24     dev vpn0 && ip link set vpn0 up

# Conditional domains (dnsmasq)
domain=lan,192.168.50.0/24,local
domain=vpn,10.50.0.0/24,local

# dns.piholePTR = HOSTNAMEFQDN
```

```
# Query the LAN address first to poison the cache, then the VPN address
dig +short -x 192.168.50.1 @127.0.0.1   # <hostname>.lan.
dig +short -x 10.50.0.1    @127.0.0.1   # before: <hostname>.lan.   after: <hostname>.vpn.
```

Before the fix the second lookup returns `<hostname>.lan.`; after the fix it correctly returns `<hostname>.vpn.`.

## Related issue or feature (if applicable)

Reported via private communication on Discourse.

## Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable)

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally. (Compiles and links cleanly; behavioral verification is the manual two-subnet repro documented above - not yet run end-to-end.)
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
