### PR TITLE
webserver: allow files.log.webserver = "-" to log to stderr

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1373,8 +1373,8 @@ void initConfig(struct config *conf)
 	conf->files.log.dnsmasq.c = validate_filepath_dash;
 
 	conf->files.log.webserver.k = "files.log.webserver";
-	conf->files.log.webserver.h = "The log file used by the webserver";
-	conf->files.log.webserver.a = cJSON_CreateStringReference("Any writable file");
+	conf->files.log.webserver.h = "The log file used by the webserver.\n\n A single dash (\"-\") makes the webserver log to stderr instead of a file.";
+	conf->files.log.webserver.a = cJSON_CreateStringReference("Any writable file, or \"-\" for stderr");
 	conf->files.log.webserver.t = CONF_STRING;
 	conf->files.log.webserver.f = FLAG_RESTART_FTL;
 	conf->files.log.webserver.d.s = (char*)"/var/log/pihole/webserver.log";

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -356,6 +356,10 @@ bool validate_filepath_dash(union conf_value *val, const char *key, char err[VAL
 // execution.
 bool validate_webserver_logfile(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
 {
+	// Dash is allowed, this enables printing to stderr instead of a file
+	if(strlen(val->s) == 1 && val->s[0] == '-')
+		return true;
+
 	// Regular file-path validation first
 	if(!validate_filepath(val, key, err))
 		return false;

--- a/src/log.c
+++ b/src/log.c
@@ -359,8 +359,11 @@ void __attribute__ ((format (printf, 1, 2))) log_web(const char *format, ...)
 	// pihole-FTL instance is logging into the same file
 	const long pid = (long)getpid();
 
-	// Open web log file
-	FILE *weblog = fopen(config.files.log.webserver.v.s, "a+");
+	// Open web log file. A single dash ("-") means "write to stderr" instead
+	// of a file, mirroring files.log.dnsmasq.
+	const char *weblog_path = config.files.log.webserver.v.s;
+	const bool weblog_stderr = weblog_path != NULL && weblog_path[0] == '-' && weblog_path[1] == '\0';
+	FILE *weblog = weblog_stderr ? stderr : fopen(weblog_path, "a+");
 
 	// Write to web log file
 	if(weblog != NULL)
@@ -370,7 +373,8 @@ void __attribute__ ((format (printf, 1, 2))) log_web(const char *format, ...)
 		vfprintf(weblog, format, args);
 		va_end(args);
 		fputc('\n',weblog);
-		fclose(weblog);
+		if(!weblog_stderr)
+			fclose(weblog);
 	}
 	else if(!daemonmode)
 	{


### PR DESCRIPTION
### What
Accept a single dash (`-`) for `files.log.webserver` to make the web server log to stderr instead of a file, mirroring the existing behaviour of `files.log.dnsmasq`.

### Why
`files.log.dnsmasq` already accepts `-` to print to stderr, but `files.log.webserver` only accepts a regular file path. That makes it impossible to run FTL without *any* on-disk log file - e.g. in a container or a confined package that ships all logs to the journal via stdout/stderr. With this change every FTL log destination has a uniform "no file" option.

### Changes
- `validate_webserver_logfile()` now accepts `-` (like `validate_filepath_dash`).
- `log_web()` writes to `stderr` when the path is `-` instead of opening a file.
- Help text / allowed-values updated.

### Notes
Default behaviour and any existing file path are unchanged.