### PR TITLE
Fix Debug builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,6 @@ set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -D
 
 # Code hardening and debugging improvements
 # -fstack-protector-strong: The program will be resistant to having its stack overflowed
-# -Wp,-D_FORTIFY_SOURCE=3 and -O1 or higher: This causes certain unsafe glibc functions to be replaced with their safer counterparts. We may have to undefine _FORTIFY_SOURCE to avoid a warning about the redefinition of this macro
 # -Wl,-z,relro: reduces the possible areas of memory in a program that can be used by an attacker that performs a successful memory corruption exploit
 # -Wl,-z,now: When combined with RELRO above, this further reduces the regions of memory available to memory corruption attacks
 # -g3: More debugging information
@@ -60,7 +59,7 @@ set(SQLITE_DEFINES "-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DEFAULT_MEMSTATUS=0 -D
 # -Wl,-z,relro: Read-only segments after relocation
 # -fno-common: Emit globals without explicit initializer from `.bss` to `.data`. This causes GCC to reject multiple definitions of global variables. This is the new default from GCC-10 on.
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set(HARDENING_FLAGS "-fstack-protector-strong -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3 -Wl,-z,relro,-z,now -fexceptions -funwind-tables -fasynchronous-unwind-tables -Wl,-z,defs -Wl,-z,now -Wl,-z,relro -fno-common")
+    set(HARDENING_FLAGS "-fstack-protector-strong -Wl,-z,relro,-z,now -fexceptions -funwind-tables -fasynchronous-unwind-tables -Wl,-z,defs -Wl,-z,now -Wl,-z,relro -fno-common")
     set(DEBUG_FLAGS "-rdynamic -fno-omit-frame-pointer")
 endif()
 
@@ -218,10 +217,11 @@ endif()
 # We define HAVE_POLL_H as this is needed for the musl builds to succeed
 set(CMAKE_C_FLAGS "-std=c17 -pipe ${WARN_FLAGS} -D_FILE_OFFSET_BITS=64 ${HARDENING_FLAGS} ${DEBUG_FLAGS} ${CMAKE_C_FLAGS} -DHAVE_POLL_H ${SQLITE_DEFINES}")
 
+# -Wp,-D_FORTIFY_SOURCE=3 and -O1 or higher: This causes certain unsafe glibc functions to be replaced with their safer counterparts. _FORTIFY_SOURCE requires -O1 or higher to build. We may have to undefine _FORTIFY_SOURCE to avoid a warning about the redefinition of this macro
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g3")
-set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -funroll-loops")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -funroll-loops -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} -g3")
-set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG")
+set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3")
 
 set(sources
         args.c


### PR DESCRIPTION
/usr/include/features.h:451:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]

## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

Tested using `gcc version 16.1.1 20260515 (Red Hat 16.1.1-2) (GCC)` and `glibc 2.43-7.fc44`

Running `./build.sh -DCMAKE_BUILD_TYPE=Debug clean` on `development fails with:
```cc
[  4%] Building C object src/zip/CMakeFiles/zip.dir/gzip.c.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/string.h:26,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/webserver/cJSON/cJSON.c:40:
/usr/include/features.h:451:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  451 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
[  4%] Compiling external/rapidoc-min.js
[  4%] Built target cJSON
[  4%] Building C object src/dotdoh/CMakeFiles/dotdoh.dir/framing.c.o
Building Pi-hole FTL daemon
   - Branch: development
   - Architecture: x86_64 (compiled locally)
   - Version: v6.7-38-gafcfb205
   - Tag: v6.7
   - Hash: afcfb205
   - Commit date: 2026-07-23 06:26:17 +0200
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/string.h:26,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/dotdoh/upstream_uri.c:16:
/usr/include/features.h:451:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  451 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [src/dotdoh/CMakeFiles/dotdoh.dir/build.make:79: src/dotdoh/CMakeFiles/dotdoh.dir/upstream_uri.c.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
[  4%] Built target gen_version
[  4%] Building C object src/webserver/CMakeFiles/webserver.dir/lua_web.c.o
[  4%] Building C object src/zip/miniz/CMakeFiles/miniz.dir/miniz.c.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdint.h:26,
                 from /usr/lib/gcc/x86_64-redhat-linux/16/include/stdint.h:11,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/dotdoh/framing.h:18,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/dotdoh/framing.c:15:
/usr/include/features.h:451:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  451 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [src/dotdoh/CMakeFiles/dotdoh.dir/build.make:93: src/dotdoh/CMakeFiles/dotdoh.dir/framing.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1250: src/dotdoh/CMakeFiles/dotdoh.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[  5%] Building C object src/webserver/CMakeFiles/webserver.dir/webserver.c.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/FTL.h:38,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/zip/gzip.c:11:
/usr/include/features.h:451:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  451 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [src/zip/CMakeFiles/zip.dir/build.make:79: src/zip/CMakeFiles/zip.dir/gzip.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:802: src/zip/CMakeFiles/zip.dir/all] Error 2
[  6%] Compiling external/rapidoc-min.js.map
[  6%] Building C object src/api/CMakeFiles/api.dir/action.c.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/FTL.h:38,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/api/2fa.c:11:
/usr/include/features.h:451:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  451 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [src/api/CMakeFiles/api.dir/build.make:79: src/api/CMakeFiles/api.dir/2fa.c.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
[  6%] Building C object src/webserver/CMakeFiles/webserver.dir/x509.c.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/FTL.h:38,
                 from /home/shared/Projects/fleet/pi-hole-FTL/src/webserver/lua_web.c:11:
/usr/include/features.h:451:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  451 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [src/webserver/CMakeFiles/webserver.dir/build.make:93: src/webserver/CMakeFiles/webserver.dir/lua_web.c.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
```

It succeeds using this patch, tested with `gcc 16.1.1-2` and `clang 22.1.8-4.fc44` with `glibc 2.43-7.fc44` and `cmake 4.3.0-1.fc44`

**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
