### PR TITLE
breaking: utilize a cached file descriptor for logging & own dnsmasq.log

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1386,7 +1386,7 @@ void initConfig(struct config *conf)
 	conf->files.log.dnsmasq.t = CONF_STRING;
 	conf->files.log.dnsmasq.f = FLAG_RESTART_FTL;
 	conf->files.log.dnsmasq.d.s = (char*)"/var/log/pihole/pihole.log";
-	conf->files.log.dnsmasq.c = validate_filepath_dash;
+	conf->files.log.dnsmasq.c = validate_filepath;
 
 	conf->files.log.webserver.k = "files.log.webserver";
 	conf->files.log.webserver.h = "The log file used by the webserver";

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1918,6 +1918,13 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 	// First, read the environment
 	getEnvVars();
 
+	// Open pihole.log and webserver.log now (with default or ENV paths)
+	// so that any log output during write_dnsmasq_config() below is not
+	// silently lost.  open_log_fds(false) will be called again after the
+	// config parse in main() to pick up any path overrides from the TOML
+	// file or legacy config.
+	open_log_fds(false);
+
 	// Try to read TOML config file
 	// If we cannot parse /etc/pihole.toml (due to missing or invalid syntax),
 	// we try to read the rotated files in /etc/pihole/config_backup starting at

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1918,13 +1918,6 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 	// First, read the environment
 	getEnvVars();
 
-	// Open pihole.log and webserver.log now (with default or ENV paths)
-	// so that any log output during write_dnsmasq_config() below is not
-	// silently lost.  open_log_fds(false) will be called again after the
-	// config parse in main() to pick up any path overrides from the TOML
-	// file or legacy config.
-	open_log_fds(false);
-
 	// Try to read TOML config file
 	// If we cannot parse /etc/pihole.toml (due to missing or invalid syntax),
 	// we try to read the rotated files in /etc/pihole/config_backup starting at
@@ -1939,6 +1932,11 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 			// about options deviating from the default are present
 			if(rewrite)
 			{
+				// Open webserver.log and pihole.log now that paths are
+				// known from the config.  CLI invocations (rewrite == false)
+				// never reach here, so log files are not created on
+				// pihole-FTL --config etc.
+				open_log_fds(false);
 				writeFTLtoml(true, NULL);
 				char errbuf[ERRBUF_SIZE] = { 0 };
 				write_dnsmasq_config(conf, DNSMASQ_INSTALL, errbuf);
@@ -1971,6 +1969,8 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 	// setupVars.conf
 	get_web_port(&config);
 
+	// Open webserver.log and pihole.log at default paths (TOML was unreadable)
+	open_log_fds(false);
 	// Initialize the TOML config file
 	writeFTLtoml(true, NULL);
 	char errbuf[ERRBUF_SIZE] = { 0 };

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -2009,7 +2009,7 @@ bool getLogFilePath(bool try_read)
 	config.files.log.ftl.d.s = (char*)"/var/log/pihole/FTL.log";
 	config.files.log.ftl.v.s = config.files.log.ftl.d.s;
 	config.files.log.ftl.c = validate_filepath;
-	config.files.log.ftl.f = FLAG_FTL_LOG;
+	config.files.log.ftl.f = FLAG_FTL_LOG | FLAG_RESTART_FTL;
 
 	// Try sources in priority order: ENV > TOML > legacy
 	if(try_read && !getLogFilePathENV() && !getLogFilePathTOML())

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1392,7 +1392,7 @@ void initConfig(struct config *conf)
 	conf->files.log.dnsmasq.t = CONF_STRING;
 	conf->files.log.dnsmasq.f = FLAG_RESTART_FTL;
 	conf->files.log.dnsmasq.d.s = (char*)"/var/log/pihole/pihole.log";
-	conf->files.log.dnsmasq.c = validate_filepath_dash;
+	conf->files.log.dnsmasq.c = validate_filepath;
 
 	conf->files.log.webserver.k = "files.log.webserver";
 	conf->files.log.webserver.h = "The log file used by the webserver";

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1924,6 +1924,13 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 	// First, read the environment
 	getEnvVars();
 
+	// Open pihole.log and webserver.log now (with default or ENV paths)
+	// so that any log output during write_dnsmasq_config() below is not
+	// silently lost.  open_log_fds(false) will be called again after the
+	// config parse in main() to pick up any path overrides from the TOML
+	// file or legacy config.
+	open_log_fds(false);
+
 	// Try to read TOML config file
 	// If we cannot parse /etc/pihole.toml (due to missing or invalid syntax),
 	// we try to read the rotated files in /etc/pihole/config_backup starting at

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -438,15 +438,6 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		fputs("\n", pihole_conf);
 	}
 
-	if(strlen(conf->files.log.dnsmasq.v.s) > 0)
-	{
-		fputs("# Specify the log file to use\n", pihole_conf);
-		fputs("# We set this even if logging is disabled to store warnings\n", pihole_conf);
-		fputs("# and errors in this file. This is useful for debugging.\n", pihole_conf);
-		fprintf(pihole_conf, "log-facility=%s\n", conf->files.log.dnsmasq.v.s);
-		fputs("\n", pihole_conf);
-	}
-
 	if(conf->dns.bogusPriv.v.b)
 	{
 		fputs("# Bogus private reverse lookups. All reverse lookups for private IP\n", pihole_conf);

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -423,18 +423,18 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 	if(conf->dns.queryLogging.v.b)
 	{
 		fputs("# Enable query logging\n", pihole_conf);
+		// FTL writes pihole.log synchronously via a cached descriptor, so
+		// dnsmasq's log-async queue is never used
 		if(conf->misc.extraLogging.v.b)
 			fputs("log-queries=proto\n", pihole_conf);
 		else
 			fputs("log-queries\n", pihole_conf);
-		fputs("log-async\n", pihole_conf);
 		fputs("\n", pihole_conf);
 	}
 	else
 	{
 		fputs("# Disable query logging\n", pihole_conf);
 		fputs("#log-queries\n", pihole_conf);
-		fputs("#log-async\n", pihole_conf);
 		fputs("\n", pihole_conf);
 	}
 

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -481,15 +481,6 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 		fputs("\n", pihole_conf);
 	}
 
