### PR TITLE
Fix EDNS MAC persistence in network table

### DIFF
--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -875,7 +875,7 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 			if(dbID >= 0)
 				log_debug(DEBUG_ARP, "Network table: Client with MAC %s is network ID %i", hwaddr, dbID);
 		}
-		if (dbID == DB_NODATA)
+		else
 		{
 			//
 			// Variant 2: Try to find a device using the same IP address within the last 24 hours
@@ -897,7 +897,7 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 		// if DHCP server is enabled
 		//
 		bool dhcp_lease = false;
-		if (dbID == DB_NODATA && config.dhcp.active.v.b)
+		if (snap_hwlen != 6 && dbID == DB_NODATA && config.dhcp.active.v.b)
 		{
 			log_debug(DEBUG_ARP, "Network table: DHCP server enabled, checking leases for IP %s", ipaddr);
 			FILE *fp = fopen(DHCPLEASESFILE, "r");
@@ -963,7 +963,7 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 		// Only try this when there is no EDNS(0) MAC address available
 		// nor a corresponding DHCP lease
 		//
-		if (dbID < 0 && dhcp_lease == false)
+		if (snap_hwlen != 6 && dbID < 0 && dhcp_lease == false)
 		{
 			unlock_shm();
 			dbID = find_device_by_mock_hwaddr(db, ipaddr);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1195,38 +1195,43 @@ setup() {
   assert_line --index 0 "1"
 }
 
-@test "EDNS(0) ECS can overwrite client address (IPv4)" {
-  # Get number of lines in the log before the test
-  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+@test "EDNS(0) MAC groups ECS addresses in network table" {
+  mac="02:00:00:00:00:01"
+  ipv4="192.168.47.97"
+  ipv6="fe80::b167:af1e:968b:dead"
 
-  # Run test command
-  run bash -c 'dig localhost +short +subnet=192.168.47.97/32 @127.0.0.1'
-  assert_line --index 0 "127.0.0.1"
+  seed="INSERT INTO network (hwaddr, interface, firstSeen, lastQuery, numQueries) VALUES ('ip-${ipv4}', 'test', 0, 0, 0); INSERT INTO network_addresses (network_id, ip) SELECT id, '${ipv4}' FROM network WHERE hwaddr = 'ip-${ipv4}';"
+  run ./pihole-FTL sqlite3 /etc/pihole/pihole-FTL.db "${seed}"
   assert_success
 
-  # Get number of lines in the log after the test
-  after="$(grep -c ^ /var/log/pihole/FTL.log)"
-
-  # Extract relevant log lines
-  run bash -c "sed -n \"${before},${after}p\" /var/log/pihole/FTL.log"
-  assert_line --partial "**** new UDP IPv4 query[A] query \"localhost\" from lo/192.168.47.97#53 "
-}
-
-@test "EDNS(0) ECS can overwrite client address (IPv6)" {
-  # Get number of lines in the log before the test
   before="$(grep -c ^ /var/log/pihole/FTL.log)"
-
-  # Run test command
-  run bash -c 'dig localhost +short +subnet=fe80::b167:af1e:968b:dead/128 @127.0.0.1'
+  run bash -c "dig localhost +short +subnet=${ipv4}/32 +ednsopt=65001:020000000001 @127.0.0.1"
   assert_line --index 0 "127.0.0.1"
   assert_success
-
-  # Get number of lines in the log after the test
   after="$(grep -c ^ /var/log/pihole/FTL.log)"
-
-  # Extract relevant log lines
   run bash -c "sed -n \"${before},${after}p\" /var/log/pihole/FTL.log"
-  assert_line --partial "**** new UDP IPv4 query[A] query \"localhost\" from lo/fe80::b167:af1e:968b:dead#53 "
+  assert_line --partial "**** new UDP IPv4 query[A] query \"localhost\" from lo/${ipv4}#53 "
+
+  before="$(grep -c ^ /var/log/pihole/FTL.log)"
+  run bash -c "dig localhost +short +subnet=${ipv6}/128 +ednsopt=65001:020000000001 @127.0.0.1"
+  assert_line --index 0 "127.0.0.1"
+  assert_success
+  after="$(grep -c ^ /var/log/pihole/FTL.log)"
+  run bash -c "sed -n \"${before},${after}p\" /var/log/pihole/FTL.log"
+  assert_line --partial "**** new UDP IPv4 query[A] query \"localhost\" from lo/${ipv6}#53 "
+
+  kill -SIGRTMIN+5 "$(cat /run/pihole-FTL.pid)"
+
+  query="SELECT lower(n.hwaddr) || '|' || a.ip FROM network AS n JOIN network_addresses AS a ON a.network_id = n.id WHERE a.ip IN ('${ipv4}', '${ipv6}') ORDER BY a.ip; SELECT 'mac_rows=' || count(*) FROM network WHERE lower(hwaddr) = '${mac}'; SELECT 'mock_rows=' || count(*) FROM network WHERE lower(hwaddr) IN ('ip-${ipv4}', 'ip-${ipv6}');"
+  expected="${mac}|${ipv4}"$'\n'"${mac}|${ipv6}"$'\n'"mac_rows=1"$'\n'"mock_rows=0"
+  for _ in $(seq 1 30); do
+    result="$(./pihole-FTL sqlite3 /etc/pihole/pihole-FTL.db "${query}")"
+    [[ "${result}" == "${expected}" ]] && break
+    sleep 0.1
+  done
+
+  run ./pihole-FTL sqlite3 /etc/pihole/pihole-FTL.db "${query}"
+  assert_output "${expected}"
 }
 
 @test "alias-client is imported and used for configured client" {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix persistence of dnsmasq's forwarded EDNS MAC when ECS supplies the logical client address.

FTL already uses the forwarded MAC in memory for client and group identity. During a network-table update, however, a MAC that is not yet in the database falls through to the recent-IP, DHCP-lease, and mock-address paths. The mock path replaces the formatted MAC with `ip-<address>`, so IPv4 and IPv6 ECS addresses from one device are persisted as separate synthetic devices. An existing mock mapping also remains associated with the address instead of being replaced by the forwarded MAC.

**How does this PR accomplish the above?:**

- Use recent-IP, DHCP-lease, and mock-address fallbacks only when no six-byte MAC is available.
- Leave the existing fallback behavior unchanged for clients without a MAC.
- Add a regression test that begins with an existing mock IPv4 mapping, sends IPv4 and IPv6 ECS queries carrying the same forwarded MAC, and verifies that both addresses converge on one MAC row with no matching mock rows left behind.

### Scope and trust boundary

This changes network-table identity persistence only. DNS responses and live client-group selection are unchanged.

Forwarded EDNS MAC data is unauthenticated and is already used for live client-group resolution. This change persists that same identity, so an incorrect or spoofed forwarded MAC can also persist in the network table. Deployments using this metadata must trust the forwarding DNS server.

### Evidence and validation

The focused regression fails against unmodified `development`:

```text
ip-192.168.47.97|192.168.47.97
ip-fe80::b167:af1e:968b:dead|fe80::b167:af1e:968b:dead
mac_rows=0
mock_rows=2
```

With this change:

```text
02:00:00:00:00:01|192.168.47.97
02:00:00:00:00:01|fe80::b167:af1e:968b:dead
mac_rows=1
mock_rows=0
```

Additional validation:

- ARM64 architecture, static executable, library, binary-classification, backtrace, and crash-handler checks passed.
- 190 BATS tests passed.
- 149 API tests passed.
- 9 final log-validation tests passed.
- An isolated x86_64 Pi-hole 2026.07.2 container using FTL v6.7 reproduced the control result and persisted both addresses under the forwarded MAC after applying the patch.
- The patched FTL binary integrity check passed.

**Link documentation PRs if any are needed to support this PR:**

None. This restores the behavior described by the existing fallback comments and does not add or change a user-facing option.

Development and test preparation were assisted by OpenAI Codex. I reviewed the final diff and validated it with the upstream test suite and an isolated Pi-hole deployment.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
