### PR TITLE
Add sync-dev-to-special workflow

### DIFF
--- a/.github/workflows/sync-dev-to-special.yml
+++ b/.github/workflows/sync-dev-to-special.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
       - name: Opening pull request
-        run: gh pr create -B special/CI_development -H development --title 'Sync development into special/CI_development' --body 'Created by Github action' --label 'internal'
+        # development is pushed far more often than master, so a sync PR is
+        # frequently already open (or the branches are already in sync). In
+        # either case gh pr create exits non-zero, which we tolerate here so
+        # the workflow doesn't go red.
+        run: gh pr create -B special/CI_development -H development --title 'Sync development into special/CI_development' --body 'Created by Github action' --label 'internal' || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-dev-to-special.yml
+++ b/.github/workflows/sync-dev-to-special.yml
@@ -1,0 +1,18 @@
+name: Sync Development to Special
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+      - name: Opening pull request
+        run: gh pr create -B special/CI_development -H development --title 'Sync development into special/CI_development' --body 'Created by Github action' --label 'internal'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Adds a `sync-dev-to-special` workflow that mirrors the existing `sync-back-to-dev` action, but keeps `special/CI_development` in sync with `development`. On every push to `development` it opens a PR from `development` into `special/CI_development`.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