-	if(strlen(conf->files.log.dnsmasq.v.s) > 0)
-	{
-		fputs("# Specify the log file to use\n", pihole_conf);
-		fputs("# We set this even if logging is disabled to store warnings\n", pihole_conf);
-		fputs("# and errors in this file. This is useful for debugging.\n", pihole_conf);
-		fprintf(pihole_conf, "log-facility=%s\n", conf->files.log.dnsmasq.v.s);
-		fputs("\n", pihole_conf);
-	}
-
 	if(conf->dns.bogusPriv.v.b)
 	{
 		fputs("# Bogus private reverse lookups. All reverse lookups for private IP\n", pihole_conf);

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -466,18 +466,18 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 	if(conf->dns.queryLogging.v.b)
 	{
 		fputs("# Enable query logging\n", pihole_conf);
+		// FTL writes pihole.log synchronously via a cached descriptor, so
+		// dnsmasq's log-async queue is never used
 		if(conf->misc.extraLogging.v.b)
 			fputs("log-queries=proto\n", pihole_conf);
 		else
 			fputs("log-queries\n", pihole_conf);
-		fputs("log-async\n", pihole_conf);
 		fputs("\n", pihole_conf);
 	}
 	else
 	{
 		fputs("# Disable query logging\n", pihole_conf);
 		fputs("#log-queries\n", pihole_conf);
-		fputs("#log-async\n", pihole_conf);
 		fputs("\n", pihole_conf);
 	}
 

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -357,17 +357,6 @@ bool validate_filepath_empty(union conf_value *val, const char *key, char err[VA
 	return validate_filepath(val, key, err);
 }
 
-// Validate file path (dash allowed), used by files.log.dnsmasq
-bool validate_filepath_dash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
-{
-	// Dash is allowed, this enabled printing to stderr
-	if(strlen(val->s) == 1 && val->s[0] == '-')
-		return true;
-
-	// else:
-	return validate_filepath(val, key, err);
-}
-
 // Validate the web server log file path. In addition to the regular file-path
 // checks, reject a path inside webserver.paths.webroot: a log file served from
 // the web server's document root can be read - and, if the path matches the

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -339,17 +339,6 @@ bool validate_filepath_empty(union conf_value *val, const char *key, char err[VA
 	return validate_filepath(val, key, err);
 }
 
-// Validate file path (dash allowed), used by files.log.dnsmasq
-bool validate_filepath_dash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
-{
-	// Dash is allowed, this enabled printing to stderr
-	if(strlen(val->s) == 1 && val->s[0] == '-')
-		return true;
-
-	// else:
-	return validate_filepath(val, key, err);
-}
-
 // Validate the web server log file path. In addition to the regular file-path
 // checks, reject a path inside webserver.paths.webroot: a log file served from
 // the web server's document root can be read - and, if the path matches the

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -24,7 +24,6 @@ bool validate_domain(union conf_value *val, const char *key, char err[VALIDATOR_
 bool validate_filepath(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath_two_slash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath_empty(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
-bool validate_filepath_dash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_webserver_logfile(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_regex_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_revServers(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -23,7 +23,6 @@ bool validate_domain(union conf_value *val, const char *key, char err[VALIDATOR_
 bool validate_filepath(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath_two_slash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath_empty(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
-bool validate_filepath_dash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_webserver_logfile(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_regex_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_revServers(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);

--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -1456,9 +1456,9 @@ void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit
 
 }
 
-void logg_warn_dnsmasq_message(char *message)
+void logg_warn_dnsmasq_message(const char *message)
 {
-	// Create message
+	// Create message (dnsmasq limits is message length to 1KiB to conform with RFC 3164; See MAX_MESSAGE in dnsmasq/log.c), account for our 'dnsmasq: ' prefix
 	char buf[2048];
 	format_dnsmasq_warn_message(buf, sizeof(buf), NULL, 0, message);
 

--- a/src/database/message-table.h
+++ b/src/database/message-table.h
@@ -25,7 +25,7 @@ void logg_subnet_warning(const char *ip, const int matching_count, const char *m
 void log_hostname_warning(const char *ip, const char *name, const unsigned int pos);
 void logg_fatal_dnsmasq_message(const char *message);
 void logg_rate_limit_message(const char *clientIP, const unsigned int rate_limit_count);
-void logg_warn_dnsmasq_message(char *message);
+void logg_warn_dnsmasq_message(const char *message);
 void log_resource_shortage(const double load, const int nprocs, const int shmem, const int disk, const char *path, const char *msg);
 void logg_inaccessible_adlist(const int dbindex, const char *address);
 void log_certificate_domain_mismatch(const char *certfile, const char *domain);

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -330,17 +330,7 @@ void my_syslog(int priority, const char *format, ...)
   va_start(ap, format);
   len = vsnprintf(buffer, MAX_MESSAGE, format, ap) + 1u; /* include zero-terminator */
   va_end(ap);
-  FTL_dnsmasq_log(buffer, priority, len > MAX_MESSAGE ? MAX_MESSAGE : len);
-  /*******************************************************************************/
-
-  if (echo_stderr) 
-    {
-      fprintf(stderr, "dnsmasq%s: ", func);
-      va_start(ap, format);
-      vfprintf(stderr, format, ap);
-      va_end(ap);
-      fputc('\n', stderr);
-    }
+  FTL_dnsmasq_log(buffer, priority, func, len > MAX_MESSAGE ? MAX_MESSAGE : len);
 
   /* Pi-hole diagnosis system */
   if(priority == LOG_WARNING)
@@ -353,6 +343,21 @@ void my_syslog(int priority, const char *format, ...)
           free(message);
         }
       va_end(ap);
+    }
+
+  /* Pi-hole: FTL owns pihole.log.  Bypass dnsmasq's file-write path
+     and syslog fallback entirely. */
+  return;
+  /*******************************************************************************/
+
+
+  if (echo_stderr) 
+    {
+      fprintf(stderr, "dnsmasq%s: ", func);
+      va_start(ap, format);
+      vfprintf(stderr, format, ap);
+      va_end(ap);
+      fputc('\n', stderr);
     }
 
   if (log_fd == -1)

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -332,26 +332,11 @@ void my_syslog(int priority, const char *format, ...)
   va_end(ap);
   FTL_dnsmasq_log(buffer, priority, func, len > MAX_MESSAGE ? MAX_MESSAGE : len);
 
-  /* Pi-hole diagnosis system */
-  if(priority == LOG_WARNING)
-    {
-      char *message;
-      va_start(ap, format);
-      if(vasprintf(&message, format, ap))
-        {
-          dnsmasq_diagnosis_warning(message);
-          free(message);
-        }
-      va_end(ap);
-    }
-
   /* Pi-hole: FTL owns pihole.log.  Bypass dnsmasq's file-write path
-     and syslog fallback entirely. */
-  return;
-  /*******************************************************************************/
-
-
-  if (echo_stderr) 
+     and syslog fallback entirely.
+     Keep echo_stderr so dnsmasq --test errors reach stderr (captured
+     by test_dnsmasq_config() in src/config/dnsmasq_config.c). */
+  if (echo_stderr)
     {
       fprintf(stderr, "dnsmasq%s: ", func);
       va_start(ap, format);
@@ -359,6 +344,9 @@ void my_syslog(int priority, const char *format, ...)
       va_end(ap);
       fputc('\n', stderr);
     }
+
+  return;
+  /*******************************************************************************/
 
   if (log_fd == -1)
     {

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -327,17 +327,7 @@ void my_syslog(int priority, const char *format, ...)
   va_start(ap, format);
   len = vsnprintf(buffer, MAX_MESSAGE, format, ap) + 1u; /* include zero-terminator */
   va_end(ap);
-  FTL_dnsmasq_log(buffer, priority, len > MAX_MESSAGE ? MAX_MESSAGE : len);
-  /*******************************************************************************/
-
-  if (echo_stderr) 
-    {
-      fprintf(stderr, "dnsmasq%s: ", func);
-      va_start(ap, format);
-      vfprintf(stderr, format, ap);
-      va_end(ap);
-      fputc('\n', stderr);
-    }
+  FTL_dnsmasq_log(buffer, priority, func, len > MAX_MESSAGE ? MAX_MESSAGE : len);
 
   /* Pi-hole diagnosis system */
   if(priority == LOG_WARNING)
@@ -350,6 +340,21 @@ void my_syslog(int priority, const char *format, ...)
           free(message);
         }
       va_end(ap);
+    }
+
+  /* Pi-hole: FTL owns pihole.log.  Bypass dnsmasq's file-write path
+     and syslog fallback entirely. */
+  return;
+  /*******************************************************************************/
+
+
+  if (echo_stderr) 
+    {
+      fprintf(stderr, "dnsmasq%s: ", func);
+      va_start(ap, format);
+      vfprintf(stderr, format, ap);
+      va_end(ap);
+      fputc('\n', stderr);
     }
 
   if (log_fd == -1)

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -329,19 +329,6 @@ void my_syslog(int priority, const char *format, ...)
   va_end(ap);
   FTL_dnsmasq_log(buffer, priority, func, len > MAX_MESSAGE ? MAX_MESSAGE : len);
 
-  /* Pi-hole diagnosis system */
-  if(priority == LOG_WARNING)
-    {
-      char *message;
-      va_start(ap, format);
-      if(vasprintf(&message, format, ap))
-        {
-          dnsmasq_diagnosis_warning(message);
-          free(message);
-        }
-      va_end(ap);
-    }
-
   /* Pi-hole: FTL owns pihole.log.  Bypass dnsmasq's file-write path
      and syslog fallback entirely. */
   return;

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -330,12 +330,10 @@ void my_syslog(int priority, const char *format, ...)
   FTL_dnsmasq_log(buffer, priority, func, len > MAX_MESSAGE ? MAX_MESSAGE : len);
 
   /* Pi-hole: FTL owns pihole.log.  Bypass dnsmasq's file-write path
-     and syslog fallback entirely. */
-  return;
-  /*******************************************************************************/
-
-
-  if (echo_stderr) 
+     and syslog fallback entirely.
+     Keep echo_stderr so dnsmasq --test errors reach stderr (captured
+     by test_dnsmasq_config() in src/config/dnsmasq_config.c). */
+  if (echo_stderr)
     {
       fprintf(stderr, "dnsmasq%s: ", func);
       va_start(ap, format);
@@ -343,6 +341,9 @@ void my_syslog(int priority, const char *format, ...)
       va_end(ap);
       fputc('\n', stderr);
     }
+
+  return;
+  /*******************************************************************************/
 
   if (log_fd == -1)
     {

--- a/src/dnsmasq/util.c
+++ b/src/dnsmasq/util.c
@@ -40,6 +40,7 @@
 
 /****** Pi-hole modification ******/
 extern int is_shm_fd(const int fd);
+extern int is_log_fd(const int fd);
 /**********************************/
 
 /* SURF random number generator */
@@ -881,7 +882,7 @@ void close_fds(long max_fd, int spare1, int spare2, int spare3)
 	    continue;
 	  
 	  /****** Pi-hole modification ******/
-	  if(is_shm_fd(fd))
+	  if(is_shm_fd(fd) || is_log_fd(fd))
 	    continue;
 	  /**********************************/
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -4269,6 +4269,10 @@ void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, 
 
 	// Write to pihole.log via shared writer (FTL owns this file now)
 	FTL_write_dnsmasq_log(payload, func);
+
+	/* Pi-hole diagnosis system */
+	if(priority == LOG_WARNING)
+		dnsmasq_diagnosis_warning(payload);
 }
 
 static const char *check_dnsmasq_name(const char *name)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3743,6 +3743,14 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 			// Configured FTL log file
 			chown_pihole(config.files.log.ftl.v.s, ent_pw);
 
+			// Configured webserver log file
+			if(config.files.log.webserver.v.s != NULL)
+				chown_pihole(config.files.log.webserver.v.s, ent_pw);
+
+			// Configured dnsmasq log file (pihole.log)
+			if(config.files.log.dnsmasq.v.s != NULL)
+				chown_pihole(config.files.log.dnsmasq.v.s, ent_pw);
+
 			// Configured FTL database file
 			chown_pihole(config.files.database.v.s, ent_pw);
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -4254,7 +4254,7 @@ static void _query_set_dnssec(queriesData *query, const enum dnssec_status dnsse
 }
 
 // Add dnsmasq log line to internal FIFO buffer (can be queried via the API)
-void FTL_dnsmasq_log(const char *payload, const int priority, const int length)
+void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, const int length)
 {
 	// Lock SHM
 	lock_shm();
@@ -4266,6 +4266,9 @@ void FTL_dnsmasq_log(const char *payload, const int priority, const int length)
 
 	// Unlock SHM
 	unlock_shm();
+
+	// Write to pihole.log via shared writer (FTL owns this file now)
+	FTL_write_dnsmasq_log(payload, func);
 }
 
 static const char *check_dnsmasq_name(const char *name)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -4267,8 +4267,11 @@ void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, 
 	// Unlock SHM
 	unlock_shm();
 
-	// Write to pihole.log via shared writer (FTL owns this file now)
-	FTL_write_dnsmasq_log(payload, func);
+	// Write to pihole.log via shared writer (FTL owns this file now).
+	// If pihole.log is unavailable, fall back to syslog for warnings and
+	// errors so they are not silently lost for the lifetime of the process.
+	if(!FTL_write_dnsmasq_log(payload, func) && priority <= LOG_WARNING)
+		syslog(priority, "%s", payload);
 
 	/* Pi-hole diagnosis system */
 	if(priority == LOG_WARNING)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -4276,6 +4276,10 @@ void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, 
 
 	// Write to pihole.log via shared writer (FTL owns this file now)
 	FTL_write_dnsmasq_log(payload, func);
+
+	/* Pi-hole diagnosis system */
+	if(priority == LOG_WARNING)
+		dnsmasq_diagnosis_warning(payload);
 }
 
 static const char *check_dnsmasq_name(const char *name)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -4261,7 +4261,7 @@ static void _query_set_dnssec(queriesData *query, const enum dnssec_status dnsse
 }
 
 // Add dnsmasq log line to internal FIFO buffer (can be queried via the API)
-void FTL_dnsmasq_log(const char *payload, const int priority, const int length)
+void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, const int length)
 {
 	// Lock SHM
 	lock_shm();
@@ -4273,6 +4273,9 @@ void FTL_dnsmasq_log(const char *payload, const int priority, const int length)
 
 	// Unlock SHM
 	unlock_shm();
+
+	// Write to pihole.log via shared writer (FTL owns this file now)
+	FTL_write_dnsmasq_log(payload, func);
 }
 
 static const char *check_dnsmasq_name(const char *name)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -4282,8 +4282,11 @@ void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, 
 	// Unlock SHM
 	unlock_shm();
 
-	// Write to pihole.log via shared writer (FTL owns this file now)
-	FTL_write_dnsmasq_log(payload, func);
+	// Write to pihole.log via shared writer (FTL owns this file now).
+	// If pihole.log is unavailable, fall back to syslog for warnings and
+	// errors so they are not silently lost for the lifetime of the process.
+	if(!FTL_write_dnsmasq_log(payload, func) && priority <= LOG_WARNING)
+		syslog(priority, "%s", payload);
 
 	/* Pi-hole diagnosis system */
 	if(priority == LOG_WARNING)

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3764,6 +3764,14 @@ void FTL_fork_and_bind_sockets(struct passwd *ent_pw, bool dnsmasq_start)
 			// Configured FTL log file
 			chown_pihole(config.files.log.ftl.v.s, ent_pw);
 
+			// Configured webserver log file
+			if(config.files.log.webserver.v.s != NULL)
+				chown_pihole(config.files.log.webserver.v.s, ent_pw);
+
+			// Configured dnsmasq log file (pihole.log)
+			if(config.files.log.dnsmasq.v.s != NULL)
+				chown_pihole(config.files.log.dnsmasq.v.s, ent_pw);
+
 			// Configured FTL database file
 			chown_pihole(config.files.database.v.s, ent_pw);
 

--- a/src/dnsmasq_interface.h
+++ b/src/dnsmasq_interface.h
@@ -57,6 +57,6 @@ bool get_dnsmasq_debug(void) __attribute__ ((pure));
 // defined in src/dnsmasq/cache.c
 extern char *querystr(char *desc, unsigned short type);
 
-extern void FTL_dnsmasq_log(const char *payload, const int priority, const int length);
+extern void FTL_dnsmasq_log(const char *payload, const int priority, const char *func, const int length);
 
 #endif // DNSMASQ_INTERFACE_H

--- a/src/log.c
+++ b/src/log.c
@@ -28,10 +28,87 @@
 #include "database/query-table.h"
 // runGC()
 #include "gc.h"
+// open(), O_WRONLY, O_CREAT, O_APPEND, O_CLOEXEC
+#include <fcntl.h>
 
 static bool print_log = true, print_stdout = true;
-static bool ftl_log_available = true;
 bool debug_flags[DEBUG_MAX] = { false };
+
+// Per-file log state: fd, path, writer-preferenced lock, reopen flag
+struct log_fd {
+	int fd;
+	const char *path;
+	pthread_mutex_t lock;
+	volatile sig_atomic_t reopen_needed;
+};
+
+static struct log_fd ftl_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
+static struct log_fd webserver_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
+static struct log_fd dnsmasq_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
+
+// dnsmasq forks per TCP query while FTL threads may be mid-write; without
+// atfork handling the child would inherit a locked log mutex and hang on the
+// first my_syslog() there.  Lock/unlock all log mutexes around fork().
+static void log_atfork_prepare(void)
+{
+	pthread_mutex_lock(&ftl_log.lock);
+	pthread_mutex_lock(&webserver_log.lock);
+	pthread_mutex_lock(&dnsmasq_log.lock);
+}
+static void log_atfork_parent(void)
+{
+	pthread_mutex_unlock(&ftl_log.lock);
+	pthread_mutex_unlock(&webserver_log.lock);
+	pthread_mutex_unlock(&dnsmasq_log.lock);
+}
+static void log_atfork_child(void)
+{
+	pthread_mutex_unlock(&ftl_log.lock);
+	pthread_mutex_unlock(&webserver_log.lock);
+	pthread_mutex_unlock(&dnsmasq_log.lock);
+}
+
+// Return 1 if this fd is associated with any logfile to avoid
+// dnsmasq closing it during initialization
+int __attribute__((pure)) is_log_fd(const int fd)
+{
+	return fd == ftl_log.fd || fd == webserver_log.fd || fd == dnsmasq_log.fd;
+}
+
+// Writer-preferenced per-file lock: only the fd for this specific log is
+// held, so writes to different files never contend.  The reopen flag is
+// per-file so SIGUSR2 only touches the fd that actually needs it.
+static bool write_log_line(struct log_fd *log, const char *line, size_t len)
+{
+	if(log->fd == -1)
+		return false;
+
+	pthread_mutex_lock(&log->lock);
+
+	if(log->reopen_needed)
+	{
+		log->reopen_needed = 0;
+		close(log->fd);
+		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+
+	ssize_t written = 0;
+	while(written < (ssize_t)len)
+	{
+		ssize_t rc = write(log->fd, line + written, len - written);
+		if(rc == -1)
+		{
+			if(errno == EINTR)
+				continue;
+			pthread_mutex_unlock(&log->lock);
+			return false;
+		}
+		written += rc;
+	}
+
+	pthread_mutex_unlock(&log->lock);
+	return true;
+}
 
 void clear_debug_flags(void)
 {
@@ -45,26 +122,61 @@ void log_ctrl(bool plog, bool pstdout)
 	print_stdout = pstdout;
 }
 
-void init_FTL_log(void)
+// Open cached log fds from config paths.
+// open_log_fds(true):  open FTL.log only (called early, before full config)
+// open_log_fds(false): open webserver.log + pihole.log (called after config)
+void open_log_fds(bool ftl)
 {
-	// Open the log file in append/create mode
-	if(config.files.log.ftl.v.s != NULL)
+	if(ftl)
 	{
-		FILE *logfile = NULL;
-		if((logfile = fopen(config.files.log.ftl.v.s, "a+")) == NULL)
+		// FTL.log - path is known from getLogFilePath()
+		if(config.files.log.ftl.v.s != NULL)
 		{
-			printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
-			       config.files.log.ftl.v.s, strerror(errno));
-			syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
-			ftl_log_available = false;
+			ftl_log.path = config.files.log.ftl.v.s;
+			ftl_log.fd = open(ftl_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+			if(ftl_log.fd == -1)
+			{
+				printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
+				       ftl_log.path, strerror(errno));
+				syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
+			}
 		}
-		else
-			ftl_log_available = true;
-
-		// Close log file
-		if(logfile != NULL)
-			fclose(logfile);
+		return;
 	}
+
+	// webserver.log + pihole.log - paths are known after readFTLconf()
+	if(config.files.log.webserver.v.s != NULL)
+	{
+		webserver_log.path = config.files.log.webserver.v.s;
+		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+
+	// pihole.log (dnsmasq) - FTL owns this file from now on
+	if(config.files.log.dnsmasq.v.s != NULL)
+	{
+		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
+		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+
+	// Register atfork handlers once, before any threads or dnsmasq forks
+	// exist, so a TCP-query fork can never inherit a locked log mutex.
+	// Invariant: fork() is never called from inside a log write, so these
+	// handlers only need to cover the case where a thread holds a log mutex
+	// at the moment of the fork.
+	static bool atfork_registered = false;
+	if(!atfork_registered)
+	{
+		atfork_registered = true;
+		pthread_atfork(log_atfork_prepare, log_atfork_parent, log_atfork_child);
+	}
+}
+
+// Signal that log fds need to be reopened (called from SIGUSR2 handler path)
+void mark_log_reopen(void)
+{
+	ftl_log.reopen_needed = 1;
+	webserver_log.reopen_needed = 1;
+	dnsmasq_log.reopen_needed = 1;
 }
 
 // Return time(NULL) but with (up to) nanosecond accuracy
@@ -254,6 +366,36 @@ const char *debugstr(const enum debug_flag flag)
 	}
 }
 
+// Write a dnsmasq log line to pihole.log in dnsmasq's exact on-disk format.
+// The message is the bare body (no timestamp, no prefix) as handed to
+// FTL_dnsmasq_log() from my_syslog().  We reproduce dnsmasq's format:
+//   "Mon Jan  1 12:00:00 2024 dnsmasq-dhcp[12345]: <message>\n"
+// where the func suffix (e.g. "-dhcp", "-tftp") comes from the priority
+// bits extracted in my_syslog().
+void FTL_write_dnsmasq_log(const char *message, const char *func)
+{
+	if(dnsmasq_log.fd == -1)
+		return;
+
+	time_t now = time(NULL);
+	char *ts = ctime(&now);
+
+	char line[2048];
+	int off = snprintf(line, sizeof(line), "%.20s dnsmasq%s[%d]: ", ts + 4, func ? func : "", getpid());
+
+	const char *msg = message ? message : "";
+	off += snprintf(line + off, sizeof(line) - off, "%s", msg);
+
+	// Clamp to buffer end - snprintf returns would-be length on truncation
+	if(off >= (int)sizeof(line))
+		off = sizeof(line) - 1;
+
+	if(off > 0 && line[off - 1] != '\n')
+		line[off++] = '\n';
+
+	write_log_line(&dnsmasq_log, line, off);
+}
+
 void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const enum debug_flag flag, const char *format, ...)
 {
 	char timestring[TIMESTR_SIZE];
@@ -294,40 +436,25 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		va_end(args);
 		add_to_fifo_buffer(FIFO_FTL, buffer, prio, len > MAX_MSG_FIFO ? MAX_MSG_FIFO : len);
 
-		bool logged = false;
-		if(ftl_log_available && config.files.log.ftl.v.s != NULL)
+		// Format full line and write to cached fd.  Bounded to one 2048-byte
+		// write per line so O_APPEND guarantees a line never interleaves with
+		// another thread's - lines past the cap are truncated (a deliberate
+		// trade-off of the cached-fd design vs. the old unbounded vfprintf()).
+		char line[2048];
+		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+		va_start(args, format);
+		off += vsnprintf(line + off, sizeof(line) - off, format, args);
+		va_end(args);
+
+		// Clamp to buffer end - snprintf returns would-be length on truncation
+		if(off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
+		line[off++] = '\n';
+
+		if(!write_log_line(&ftl_log, line, off))
 		{
-			// Open log file
-			FILE *logfile = fopen(config.files.log.ftl.v.s, "a+");
-
-			// Write to log file
-			if(logfile != NULL)
-			{
-				// Prepend message with identification string and priority
-				fprintf(logfile, "%s [%s] %s: ", timestring, idstr, prio);
-
-				// Log message
-				va_start(args, format);
-				vfprintf(logfile, format, args);
-				va_end(args);
-
-				// Append newline character to the end of the file
-				fputc('\n', logfile);
-
-				// Close file after writing
-				fclose(logfile);
-
-				logged = true;
-			}
-			else if(!daemonmode)
-			{
-				printf("!!! WARNING: Writing to FTL\'s log file failed!\n");
-				syslog(LOG_ERR, "Writing to FTL\'s log file failed!");
-			}
-		}
-		if(!logged)
-		{
-			// Syslog logging
+			// Fallback: syslog if fd is unavailable or write failed
 			va_start(args, format);
 			vsyslog(priority, format, args);
 			va_end(args);
@@ -354,16 +481,8 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 	get_idstr(idstr, sizeof(idstr));
 	const char *prio = priostr(priority, flag);
 
-	// Open web log file (if a path is configured)
-	FILE *weblog = NULL;
-	if(print_log && config.files.log.webserver.v.s != NULL)
-		weblog = fopen(config.files.log.webserver.v.s, "a+");
-
-	// _FTL_log() prints these itself, so do not print them twice
-	const bool relay = print_log && weblog == NULL && priority <= LOG_WARNING;
-
 	// Print to stdout before writing to file
-	if(!relay && (!daemonmode || cli_mode) && print_stdout)
+	if((!daemonmode || cli_mode) && print_stdout)
 	{
 		// Only print time/ID string when not in direct user interaction (CLI mode)
 		if(!cli_mode)
@@ -377,28 +496,30 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 	// Print to log file or FIFO
 	if(print_log)
 	{
-		// Add line to FIFO buffer. It lives in shared memory and is
-		// independent of the log file, so it is filled even when we relay
+		// Add line to FIFO buffer
 		char buffer[MAX_MSG_FIFO + 1u];
 		va_start(args, format);
 		const size_t len = vsnprintf(buffer, MAX_MSG_FIFO, format, args) + 1u; /* include zero-terminator */
 		va_end(args);
 		add_to_fifo_buffer(FIFO_WEBSERVER, buffer, prio, len > MAX_MSG_FIFO ? MAX_MSG_FIFO : len);
 
-		if(relay)
+		// Format full line and write to cached fd
+		char line[2048];
+		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+		va_start(args, format);
+		off += vsnprintf(line + off, sizeof(line) - off, format, args);
+		va_end(args);
+
+		// Clamp to buffer end - snprintf returns would-be length on truncation
+		if(off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
+		line[off++] = '\n';
+
+		if(!write_log_line(&webserver_log, line, off) && config.files.log.webserver.v.s != NULL && !daemonmode)
 		{
-			// No web log available - keep severe messages durable in FTL.log/syslog
+			// No web log available - keep severe messages durable
 			_FTL_log(priority, flag, "%s", buffer);
-		}
-		else if(weblog != NULL)
-		{
-			// Write to web log file
-			fprintf(weblog, "%s [%s] %s: ", timestring, idstr, prio);
-			va_start(args, format);
-			vfprintf(weblog, format, args);
-			va_end(args);
-			fputc('\n',weblog);
-			fclose(weblog);
 		}
 	}
 }
@@ -817,6 +938,13 @@ bool flush_dnsmasq_log(void)
 		return false;
 	}
 	fclose(logfile);
+
+	// Reopen the cached fd to point at the new empty file
+	pthread_mutex_lock(&dnsmasq_log.lock);
+	if(dnsmasq_log.fd != -1)
+		close(dnsmasq_log.fd);
+	dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	pthread_mutex_unlock(&dnsmasq_log.lock);
 
 	// Flush dnsmasq FIFO logs
 	if(fifo_log)

--- a/src/log.c
+++ b/src/log.c
@@ -154,7 +154,24 @@ void open_log_fds(bool ftl)
 	// pihole.log (dnsmasq) - FTL owns this file from now on
 	if(config.files.log.dnsmasq.v.s != NULL)
 	{
-		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
+		// "-" used to select stderr via dnsmasq's log-facility; since FTL
+		// writes pihole.log itself it is no longer supported.  Fall back to
+		// the default path so no file named "-" is created.
+		const char *path = config.files.log.dnsmasq.v.s;
+		if(strcmp(path, "-") == 0)
+		{
+			log_warn("files.log.dnsmasq = \"-\" (log to stderr) is no longer supported, using %s instead (see https://github.com/pi-hole/FTL/pull/2960)",
+			         config.files.log.dnsmasq.d.s);
+			path = config.files.log.dnsmasq.d.s;
+
+			// Heal the config value to the effective path so writeFTLtoml(),
+			// the API and chown_pihole() all see it and "-" is not persisted
+			if(config.files.log.dnsmasq.t == CONF_STRING_ALLOCATED)
+				free(config.files.log.dnsmasq.v.s);
+			config.files.log.dnsmasq.v.s = strdup(path);
+			config.files.log.dnsmasq.t = CONF_STRING_ALLOCATED;
+		}
+		dnsmasq_log.path = path;
 		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 	}
 
@@ -852,7 +869,7 @@ void print_FTL_version(void)
 }
 
 // Skip leading string if found
-static char *skipStr(const char *startstr, char *message)
+static const char *skipStr(const char *startstr, const char *message)
 {
 	const size_t startlen = strlen(startstr);
 	if(strncmp(startstr, message, startlen) == 0)
@@ -861,7 +878,7 @@ static char *skipStr(const char *startstr, char *message)
 		return message;
 }
 
-void dnsmasq_diagnosis_warning(char *message)
+void dnsmasq_diagnosis_warning(const char *message)
 {
 	// Crop away any existing initial "warning: "
 	logg_warn_dnsmasq_message(skipStr("warning: ", message));

--- a/src/log.c
+++ b/src/log.c
@@ -34,10 +34,10 @@
 static bool print_log = true, print_stdout = true;
 bool debug_flags[DEBUG_MAX] = { false };
 
-// Per-file log state: fd, path, writer-preferenced lock, reopen flag
+// Per-file log state: fd, path (owned copy), writer-preferenced lock, reopen flag
 struct log_fd {
 	int fd;
-	const char *path;
+	char *path;
 	pthread_mutex_t lock;
 	volatile sig_atomic_t reopen_needed;
 };
@@ -75,21 +75,47 @@ int __attribute__((pure)) is_log_fd(const int fd)
 	return fd == ftl_log.fd || fd == webserver_log.fd || fd == dnsmasq_log.fd;
 }
 
+// Reopen the log if requested.  Must be called with log->lock held.
+// Testing reopen_needed before fd == -1 lets SIGUSR2 revive a log whose
+// initial open failed (missing directory, transient EACCES, ...) and makes
+// sure a flush honors a rotation that happened since the last write.
+static void reopen_log_fd(struct log_fd *log)
+{
+	if(!log->reopen_needed)
+		return;
+
+	log->reopen_needed = 0;
+	if(log->fd != -1)
+		close(log->fd);
+	if(log->path != NULL)
+		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	else
+		log->fd = -1;
+}
+
 // Writer-preferenced per-file lock: only the fd for this specific log is
 // held, so writes to different files never contend.  The reopen flag is
 // per-file so SIGUSR2 only touches the fd that actually needs it.
 static bool write_log_line(struct log_fd *log, const char *line, size_t len)
 {
-	if(log->fd == -1)
+	// Do not try to write when the path is unknown
+	if(log->path == NULL)
 		return false;
 
+	// log->fd and log->reopen_needed are only accessed under the lock so a
+	// reopen (e.g. from flush_dnsmasq_log()) can never race a concurrent write
 	pthread_mutex_lock(&log->lock);
 
-	if(log->reopen_needed)
+	// Reopen the log if requested.  This must be tested before the fd == -1
+	// check so that SIGUSR2 can revive a log whose initial open failed (missing
+	// directory, transient EACCES, ...).
+	reopen_log_fd(log);
+
+	// No usable descriptor: let the caller fall back to another channel
+	if(log->fd == -1)
 	{
-		log->reopen_needed = 0;
-		close(log->fd);
-		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+		pthread_mutex_unlock(&log->lock);
+		return false;
 	}
 
 	ssize_t written = 0;
@@ -122,6 +148,18 @@ void log_ctrl(bool plog, bool pstdout)
 	print_stdout = pstdout;
 }
 
+// Set a log_fd path from a config string.  The path is duplicated so
+// that a config replacement (free_config + memcpy) cannot leave a
+// dangling pointer in the reopen path.
+static void set_log_path(struct log_fd *log, const char *path)
+{
+	if(log->path != NULL && path != NULL && strcmp(log->path, path) == 0)
+		return; // unchanged
+	if(log->path != NULL)
+		free(log->path);
+	log->path = path != NULL ? strdup(path) : NULL;
+}
+
 // Open cached log fds from config paths.
 // open_log_fds(true):  open FTL.log only (called early, before full config)
 // open_log_fds(false): open webserver.log + pihole.log (called after config)
@@ -132,7 +170,7 @@ void open_log_fds(bool ftl)
 		// FTL.log - path is known from getLogFilePath()
 		if(config.files.log.ftl.v.s != NULL)
 		{
-			ftl_log.path = config.files.log.ftl.v.s;
+			set_log_path(&ftl_log, config.files.log.ftl.v.s);
 			ftl_log.fd = open(ftl_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 			if(ftl_log.fd == -1)
 			{
@@ -147,8 +185,15 @@ void open_log_fds(bool ftl)
 	// webserver.log + pihole.log - paths are known after readFTLconf()
 	if(config.files.log.webserver.v.s != NULL)
 	{
-		webserver_log.path = config.files.log.webserver.v.s;
+		set_log_path(&webserver_log, config.files.log.webserver.v.s);
+		if(webserver_log.fd >= 0)
+			close(webserver_log.fd);
 		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+		if(webserver_log.fd == -1)
+		{
+			log_warn("webserver.log is unavailable (%s); warnings are still relayed to the FTL log",
+			         strerror(errno));
+		}
 	}
 
 	// pihole.log (dnsmasq) - FTL owns this file from now on
@@ -171,8 +216,17 @@ void open_log_fds(bool ftl)
 			config.files.log.dnsmasq.v.s = strdup(path);
 			config.files.log.dnsmasq.t = CONF_STRING_ALLOCATED;
 		}
-		dnsmasq_log.path = path;
+		set_log_path(&dnsmasq_log, path);
+		if(dnsmasq_log.fd >= 0)
+			close(dnsmasq_log.fd);
 		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+		if(dnsmasq_log.fd == -1)
+		{
+			// misc.hide_dnsmasq_warn only hides dnsmasq warnings from the web
+			// diagnosis table; it does not affect how they are logged here
+			log_warn("pihole.log is unavailable (%s); dnsmasq warnings are relayed to syslog",
+			         strerror(errno));
+		}
 	}
 
 	// Register atfork handlers once, before any threads or dnsmasq forks
@@ -386,31 +440,41 @@ const char *debugstr(const enum debug_flag flag)
 // Write a dnsmasq log line to pihole.log in dnsmasq's exact on-disk format.
 // The message is the bare body (no timestamp, no prefix) as handed to
 // FTL_dnsmasq_log() from my_syslog().  We reproduce dnsmasq's format:
-//   "Mon Jan  1 12:00:00 2024 dnsmasq-dhcp[12345]: <message>\n"
+//   "Jan  1 12:00:00 dnsmasq-dhcp[12345]: <message>\n"
 // where the func suffix (e.g. "-dhcp", "-tftp") comes from the priority
 // bits extracted in my_syslog().
-void FTL_write_dnsmasq_log(const char *message, const char *func)
+bool FTL_write_dnsmasq_log(const char *message, const char *func)
 {
-	if(dnsmasq_log.fd == -1)
-		return;
-
+	// Locale-independent and thread-safe (unlike ctime()), and keeps the
+	// on-disk format byte-identical to what dnsmasq wrote before.
 	time_t now = time(NULL);
-	char *ts = ctime(&now);
+	char ctime_buf[26];
+	const char *ctime_str = ctime_r(&now, ctime_buf);
+	if(ctime_str == NULL)
+		ctime_str = "Thu Jan  1 00:00:00 1970\n";
+	char ts_buf[16];
+	snprintf(ts_buf, sizeof(ts_buf), "%.15s", ctime_str + 4);
 
 	char line[2048];
-	int off = snprintf(line, sizeof(line), "%.20s dnsmasq%s[%d]: ", ts + 4, func ? func : "", getpid());
+	int off = snprintf(line, sizeof(line), "%s dnsmasq%s[%d]: ", ts_buf, func ? func : "", getpid());
+
+	// Clamp before using off as an offset - snprintf returns the would-be
+	// length on truncation and sizeof(line) - off would underflow otherwise;
+	// it may also return negative on an encoding error
+	if(off < 0 || off >= (int)sizeof(line))
+		off = sizeof(line) - 1;
 
 	const char *msg = message ? message : "";
 	off += snprintf(line + off, sizeof(line) - off, "%s", msg);
 
 	// Clamp to buffer end - snprintf returns would-be length on truncation
-	if(off >= (int)sizeof(line))
+	if(off < 0 || off >= (int)sizeof(line))
 		off = sizeof(line) - 1;
 
 	if(off > 0 && line[off - 1] != '\n')
 		line[off++] = '\n';
 
-	write_log_line(&dnsmasq_log, line, off);
+	return write_log_line(&dnsmasq_log, line, off);
 }
 
 void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const enum debug_flag flag, const char *format, ...)
@@ -459,12 +523,19 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		// trade-off of the cached-fd design vs. the old unbounded vfprintf()).
 		char line[2048];
 		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+
+		// Clamp before using off as an offset - snprintf returns the would-be
+		// length on truncation and sizeof(line) - off would underflow otherwise;
+		// it may also return negative on an encoding error
+		if(off < 0 || off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
 		va_start(args, format);
 		off += vsnprintf(line + off, sizeof(line) - off, format, args);
 		va_end(args);
 
 		// Clamp to buffer end - snprintf returns would-be length on truncation
-		if(off >= (int)sizeof(line))
+		if(off < 0 || off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
 		line[off++] = '\n';
@@ -498,9 +569,17 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 	get_idstr(idstr, sizeof(idstr));
 	const char *prio = priostr(priority, flag);
 
+	// Relay severe messages through _FTL_log() when webserver.log is
+	// unavailable or a write fails, and skip the stdout print when a
+	// relay will happen - _FTL_log() prints it itself, so it would
+	// otherwise appear twice.
+	const bool severe = print_log && priority <= LOG_WARNING;
+	bool printed_stdout = false;
+
 	// Print to stdout before writing to file
-	if((!daemonmode || cli_mode) && print_stdout)
+	if(!(severe && webserver_log.fd == -1) && (!daemonmode || cli_mode) && print_stdout)
 	{
+		printed_stdout = true;
 		// Only print time/ID string when not in direct user interaction (CLI mode)
 		if(!cli_mode)
 			printf("%s [%s] %s: ", timestring, idstr, prio);
@@ -523,20 +602,32 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 		// Format full line and write to cached fd
 		char line[2048];
 		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+
+		// Clamp before using off as an offset - snprintf returns the would-be
+		// length on truncation and sizeof(line) - off would underflow otherwise;
+		// it may also return negative on an encoding error
+		if(off < 0 || off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
 		va_start(args, format);
 		off += vsnprintf(line + off, sizeof(line) - off, format, args);
 		va_end(args);
 
 		// Clamp to buffer end - snprintf returns would-be length on truncation
-		if(off >= (int)sizeof(line))
+		if(off < 0 || off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
 		line[off++] = '\n';
 
-		if(!write_log_line(&webserver_log, line, off) && config.files.log.webserver.v.s != NULL && !daemonmode)
+		if(!write_log_line(&webserver_log, line, off))
 		{
-			// No web log available - keep severe messages durable
-			_FTL_log(priority, flag, "%s", buffer);
+			// Web log write failed (unusable descriptor or a mid-write
+			// error) - keep severe messages durable by relaying them to
+			// FTL.log/syslog, matching _FTL_log()'s own fallback.  Skip
+			// the relay when we already printed to stdout above so the
+			// line does not appear twice on the console.
+			if(severe && !printed_stdout)
+				_FTL_log(priority, flag, "%s", buffer);
 		}
 	}
 }
@@ -942,28 +1033,28 @@ void add_to_fifo_buffer(const enum fifo_logs which, const char *payload, const c
 bool flush_dnsmasq_log(void)
 {
 	const double mintime = double_time();
+	int trunc_err = 0;
 
 	// Lock shared memory
 	lock_shm();
 
-	// Open file in write mode to truncate it
-	FILE *logfile = fopen(config.files.log.dnsmasq.v.s, "w");
-	if(!logfile)
-	{
-		log_err("Could not open log file %s for truncation: %s\n", config.files.log.dnsmasq.v.s, strerror(errno));
-		unlock_shm();
-		return false;
-	}
-	fclose(logfile);
-
-	// Reopen the cached fd to point at the new empty file
+	// Truncate pihole.log via its cached fd; O_APPEND appends future writes
+	// to the empty file.  Lock order stays SHM first, then the per-file lock.
 	pthread_mutex_lock(&dnsmasq_log.lock);
-	if(dnsmasq_log.fd != -1)
-		close(dnsmasq_log.fd);
-	dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+
+	// Reopen first if logrotate's SIGUSR2 fired since the last write, so the
+	// truncation hits the current file instead of the rotated one the cached
+	// fd still points at.
+	reopen_log_fd(&dnsmasq_log);
+
+	if(dnsmasq_log.fd == -1)
+		trunc_err = -1;          // no log file open
+	else if(ftruncate(dnsmasq_log.fd, 0) == -1)
+		trunc_err = errno;       // the fd stays usable for future writes
 	pthread_mutex_unlock(&dnsmasq_log.lock);
 
-	// Flush dnsmasq FIFO logs
+	// Flush the FIFO, in-memory datastructure and database even if the
+	// truncation above failed; the log file is then just left non-empty
 	if(fifo_log)
 		memset(&fifo_log->logs[FIFO_DNSMASQ], 0, sizeof(fifo_log->logs[FIFO_DNSMASQ]));
 
@@ -973,12 +1064,21 @@ bool flush_dnsmasq_log(void)
 	// Unlock shared memory
 	unlock_shm();
 
+	// Report a failed truncation now that the SHM lock is released
+	if(trunc_err == -1)
+		log_warn("Could not truncate pihole.log: no log file is open");
+	else if(trunc_err > 0)
+		log_err("Could not truncate log file %s: %s", dnsmasq_log.path, strerror(trunc_err));
+
 	// Flush last 24 hours of on-disk database
 	if(!delete_old_queries_from_db(false, mintime))
 	{
 		log_err("Could not flush on-disk database");
 		return false;
 	}
+
+	if(trunc_err != 0)
+		return false;
 
 	log_info("Log has been flushed due to API request");
 

--- a/src/log.c
+++ b/src/log.c
@@ -175,6 +175,8 @@ void open_log_fds(bool ftl)
 	if(config.files.log.webserver.v.s != NULL)
 	{
 		set_log_path(&webserver_log, config.files.log.webserver.v.s);
+		if(webserver_log.fd >= 0)
+			close(webserver_log.fd);
 		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 		if(webserver_log.fd == -1)
 		{
@@ -187,6 +189,8 @@ void open_log_fds(bool ftl)
 	if(config.files.log.dnsmasq.v.s != NULL)
 	{
 		set_log_path(&dnsmasq_log, config.files.log.dnsmasq.v.s);
+		if(dnsmasq_log.fd >= 0)
+			close(dnsmasq_log.fd);
 		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 		if(dnsmasq_log.fd == -1)
 		{

--- a/src/log.c
+++ b/src/log.c
@@ -335,7 +335,7 @@ const char *debugstr(const enum debug_flag flag)
 // Write a dnsmasq log line to pihole.log in dnsmasq's exact on-disk format.
 // The message is the bare body (no timestamp, no prefix) as handed to
 // FTL_dnsmasq_log() from my_syslog().  We reproduce dnsmasq's format:
-//   "Mon Jan  1 12:00:00 2024 dnsmasq-dhcp[12345]: <message>\n"
+//   "Jan  1 12:00:00 dnsmasq-dhcp[12345]: <message>\n"
 // where the func suffix (e.g. "-dhcp", "-tftp") comes from the priority
 // bits extracted in my_syslog().
 void FTL_write_dnsmasq_log(const char *message, const char *func)
@@ -343,11 +343,14 @@ void FTL_write_dnsmasq_log(const char *message, const char *func)
 	if(dnsmasq_log.fd == -1)
 		return;
 
+	struct tm tm;
 	time_t now = time(NULL);
-	char *ts = ctime(&now);
+	localtime_r(&now, &tm);
+	char ts_buf[16];
+	strftime(ts_buf, sizeof(ts_buf), "%b %e %H:%M:%S", &tm);
 
 	char line[2048];
-	int off = snprintf(line, sizeof(line), "%.20s dnsmasq%s[%d]: ", ts + 4, func ? func : "", getpid());
+	int off = snprintf(line, sizeof(line), "%s dnsmasq%s[%d]: ", ts_buf, func ? func : "", getpid());
 
 	const char *msg = message ? message : "";
 	off += snprintf(line + off, sizeof(line) - off, "%s", msg);

--- a/src/log.c
+++ b/src/log.c
@@ -434,7 +434,7 @@ bool FTL_write_dnsmasq_log(const char *message, const char *func)
 	char ctime_buf[26];
 	const char *ctime_str = ctime_r(&now, ctime_buf);
 	if(ctime_str == NULL)
-		ctime_str = "Jan  1 00:00:00 ";
+		ctime_str = "Thu Jan  1 00:00:00 1970\n";
 	char ts_buf[16];
 	snprintf(ts_buf, sizeof(ts_buf), "%.15s", ctime_str + 4);
 

--- a/src/log.c
+++ b/src/log.c
@@ -127,6 +127,11 @@ void open_log_fds(bool ftl)
 	{
 		webserver_log.path = config.files.log.webserver.v.s;
 		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+		if(webserver_log.fd == -1)
+		{
+			log_warn("webserver.log is unavailable (%s); warnings are still relayed to the FTL log",
+			         strerror(errno));
+		}
 	}
 
 	// pihole.log (dnsmasq) — FTL owns this file from now on
@@ -482,7 +487,7 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 
 		line[off++] = '\n';
 
-		if(!write_log_line(&webserver_log, line, off) && config.files.log.webserver.v.s != NULL && !daemonmode)
+		if(!write_log_line(&webserver_log, line, off) && priority <= LOG_WARNING)
 		{
 			// No web log available - keep severe messages durable
 			_FTL_log(priority, flag, "%s", buffer);

--- a/src/log.c
+++ b/src/log.c
@@ -70,9 +70,8 @@ static void log_atfork_child(void)
 }
 
 // Return 1 if this fd is associated with any logfile to avoid
-// dnsmasq closing it during initialization.
-// Not marked pure: the descriptors are reassigned on reopen from another thread.
-int is_log_fd(const int fd)
+// dnsmasq closing it during initialization
+int __attribute__((pure)) is_log_fd(const int fd)
 {
 	return fd == ftl_log.fd || fd == webserver_log.fd || fd == dnsmasq_log.fd;
 }
@@ -428,7 +427,7 @@ bool FTL_write_dnsmasq_log(const char *message, const char *func)
 	// format byte-identical to what we wrote before.
 	time_t now = time(NULL);
 	char ctime_buf[26];
-	char *ctime_str = ctime_r(&now, ctime_buf);
+	const char *ctime_str = ctime_r(&now, ctime_buf);
 	if(ctime_str == NULL)
 		ctime_str = "Jan  1 00:00:00 ";
 	char ts_buf[16];

--- a/src/log.c
+++ b/src/log.c
@@ -144,7 +144,7 @@ void open_log_fds(bool ftl)
 {
 	if(ftl)
 	{
-		// FTL.log — path is known from getLogFilePath()
+		// FTL.log - path is known from getLogFilePath()
 		if(config.files.log.ftl.v.s != NULL)
 		{
 			ftl_log.path = config.files.log.ftl.v.s;
@@ -159,7 +159,7 @@ void open_log_fds(bool ftl)
 		return;
 	}
 
-	// webserver.log + pihole.log — paths are known after readFTLconf()
+	// webserver.log + pihole.log - paths are known after readFTLconf()
 	if(config.files.log.webserver.v.s != NULL)
 	{
 		webserver_log.path = config.files.log.webserver.v.s;
@@ -171,7 +171,7 @@ void open_log_fds(bool ftl)
 		}
 	}
 
-	// pihole.log (dnsmasq) — FTL owns this file from now on
+	// pihole.log (dnsmasq) - FTL owns this file from now on
 	if(config.files.log.dnsmasq.v.s != NULL)
 	{
 		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
@@ -411,7 +411,7 @@ void FTL_write_dnsmasq_log(const char *message, const char *func)
 	const char *msg = message ? message : "";
 	off += snprintf(line + off, sizeof(line) - off, "%s", msg);
 
-	// Clamp to buffer end — snprintf returns would-be length on truncation
+	// Clamp to buffer end - snprintf returns would-be length on truncation
 	if(off >= (int)sizeof(line))
 		off = sizeof(line) - 1;
 
@@ -468,7 +468,7 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		off += vsnprintf(line + off, sizeof(line) - off, format, args);
 		va_end(args);
 
-		// Clamp to buffer end — snprintf returns would-be length on truncation
+		// Clamp to buffer end - snprintf returns would-be length on truncation
 		if(off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
@@ -532,7 +532,7 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 		off += vsnprintf(line + off, sizeof(line) - off, format, args);
 		va_end(args);
 
-		// Clamp to buffer end — snprintf returns would-be length on truncation
+		// Clamp to buffer end - snprintf returns would-be length on truncation
 		if(off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 

--- a/src/log.c
+++ b/src/log.c
@@ -815,7 +815,7 @@ void print_FTL_version(void)
 }
 
 // Skip leading string if found
-static char *skipStr(const char *startstr, char *message)
+static const char *skipStr(const char *startstr, const char *message)
 {
 	const size_t startlen = strlen(startstr);
 	if(strncmp(startstr, message, startlen) == 0)
@@ -824,7 +824,7 @@ static char *skipStr(const char *startstr, char *message)
 		return message;
 }
 
-void dnsmasq_diagnosis_warning(char *message)
+void dnsmasq_diagnosis_warning(const char *message)
 {
 	// Crop away any existing initial "warning: "
 	logg_warn_dnsmasq_message(skipStr("warning: ", message));

--- a/src/log.c
+++ b/src/log.c
@@ -28,10 +28,65 @@
 #include "database/query-table.h"
 // runGC()
 #include "gc.h"
+// open(), O_WRONLY, O_CREAT, O_APPEND
+#include <fcntl.h>
 
 static bool print_log = true, print_stdout = true;
-static bool ftl_log_available = true;
 bool debug_flags[DEBUG_MAX] = { false };
+
+// Per-file log state: fd, path, writer-preferenced lock, reopen flag
+struct log_fd {
+	int fd;
+	const char *path;
+	pthread_mutex_t lock;
+	volatile sig_atomic_t reopen_needed;
+};
+
+static struct log_fd ftl_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
+static struct log_fd webserver_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
+static struct log_fd dnsmasq_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
+
+// Return 1 if this fd is associated with any logfile to avoid
+// dnsmasq closing it during initialization
+int __attribute__((pure)) is_log_fd(const int fd)
+{
+	return fd == ftl_log.fd || fd == webserver_log.fd || fd == dnsmasq_log.fd;
+}
+
+// Writer-preferenced per-file lock: only the fd for this specific log is
+// held, so writes to different files never contend.  The reopen flag is
+// per-file so SIGUSR2 only touches the fd that actually needs it.
+static bool write_log_line(struct log_fd *log, const char *line, size_t len)
+{
+	if(log->fd == -1)
+		return false;
+
+	pthread_mutex_lock(&log->lock);
+
+	if(log->reopen_needed)
+	{
+		log->reopen_needed = 0;
+		close(log->fd);
+		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+
+	ssize_t written = 0;
+	while(written < (ssize_t)len)
+	{
+		ssize_t rc = write(log->fd, line + written, len - written);
+		if(rc == -1)
+		{
+			if(errno == EINTR)
+				continue;
+			pthread_mutex_unlock(&log->lock);
+			return false;
+		}
+		written += rc;
+	}
+
+	pthread_mutex_unlock(&log->lock);
+	return true;
+}
 
 void clear_debug_flags(void)
 {
@@ -45,26 +100,49 @@ void log_ctrl(bool plog, bool pstdout)
 	print_stdout = pstdout;
 }
 
-void init_FTL_log(void)
+// Open cached log fds from config paths.
+// open_log_fds(true):  open FTL.log only (called early, before full config)
+// open_log_fds(false): open webserver.log + pihole.log (called after config)
+void open_log_fds(bool ftl)
 {
-	// Open the log file in append/create mode
-	if(config.files.log.ftl.v.s != NULL)
+	if(ftl)
 	{
-		FILE *logfile = NULL;
-		if((logfile = fopen(config.files.log.ftl.v.s, "a+")) == NULL)
+		// FTL.log — path is known from getLogFilePath()
+		if(config.files.log.ftl.v.s != NULL)
 		{
-			printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
-			       config.files.log.ftl.v.s, strerror(errno));
-			syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
-			ftl_log_available = false;
+			ftl_log.path = config.files.log.ftl.v.s;
+			ftl_log.fd = open(ftl_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+			if(ftl_log.fd == -1)
+			{
+				printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
+				       ftl_log.path, strerror(errno));
+				syslog(LOG_ERR, "Opening of FTL\'s log file failed, using syslog instead!");
+			}
 		}
-		else
-			ftl_log_available = true;
-
-		// Close log file
-		if(logfile != NULL)
-			fclose(logfile);
+		return;
 	}
+
+	// webserver.log + pihole.log — paths are known after readFTLconf()
+	if(config.files.log.webserver.v.s != NULL)
+	{
+		webserver_log.path = config.files.log.webserver.v.s;
+		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+
+	// pihole.log (dnsmasq) — FTL owns this file from now on
+	if(config.files.log.dnsmasq.v.s != NULL)
+	{
+		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
+		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+}
+
+// Signal that log fds need to be reopened (called from SIGUSR2 handler path)
+void mark_log_reopen(void)
+{
+	ftl_log.reopen_needed = 1;
+	webserver_log.reopen_needed = 1;
+	dnsmasq_log.reopen_needed = 1;
 }
 
 // Return time(NULL) but with (up to) nanosecond accuracy
@@ -254,6 +332,36 @@ const char *debugstr(const enum debug_flag flag)
 	}
 }
 
+// Write a dnsmasq log line to pihole.log in dnsmasq's exact on-disk format.
+// The message is the bare body (no timestamp, no prefix) as handed to
+// FTL_dnsmasq_log() from my_syslog().  We reproduce dnsmasq's format:
+//   "Mon Jan  1 12:00:00 2024 dnsmasq-dhcp[12345]: <message>\n"
+// where the func suffix (e.g. "-dhcp", "-tftp") comes from the priority
+// bits extracted in my_syslog().
+void FTL_write_dnsmasq_log(const char *message, const char *func)
+{
+	if(dnsmasq_log.fd == -1)
+		return;
+
+	time_t now = time(NULL);
+	char *ts = ctime(&now);
+
+	char line[2048];
+	int off = snprintf(line, sizeof(line), "%.20s dnsmasq%s[%d]: ", ts + 4, func ? func : "", getpid());
+
+	const char *msg = message ? message : "";
+	off += snprintf(line + off, sizeof(line) - off, "%s", msg);
+
+	// Clamp to buffer end — snprintf returns would-be length on truncation
+	if(off >= (int)sizeof(line))
+		off = sizeof(line) - 1;
+
+	if(off > 0 && line[off - 1] != '\n')
+		line[off++] = '\n';
+
+	write_log_line(&dnsmasq_log, line, off);
+}
+
 void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const enum debug_flag flag, const char *format, ...)
 {
 	char timestring[TIMESTR_SIZE];
@@ -294,40 +402,22 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		va_end(args);
 		add_to_fifo_buffer(FIFO_FTL, buffer, prio, len > MAX_MSG_FIFO ? MAX_MSG_FIFO : len);
 
-		bool logged = false;
-		if(ftl_log_available && config.files.log.ftl.v.s != NULL)
+		// Format full line and write to cached fd
+		char line[2048];
+		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+		va_start(args, format);
+		off += vsnprintf(line + off, sizeof(line) - off, format, args);
+		va_end(args);
+
+		// Clamp to buffer end — snprintf returns would-be length on truncation
+		if(off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
+		line[off++] = '\n';
+
+		if(!write_log_line(&ftl_log, line, off))
 		{
-			// Open log file
-			FILE *logfile = fopen(config.files.log.ftl.v.s, "a+");
-
-			// Write to log file
-			if(logfile != NULL)
-			{
-				// Prepend message with identification string and priority
-				fprintf(logfile, "%s [%s] %s: ", timestring, idstr, prio);
-
-				// Log message
-				va_start(args, format);
-				vfprintf(logfile, format, args);
-				va_end(args);
-
-				// Append newline character to the end of the file
-				fputc('\n', logfile);
-
-				// Close file after writing
-				fclose(logfile);
-
-				logged = true;
-			}
-			else if(!daemonmode)
-			{
-				printf("!!! WARNING: Writing to FTL\'s log file failed!\n");
-				syslog(LOG_ERR, "Writing to FTL\'s log file failed!");
-			}
-		}
-		if(!logged)
-		{
-			// Syslog logging
+			// Fallback: syslog if fd is unavailable or write failed
 			va_start(args, format);
 			vsyslog(priority, format, args);
 			va_end(args);
@@ -354,16 +444,8 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 	get_idstr(idstr, sizeof(idstr));
 	const char *prio = priostr(priority, flag);
 
-	// Open web log file (if a path is configured)
-	FILE *weblog = NULL;
-	if(print_log && config.files.log.webserver.v.s != NULL)
-		weblog = fopen(config.files.log.webserver.v.s, "a+");
-
-	// _FTL_log() prints these itself, so do not print them twice
-	const bool relay = print_log && weblog == NULL && priority <= LOG_WARNING;
-
 	// Print to stdout before writing to file
-	if(!relay && (!daemonmode || cli_mode) && print_stdout)
+	if((!daemonmode || cli_mode) && print_stdout)
 	{
 		// Only print time/ID string when not in direct user interaction (CLI mode)
 		if(!cli_mode)
@@ -377,28 +459,30 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 	// Print to log file or FIFO
 	if(print_log)
 	{
-		// Add line to FIFO buffer. It lives in shared memory and is
-		// independent of the log file, so it is filled even when we relay
+		// Add line to FIFO buffer
 		char buffer[MAX_MSG_FIFO + 1u];
 		va_start(args, format);
 		const size_t len = vsnprintf(buffer, MAX_MSG_FIFO, format, args) + 1u; /* include zero-terminator */
 		va_end(args);
 		add_to_fifo_buffer(FIFO_WEBSERVER, buffer, prio, len > MAX_MSG_FIFO ? MAX_MSG_FIFO : len);
 
-		if(relay)
+		// Format full line and write to cached fd
+		char line[2048];
+		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+		va_start(args, format);
+		off += vsnprintf(line + off, sizeof(line) - off, format, args);
+		va_end(args);
+
+		// Clamp to buffer end — snprintf returns would-be length on truncation
+		if(off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
+		line[off++] = '\n';
+
+		if(!write_log_line(&webserver_log, line, off) && config.files.log.webserver.v.s != NULL && !daemonmode)
 		{
-			// No web log available - keep severe messages durable in FTL.log/syslog
+			// No web log available - keep severe messages durable
 			_FTL_log(priority, flag, "%s", buffer);
-		}
-		else if(weblog != NULL)
-		{
-			// Write to web log file
-			fprintf(weblog, "%s [%s] %s: ", timestring, idstr, prio);
-			va_start(args, format);
-			vfprintf(weblog, format, args);
-			va_end(args);
-			fputc('\n',weblog);
-			fclose(weblog);
 		}
 	}
 }
@@ -817,6 +901,13 @@ bool flush_dnsmasq_log(void)
 		return false;
 	}
 	fclose(logfile);
+
+	// Reopen the cached fd to point at the new empty file
+	pthread_mutex_lock(&dnsmasq_log.lock);
+	if(dnsmasq_log.fd != -1)
+		close(dnsmasq_log.fd);
+	dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+	pthread_mutex_unlock(&dnsmasq_log.lock);
 
 	// Flush dnsmasq FIFO logs
 	if(fifo_log)

--- a/src/log.c
+++ b/src/log.c
@@ -46,6 +46,29 @@ static struct log_fd ftl_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
 static struct log_fd webserver_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
 static struct log_fd dnsmasq_log = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER };
 
+// dnsmasq forks per TCP query while FTL threads may be mid-write.  Without
+// atfork handling the child would inherit one of the per-file mutexes locked
+// and the first my_syslog() there would block forever, hanging that query.
+// Lock all log mutexes before fork() and release them in both parent and child.
+static void log_atfork_prepare(void)
+{
+	pthread_mutex_lock(&ftl_log.lock);
+	pthread_mutex_lock(&webserver_log.lock);
+	pthread_mutex_lock(&dnsmasq_log.lock);
+}
+static void log_atfork_parent(void)
+{
+	pthread_mutex_unlock(&ftl_log.lock);
+	pthread_mutex_unlock(&webserver_log.lock);
+	pthread_mutex_unlock(&dnsmasq_log.lock);
+}
+static void log_atfork_child(void)
+{
+	pthread_mutex_unlock(&ftl_log.lock);
+	pthread_mutex_unlock(&webserver_log.lock);
+	pthread_mutex_unlock(&dnsmasq_log.lock);
+}
+
 // Return 1 if this fd is associated with any logfile to avoid
 // dnsmasq closing it during initialization
 int __attribute__((pure)) is_log_fd(const int fd)
@@ -158,6 +181,15 @@ void open_log_fds(bool ftl)
 			log_warn("pihole.log is unavailable (%s); dnsmasq warnings are still relayed to the FTL log",
 			         strerror(errno));
 		}
+	}
+
+	// Register atfork handlers once, before any threads or dnsmasq forks
+	// exist, so a TCP-query fork can never inherit a locked log mutex
+	static bool atfork_registered = false;
+	if(!atfork_registered)
+	{
+		atfork_registered = true;
+		pthread_atfork(log_atfork_prepare, log_atfork_parent, log_atfork_child);
 	}
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -359,11 +359,14 @@ const char *debugstr(const enum debug_flag flag)
 // bits extracted in my_syslog().
 void FTL_write_dnsmasq_log(const char *message, const char *func)
 {
-	struct tm tm;
+	// Locale-independent timestamp: ctime() renders the month/day in the
+	// C locale regardless of setlocale(LC_ALL, ""), so the buffer cannot
+	// overflow with non-English month names (strftime("%b") would emit
+	// e.g. six bytes for ru_RU). This is dnsmasq's own idiom and keeps
+	// the on-disk format byte-identical to what we wrote before.
 	time_t now = time(NULL);
-	localtime_r(&now, &tm);
 	char ts_buf[16];
-	strftime(ts_buf, sizeof(ts_buf), "%b %e %H:%M:%S", &tm);
+	snprintf(ts_buf, sizeof(ts_buf), "%.15s", ctime(&now) + 4);
 
 	char line[2048];
 	int off = snprintf(line, sizeof(line), "%s dnsmasq%s[%d]: ", ts_buf, func ? func : "", getpid());

--- a/src/log.c
+++ b/src/log.c
@@ -178,8 +178,14 @@ void open_log_fds(bool ftl)
 		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 		if(dnsmasq_log.fd == -1)
 		{
-			log_warn("pihole.log is unavailable (%s); dnsmasq warnings are still relayed to the FTL log",
-			         strerror(errno));
+			// Warn regardless - the hide_dnsmasq_warn setting only controls
+			// whether the warnings themselves are shown, not this notice
+			if(config.misc.hide_dnsmasq_warn.v.b)
+				log_warn("pihole.log is unavailable (%s); dnsmasq warnings are hidden (misc.hide_dnsmasq_warn)",
+				         strerror(errno));
+			else
+				log_warn("pihole.log is unavailable (%s); dnsmasq warnings are still relayed to the FTL log",
+				         strerror(errno));
 		}
 	}
 

--- a/src/log.c
+++ b/src/log.c
@@ -144,7 +144,8 @@ static void set_log_path(struct log_fd *log, const char *path)
 {
 	if(log->path != NULL && path != NULL && strcmp(log->path, path) == 0)
 		return; // unchanged
-	free(log->path);
+	if(log->path != NULL)
+		free(log->path);
 	log->path = path != NULL ? strdup(path) : NULL;
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -408,6 +408,11 @@ void FTL_write_dnsmasq_log(const char *message, const char *func)
 	char line[2048];
 	int off = snprintf(line, sizeof(line), "%s dnsmasq%s[%d]: ", ts_buf, func ? func : "", getpid());
 
+	// Clamp before using off as an offset - snprintf returns the would-be
+	// length on truncation and sizeof(line) - off would underflow otherwise
+	if(off >= (int)sizeof(line))
+		off = sizeof(line) - 1;
+
 	const char *msg = message ? message : "";
 	off += snprintf(line + off, sizeof(line) - off, "%s", msg);
 
@@ -464,6 +469,12 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		// Format full line and write to cached fd
 		char line[2048];
 		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+
+		// Clamp before using off as an offset - snprintf returns the would-be
+		// length on truncation and sizeof(line) - off would underflow otherwise
+		if(off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
 		va_start(args, format);
 		off += vsnprintf(line + off, sizeof(line) - off, format, args);
 		va_end(args);
@@ -528,6 +539,12 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 		// Format full line and write to cached fd
 		char line[2048];
 		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
+
+		// Clamp before using off as an offset - snprintf returns the would-be
+		// length on truncation and sizeof(line) - off would underflow otherwise
+		if(off >= (int)sizeof(line))
+			off = sizeof(line) - 1;
+
 		va_start(args, format);
 		off += vsnprintf(line + off, sizeof(line) - off, format, args);
 		va_end(args);

--- a/src/log.c
+++ b/src/log.c
@@ -28,7 +28,7 @@
 #include "database/query-table.h"
 // runGC()
 #include "gc.h"
-// open(), O_WRONLY, O_CREAT, O_APPEND
+// open(), O_WRONLY, O_CREAT, O_APPEND, O_CLOEXEC
 #include <fcntl.h>
 
 static bool print_log = true, print_stdout = true;
@@ -67,7 +67,7 @@ static bool write_log_line(struct log_fd *log, const char *line, size_t len)
 	{
 		log->reopen_needed = 0;
 		close(log->fd);
-		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 	}
 
 	ssize_t written = 0;
@@ -111,7 +111,7 @@ void open_log_fds(bool ftl)
 		if(config.files.log.ftl.v.s != NULL)
 		{
 			ftl_log.path = config.files.log.ftl.v.s;
-			ftl_log.fd = open(ftl_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+			ftl_log.fd = open(ftl_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 			if(ftl_log.fd == -1)
 			{
 				printf("ERROR: Opening of FTL log (%s) failed: %s\nUsing syslog instead!\n",
@@ -126,14 +126,14 @@ void open_log_fds(bool ftl)
 	if(config.files.log.webserver.v.s != NULL)
 	{
 		webserver_log.path = config.files.log.webserver.v.s;
-		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 	}
 
 	// pihole.log (dnsmasq) — FTL owns this file from now on
 	if(config.files.log.dnsmasq.v.s != NULL)
 	{
 		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
-		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 	}
 }
 
@@ -906,7 +906,7 @@ bool flush_dnsmasq_log(void)
 	pthread_mutex_lock(&dnsmasq_log.lock);
 	if(dnsmasq_log.fd != -1)
 		close(dnsmasq_log.fd);
-	dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP);
+	dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 	pthread_mutex_unlock(&dnsmasq_log.lock);
 
 	// Flush dnsmasq FIFO logs

--- a/src/log.c
+++ b/src/log.c
@@ -153,6 +153,11 @@ void open_log_fds(bool ftl)
 	{
 		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
 		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+		if(dnsmasq_log.fd == -1)
+		{
+			log_warn("pihole.log is unavailable (%s); dnsmasq warnings are still relayed to the FTL log",
+			         strerror(errno));
+		}
 	}
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -58,16 +58,30 @@ int __attribute__((pure)) is_log_fd(const int fd)
 // per-file so SIGUSR2 only touches the fd that actually needs it.
 static bool write_log_line(struct log_fd *log, const char *line, size_t len)
 {
-	if(log->fd == -1)
+	// Do not try to write when the path is unknown
+	if(log->path == NULL)
 		return false;
 
+	// log->fd and log->reopen_needed are only accessed under the lock so a
+	// reopen (e.g. from flush_dnsmasq_log()) can never race a concurrent write
 	pthread_mutex_lock(&log->lock);
 
+	// Reopen the log if requested.  This must be tested before the fd == -1
+	// check so that SIGUSR2 can revive a log whose initial open failed (missing
+	// directory, transient EACCES, ...).
 	if(log->reopen_needed)
 	{
 		log->reopen_needed = 0;
-		close(log->fd);
+		if(log->fd != -1)
+			close(log->fd);
 		log->fd = open(log->path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	}
+
+	// No usable descriptor: let the caller fall back to another channel
+	if(log->fd == -1)
+	{
+		pthread_mutex_unlock(&log->lock);
+		return false;
 	}
 
 	ssize_t written = 0;
@@ -345,9 +359,6 @@ const char *debugstr(const enum debug_flag flag)
 // bits extracted in my_syslog().
 void FTL_write_dnsmasq_log(const char *message, const char *func)
 {
-	if(dnsmasq_log.fd == -1)
-		return;
-
 	struct tm tm;
 	time_t now = time(NULL);
 	localtime_r(&now, &tm);

--- a/src/log.c
+++ b/src/log.c
@@ -34,10 +34,10 @@
 static bool print_log = true, print_stdout = true;
 bool debug_flags[DEBUG_MAX] = { false };
 
-// Per-file log state: fd, path, writer-preferenced lock, reopen flag
+// Per-file log state: fd, path (owned copy), writer-preferenced lock, reopen flag
 struct log_fd {
 	int fd;
-	const char *path;
+	char *path;
 	pthread_mutex_t lock;
 	volatile sig_atomic_t reopen_needed;
 };
@@ -70,8 +70,9 @@ static void log_atfork_child(void)
 }
 
 // Return 1 if this fd is associated with any logfile to avoid
-// dnsmasq closing it during initialization
-int __attribute__((pure)) is_log_fd(const int fd)
+// dnsmasq closing it during initialization.
+// Not marked pure: the descriptors are reassigned on reopen from another thread.
+int is_log_fd(const int fd)
 {
 	return fd == ftl_log.fd || fd == webserver_log.fd || fd == dnsmasq_log.fd;
 }
@@ -137,6 +138,17 @@ void log_ctrl(bool plog, bool pstdout)
 	print_stdout = pstdout;
 }
 
+// Set a log_fd path from a config string.  The path is duplicated so
+// that a config replacement (free_config + memcpy) cannot leave a
+// dangling pointer in the reopen path.
+static void set_log_path(struct log_fd *log, const char *path)
+{
+	if(log->path != NULL && path != NULL && strcmp(log->path, path) == 0)
+		return; // unchanged
+	free(log->path);
+	log->path = path != NULL ? strdup(path) : NULL;
+}
+
 // Open cached log fds from config paths.
 // open_log_fds(true):  open FTL.log only (called early, before full config)
 // open_log_fds(false): open webserver.log + pihole.log (called after config)
@@ -147,7 +159,7 @@ void open_log_fds(bool ftl)
 		// FTL.log - path is known from getLogFilePath()
 		if(config.files.log.ftl.v.s != NULL)
 		{
-			ftl_log.path = config.files.log.ftl.v.s;
+			set_log_path(&ftl_log, config.files.log.ftl.v.s);
 			ftl_log.fd = open(ftl_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 			if(ftl_log.fd == -1)
 			{
@@ -162,7 +174,7 @@ void open_log_fds(bool ftl)
 	// webserver.log + pihole.log - paths are known after readFTLconf()
 	if(config.files.log.webserver.v.s != NULL)
 	{
-		webserver_log.path = config.files.log.webserver.v.s;
+		set_log_path(&webserver_log, config.files.log.webserver.v.s);
 		webserver_log.fd = open(webserver_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 		if(webserver_log.fd == -1)
 		{
@@ -174,7 +186,7 @@ void open_log_fds(bool ftl)
 	// pihole.log (dnsmasq) - FTL owns this file from now on
 	if(config.files.log.dnsmasq.v.s != NULL)
 	{
-		dnsmasq_log.path = config.files.log.dnsmasq.v.s;
+		set_log_path(&dnsmasq_log, config.files.log.dnsmasq.v.s);
 		dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
 		if(dnsmasq_log.fd == -1)
 		{
@@ -190,7 +202,10 @@ void open_log_fds(bool ftl)
 	}
 
 	// Register atfork handlers once, before any threads or dnsmasq forks
-	// exist, so a TCP-query fork can never inherit a locked log mutex
+	// exist, so a TCP-query fork can never inherit a locked log mutex.
+	// Invariant: fork() is never called from inside a log write, so the
+	// atfork prepare/parent/child handlers only need to cover the case
+	// where a thread holds a log mutex at the moment of the fork.
 	static bool atfork_registered = false;
 	if(!atfork_registered)
 	{
@@ -400,36 +415,45 @@ const char *debugstr(const enum debug_flag flag)
 //   "Jan  1 12:00:00 dnsmasq-dhcp[12345]: <message>\n"
 // where the func suffix (e.g. "-dhcp", "-tftp") comes from the priority
 // bits extracted in my_syslog().
-void FTL_write_dnsmasq_log(const char *message, const char *func)
+bool FTL_write_dnsmasq_log(const char *message, const char *func)
 {
-	// Locale-independent timestamp: ctime() renders the month/day in the
+	// Locale-independent timestamp: ctime_r() renders the month/day in the
 	// C locale regardless of setlocale(LC_ALL, ""), so the buffer cannot
 	// overflow with non-English month names (strftime("%b") would emit
-	// e.g. six bytes for ru_RU). This is dnsmasq's own idiom and keeps
-	// the on-disk format byte-identical to what we wrote before.
+	// e.g. six bytes for ru_RU). ctime_r() is reentrant, unlike ctime()
+	// which returns a pointer to a static buffer shared with localtime()
+	// and asctime() - critical since FTL_write_dnsmasq_log() runs on the
+	// DNS thread while the webserver, database and NTP threads format their
+	// own timestamps. This is dnsmasq's own idiom and keeps the on-disk
+	// format byte-identical to what we wrote before.
 	time_t now = time(NULL);
+	char ctime_buf[26];
+	char *ctime_str = ctime_r(&now, ctime_buf);
+	if(ctime_str == NULL)
+		ctime_str = "Jan  1 00:00:00 ";
 	char ts_buf[16];
-	snprintf(ts_buf, sizeof(ts_buf), "%.15s", ctime(&now) + 4);
+	snprintf(ts_buf, sizeof(ts_buf), "%.15s", ctime_str + 4);
 
 	char line[2048];
 	int off = snprintf(line, sizeof(line), "%s dnsmasq%s[%d]: ", ts_buf, func ? func : "", getpid());
 
 	// Clamp before using off as an offset - snprintf returns the would-be
-	// length on truncation and sizeof(line) - off would underflow otherwise
-	if(off >= (int)sizeof(line))
+	// length on truncation and sizeof(line) - off would underflow otherwise;
+	// it may also return negative on an encoding error
+	if(off < 0 || off >= (int)sizeof(line))
 		off = sizeof(line) - 1;
 
 	const char *msg = message ? message : "";
 	off += snprintf(line + off, sizeof(line) - off, "%s", msg);
 
 	// Clamp to buffer end - snprintf returns would-be length on truncation
-	if(off >= (int)sizeof(line))
+	if(off < 0 || off >= (int)sizeof(line))
 		off = sizeof(line) - 1;
 
 	if(off > 0 && line[off - 1] != '\n')
 		line[off++] = '\n';
 
-	write_log_line(&dnsmasq_log, line, off);
+	return write_log_line(&dnsmasq_log, line, off);
 }
 
 void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const enum debug_flag flag, const char *format, ...)
@@ -477,8 +501,9 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
 
 		// Clamp before using off as an offset - snprintf returns the would-be
-		// length on truncation and sizeof(line) - off would underflow otherwise
-		if(off >= (int)sizeof(line))
+		// length on truncation and sizeof(line) - off would underflow otherwise;
+		// it may also return negative on an encoding error
+		if(off < 0 || off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
 		va_start(args, format);
@@ -486,7 +511,7 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		va_end(args);
 
 		// Clamp to buffer end - snprintf returns would-be length on truncation
-		if(off >= (int)sizeof(line))
+		if(off < 0 || off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
 		line[off++] = '\n';
@@ -547,8 +572,9 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 		int off = snprintf(line, sizeof(line), "%s [%s] %s: ", timestring, idstr, prio);
 
 		// Clamp before using off as an offset - snprintf returns the would-be
-		// length on truncation and sizeof(line) - off would underflow otherwise
-		if(off >= (int)sizeof(line))
+		// length on truncation and sizeof(line) - off would underflow otherwise;
+		// it may also return negative on an encoding error
+		if(off < 0 || off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
 		va_start(args, format);
@@ -556,7 +582,7 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 		va_end(args);
 
 		// Clamp to buffer end - snprintf returns would-be length on truncation
-		if(off >= (int)sizeof(line))
+		if(off < 0 || off >= (int)sizeof(line))
 			off = sizeof(line) - 1;
 
 		line[off++] = '\n';
@@ -975,10 +1001,10 @@ bool flush_dnsmasq_log(void)
 	lock_shm();
 
 	// Open file in write mode to truncate it
-	FILE *logfile = fopen(config.files.log.dnsmasq.v.s, "w");
+	FILE *logfile = fopen(dnsmasq_log.path, "w");
 	if(!logfile)
 	{
-		log_err("Could not open log file %s for truncation: %s\n", config.files.log.dnsmasq.v.s, strerror(errno));
+		log_err("Could not open log file %s for truncation: %s\n", dnsmasq_log.path, strerror(errno));
 		unlock_shm();
 		return false;
 	}
@@ -989,6 +1015,8 @@ bool flush_dnsmasq_log(void)
 	if(dnsmasq_log.fd != -1)
 		close(dnsmasq_log.fd);
 	dnsmasq_log.fd = open(dnsmasq_log.path, O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC, S_IRUSR|S_IWUSR|S_IRGRP);
+	if(dnsmasq_log.fd == -1)
+		log_warn("pihole.log reopen failed after flush (%s)", strerror(errno));
 	pthread_mutex_unlock(&dnsmasq_log.lock);
 
 	// Flush dnsmasq FIFO logs

--- a/src/log.h
+++ b/src/log.h
@@ -58,7 +58,7 @@ const char *priostr(const int priority, const enum debug_flag flag)  __attribute
 const char *debugstr(const enum debug_flag flag) __attribute__((const));
 const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));
 void print_FTL_version(void);
-void dnsmasq_diagnosis_warning(char *message);
+void dnsmasq_diagnosis_warning(const char *message);
 
 // The actual logging routine can take extra options for specialized logging
 // The more general interfaces can be defined here as appropriate shortcuts

--- a/src/log.h
+++ b/src/log.h
@@ -43,7 +43,9 @@ extern bool debug_flags[DEBUG_MAX];
 extern bool only_testing;
 
 void clear_debug_flags(void);
-void init_FTL_log(void);
+void open_log_fds(bool ftl);
+void mark_log_reopen(void);
+void FTL_write_dnsmasq_log(const char *message, const char *func);
 void log_counter_info(void);
 void format_memory_size(char prefix[2], const off_t bytes, double * const formatted);
 void format_time(char buffer[42], unsigned long seconds, double milliseconds);
@@ -101,6 +103,7 @@ const char *short_path(const char *full_path) __attribute__ ((pure));
 void add_to_fifo_buffer(const enum fifo_logs which, const char *payload, const char *prio, const size_t length);
 
 bool flush_dnsmasq_log(void);
+int is_log_fd(const int fd);
 
 typedef struct {
 	struct {

--- a/src/log.h
+++ b/src/log.h
@@ -45,7 +45,7 @@ extern bool only_testing;
 void clear_debug_flags(void);
 void open_log_fds(bool ftl);
 void mark_log_reopen(void);
-void FTL_write_dnsmasq_log(const char *message, const char *func);
+bool FTL_write_dnsmasq_log(const char *message, const char *func);
 void log_counter_info(void);
 void format_memory_size(char prefix[2], const off_t bytes, double * const formatted);
 void format_time(char buffer[42], unsigned long seconds, double milliseconds);

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,8 @@ int main (int argc, char *argv[])
 	if(readFTLconf(&config, true))
 		log_info("Parsed config file "GLOBALTOMLPATH" successfully");
 
-	// Open webserver.log and pihole.log (paths now known after config parse)
+	// Re-open webserver.log and pihole.log to pick up any path overrides
+	// from the TOML file or legacy config
 	open_log_fds(false);
 
 	// Check if another FTL process is already running

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@ int main (int argc, char *argv[])
 	// it if needed
 	username = getUserName();
 
-	// Obtain log file location
+	// Obtain FTL.log file location
 	getLogFilePath(true);
 
 	// Store binary path and PIE load base address for crash-time backtrace.
@@ -65,8 +65,8 @@ int main (int argc, char *argv[])
 	// to have arg{c,v}_dnsmasq initialized
 	parse_args(argc, argv);
 
-	// Initialize FTL log
-	init_FTL_log();
+	// Open FTL.log early (other logs opened after config parse)
+	open_log_fds(true);
 	// Try to open FTL log
 	init_config_mutex();
 	timer_start(EXIT_TIMER);
@@ -82,6 +82,9 @@ int main (int argc, char *argv[])
 	// settings are present and have a valid value
 	if(readFTLconf(&config, true))
 		log_info("Parsed config file "GLOBALTOMLPATH" successfully");
+
+	// Open webserver.log and pihole.log (paths now known after config parse)
+	open_log_fds(false);
 
 	// Check if another FTL process is already running
 	if(another_FTL())

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@ int main (int argc, char *argv[])
 	// it if needed
 	username = getUserName();
 
-	// Obtain log file location
+	// Obtain FTL.log file location
 	getLogFilePath(true);
 
 	// Store binary path and PIE load base address for crash-time backtrace.
@@ -67,8 +67,8 @@ int main (int argc, char *argv[])
 	// to have arg{c,v}_dnsmasq initialized
 	parse_args(argc, argv);
 
-	// Initialize FTL log
-	init_FTL_log();
+	// Open FTL.log early (other logs opened after config parse)
+	open_log_fds(true);
 	// Try to open FTL log
 	init_config_mutex();
 	timer_start(EXIT_TIMER);
@@ -84,6 +84,9 @@ int main (int argc, char *argv[])
 	// settings are present and have a valid value
 	if(readFTLconf(&config, true))
 		log_info("Parsed config file "GLOBALTOMLPATH" successfully");
+
+	// Open webserver.log and pihole.log (paths now known after config parse)
+	open_log_fds(false);
 
 	// Check if another FTL process is already running
 	if(another_FTL())

--- a/src/main.c
+++ b/src/main.c
@@ -85,7 +85,8 @@ int main (int argc, char *argv[])
 	if(readFTLconf(&config, true))
 		log_info("Parsed config file "GLOBALTOMLPATH" successfully");
 
-	// Open webserver.log and pihole.log (paths now known after config parse)
+	// Re-open webserver.log and pihole.log to pick up any path overrides
+	// from the TOML file or legacy config
 	open_log_fds(false);
 
 	// Check if another FTL process is already running

--- a/src/main.c
+++ b/src/main.c
@@ -85,10 +85,6 @@ int main (int argc, char *argv[])
 	if(readFTLconf(&config, true))
 		log_info("Parsed config file "GLOBALTOMLPATH" successfully");
 
-	// Re-open webserver.log and pihole.log to pick up any path overrides
-	// from the TOML file or legacy config
-	open_log_fds(false);
-
 	// Check if another FTL process is already running
 	if(another_FTL())
 		return EXIT_FAILURE;

--- a/src/signals.c
+++ b/src/signals.c
@@ -1413,6 +1413,26 @@ void handle_signals(void)
 	FTLstarttime = time(NULL);
 }
 
+// SIGUSR2: reopen all log fds (logrotate).
+// Registered after dnsmasq so it replaces dnsmasq's handler for this
+// signal - FTL owns all on-disk logs now.
+static void SIGUSR2_handler(int signum, siginfo_t *si, void *context)
+{
+	(void)signum; (void)si; (void)context;
+	const int _errno = errno;
+
+	// Ignore outside main process (TCP forks)
+	if(mpid != getpid())
+	{
+		errno = _errno;
+		return;
+	}
+
+	mark_log_reopen();
+
+	errno = _errno;
+}
+
 // Register real-time signal handler
 void handle_realtime_signals(void)
 {
@@ -1438,6 +1458,15 @@ void handle_realtime_signals(void)
 		SIGACTION.sa_sigaction = &SIGRT_handler;
 		sigaction(signum, &SIGACTION, NULL);
 	}
+
+	// Register SIGUSR2 for log reopen (replaces dnsmasq's handler).
+	// This must run after dnsmasq has registered its own sig_handler
+	// so that FTL's handler wins for SIGUSR2 specifically.
+	struct sigaction sigact = { 0 };
+	sigact.sa_flags = SA_SIGINFO;
+	sigemptyset(&sigact.sa_mask);
+	sigact.sa_sigaction = &SIGUSR2_handler;
+	sigaction(SIGUSR2, &sigact, NULL);
 }
 
 // Return PID of the main FTL process

--- a/src/signals.c
+++ b/src/signals.c
@@ -611,7 +611,7 @@ enum a2l_run {
 	A2L_RUN_OK = 0,          // addr2line ran (frames may still lack debug info)
 	A2L_RUN_TIMED_OUT = 1,   // exceeded the wall-clock deadline
 	A2L_RUN_MISSING = -1,    // addr2line could not be executed (exit 127)
-	A2L_RUN_SPAWN_FAIL = -2, // pipe2()/fork() failed (resource exhaustion)
+	A2L_RUN_SPAWN_FAIL = -2, // pipe2()/_Fork() failed (resource exhaustion)
 };
 
 // Spawn "addr2line -f -e <obj> <rel...>" for one object and read its output,
@@ -619,9 +619,12 @@ enum a2l_run {
 // SIGALRM/itimer watchdog this keeps no process-wide signal or timer state and
 // performs no cross-thread siglongjmp(), so it is safe in the multi-threaded
 // daemon.  Spawning directly avoids popen()'s /bin/sh and stdio buffering.
-// This is not async-signal-safe (it uses snprintf(), poll() and execvp());
-// symbolization is a best-effort step that runs only after the raw frame
-// addresses have already been collected and can be logged.
+// _Fork() is used instead of fork() because it is explicitly async-signal-safe
+// and does not call the pthread_atfork() handlers, so a thread holding a log
+// mutex cannot stall us here (see the log_atfork_prepare() handlers in log.c).
+// This function itself is not async-signal-safe (it uses snprintf(), poll(),
+// and execvp()); symbolization is a best-effort step that runs only after the
+// raw frame addresses have already been collected and can be logged.
 static enum a2l_run run_addr2line_object(const char *obj, struct frame_info *fi,
                                          const int *order, const int ng)
 {
@@ -648,7 +651,10 @@ static enum a2l_run run_addr2line_object(const char *obj, struct frame_info *fi,
 	if(pipe2(pipefd, O_CLOEXEC) != 0)
 		return A2L_RUN_SPAWN_FAIL;
 
-	const pid_t pid = fork();
+	// _Fork() rather than fork(): _Fork() is async-signal-safe and does not
+	// call the pthread_atfork() handlers registered in log.c, so a thread
+	// parked in write() on a log mutex cannot stall the crash handler here.
+	const pid_t pid = _Fork();
 	if(pid < 0)
 	{
 		close(pipefd[0]);

--- a/src/signals.c
+++ b/src/signals.c
@@ -1413,6 +1413,26 @@ void handle_signals(void)
 	FTLstarttime = time(NULL);
 }
 
+// SIGUSR2: reopen all log fds (logrotate).
+// Registered after dnsmasq so it replaces dnsmasq's handler for this
+// signal — FTL owns all on-disk logs now.
+static void SIGUSR2_handler(int signum, siginfo_t *si, void *context)
+{
+	(void)signum; (void)si; (void)context;
+	const int _errno = errno;
+
+	// Ignore outside main process (TCP forks)
+	if(mpid != getpid())
+	{
+		errno = _errno;
+		return;
+	}
+
+	mark_log_reopen();
+
+	errno = _errno;
+}
+
 // Register real-time signal handler
 void handle_realtime_signals(void)
 {
@@ -1438,6 +1458,15 @@ void handle_realtime_signals(void)
 		SIGACTION.sa_sigaction = &SIGRT_handler;
 		sigaction(signum, &SIGACTION, NULL);
 	}
+
+	// Register SIGUSR2 for log reopen (replaces dnsmasq's handler).
+	// This must run after dnsmasq has registered its own sig_handler
+	// so that FTL's handler wins for SIGUSR2 specifically.
+	struct sigaction sigact = { 0 };
+	sigact.sa_flags = SA_SIGINFO;
+	sigemptyset(&sigact.sa_mask);
+	sigact.sa_sigaction = &SIGUSR2_handler;
+	sigaction(SIGUSR2, &sigact, NULL);
 }
 
 // Return PID of the main FTL process

--- a/src/signals.c
+++ b/src/signals.c
@@ -1415,7 +1415,7 @@ void handle_signals(void)
 
 // SIGUSR2: reopen all log fds (logrotate).
 // Registered after dnsmasq so it replaces dnsmasq's handler for this
-// signal — FTL owns all on-disk logs now.
+// signal - FTL owns all on-disk logs now.
 static void SIGUSR2_handler(int signum, siginfo_t *si, void *context)
 {
 	(void)signum; (void)si; (void)context;


### PR DESCRIPTION
## Breaking changes

**`files.log.dnsmasq = "-"` is no longer supported.** The `"-"` value used to select stderr logging via dnsmasq's `log-facility`. Since FTL writes `pihole.log` itself, this value is retired: when it is encountered, FTL logs a hint and migrates existing `-` values to the default path (`/var/log/pihole/pihole.log`) instead of silently creating a file named `-`.

**Custom `log-facility` settings in dnsmasq configs no longer take effect.** Since FTL owns `pihole.log` and dnsmasq's own file-write path is bypassed, neither `log-facility=<path>` nor `log-facility=-` in a custom dnsmasq config (e.g. `dnsmasq.d`) is honored anymore - every dnsmasq line goes to `files.log.dnsmasq` regardless of what the option points at, including stderr. This is also why `files.log.dnsmasq = "-"` (which generated `log-facility=-`) is retired: the stderr channel it selected no longer exists in the daemon path.

**dnsmasq's `log-async` option is dropped from the generated config.** The option drove dnsmasq's asynchronous writer queue, which this PR bypasses entirely, so it no longer had any effect. The trade-off: every query-log line is now a blocking `write()` on the DNS thread. A dedicated asynchronous writer for FTL is planned in the future.

**FTL owns `pihole.log` and keeps descriptors open, so rotation now needs `SIGUSR2`.** This also applies to `FTL.log` and `webserver.log`, which previously re-opened per line and needed no postrotate. The companion [pi-hole/pi-hole#6672](https://github.com/pi-hole/pi-hole/pull/6672) adds `kill -USR2` to the `FTL.log` and `webserver.log` logrotate stanzas.

## What does this PR aim to accomplish?

FTL writes `FTL.log` and `webserver.log` today by opening, writing and closing the file for every line. This PR replaces that with a cached file descriptor per log file and extends the same mechanism to `pihole.log`, which from now on is written by FTL itself instead of by dnsmasq.

dnsmasq's own stderr/file/syslog write paths are bypassed: every dnsmasq line is routed through FTL and appended to `pihole.log` via the cached descriptor. This gives all three logs a consistent on-disk format and makes FTL the single owner of all on-disk logging.

The mechanism is the design discussed in https://github.com/pi-hole/FTL/pull/2897, and this PR builds on top of https://github.com/pi-hole/FTL/pull/2958.

## How does this PR accomplish the above?

- **Cached descriptors:** a `struct log_fd` per log file caches the path, descriptor, reopen flag and a per-file mutex. Writes are plain `O_APPEND` `write()`s (atomic per line); the mutex only guards the `SIGUSR2` reopen.
- **Fork safety:** `pthread_atfork()` handlers take and release all three per-file mutexes around `fork()`, registered before any threads or dnsmasq forks exist. A TCP-query fork can never inherit a locked log mutex and hang the first log write there.
- **`SIGUSR2` handling:** FTL registers its own `SIGUSR2` handler (replacing dnsmasq's) that marks all three logs for reopen. `write_log_line()` tests the reopen *before* the `fd == -1` fast path, so a failed initial open (missing directory, transient `EACCES`, rotation timing) is recovered instead of disabling that log for the life of the process. `SIGUSR2` in the TCP-query forks is ignored.
- **dnsmasq routing:** `my_syslog()` logs through `FTL_dnsmasq_log()`/`FTL_write_dnsmasq_log()`; dnsmasq's own file and syslog fallback paths are bypassed. `echo_stderr` is kept so `dnsmasq --test` errors still reach stderr (used by config testing).
- **Fallbacks:** a failed `pihole.log` open is reported at startup (the message adapts to `misc.hide_dnsmasq_warn`); while `pihole.log` is unavailable, dnsmasq warnings and errors fall back to syslog so they are not silently dropped for the lifetime of the process. `webserver.log` messages keep their existing relay to `_FTL_log()` for `<= LOG_WARNING` when no descriptor is available.
- **Privilege handling:** `FTL_fork_and_bind_sockets()` now chowns `webserver.log` and `pihole.log` alongside `FTL.log` when dropping from root, so freshly created files are `pihole`-owned.
- **Flush:** `pihole.log` is truncated through the cached descriptor on the flush timer instead of the `fopen("w")` + close + reopen dance.
- **Timestamps:** the dnsmasq timestamp buffer uses `ctime_r()` (locale-independent, thread-safe) so `pihole.log` lines stay byte-identical to what we wrote before, in any locale.

## How to test the change during review

- Start/restart FTL, enable query logging, and confirm replies land in `pihole.log` with the same format as before.
- `logrotate --force` the Pi-hole log files (or send `kill -USR2` manually) and confirm FTL reopens the fresh files instead of writing into the rotated ones.
- Set `files.log.dnsmasq` to `"-"` via `pihole-FTL --config files.log.dnsmasq "-"` and verify that it is rejected.
- Run `pihole-FTL --config` / `--teleporter` etc. as a non-root user and confirm no log files are created.

## Link documentation PRs if any are needed to support this PR:

A docs PR covering the many logging changes is planned but not yet opened.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
