### PR TITLE
Remove BATS monkey patch for CI output

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pi-hole/ftl-build:v2.19
+FROM ghcr.io/pi-hole/ftl-build:v2.22
 
 WORKDIR /app
 

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -16,11 +16,6 @@ ENV BUILD_OPTS=${BUILD_OPTS}
 # Setting TERM is needed for pretty output in BATS tests
 ENV TERM=xterm
 
-# Monkeypatch BATS to remove duplicate output of starting and finished test
-# BATS uses ANSI escape codes to overwrite the line after the test has finished
-# This is not supported by Github Actions as it does not provide a TTY to the docker build container
-RUN sed -i '/buffer_with_truncation /d' /bats/bats-core/libexec/bats-core/bats-format-pretty
-
 # Build FTL
 # Remove possible old build files
 RUN rm -rf cmake && \


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Depends on https://github.com/pi-hole/docker-base-images/pull/174 and need a new tagged ftl-build image

With BATS 1.14. the fix for douled BATS output on CI is not needed anymore. 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
