### PR TITLE
Fix out-of-bounds read in `get_api_string()` with a long web prefix

### DIFF
--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -556,9 +556,9 @@ unsigned short get_api_string(char **buf, const bool domain)
 			return 0;
 		}
 
-		// Check if snprintf() truncated the string (this should never
-		// happen as we allocate enough memory for the domain to fit)
-		if((size_t)this_len >= bufsz - len - 1)
+		// Reject the URL if snprintf() truncated it to fit api_str (this_len is
+		// the would-be length) or if it does not fit the destination buffer.
+		if((size_t)this_len >= MAX_URL_LEN || (size_t)this_len >= bufsz - len - 1)
 		{
 			log_err("API URL buffer too small!");
 			free(api_str);


### PR DESCRIPTION
# What does this implement/fix?

`get_api_string()` builds the TXT record served for the `api.ftl`, `domain.api.ftl` and `local.api.ftl` lookups by formatting each webserver port's API URL into a fixed `MAX_URL_LEN` (255) byte `api_str`. `snprintf()` returns the length it *would* have written, and the existing truncation guard only compared that length against the space left in the destination buffer (`bufsz - len - 1`), which grows with the port index. A long `webserver.paths.prefix` can therefore make the formatted URL exceed 255 bytes while still passing the guard, after which `memmem()` is called with that inflated needle length and reads past the end of the `api_str` allocation (the stored length-prefix byte and the `len` increment are wrong as well).

This adds a second condition that rejects the URL when `this_len` reaches the `api_str` capacity, so the needle length handed to `memmem()` can never exceed the allocation. The normal path (a URL that fits) is unchanged.

## How to test the change during review

1. Configure a long web prefix and at least two webserver ports so the loop index advances, e.g. in `pihole.toml`:
   - `webserver.paths.prefix` set to a path of ~230+ characters
   - `webserver.port = "80,443s"`
2. Build FTL with AddressSanitizer (a `Debug` build with `-fsanitize=address`) and start it.
3. Query the API TXT record: `dig +short TXT local.api.ftl @127.0.0.1` (also `api.ftl` and `domain.api.ftl`).
   - Before this change: ASan reports a heap-buffer-overflow READ inside `get_api_string()` / `memmem()`.
   - After this change: no overflow; the over-long URL is dropped with `API URL buffer too small!` and the remaining, well-formed URLs are returned normally.
4. Regression: with a normal (short or empty) prefix, confirm `api.ftl`, `domain.api.ftl` and `local.api.ftl` still return the expected API URLs. The existing webserver/API tests in the CI suite cover this normal path.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
