### PR TITLE
ci: build riscv64 natively on the RISE project runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,13 @@ jobs:
             build_opts: ""
           - platform: linux/riscv64
             bin_name: pihole-FTL-riscv64
-            runner: ubuntu-24.04-arm
+            # Native RISC-V runner from the RISE project (Scaleway EM-RV1) so we
+            # build natively instead of under QEMU emulation. The early-access
+            # ubuntu-26.04-riscv pool never picked our jobs up, so use the GA label.
+            # https://riscv-runners.riseproject.dev/docs/getting-started/labels
+            runner: ubuntu-24.04-riscv
             build_opts: ""
+            native: true
     runs-on: ${{ matrix.runner }}
     env:
       CI_ARCH: ${{ matrix.platform }}
@@ -111,9 +116,10 @@ jobs:
       -
         name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
-      # QEMU should come before Buildx
+      # QEMU should come before Buildx. Not needed on native runners.
       -
         name: Set up QEMU
+        if: ${{ matrix.native != true }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
       -
         name: Set up Docker Buildx
@@ -131,7 +137,7 @@ jobs:
           timeout_minutes: 30
           command: |
             docker buildx build \
-              --platform ${{ matrix.platform }} \
+              ${{ matrix.native != true && format('--platform {0}', matrix.platform) || '' }} \
               --pull \
               --load \
               --build-arg "CI_ARCH=${{ matrix.platform }}" \
@@ -152,7 +158,7 @@ jobs:
             STATIC="true"
             if [ "${{ matrix.build_opts }}" = "clang" ]; then STATIC="false"; fi
             docker run --rm \
-              --platform ${{ matrix.platform }} \
+              ${{ matrix.native != true && format('--platform {0}', matrix.platform) || '' }} \
               --env CI_ARCH=${{ matrix.platform }} \
               --env BUILD_OPTS=${{ matrix.build_opts }} \
               --env STATIC=${STATIC} \
@@ -162,7 +168,7 @@ jobs:
         name: Export FTL files from ftl-build container (QEMU)
         # Create a temporary container to extract the built files
         run: |
-            docker create --platform ${{ matrix.platform }} --name temp-container ftl-builder:local
+            docker create ${{ matrix.native != true && format('--platform {0}', matrix.platform) || '' }} --name temp-container ftl-builder:local
             docker cp temp-container:/pihole-FTL ./pihole-FTL
             docker cp temp-container:/api-docs.tar.gz ./api-docs.tar.gz
             docker cp temp-container:/pihole.toml ./pihole.toml


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

riscv64 is the only architecture we still cross-build under QEMU, and it's comfortably the slowest leg of the build. The [RISE project](https://riscv-runners.riseproject.dev/docs/getting-started/labels) now offers native RISC-V GitHub Actions runners, so this points the riscv64 matrix entry at their early-access `ubuntu-26.04-riscv` label (Spacemit K3 hardware) and skips QEMU setup and the `--platform` flags on that one native leg via a `native` matrix flag.

Very much an experiment: I want to see whether the job actually gets picked up by their runners and, if so, how the native build times stack up against emulation. Happy to fall back to the GA `ubuntu-24.04-riscv` label, or revert entirely, depending on how it behaves.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
