### PR TITLE
Serve HTTP/2 and HTTP/3 on the webserver, add DoH2/DoH3 support

### DIFF
--- a/.github/.codespellignore
+++ b/.github/.codespellignore
@@ -13,3 +13,6 @@ iif
 prefered
 padd
 rabit
+clen
+te
+ans

--- a/.github/.codespellignore
+++ b/.github/.codespellignore
@@ -14,5 +14,3 @@ prefered
 padd
 rabit
 clen
-te
-ans

--- a/.github/.codespellignore_lines
+++ b/.github/.codespellignore_lines
@@ -1,3 +1,4 @@
 			self.errors.append("Exception when GETing from FTL: " + str(e))
 //    sitten -> sittin (substitution of "i" for "e"),
 //    sittin -> sitting (insertion of "g" at the end).
+		"upgrade", "te", "host", "http2-settings",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
               --env BUILD_OPTS=${{ matrix.build_opts }} \
               --env STATIC=${STATIC} \
               ftl-builder:local \
-              /bin/bash -c "test/arch_test.sh && test/run.sh"
+              /bin/bash -c "test/arch_test.sh && test/run.sh && test/http2_test.sh"
       -
         name: Export FTL files from ftl-build container (QEMU)
         # Create a temporary container to extract the built files

--- a/build.sh
+++ b/build.sh
@@ -94,6 +94,9 @@ fi
 if [[ -n "${debug}" ]]; then
     install=1
     restart=1
+    # Propagate into test/run.sh so it attaches gdb to the test instance and
+    # dumps a backtrace when FTL crashes during the suite
+    export GDB=1
 fi
 
 # If we are building in debug mode, ensure CMake is configured for a Debug build
@@ -201,21 +204,24 @@ cmake --build . -- ${MAKEFLAGS}
 # Checksum verification
 ./pihole-FTL verify
 
+# Always copy the freshly built binary (and the regression test harnesses) to the
+# repository root, so test/run.sh runs exactly what we just built regardless of
+# whether we also install it system-wide. Skipping this on install let the tests
+# silently run a stale repo-root binary.
+echo "Copying compiled pihole-FTL binary to repository root"
+cp pihole-FTL ../
+# Copy the regression test binaries alongside it so the bats tests can run them
+# from the repo root.
+for regression_bin in tar_regression gzip_regression dotdoh_regression; do
+    if [[ -f "${regression_bin}" ]]; then
+        cp "${regression_bin}" ../
+    fi
+done
+
 # If we are asked to install, we do this here (requires root privileges)
-# Otherwise, we simply copy the binary one level down
 if [[ -n "${install}" ]]; then
     echo "Installing pihole-FTL"
     ${SUDO} cmake --install .
-else
-    echo "Copying compiled pihole-FTL binary to repository root"
-    cp pihole-FTL ../
-    # Copy the regression test binaries alongside it so the bats tests can run
-    # them from the repo root.
-    for regression_bin in tar_regression gzip_regression dotdoh_regression; do
-        if [[ -f "${regression_bin}" ]]; then
-            cp "${regression_bin}" ../
-        fi
-    done
 fi
 
 # If we are asked to run tests, we do this here
@@ -233,16 +239,22 @@ if [[ -n "${testhttp2}" ]]; then
     bash test/http2_test.sh
 fi
 
-# If we are asked to restart, we do this here
+# If we are asked to restart, we do this here. This drives the systemd service,
+# so skip it where there is no service manager (e.g. inside the test container,
+# where test/run.sh manages its own FTL instance instead).
 if [[ -n "${restart}" ]]; then
-    echo "Restarting pihole-FTL"
+    if command -v systemctl &> /dev/null; then
+        echo "Restarting pihole-FTL"
 
-    # First, reset the failure-counter in case a previous error caused a
-    # restarting loop now preventing systemd from starting FTL
-    ${SUDO} systemctl reset-failed pihole-FTL
+        # First, reset the failure-counter in case a previous error caused a
+        # restarting loop now preventing systemd from starting FTL
+        ${SUDO} systemctl reset-failed pihole-FTL
 
-    # Restart FTL
-    ${SUDO} systemctl restart pihole-FTL
+        # Restart FTL
+        ${SUDO} systemctl restart pihole-FTL
+    else
+        echo "Skipping restart: no systemctl (not a systemd host)"
+    fi
 fi
 
 # If we are asked to clean the logs, we do this here
@@ -254,22 +266,28 @@ if [[ -n "${clean_logs}" ]]; then
     done
 fi
 
-# If we want to attach the debugger, we do this here
-if [[ -n "${debug}" ]]; then
-    echo "Waiting for pihole-FTL to start..."
-    pid_file=/run/pihole-FTL.pid
+# If we want to attach the debugger, we do this here. This targets the live
+# systemd-managed daemon; in a container there is none to attach to (test/run.sh
+# already attaches gdb to the test instance via GDB=1 above), so skip it there.
+if [[ -n "${debug}" && -n "${test}" ]]; then
+    if command -v systemctl &> /dev/null; then
+        echo "Waiting for pihole-FTL to start..."
+        pid_file=/run/pihole-FTL.pid
 
-    # Loop until the pid file is created and non-empty
-    while [ ! -f "${pid_file}" ] || [ ! -s "${pid_file}" ]; do
-        sleep 0.1
-    done
+        # Loop until the pid file is created and non-empty
+        while [ ! -f "${pid_file}" ] || [ ! -s "${pid_file}" ]; do
+            sleep 0.1
+        done
 
-    # Get the pid from the pid file
-    pid=$(cat "${pid_file}")
+        # Get the pid from the pid file
+        pid=$(cat "${pid_file}")
 
-    # Attach gdb to the process
-    echo "Attaching debugger to pihole-FTL (PID: ${pid})..."
-    ${SUDO} gdb -p "${pid}"
+        # Attach gdb to the process
+        echo "Attaching debugger to pihole-FTL (PID: ${pid})..."
+        ${SUDO} gdb -p "${pid}"
+    else
+        echo "Skipping debugger attach: no systemd service (test/run.sh handles GDB via GDB=1)"
+    fi
 fi
 
 # If we are asked to tail the log, we do this here

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ do
         "dev"            ) dev=1;;
         "test"           ) test=1;;
         "test-perf"      ) test=1; export RUN_PERF_TEST=1;;
+        "test-http2"     ) testhttp2=1;;
         "clean-logs"     ) clean_logs=1;;
         "clang"          ) clang=1;;
         "ci"             ) builddir="cmake_ci/";;
@@ -221,6 +222,15 @@ fi
 if [[ -n "${test}" ]]; then
     cd ..
     bash test/run.sh
+fi
+
+# Dedicated TLS terminator test. The regular suite exercises the plain HTTP/1.1
+# port; this starts a throwaway FTL instance and drives the TLS port directly to
+# cover HTTP/2, ALPN fall-through, POST-body forwarding, the long CSP header and
+# PROXY protocol v2 client-IP forwarding.
+if [[ -n "${testhttp2}" ]]; then
+    cd ..
+    bash test/http2_test.sh
 fi
 
 # If we are asked to restart, we do this here

--- a/patch/civetweb.sh
+++ b/patch/civetweb.sh
@@ -23,4 +23,7 @@ patch -p1 < patch/civetweb/0001-Expose-bound-to-addresses-from-CivetWeb-to-the-f
 echo "Applying patch 0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch"
 patch -p1 < patch/civetweb/0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch
 
+echo "Applying patch 0001-Adopt-client-address-from-PROXY-protocol-v2.patch"
+patch -p1 < patch/civetweb/0001-Adopt-client-address-from-PROXY-protocol-v2.patch
+
 echo "ALL PATCHES APPLIED OKAY"

--- a/patch/civetweb/0001-Adopt-client-address-from-PROXY-protocol-v2.patch
+++ b/patch/civetweb/0001-Adopt-client-address-from-PROXY-protocol-v2.patch
@@ -1,0 +1,128 @@
+diff --git a/src/webserver/civetweb/civetweb.c b/src/webserver/civetweb/civetweb.c
+index 357d259ed..061cc1363 100644
+--- a/src/webserver/civetweb/civetweb.c
++++ b/src/webserver/civetweb/civetweb.c
+@@ -20318,6 +20318,112 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
+ #endif /* ALTERNATIVE_QUEUE */
+ 
+ 
++/* Pi-hole: parse a PROXY protocol v2 header on a fresh connection coming from
++ * the in-process TLS terminator (which reaches CivetWeb on the loopback
++ * backend), and replace the remote address with the real client the header
++ * announces. This keeps client-IP-based logging and authentication accurate
++ * behind the terminator. Only loopback connections are trusted, so a plain-HTTP
++ * client on a public port cannot spoof its address this way; a no-op if no
++ * PROXY header is present (e.g. a direct localhost request). */
++static void
++parse_proxy_protocol_v2(struct mg_connection *conn)
++{
++	static const unsigned char sig[12] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
++	                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
++	struct pollfd pfd;
++	unsigned char hdr[16];
++	unsigned char buf[16 + 216]; /* 216 = largest v2 address block */
++	size_t addr_len, total, got;
++	int have;
++	const unsigned char *a;
++
++	/* Only trust the header on loopback connections (from the terminator). */
++	if (conn->client.lsa.sa.sa_family == AF_INET) {
++		if (conn->client.lsa.sin.sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
++			return;
++		}
++#if defined(USE_IPV6)
++	} else if (conn->client.lsa.sa.sa_family == AF_INET6) {
++		if (!IN6_IS_ADDR_LOOPBACK(&conn->client.lsa.sin6.sin6_addr)) {
++			return;
++		}
++#endif
++	} else {
++		return;
++	}
++
++	/* Peek the fixed 16-byte v2 header. Retry until 16 bytes are available, or
++	 * bail as soon as the available prefix already fails to match the
++	 * signature (i.e. this is a normal request, not a PROXY header). */
++	have = 0;
++	while (have < 16) {
++		int n;
++		pfd.fd = conn->client.sock;
++		pfd.events = POLLIN;
++		pfd.revents = 0;
++		if (poll(&pfd, 1, 1000) <= 0) {
++			return;
++		}
++		n = (int)recv(conn->client.sock, hdr, sizeof(hdr), MSG_PEEK);
++		if (n <= 0) {
++			return;
++		}
++		if (memcmp(hdr, sig, (n < 12) ? (size_t)n : (size_t)12) != 0) {
++			return;
++		}
++		have = n;
++	}
++	if ((hdr[12] & 0xF0) != 0x20) {
++		return; /* not version 2 */
++	}
++
++	addr_len = ((size_t)hdr[14] << 8) | (size_t)hdr[15];
++	total = 16 + addr_len;
++	if (total > sizeof(buf)) {
++		return;
++	}
++
++	/* Consume the whole header for real so the HTTP request follows it. */
++	got = 0;
++	while (got < total) {
++		int n;
++		pfd.fd = conn->client.sock;
++		pfd.events = POLLIN;
++		pfd.revents = 0;
++		if (poll(&pfd, 1, 1000) <= 0) {
++			return;
++		}
++		n = (int)recv(conn->client.sock, buf + got, total - got, 0);
++		if (n <= 0) {
++			return;
++		}
++		got += (size_t)n;
++	}
++
++	/* Only the PROXY command (0x01) carries a real address; LOCAL (0x00) keeps
++	 * the original one. */
++	if ((hdr[12] & 0x0F) != 0x01) {
++		return;
++	}
++
++	a = buf + 16;
++	if (hdr[13] == 0x11 && addr_len >= 12) { /* TCP over IPv4 */
++		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
++		conn->client.rsa.sin.sin_family = AF_INET;
++		memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
++		memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
++	}
++#if defined(USE_IPV6)
++	else if (hdr[13] == 0x21 && addr_len >= 36) { /* TCP over IPv6 */
++		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
++		conn->client.rsa.sin6.sin6_family = AF_INET6;
++		memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
++		memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
++	}
++#endif
++}
++
++
+ static void
+ worker_thread_run(struct mg_connection *conn)
+ {
+@@ -20403,6 +20509,10 @@ worker_thread_run(struct mg_connection *conn)
+ #endif
+ 		conn->conn_birth_time = time(NULL);
+ 
++		/* Pi-hole: adopt the real client address from a PROXY protocol v2
++		 * header if this connection comes from the loopback TLS terminator. */
++		parse_proxy_protocol_v2(conn);
++
+ 		/* Fill in IP, port info early so even if SSL setup below fails,
+ 		 * error handler would have the corresponding info.
+ 		 * Thanks to Johannes Winkelmann for the patch.

--- a/patch/civetweb/0001-Adopt-client-address-from-PROXY-protocol-v2.patch
+++ b/patch/civetweb/0001-Adopt-client-address-from-PROXY-protocol-v2.patch
@@ -1,43 +1,169 @@
 diff --git a/src/webserver/civetweb/civetweb.c b/src/webserver/civetweb/civetweb.c
-index 357d259ed..061cc1363 100644
+index 357d259ed..b1bc545bd 100644
 --- a/src/webserver/civetweb/civetweb.c
 +++ b/src/webserver/civetweb/civetweb.c
-@@ -20318,6 +20318,112 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
+@@ -2105,6 +2105,7 @@ enum {
+ #endif
+ 	ADDITIONAL_HEADER,
+ 	ALLOW_INDEX_SCRIPT_SUB_RES,
++	PROXY_PROTOCOL_SECRET,
+ 
+ 	NUM_OPTIONS
+ };
+@@ -2271,6 +2272,7 @@ static const struct mg_option config_options[] = {
+ #endif
+     {"additional_header", MG_CONFIG_TYPE_STRING_MULTILINE, NULL},
+     {"allow_index_script_resource", MG_CONFIG_TYPE_BOOLEAN, "no"},
++    {"proxy_protocol_secret", MG_CONFIG_TYPE_STRING, NULL},
+ 
+     {NULL, MG_CONFIG_TYPE_UNKNOWN, NULL}};
+ 
+@@ -2607,6 +2609,8 @@ struct mg_connection {
+ 	char *path_info;          /* PATH_INFO part of the URL */
+ 
+ 	int must_close;       /* 1 if connection must be closed */
++	unsigned char proxy_is_ssl; /* Pi-hole: PROXY v2 announced a TLS-terminated
++	                             * client (PP2_TYPE_SSL), so treat as HTTPS */
+ 	int accept_gzip;      /* 1 if gzip encoding is accepted */
+ 	int in_error_handler; /* 1 if in handler for user defined error
+ 	                       * pages */
+@@ -20318,6 +20322,12 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
  #endif /* ALTERNATIVE_QUEUE */
  
  
-+/* Pi-hole: parse a PROXY protocol v2 header on a fresh connection coming from
-+ * the in-process TLS terminator (which reaches CivetWeb on the loopback
-+ * backend), and replace the remote address with the real client the header
-+ * announces. This keeps client-IP-based logging and authentication accurate
-+ * behind the terminator. Only loopback connections are trusted, so a plain-HTTP
-+ * client on a public port cannot spoof its address this way; a no-op if no
-+ * PROXY header is present (e.g. a direct localhost request). */
++/* Pi-hole: adopt the real client address from a PROXY protocol v2 header sent
++ * by the loopback TLS terminator. Kept in its own unit to keep this patch
++ * small; parse_proxy_protocol_v2() is defined there. */
++#include "proxy_v2.inl"
++
++
+ static void
+ worker_thread_run(struct mg_connection *conn)
+ {
+@@ -20403,6 +20413,10 @@ worker_thread_run(struct mg_connection *conn)
+ #endif
+ 		conn->conn_birth_time = time(NULL);
+ 
++		/* Pi-hole: adopt the real client address from a PROXY protocol v2
++		 * header if this connection comes from the loopback TLS terminator. */
++		parse_proxy_protocol_v2(conn);
++
+ 		/* Fill in IP, port info early so even if SSL setup below fails,
+ 		 * error handler would have the corresponding info.
+ 		 * Thanks to Johannes Winkelmann for the patch.
+@@ -20421,7 +20435,9 @@ worker_thread_run(struct mg_connection *conn)
+ 		            (conn->client.is_ssl ? "SSL " : ""),
+ 		            conn->request_info.remote_addr);
+ 
+-		conn->request_info.is_ssl = conn->client.is_ssl;
++		/* Pi-hole: a PROXY v2 header from the TLS terminator can mark an
++		 * otherwise-plaintext loopback connection as HTTPS (PP2_TYPE_SSL). */
++		conn->request_info.is_ssl = conn->client.is_ssl || conn->proxy_is_ssl;
+ 
+ 		if (conn->client.is_ssl) {
+ 
+diff --git a/src/webserver/civetweb/proxy_v2.inl b/src/webserver/civetweb/proxy_v2.inl
+new file mode 100644
+index 000000000..a164ee2ac
+--- /dev/null
++++ b/src/webserver/civetweb/proxy_v2.inl
+@@ -0,0 +1,225 @@
++/* PROXY protocol v2 support.
++ *
++ * When the "proxy_protocol_secret" option is set, civetweb parses a PROXY
++ * protocol v2 header at the start of each new connection. The header is trusted
++ * only if it carries a custom TLV whose value equals the configured secret; a
++ * trusted header's announced client address (and TLS status, via the standard
++ * PP2_TYPE_SSL TLV) then replaces the transport peer. The shared secret lets a
++ * trusted upstream terminator or L4 proxy authenticate itself where source-
++ * address trust is not possible (a loopback backend, a sidecar, a shared host).
++ * With no secret configured the parser is a no-op, so normal requests are
++ * unaffected.
++ *
++ * Kept in a separate unit that civetweb.c #includes, so that when this is
++ * vendored the change to civetweb.c stays a one-line include plus the two call
++ * sites. */
++
++/* Custom PROXY v2 TLV (in the PP2_TYPE_MIN_CUSTOM 0xE0-0xEF range) carrying the
++ * shared secret that authenticates the header. */
++#define PP2_TYPE_PROXY_SECRET 0xE0
++/* Standard PROXY v2 TLV announcing the client spoke TLS to the proxy. */
++#define PP2_TYPE_SSL 0x20
++#define PP2_CLIENT_SSL 0x01
++
++static int
++proxy_v2_hexdigit(char c)
++{
++	if (c >= '0' && c <= '9') {
++		return c - '0';
++	}
++	if (c >= 'a' && c <= 'f') {
++		return c - 'a' + 10;
++	}
++	if (c >= 'A' && c <= 'F') {
++		return c - 'A' + 10;
++	}
++	return -1;
++}
++
++/* Decode the hex string `hex` into up to out_sz bytes of `out`. Returns the
++ * number of bytes decoded, or -1 on an odd length or a non-hex character. */
++static int
++proxy_v2_hex_decode(const char *hex, unsigned char *out, size_t out_sz)
++{
++	size_t n = 0;
++	while (hex[0] != '\0') {
++		int hi, lo;
++		if (hex[1] == '\0' || n >= out_sz) {
++			return -1;
++		}
++		hi = proxy_v2_hexdigit(hex[0]);
++		lo = proxy_v2_hexdigit(hex[1]);
++		if (hi < 0 || lo < 0) {
++			return -1;
++		}
++		out[n++] = (unsigned char)((hi << 4) | lo);
++		hex += 2;
++	}
++	return (int)n;
++}
++
++/* Parse a PROXY protocol v2 header on a fresh connection and, if it is trusted
++ * (carries the configured secret), replace the remote address with the real
++ * client the header announces. A no-op when the feature is disabled or no PROXY
++ * header is present. */
 +static void
 +parse_proxy_protocol_v2(struct mg_connection *conn)
 +{
 +	static const unsigned char sig[12] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
 +	                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
++	const char *secret_hex;
++	unsigned char secret[64];
++	int secret_len;
 +	struct pollfd pfd;
 +	unsigned char hdr[16];
 +	unsigned char buf[16 + 216]; /* 216 = largest v2 address block */
-+	size_t addr_len, total, got;
++	size_t addr_len, total, got, addr_size = 0;
 +	int have;
 +	const unsigned char *a;
 +
-+	/* Only trust the header on loopback connections (from the terminator). */
-+	if (conn->client.lsa.sa.sa_family == AF_INET) {
-+		if (conn->client.lsa.sin.sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
-+			return;
-+		}
-+#if defined(USE_IPV6)
-+	} else if (conn->client.lsa.sa.sa_family == AF_INET6) {
-+		if (!IN6_IS_ADDR_LOOPBACK(&conn->client.lsa.sin6.sin6_addr)) {
-+			return;
-+		}
-+#endif
-+	} else {
++	/* Worker connection structs are reused across connections, so clear any
++	 * TLS-terminated marker from a previous connection before every early
++	 * return below - otherwise a later plaintext request on the same worker
++	 * would inherit a stale proxy_is_ssl and be mislabelled as HTTPS. */
++	conn->proxy_is_ssl = 0;
++
++	/* Opt-in: with no configured secret there is nothing to trust, so do not
++	 * touch the connection at all. */
++	secret_hex = (conn->dom_ctx != NULL)
++	                 ? conn->dom_ctx->config[PROXY_PROTOCOL_SECRET]
++	                 : NULL;
++	if (secret_hex == NULL || secret_hex[0] == '\0') {
 +		return;
++	}
++	secret_len = proxy_v2_hex_decode(secret_hex, secret, sizeof(secret));
++	if (secret_len <= 0) {
++		return; /* misconfigured secret */
 +	}
 +
 +	/* Peek the fixed 16-byte v2 header. Retry until 16 bytes are available, or
@@ -57,6 +183,13 @@ index 357d259ed..061cc1363 100644
 +			return;
 +		}
 +		if (memcmp(hdr, sig, (n < 12) ? (size_t)n : (size_t)12) != 0) {
++			return;
++		}
++		/* MSG_PEEK does not consume, so poll() keeps reporting the same bytes
++		 * readable: if the peeked count did not grow since the last iteration
++		 * the peer has stalled mid-signature. Bail instead of spinning at 100%
++		 * CPU (a real proxy writes all 16 bytes in one segment). */
++		if (n <= have) {
 +			return;
 +		}
 +		have = n;
@@ -95,34 +228,68 @@ index 357d259ed..061cc1363 100644
 +	}
 +
 +	a = buf + 16;
++	/* Note the address family/size but do NOT adopt the address yet - the header
++	 * must first prove it is trusted via the secret TLV below. */
 +	if (hdr[13] == 0x11 && addr_len >= 12) { /* TCP over IPv4 */
-+		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
-+		conn->client.rsa.sin.sin_family = AF_INET;
-+		memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
-+		memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
++		addr_size = 12;
 +	}
 +#if defined(USE_IPV6)
 +	else if (hdr[13] == 0x21 && addr_len >= 36) { /* TCP over IPv6 */
-+		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
-+		conn->client.rsa.sin6.sin6_family = AF_INET6;
-+		memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
-+		memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
++		addr_size = 36;
 +	}
 +#endif
++	if (addr_size == 0) {
++		return; /* unsupported/short address block */
++	}
++
++	/* Walk the TLVs that follow the address block. Require the shared secret
++	 * (PP2_TYPE_PROXY_SECRET) before trusting the header, and note a
++	 * PP2_TYPE_SSL with PP2_CLIENT_SSL set (the client used TLS to the proxy). */
++	{
++		int token_ok = 0, ssl_flag = 0;
++		size_t off = addr_size;
++		while (off + 3 <= addr_len) {
++			const unsigned char t = a[off];
++			const size_t l = ((size_t)a[off + 1] << 8) | (size_t)a[off + 2];
++			off += 3;
++			if (off + l > addr_len) {
++				break;
++			}
++			if (t == PP2_TYPE_PROXY_SECRET && l == (size_t)secret_len) {
++				/* Constant-time compare so a co-resident process cannot time
++				 * byte-wise matching to recover the secret. */
++				unsigned char diff = 0;
++				size_t i;
++				for (i = 0; i < (size_t)secret_len; i++) {
++					diff |= (unsigned char)(a[off + i] ^ secret[i]);
++				}
++				if (diff == 0) {
++					token_ok = 1;
++				}
++			} else if (t == PP2_TYPE_SSL && l >= 1 && (a[off] & PP2_CLIENT_SSL)) {
++				ssl_flag = 1;
++			}
++			off += l;
++		}
++		if (!token_ok) {
++			return; /* secret missing or wrong - ignore the header */
++		}
++
++		/* Trusted: adopt the real client address and TLS status. */
++		if (hdr[13] == 0x11) { /* TCP over IPv4 */
++			memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
++			conn->client.rsa.sin.sin_family = AF_INET;
++			memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
++			memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
++		}
++#if defined(USE_IPV6)
++		else { /* TCP over IPv6 */
++			memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
++			conn->client.rsa.sin6.sin6_family = AF_INET6;
++			memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
++			memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
++		}
++#endif
++		conn->proxy_is_ssl = ssl_flag ? 1 : 0;
++	}
 +}
-+
-+
- static void
- worker_thread_run(struct mg_connection *conn)
- {
-@@ -20403,6 +20509,10 @@ worker_thread_run(struct mg_connection *conn)
- #endif
- 		conn->conn_birth_time = time(NULL);
- 
-+		/* Pi-hole: adopt the real client address from a PROXY protocol v2
-+		 * header if this connection comes from the loopback TLS terminator. */
-+		parse_proxy_protocol_v2(conn);
-+
- 		/* Fill in IP, port info early so even if SSL setup below fails,
- 		 * error handler would have the corresponding info.
- 		 * Thanks to Johannes Winkelmann for the patch.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -572,18 +572,28 @@ if(LIBSSL AND LIBCRYPTO AND USE_TLS)
         message(STATUS "Building FTL with HTTP/2 support: NO (nghttp2 not found)")
     endif()
 
-    # HTTP/3 for the TLS terminator (OpenSSL QUIC + nghttp3). Optional and
-    # additionally requires QUIC support in the linked OpenSSL; without it the
-    # terminator serves HTTP/1.1 and (if built) HTTP/2 only. HTTP/3 also needs
-    # OpenSSL >= 4.0 for SSL_get_peer_addr() to forward the real client address;
-    # terminator.c raises a #error against an older OpenSSL.
+    # HTTP/3 for the TLS terminator (OpenSSL QUIC + nghttp3). Requires nghttp3
+    # AND OpenSSL >= 4.0, which provides SSL_get_peer_addr() (the per-connection
+    # QUIC peer getter used to forward the real client IP). Against an older
+    # OpenSSL such as 3.5.x, HTTP/3 and QUIC are disabled at build time and the
+    # terminator serves HTTP/1.1 and (if built) HTTP/2 only.
+    include(CheckCSourceCompiles)
+    check_c_source_compiles("
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+#error OpenSSL < 4.0 has no QUIC peer-address API
+#endif
+int main(void) { return 0; }
+" OPENSSL_HAS_QUIC_PEER_ADDR)
     find_library(LIBNGHTTP3 NAMES libnghttp3${LIBRARY_SUFFIX} nghttp3)
-    if(LIBNGHTTP3)
+    if(LIBNGHTTP3 AND OPENSSL_HAS_QUIC_PEER_ADDR)
         message(STATUS "Building FTL with HTTP/3 support: YES")
         target_compile_definitions(webserver PRIVATE HAVE_HTTP3)
         # The dotdoh client speaks DoH3 (HTTP/3 over QUIC) on h3:// upstreams.
         target_compile_definitions(dotdoh PRIVATE HAVE_HTTP3)
         target_link_libraries(pihole-FTL ${LIBNGHTTP3})
+    elseif(LIBNGHTTP3)
+        message(STATUS "Building FTL with HTTP/3 support: NO (OpenSSL < 4.0 lacks the QUIC peer-address API)")
     else()
         message(STATUS "Building FTL with HTTP/3 support: NO (nghttp3 not found)")
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,12 +220,14 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-# Emit each function/variable in its own section and let the linker drop the
-# unreferenced ones (-Wl,--gc-sections). Combined with the static libraries
-# built with the same flags (see the ftl-build image), this strips dead code -
-# including large unused parts of OpenSSL - from the shipped binary.
+# Emit each function/variable in its own section so the linker can drop the
+# unreferenced ones at link time (-Wl,--gc-sections, added as a link option
+# below). Combined with the static libraries built with the same flags (see the
+# ftl-build image), this strips dead code - including large unused parts of
+# OpenSSL - from the shipped binary.
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    set(HARDENING_FLAGS "${HARDENING_FLAGS} -ffunction-sections -fdata-sections -Wl,--gc-sections")
+    set(HARDENING_FLAGS "${HARDENING_FLAGS} -ffunction-sections -fdata-sections")
+    add_link_options(-Wl,--gc-sections)
 endif()
 
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,11 +221,14 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
 endif()
 
 # Emit each function/variable in its own section so the linker can drop the
-# unreferenced ones at link time (-Wl,--gc-sections, added as a link option
-# below). Combined with the static libraries built with the same flags (see the
-# ftl-build image), this strips dead code - including large unused parts of
-# OpenSSL - from the shipped binary.
-if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+# unreferenced ones at link time (-Wl,--gc-sections). Combined with the static
+# libraries built with the same flags (see the ftl-build image), this strips dead
+# code - including large unused parts of OpenSSL - from the shipped binary. Probe
+# the linker for the flag rather than assuming it from the compiler: it is a GNU
+# ld/gold/lld feature, so e.g. Apple's ld64 (which spells it -dead_strip) skips it.
+include(CheckLinkerFlag)
+check_linker_flag(C "-Wl,--gc-sections" HAVE_LD_GC_SECTIONS)
+if (HAVE_LD_GC_SECTIONS)
     set(HARDENING_FLAGS "${HARDENING_FLAGS} -ffunction-sections -fdata-sections")
     add_link_options(-Wl,--gc-sections)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,14 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
+# Emit each function/variable in its own section and let the linker drop the
+# unreferenced ones (-Wl,--gc-sections). Combined with the static libraries
+# built with the same flags (see the ftl-build image), this strips dead code -
+# including large unused parts of OpenSSL - from the shipped binary.
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(HARDENING_FLAGS "${HARDENING_FLAGS} -ffunction-sections -fdata-sections -Wl,--gc-sections")
+endif()
+
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
 # We define HAVE_POLL_H as this is needed for the musl builds to succeed
 set(CMAKE_C_FLAGS "-std=c17 -pipe ${WARN_FLAGS} -D_FILE_OFFSET_BITS=64 ${HARDENING_FLAGS} ${DEBUG_FLAGS} ${CMAKE_C_FLAGS} -DHAVE_POLL_H ${SQLITE_DEFINES}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -208,10 +208,16 @@ if(STATIC)
 else()
     message(STATUS "Compiling dynamically linked executable")
 endif()
-# -pie -fPIE: (Dynamic) position independent executable
-
+# Position-independent executable (image ASLR). -fPIE compiles the objects
+# position-independent; the executable is then linked PIE via -pie (dynamic
+# build) or -static-pie (static build, set on the link line below). A plain
+# -static silently overrides -pie and yields a non-PIE binary with a fixed load
+# address, so the static build - the one we actually ship - must use -static-pie.
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set(HARDENING_FLAGS "${HARDENING_FLAGS} -pie -fPIE")
+    set(HARDENING_FLAGS "${HARDENING_FLAGS} -fPIE")
+    if(NOT STATIC)
+        set(HARDENING_FLAGS "${HARDENING_FLAGS} -pie")
+    endif()
 endif()
 
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
@@ -308,7 +314,7 @@ add_executable(pihole-FTL
 if(STATIC)
     set_target_properties(pihole-FTL PROPERTIES LINK_SEARCH_START_STATIC ON)
     set_target_properties(pihole-FTL PROPERTIES LINK_SEARCH_END_STATIC ON)
-    target_link_libraries(pihole-FTL -static-libgcc -static)
+    target_link_libraries(pihole-FTL -static-libgcc -static-pie)
     set(LIBRARY_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 else()
     find_library(LIBMATH m)
@@ -559,9 +565,27 @@ if(LIBSSL AND LIBCRYPTO AND USE_TLS)
     if(LIBNGHTTP2)
         message(STATUS "Building FTL with HTTP/2 support: YES")
         target_compile_definitions(webserver PRIVATE HAVE_HTTP2)
+        # The dotdoh client auto-negotiates HTTP/2 (DoH2) on https:// upstreams.
+        target_compile_definitions(dotdoh PRIVATE HAVE_HTTP2)
         target_link_libraries(pihole-FTL ${LIBNGHTTP2})
     else()
         message(STATUS "Building FTL with HTTP/2 support: NO (nghttp2 not found)")
+    endif()
+
+    # HTTP/3 for the TLS terminator (OpenSSL QUIC + nghttp3). Optional and
+    # additionally requires QUIC support in the linked OpenSSL; without it the
+    # terminator serves HTTP/1.1 and (if built) HTTP/2 only. HTTP/3 also needs
+    # OpenSSL >= 4.0 for SSL_get_peer_addr() to forward the real client address;
+    # terminator.c raises a #error against an older OpenSSL.
+    find_library(LIBNGHTTP3 NAMES libnghttp3${LIBRARY_SUFFIX} nghttp3)
+    if(LIBNGHTTP3)
+        message(STATUS "Building FTL with HTTP/3 support: YES")
+        target_compile_definitions(webserver PRIVATE HAVE_HTTP3)
+        # The dotdoh client speaks DoH3 (HTTP/3 over QUIC) on h3:// upstreams.
+        target_compile_definitions(dotdoh PRIVATE HAVE_HTTP3)
+        target_link_libraries(pihole-FTL ${LIBNGHTTP3})
+    else()
+        message(STATUS "Building FTL with HTTP/3 support: NO (nghttp3 not found)")
     endif()
 else()
     message(STATUS "Building FTL with TLS support: NO")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -208,16 +208,10 @@ if(STATIC)
 else()
     message(STATUS "Compiling dynamically linked executable")
 endif()
-# Position-independent executable (image ASLR). -fPIE compiles the objects
-# position-independent; the executable is then linked PIE via -pie (dynamic
-# build) or -static-pie (static build, set on the link line below). A plain
-# -static silently overrides -pie and yields a non-PIE binary with a fixed load
-# address, so the static build - the one we actually ship - must use -static-pie.
+# -pie -fPIE: (Dynamic) position independent executable
+
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set(HARDENING_FLAGS "${HARDENING_FLAGS} -fPIE")
-    if(NOT STATIC)
-        set(HARDENING_FLAGS "${HARDENING_FLAGS} -pie")
-    endif()
+    set(HARDENING_FLAGS "${HARDENING_FLAGS} -pie -fPIE")
 endif()
 
 # -FILE_OFFSET_BITS=64: used by stat(). Avoids problems with files > 2 GB on 32bit machines
@@ -314,7 +308,7 @@ add_executable(pihole-FTL
 if(STATIC)
     set_target_properties(pihole-FTL PROPERTIES LINK_SEARCH_START_STATIC ON)
     set_target_properties(pihole-FTL PROPERTIES LINK_SEARCH_END_STATIC ON)
-    target_link_libraries(pihole-FTL -static-libgcc -static-pie)
+    target_link_libraries(pihole-FTL -static-libgcc -static)
     set(LIBRARY_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 else()
     find_library(LIBMATH m)
@@ -549,20 +543,17 @@ option(USE_TLS "Build FTL with TLS support, if available" ON)
 find_library(LIBSSL NAMES libssl${LIBRARY_SUFFIX} ssl)
 find_library(LIBCRYPTO NAMES libcrypto${LIBRARY_SUFFIX} crypto)
 if(LIBSSL AND LIBCRYPTO AND USE_TLS)
-    # Enable TLS support in civetweb using its OpenSSL backend
+    # OpenSSL is used by the TLS terminator, the x509 certificate handling and
+    # the dotdoh client. civetweb itself is always built without TLS (NO_SSL,
+    # set in its own CMakeLists) since the terminator does TLS termination now.
     message(STATUS "Building FTL with TLS support: YES")
     target_compile_definitions(core PRIVATE HAVE_TLS)
-    # OPENSSL_API_3_0 selects civetweb's OpenSSL backend, NO_SSL_DL (set in
-    # the civetweb CMakeLists) links it statically instead of via dlopen
-    target_compile_definitions(civetweb PRIVATE OPENSSL_API_3_0)
     target_compile_definitions(webserver PRIVATE HAVE_TLS)
     target_compile_definitions(dotdoh PRIVATE HAVE_TLS)
     # Link against OpenSSL, the order is important (libssl depends on libcrypto)
     target_link_libraries(pihole-FTL ${LIBSSL} ${LIBCRYPTO})
 else()
-    # Disable TLS support in civetweb if OpenSSL is not selected or not available
     message(STATUS "Building FTL with TLS support: NO")
-    target_compile_definitions(civetweb PRIVATE NO_SSL)
 endif()
 
 # After finishing building the FTL binary, we append the sha256sum of the binary

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -552,6 +552,17 @@ if(LIBSSL AND LIBCRYPTO AND USE_TLS)
     target_compile_definitions(dotdoh PRIVATE HAVE_TLS)
     # Link against OpenSSL, the order is important (libssl depends on libcrypto)
     target_link_libraries(pihole-FTL ${LIBSSL} ${LIBCRYPTO})
+
+    # HTTP/2 for the TLS terminator (nghttp2). Optional: without it the
+    # terminator negotiates HTTP/1.1 only.
+    find_library(LIBNGHTTP2 NAMES libnghttp2${LIBRARY_SUFFIX} nghttp2)
+    if(LIBNGHTTP2)
+        message(STATUS "Building FTL with HTTP/2 support: YES")
+        target_compile_definitions(webserver PRIVATE HAVE_HTTP2)
+        target_link_libraries(pihole-FTL ${LIBNGHTTP2})
+    else()
+        message(STATUS "Building FTL with HTTP/2 support: NO (nghttp2 not found)")
+    endif()
 else()
     message(STATUS "Building FTL with TLS support: NO")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,12 +223,8 @@ endif()
 # Emit each function/variable in its own section so the linker can drop the
 # unreferenced ones at link time (-Wl,--gc-sections). Combined with the static
 # libraries built with the same flags (see the ftl-build image), this strips dead
-# code - including large unused parts of OpenSSL - from the shipped binary. Probe
-# the linker for the flag rather than assuming it from the compiler: it is a GNU
-# ld/gold/lld feature, so e.g. Apple's ld64 (which spells it -dead_strip) skips it.
-include(CheckLinkerFlag)
-check_linker_flag(C "-Wl,--gc-sections" HAVE_LD_GC_SECTIONS)
-if (HAVE_LD_GC_SECTIONS)
+# code - including large unused parts of OpenSSL - from the shipped binary.
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     set(HARDENING_FLAGS "${HARDENING_FLAGS} -ffunction-sections -fdata-sections")
     add_link_options(-Wl,--gc-sections)
 endif()

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -101,24 +101,21 @@ static struct {
 		.v4 = { "9.9.9.9", "149.112.112.112" },
 		.v6 = {	"2620:fe::fe", "2620:fe::9" },
 		.dot = { "tls://dns.quad9.net@9.9.9.9", "tls://dns.quad9.net@[2620:fe::fe]" },
-		// TODO: Quad9 DoH is HTTP/2-only; our DoH client speaks HTTP/1.1. Re-enable once we have native HTTP/2.
-		//.doh = { "https://dns.quad9.net@9.9.9.9/dns-query", "https://dns.quad9.net@[2620:fe::fe]/dns-query" }
+		.doh = { "https://dns.quad9.net@9.9.9.9/dns-query", "https://dns.quad9.net@[2620:fe::fe]/dns-query" }
 	},
 	{
 		.name = "Quad9 (unfiltered, no DNSSEC)",
 		.v4 = { "9.9.9.10", "149.112.112.10" },
 		.v6 = {	"2620:fe::10", "2620:fe::fe:10" },
 		.dot = { "tls://dns10.quad9.net@9.9.9.10", "tls://dns10.quad9.net@[2620:fe::10]" },
-		// TODO: Quad9 DoH is HTTP/2-only; our DoH client speaks HTTP/1.1. Re-enable once we have native HTTP/2.
-		//.doh = { "https://dns10.quad9.net@9.9.9.10/dns-query", "https://dns10.quad9.net@[2620:fe::10]/dns-query" }
+		.doh = { "https://dns10.quad9.net@9.9.9.10/dns-query", "https://dns10.quad9.net@[2620:fe::10]/dns-query" }
 	},
 	{
 		.name = "Quad9 (filtered, ECS, DNSSEC)",
 		.v4 = { "9.9.9.11", "149.112.112.11" },
 		.v6 = {	"2620:fe::11", "2620:fe::fe:11" },
 		.dot = { "tls://dns11.quad9.net@9.9.9.11", "tls://dns11.quad9.net@[2620:fe::11]" },
-		// TODO: Quad9 DoH is HTTP/2-only; our DoH client speaks HTTP/1.1. Re-enable once we have native HTTP/2.
-		//.doh = { "https://dns11.quad9.net@9.9.9.11/dns-query", "https://dns11.quad9.net@[2620:fe::11]/dns-query" }
+		.doh = { "https://dns11.quad9.net@9.9.9.11/dns-query", "https://dns11.quad9.net@[2620:fe::11]/dns-query" }
 	},
 	{
 		.name = "Cloudflare (DNSSEC)",

--- a/src/args.c
+++ b/src/args.c
@@ -1152,15 +1152,9 @@ void parse_args(int argc, char *argv[])
 			else
 				printf("HTTP/2:          %sNo%s\n", red, normal);
 			if(webserver_have_http3())
-			{
 				printf("HTTP/3:          %sYes%s\n", green, normal);
-				printf("QUIC:            %sYes%s\n", green, normal);
-			}
 			else
-			{
 				printf("HTTP/3:          %sNo%s\n", red, normal);
-				printf("QUIC:            %sNo%s\n", red, normal);
-			}
 			printf("\n");
 			printf("****************************** %s%sOpenSSL%s ******************************\n",
 			       yellow, bold, normal);

--- a/src/args.c
+++ b/src/args.c
@@ -63,6 +63,8 @@
 #include "tools/dhcp-discover.h"
 // mg_version()
 #include "webserver/civetweb/civetweb.h"
+// webserver_have_http2()/webserver_have_http3() for the --version report
+#include "webserver/webserver.h"
 // cJSON_Version()
 #include "webserver/cJSON/cJSON.h"
 #include "config/cli.h"
@@ -1030,6 +1032,7 @@ void parse_args(int argc, char *argv[])
 			const char *green = cli_color(COL_GREEN);
 			const char *red = cli_color(COL_RED);
 			const char *yellow = cli_color(COL_YELLOW);
+			const char *blue = cli_color(COL_BLUE);
 
 			// Print FTL version
 			printf("****************************** %s%sFTL%s **********************************\n",
@@ -1086,10 +1089,13 @@ void parse_args(int argc, char *argv[])
 				printf("Files: %sYes%s, ", green, normal);
 			else
 				printf("Files: %sNo%s, ", red, normal);
-			if(mg_check_feature(MG_FEATURES_TLS))
-				printf("TLS: %sYes%s, ", green, normal);
-			else
-				printf("TLS: %sNo%s, ", red, normal);
+			// CivetWeb is built NO_SSL, so its own TLS feature is always off;
+			// TLS is provided by FTL's in-process backend instead.
+#ifdef HAVE_TLS
+			printf("TLS: %sYes%s %s(via TLS backend)%s, ", green, normal, blue, normal);
+#else
+			printf("TLS: %sNo%s, ", red, normal);
+#endif
 			if(mg_check_feature(MG_FEATURES_CGI))
 				printf("CGI: %sYes%s, ", green, normal);
 			else
@@ -1122,8 +1128,9 @@ void parse_args(int argc, char *argv[])
 				printf("Compression: %sYes%s\n", green, normal);
 			else
 				printf("Compression: %sNo%s\n", red, normal);
-			if(mg_check_feature(MG_FEATURES_HTTP2))
-				printf("                 HTTP2: %sYes%s, ", green, normal);
+			// Likewise CivetWeb's native HTTP/2 stays off; the backend serves it.
+			if(webserver_have_http2())
+				printf("                 HTTP2: %sYes%s %s(via TLS backend)%s, ", green, normal, blue, normal);
 			else
 				printf("                 HTTP2: %sNo%s, ", red, normal);
 			if(mg_check_feature(MG_FEATURES_X_DOMAIN_SOCKET))
@@ -1132,6 +1139,29 @@ void parse_args(int argc, char *argv[])
 				printf("Unix domain sockets: %sNo%s\n", red, normal);
 			printf("\n");
 #ifdef HAVE_TLS
+			// FTL fronts the (plain-HTTP) CivetWeb backend with an in-process
+			// engine that terminates TLS and speaks the modern HTTP versions.
+			// Unencrypted HTTP/1.0 and HTTP/1.1 stay served directly on non-TLS
+			// ports, so this only adds capabilities, it removes none.
+			printf("************************ %s%sAdvanced TLS backend%s ***********************\n",
+			       yellow, bold, normal);
+			printf("HTTP/1.0:        %sYes%s (plaintext)\n", green, normal);
+			printf("HTTP/1.1:        %sYes%s\n", green, normal);
+			if(webserver_have_http2())
+				printf("HTTP/2:          %sYes%s\n", green, normal);
+			else
+				printf("HTTP/2:          %sNo%s\n", red, normal);
+			if(webserver_have_http3())
+			{
+				printf("HTTP/3:          %sYes%s\n", green, normal);
+				printf("QUIC:            %sYes%s\n", green, normal);
+			}
+			else
+			{
+				printf("HTTP/3:          %sNo%s\n", red, normal);
+				printf("QUIC:            %sNo%s\n", red, normal);
+			}
+			printf("\n");
 			printf("****************************** %s%sOpenSSL%s ******************************\n",
 			       yellow, bold, normal);
 			printf("Version:         %s%s"OPENSSL_FULL_VERSION_STR"%s\n", green, bold, normal);

--- a/src/dotdoh/CMakeLists.txt
+++ b/src/dotdoh/CMakeLists.txt
@@ -19,6 +19,8 @@ set(dotdoh_sources
         registry.h
         tls_client.c
         tls_client.h
+        quic_client.c
+        quic_client.h
         proxy.c
         proxy.h
         )

--- a/src/dotdoh/edns_pad.c
+++ b/src/dotdoh/edns_pad.c
@@ -58,6 +58,44 @@ static bool skip_name(const uint8_t *buf, size_t len, size_t *pos)
 	return true;
 }
 
+// Requestor's advertised UDP payload size from the query's EDNS OPT record (the
+// OPT CLASS field, RFC 6891), or 512 (the pre-EDNS default / RFC floor) when the
+// query carries no OPT or cannot be parsed. Used to decide when a UDP answer must
+// be TC-truncated so dnsmasq retries over TCP instead of receiving a byte-chopped
+// datagram. Reads only up to the OPT RR; the padding appended later does not move
+// the CLASS field, so this may be called before or after edns_pad_query().
+uint16_t __attribute__((pure)) edns_query_udp_size(const uint8_t *buf, size_t len)
+{
+	if(len < 12)
+		return 512;
+	const uint16_t qdcount = (uint16_t)((buf[4] << 8) | buf[5]);
+	const uint16_t ancount = (uint16_t)((buf[6] << 8) | buf[7]);
+	const uint16_t nscount = (uint16_t)((buf[8] << 8) | buf[9]);
+	const uint16_t arcount = (uint16_t)((buf[10] << 8) | buf[11]);
+	size_t pos = 12;
+	for(uint16_t i = 0; i < qdcount; i++)
+	{
+		if(!skip_name(buf, len, &pos) || pos + 4 > len)
+			return 512;
+		pos += 4;
+	}
+	const unsigned long total_rr = (unsigned long)ancount + nscount + arcount;
+	for(unsigned long i = 0; i < total_rr; i++)
+	{
+		if(!skip_name(buf, len, &pos) || pos + 10 > len)
+			return 512;
+		const uint16_t type = (uint16_t)((buf[pos] << 8) | buf[pos + 1]);
+		const uint16_t cls = (uint16_t)((buf[pos + 2] << 8) | buf[pos + 3]);
+		const size_t rdlen = (size_t)((buf[pos + 8] << 8) | buf[pos + 9]);
+		if(pos + 10 + rdlen > len)
+			return 512;
+		if(type == DNS_TYPE_OPT)
+			return cls < 512 ? 512 : cls; // RFC 6891: values below 512 are 512
+		pos += 10 + rdlen;
+	}
+	return 512;
+}
+
 size_t edns_pad_query(uint8_t *buf, size_t len, size_t bufsz)
 {
 	// Need at least a fixed 12-byte header to look at.

--- a/src/dotdoh/edns_pad.h
+++ b/src/dotdoh/edns_pad.h
@@ -32,4 +32,8 @@
 // dropped.
 size_t edns_pad_query(uint8_t *buf, size_t len, size_t bufsz);
 
+// Requestor's advertised EDNS UDP payload size from a query (OPT CLASS field), or
+// 512 when absent/unparsable. See edns_pad.c for details.
+uint16_t edns_query_udp_size(const uint8_t *buf, size_t len) __attribute__((pure));
+
 #endif // DOTDOH_EDNS_PAD_H

--- a/src/dotdoh/framing.c
+++ b/src/dotdoh/framing.c
@@ -165,8 +165,13 @@ ssize_t doh_parse_response(const uint8_t *buf, size_t buflen,
 		return -1;
 
 	// Status line must be exactly "HTTP/x.y 200 " - require the 3-digit code to
-	// be followed by a space or CR so a malformed "2000" is rejected.
-	const uint8_t *sp = memchr(buf, ' ', hlen);
+	// be followed by a space or CR so a malformed "2000" is rejected. Search for
+	// the separating space only within the status line (up to the first CR), so a
+	// space inside a later header VALUE cannot be mistaken for the status code.
+	const uint8_t *eol = memchr(buf, '\r', hlen);
+	if(eol == NULL)
+		return -1;
+	const uint8_t *sp = memchr(buf, ' ', (size_t)(eol - buf));
 	if(sp == NULL || sp + 5 > buf + hlen)
 		return -1;
 	if(!(sp[1] == '2' && sp[2] == '0' && sp[3] == '0' &&

--- a/src/dotdoh/proxy.c
+++ b/src/dotdoh/proxy.c
@@ -24,6 +24,7 @@
 #include "proxy.h"
 #include "registry.h"
 #include "tls_client.h"
+#include "quic_client.h"
 #include "framing.h"
 #include "edns_pad.h"
 // global config
@@ -52,9 +53,30 @@ struct proxy_up {
 	bool active;                    // armed: listener bound and pool ready
 	struct upstream_uri uri;        // parsed descriptor
 	struct proxy_listener listener; // bound UDP+TCP pair
-	struct tls_pool *pool;          // per-upstream connection pool
-	char target[INET_ADDRSTRLEN + 8]; // "<ip>#<port>", for logging
+	struct tls_pool *pool;          // per-upstream TCP pool (DoT/DoH over TLS)
+	struct quic_pool *qpool;        // per-upstream QUIC pool (DoH3 only)
+	char target[INET_ADDRSTRLEN + 8]; // "127.47.11.N#P", for logging
 };
+
+// Human-readable transport name for logging. Kept as an if-ladder (not a switch)
+// to avoid -Wswitch-enum churn; UST_PLAIN never reaches the proxy.
+static const char *ustype_name(enum ustype t)
+{
+	if(t == UST_DOT)  return "DoT";
+	if(t == UST_DOH)  return "DoH";
+	if(t == UST_DOH3) return "DoH3";
+	return "?";
+}
+
+// Route one exchange to the transport this upstream uses: DoH3 goes over QUIC,
+// everything else over the TCP TLS pool. Returns the answer length or -1.
+static ssize_t up_exchange(struct proxy_up *up, const uint8_t *query, size_t qlen,
+                           uint8_t *answer, size_t answer_sz)
+{
+	if(up->uri.type == UST_DOH3)
+		return quic_pool_exchange(up->qpool, query, qlen, answer, answer_sz);
+	return tls_pool_exchange(up->pool, query, qlen, answer, answer_sz);
+}
 
 static struct proxy_up g_ups[DOTDOH_MAX_UPSTREAMS];
 static int g_nups = 0;       // number of encrypted upstreams recorded
@@ -160,7 +182,9 @@ void dotdoh_init(void)
 	cJSON *it = NULL;
 	cJSON_ArrayForEach(it, ups)
 		if(it != NULL && cJSON_IsString(it) && it->valuestring != NULL &&
-		   (strncmp(it->valuestring, "tls://", 6) == 0 || strncmp(it->valuestring, "https://", 8) == 0))
+		   (strncmp(it->valuestring, "tls://", 6) == 0 ||
+		    strncmp(it->valuestring, "https://", 8) == 0 ||
+		    strncmp(it->valuestring, "h3://", 5) == 0))
 			n_encrypted++;
 	if(n_encrypted == 0)
 		return; // fail-closed: nothing to arm, no plaintext fallback
@@ -203,15 +227,27 @@ void dotdoh_init(void)
 		// queries fail over, never downgrade to plaintext.
 		if(tls_ok && proxy_listener_bind(enc, &up->listener))
 		{
-			up->pool = tls_pool_new(&u, g_pool_k);
-			if(up->pool != NULL)
+			// DoH3 runs over QUIC and owns a separate pool type; DoT and DoH
+			// over TLS share the TCP pool. Only one is ever non-NULL.
+			bool pool_ok;
+			if(u.type == UST_DOH3)
+			{
+				up->qpool = quic_pool_new(&u, g_pool_k);
+				pool_ok = (up->qpool != NULL);
+			}
+			else
+			{
+				up->pool = tls_pool_new(&u, g_pool_k);
+				pool_ok = (up->pool != NULL);
+			}
+			if(pool_ok)
 			{
 				snprintf(up->target, sizeof(up->target), "%s#%d",
 				         up->listener.ip, up->listener.port);
 				up->active = true;
 				g_nactive++;
 				log_info("dotdoh: %s upstream %s armed on %s",
-				         u.type == UST_DOT ? "DoT" : "DoH", u.verify_name, up->target);
+				         ustype_name(u.type), u.verify_name, up->target);
 			}
 			else
 				proxy_listener_close(&up->listener);
@@ -389,7 +425,7 @@ static void handle_udp(struct proxy_up *up)
 	// ciphertext size no longer leaks the query. Only this encrypted leg is
 	// padded; the plaintext dnsmasq spoke to us over loopback is left untouched.
 	const size_t qlen = edns_pad_query(query, (size_t)n, sizeof(query));
-	const ssize_t a = tls_pool_exchange(up->pool, query, qlen, answer, sizeof(answer));
+	const ssize_t a = up_exchange(up, query, qlen, answer, sizeof(answer));
 	if(a < 0)
 		return; // drop -> dnsmasq times out and fails over
 
@@ -471,7 +507,7 @@ static void handle_tcp(struct proxy_up *up)
 
 		// Pad before encrypting (see handle_udp()); the loopback leg stays plain.
 		const size_t plen = edns_pad_query(query, qlen, sizeof(query));
-		const ssize_t a = tls_pool_exchange(up->pool, query, plen, answer, sizeof(answer));
+		const ssize_t a = up_exchange(up, query, plen, answer, sizeof(answer));
 		if(a < 0)
 			break; // drop: closing the connection makes dnsmasq retry/fail over
 
@@ -498,10 +534,21 @@ static void emit_summary(void)
 {
 	for(int i = 0; i < g_nups; i++)
 	{
-		if(!g_ups[i].active || g_ups[i].pool == NULL)
+		if(!g_ups[i].active)
 			continue;
 		struct dotdoh_stats s;
-		tls_pool_get_stats(g_ups[i].pool, &s);
+		if(g_ups[i].uri.type == UST_DOH3)
+		{
+			if(g_ups[i].qpool == NULL)
+				continue;
+			quic_pool_get_stats(g_ups[i].qpool, &s);
+		}
+		else
+		{
+			if(g_ups[i].pool == NULL)
+				continue;
+			tls_pool_get_stats(g_ups[i].pool, &s);
+		}
 		const double avg = s.sessions_closed > 0
 		                 ? (double)s.queries_per_session_sum / (double)s.sessions_closed : 0.0;
 		log_debug(DEBUG_DOTDOH,
@@ -597,6 +644,8 @@ void dotdoh_cleanup(void)
 	{
 		if(g_ups[i].pool != NULL)
 			tls_pool_free(g_ups[i].pool);
+		if(g_ups[i].qpool != NULL)
+			quic_pool_free(g_ups[i].qpool);
 		if(g_ups[i].active)
 			proxy_listener_close(&g_ups[i].listener);
 		memset(&g_ups[i], 0, sizeof(g_ups[i]));

--- a/src/dotdoh/proxy.c
+++ b/src/dotdoh/proxy.c
@@ -414,27 +414,27 @@ static bool write_full(int fd, const uint8_t *buf, size_t len, uint64_t deadline
 // section, with the answer/authority/additional counts cleared - from a full
 // answer too large for a UDP datagram, so dnsmasq retries the query over TCP.
 // Returns the length written, or 0 if the answer is too short/malformed to parse.
-static size_t dns_truncated_response(const uint8_t *ans, size_t alen,
+static size_t dns_truncated_response(const uint8_t *answer, size_t alen,
                                      uint8_t *out, size_t out_sz)
 {
 	if(alen < 12)
 		return 0;
-	const unsigned qd = ((unsigned)ans[4] << 8) | ans[5];
+	const unsigned qd = ((unsigned)answer[4] << 8) | answer[5];
 	size_t off = 12;
 	for(unsigned q = 0; q < qd && off < alen; q++)
 	{
 		// Walk the QNAME labels; compression is not legal in a question.
-		while(off < alen && ans[off] != 0)
+		while(off < alen && answer[off] != 0)
 		{
-			if((ans[off] & 0xC0) != 0)
+			if((answer[off] & 0xC0) != 0)
 				return 0;
-			off += (size_t)ans[off] + 1;
+			off += (size_t)answer[off] + 1;
 		}
 		off += 1 + 4; // root label + QTYPE + QCLASS
 	}
 	if(off > alen || off > out_sz)
 		return 0;
-	memcpy(out, ans, off);
+	memcpy(out, answer, off);
 	out[2] |= 0x02;                      // set TC
 	out[6] = out[7] = 0;                 // ANCOUNT = 0
 	out[8] = out[9] = 0;                 // NSCOUNT = 0

--- a/src/dotdoh/proxy.c
+++ b/src/dotdoh/proxy.c
@@ -58,8 +58,8 @@ struct proxy_up {
 	char target[INET_ADDRSTRLEN + 8]; // "127.47.11.N#P", for logging
 };
 
-// Human-readable transport name for logging. Kept as an if-ladder (not a switch)
-// to avoid -Wswitch-enum churn; UST_PLAIN never reaches the proxy.
+// Transport name for logging. An if-ladder (not a switch) dodges -Wswitch-enum;
+// UST_PLAIN never reaches the proxy.
 static const char *ustype_name(enum ustype t)
 {
 	if(t == UST_DOT)  return "DoT";
@@ -68,8 +68,8 @@ static const char *ustype_name(enum ustype t)
 	return "?";
 }
 
-// Route one exchange to the transport this upstream uses: DoH3 goes over QUIC,
-// everything else over the TCP TLS pool. Returns the answer length or -1.
+// Route one exchange to this upstream's transport: DoH3 over QUIC, else the TCP
+// TLS pool. Returns the answer length or -1.
 static ssize_t up_exchange(struct proxy_up *up, const uint8_t *query, size_t qlen,
                            uint8_t *answer, size_t answer_sz)
 {
@@ -193,6 +193,11 @@ void dotdoh_init(void)
 	if(!tls_ok)
 		log_err("dotdoh: TLS init failed - encrypted upstreams are disabled");
 
+	// Bring up the QUIC context for h3:// (separate OpenSSL ctx, same trust store).
+	// Failure fails closed: h3:// pools stay un-armed, DoT/DoH keep working. No-op
+	// stub without QUIC/nghttp3.
+	quic_client_global_init(config.dns.upstreamCA.v.s);
+
 	compute_scale(n_encrypted);
 
 	// Walk the upstreams in order. Each encrypted entry consumes one slot (enc)
@@ -227,8 +232,7 @@ void dotdoh_init(void)
 		// queries fail over, never downgrade to plaintext.
 		if(tls_ok && proxy_listener_bind(enc, &up->listener))
 		{
-			// DoH3 runs over QUIC and owns a separate pool type; DoT and DoH
-			// over TLS share the TCP pool. Only one is ever non-NULL.
+			// DoH3 uses the QUIC pool; DoT/DoH share the TCP pool - only one is non-NULL.
 			bool pool_ok;
 			if(u.type == UST_DOH3)
 			{
@@ -402,6 +406,42 @@ static bool write_full(int fd, const uint8_t *buf, size_t len, uint64_t deadline
 	return true;
 }
 
+// IPv4 UDP payload cap (65535 - 20 IP - 8 UDP). A DNS answer above this cannot be
+// sent in a single loopback UDP datagram.
+#define UDP4_MAX_PAYLOAD 65507u
+
+// Build a minimal TC=1 (truncated) response - the DNS header plus the question
+// section, with the answer/authority/additional counts cleared - from a full
+// answer too large for a UDP datagram, so dnsmasq retries the query over TCP.
+// Returns the length written, or 0 if the answer is too short/malformed to parse.
+static size_t dns_truncated_response(const uint8_t *ans, size_t alen,
+                                     uint8_t *out, size_t out_sz)
+{
+	if(alen < 12)
+		return 0;
+	const unsigned qd = ((unsigned)ans[4] << 8) | ans[5];
+	size_t off = 12;
+	for(unsigned q = 0; q < qd && off < alen; q++)
+	{
+		// Walk the QNAME labels; compression is not legal in a question.
+		while(off < alen && ans[off] != 0)
+		{
+			if((ans[off] & 0xC0) != 0)
+				return 0;
+			off += (size_t)ans[off] + 1;
+		}
+		off += 1 + 4; // root label + QTYPE + QCLASS
+	}
+	if(off > alen || off > out_sz)
+		return 0;
+	memcpy(out, ans, off);
+	out[2] |= 0x02;                      // set TC
+	out[6] = out[7] = 0;                 // ANCOUNT = 0
+	out[8] = out[9] = 0;                 // NSCOUNT = 0
+	out[10] = out[11] = 0;               // ARCOUNT = 0
+	return off;
+}
+
 // A single UDP query from dnsmasq: receive, forward over TLS, send the answer
 // back to the same source. On failure we drop it (see the file header).
 static void handle_udp(struct proxy_up *up)
@@ -421,6 +461,15 @@ static void handle_udp(struct proxy_up *up)
 	if(!is_loopback_v4(&src))
 		return;
 
+	// The requestor's advertised UDP payload size, read before padding. A stream
+	// upstream (DoT/DoH/DoH3) is not bound by it (RFC 7766) and may return a full
+	// answer, but we are emulating a DNS server to dnsmasq and must honour it: an
+	// answer above it (capped at the IP datagram limit) is TC-truncated so dnsmasq
+	// retries over TCP, rather than sent whole and silently byte-chopped by
+	// dnsmasq's receive buffer (breaking DNSSEC and large answers).
+	const uint16_t udp_max = edns_query_udp_size(query, (size_t)n);
+	const size_t max_reply = udp_max < UDP4_MAX_PAYLOAD ? udp_max : UDP4_MAX_PAYLOAD;
+
 	// Pad the query to a block boundary (RFC 8467) before it is encrypted, so the
 	// ciphertext size no longer leaks the query. Only this encrypted leg is
 	// padded; the plaintext dnsmasq spoke to us over loopback is left untouched.
@@ -429,6 +478,16 @@ static void handle_udp(struct proxy_up *up)
 	if(a < 0)
 		return; // drop -> dnsmasq times out and fails over
 
+	if((size_t)a > max_reply)
+	{
+		// Reply TC=1 so dnsmasq retries over TCP, where the length-prefixed leg
+		// carries the whole answer.
+		uint8_t tc[512];
+		const size_t tlen = dns_truncated_response(answer, (size_t)a, tc, sizeof(tc));
+		if(tlen > 0)
+			sendto(up->listener.udp_fd, tc, tlen, 0, (struct sockaddr *)&src, sl);
+		return;
+	}
 	sendto(up->listener.udp_fd, answer, (size_t)a, 0, (struct sockaddr *)&src, sl);
 }
 
@@ -655,4 +714,5 @@ void dotdoh_cleanup(void)
 	g_armed = false;
 	g_uri_count = 0;
 	tls_client_global_free();
+	quic_client_global_free();
 }

--- a/src/dotdoh/quic_client.c
+++ b/src/dotdoh/quic_client.c
@@ -1,0 +1,120 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Outbound QUIC client for DoH3 upstreams (HTTP/3 over QUIC)
+*
+*  Talks HTTP/3 over QUIC to the real upstream resolver. Like the TCP client it
+*  is strict and fail-closed: a failed handshake or exchange returns -1 and the
+*  query is dropped, so FTL fails over to the next server rather than downgrading
+*  to plaintext. Each upstream owns a bounded QUIC connection pool that many
+*  worker threads borrow concurrently, mirroring the tls_client pool model.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "log.h"
+#include "quic_client.h"
+
+// DoH3 fundamentally needs OpenSSL QUIC plus nghttp3; both are gated by the same
+// flags the webserver HTTP/3 terminator uses. Without them there is no QUIC
+// transport, so the pool cannot be created and every exchange fails closed.
+#if defined(HAVE_TLS) && defined(HAVE_HTTP3)
+
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+// Per-upstream QUIC pool. For now it only carries the immutable upstream
+// descriptor, the connection cap and the diagnostic counters; the actual QUIC
+// connection state (OpenSSL QUIC SSL objects, nghttp3 connections, the UDP BIO)
+// is added when the exchange is implemented. The lock guards the stats.
+struct quic_pool {
+	struct upstream_uri u;      // upstream descriptor (immutable)
+	int max;                    // connection cap (immutable)
+	pthread_mutex_t lock;       // guards stats
+	struct dotdoh_stats stats;
+};
+
+struct quic_pool *quic_pool_new(const struct upstream_uri *u, int max_conns)
+{
+	if(u == NULL || max_conns < 1)
+		return NULL;
+	struct quic_pool *p = calloc(1, sizeof(*p));
+	if(p == NULL)
+		return NULL;
+	p->u = *u;
+	p->max = max_conns;
+	pthread_mutex_init(&p->lock, NULL);
+	return p;
+}
+
+void quic_pool_free(struct quic_pool *p)
+{
+	if(p == NULL)
+		return;
+	pthread_mutex_destroy(&p->lock);
+	free(p);
+}
+
+// The QUIC/nghttp3 exchange is not implemented yet: the pool is armed so an
+// h3:// upstream gets its loopback listener and routing, but until the transport
+// is wired up every exchange fails closed. The trivial body is a const-folding
+// candidate, so silence -Wsuggest-attribute here (the attribute cannot be
+// applied - the real implementation has side effects). clang lacks the warning.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#endif
+ssize_t quic_pool_exchange(struct quic_pool *p, const uint8_t *query, size_t qlen,
+                           uint8_t *answer, size_t answer_sz)
+{
+	(void)p; (void)query; (void)qlen; (void)answer; (void)answer_sz;
+	return -1;
+}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+void quic_pool_get_stats(struct quic_pool *p, struct dotdoh_stats *out)
+{
+	if(p == NULL || out == NULL)
+		return;
+	pthread_mutex_lock(&p->lock);
+	*out = p->stats;
+	pthread_mutex_unlock(&p->lock);
+}
+
+#else // no QUIC / HTTP3 support in this build
+
+// Without OpenSSL QUIC + nghttp3 there is no DoH3 transport. The pool cannot be
+// created and every exchange fails closed; the config layer refuses to arm an
+// h3:// upstream when quic_pool_new() returns NULL. These trivial stubs are
+// const-folding candidates, so silence the GCC-only attribute suggestion (the
+// malloc attribute on quic_pool_new() also conflicts with -Wsuggest-attribute).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#endif
+struct quic_pool *quic_pool_new(const struct upstream_uri *u, int max_conns)
+{
+	(void)u; (void)max_conns;
+	return NULL;
+}
+void quic_pool_free(struct quic_pool *p) { (void)p; }
+ssize_t quic_pool_exchange(struct quic_pool *p, const uint8_t *query, size_t qlen,
+                           uint8_t *answer, size_t answer_sz)
+{
+	(void)p; (void)query; (void)qlen; (void)answer; (void)answer_sz;
+	return -1;
+}
+void quic_pool_get_stats(struct quic_pool *p, struct dotdoh_stats *out) { (void)p; (void)out; }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#endif // HAVE_TLS && HAVE_HTTP3

--- a/src/dotdoh/quic_client.c
+++ b/src/dotdoh/quic_client.c
@@ -8,8 +8,9 @@
 *  Talks HTTP/3 over QUIC to the real upstream resolver. Like the TCP client it
 *  is strict and fail-closed: a failed handshake or exchange returns -1 and the
 *  query is dropped, so FTL fails over to the next server rather than downgrading
-*  to plaintext. Each upstream owns a bounded QUIC connection pool that many
-*  worker threads borrow concurrently, mirroring the tls_client pool model.
+*  to plaintext. Each upstream owns a QUIC pool; a worker performs one exchange
+*  over its own short-lived QUIC connection, so many workers run concurrently
+*  without sharing a (non-thread-safe) OpenSSL QUIC connection object.
 *
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
@@ -18,29 +19,147 @@
 #include "log.h"
 #include "quic_client.h"
 
-// DoH3 fundamentally needs OpenSSL QUIC plus nghttp3; both are gated by the same
-// flags the webserver HTTP/3 terminator uses. Without them there is no QUIC
-// transport, so the pool cannot be created and every exchange fails closed.
+// DoH3 needs OpenSSL QUIC plus nghttp3 (same flags as the webserver HTTP/3
+// terminator). Without them the pool cannot be created and exchanges fail closed.
 #if defined(HAVE_TLS) && defined(HAVE_HTTP3)
+
+#include "framing.h" // DNS_MSG_MAX
+
+#include <openssl/quic.h>
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/opensslv.h>
+#include <nghttp3/nghttp3.h>
+
+// Shares OpenSSL's QUIC stack with the terminator, which requires OpenSSL >= 4.0.
+// Refuse to build rather than link against a QUIC API that is not there.
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+#error "DoH3 requires OpenSSL >= 4.0 (native QUIC client). Upgrade OpenSSL to 4.0 or later, or build without nghttp3 to disable DoH3."
+#endif
 
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#include <time.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
 
-// Per-upstream QUIC pool. For now it only carries the immutable upstream
-// descriptor, the connection cap and the diagnostic counters; the actual QUIC
-// connection state (OpenSSL QUIC SSL objects, nghttp3 connections, the UDP BIO)
-// is added when the exchange is implemented. The lock guards the stats.
+// Overall budget (ms) for one QUIC exchange (connect + handshake + request +
+// response), so a bad upstream cannot pin a worker; on expiry, dnsmasq fails over.
+#define QUIC_EXCHANGE_TIMEOUT_MS 10000
+
+// Trust-anchor locations when no CA path is set, kept in step with tls_client.c.
+// FTL's musl binary runs on any of these distros, so this is not Debian-only.
+static const char *const QUIC_DEFAULT_CA_FILES[] = {
+	"/etc/ssl/certs/ca-certificates.crt", // Debian, Ubuntu, Alpine, Gentoo
+	"/etc/pki/tls/certs/ca-bundle.crt",   // RHEL, Fedora, CentOS
+	"/etc/ssl/ca-bundle.pem",             // openSUSE
+	"/etc/ssl/cert.pem",                  // Alpine, *BSD, macOS
+};
+#define QUIC_DEFAULT_CA_DIR "/etc/ssl/certs"
+
+// Shared, read-only-after-init QUIC context: one SSL_CTX carries the trust store
+// and fail-closed verify for all DoH3 upstreams. Built once (single-threaded) in
+// quic_client_global_init(), so a plain flag is enough.
+static bool g_ready = false;
+static SSL_CTX *g_qctx = NULL;
+
+// Per-upstream QUIC pool. In the connection-per-exchange model it holds only the
+// immutable upstream descriptor and the stats (lock-guarded); the QUIC connection
+// is short-lived on the worker stack for one exchange.
 struct quic_pool {
 	struct upstream_uri u;      // upstream descriptor (immutable)
-	int max;                    // connection cap (immutable)
+	int max;                    // connection cap (immutable; informational here)
 	pthread_mutex_t lock;       // guards stats
 	struct dotdoh_stats stats;
 };
 
+// Monotonic clock in milliseconds, for the exchange deadline.
+static uint64_t now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+// Milliseconds left until deadline, clamped to [0, cap].
+static int ms_left(uint64_t deadline, int cap)
+{
+	const uint64_t n = now_ms();
+	if(n >= deadline)
+		return 0;
+	const uint64_t left = deadline - n;
+	return left < (uint64_t)cap ? (int)left : cap;
+}
+
+// Monotonic timestamp in nanoseconds for nghttp3's bookkeeping.
+static nghttp3_tstamp h3_now(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (nghttp3_tstamp)ts.tv_sec * 1000000000ull + (nghttp3_tstamp)ts.tv_nsec;
+}
+
+// Load trust anchors into ctx exactly like tls_client.c: an explicit path wins,
+// otherwise try each well-known system bundle and finally the hashed directory.
+static bool load_ca(SSL_CTX *ctx, const char *ca_file)
+{
+	if(ca_file != NULL && ca_file[0] != '\0')
+		return SSL_CTX_load_verify_file(ctx, ca_file) == 1;
+	for(size_t i = 0; i < sizeof(QUIC_DEFAULT_CA_FILES) / sizeof(*QUIC_DEFAULT_CA_FILES); i++)
+		if(SSL_CTX_load_verify_file(ctx, QUIC_DEFAULT_CA_FILES[i]) == 1)
+			return true;
+	return SSL_CTX_load_verify_dir(ctx, QUIC_DEFAULT_CA_DIR) == 1;
+}
+
+bool quic_client_global_init(const char *ca_file)
+{
+	if(g_ready)
+		return true;
+
+	g_qctx = SSL_CTX_new(OSSL_QUIC_client_method());
+	if(g_qctx == NULL)
+	{
+		log_err("dotdoh: QUIC SSL_CTX_new() failed");
+		return false;
+	}
+
+	// Fail-closed heart of the client: a bad chain aborts the handshake. The
+	// hostname/IP is bound per-connection below. QUIC mandates TLS 1.3, so no
+	// min-version call is needed.
+	SSL_CTX_set_verify(g_qctx, SSL_VERIFY_PEER, NULL);
+
+	if(!load_ca(g_qctx, ca_file))
+	{
+		log_err("dotdoh: could not load a CA trust store for DoH3 "
+		        "(set dns.upstreamCA or install a system CA bundle)");
+		SSL_CTX_free(g_qctx);
+		g_qctx = NULL;
+		return false;
+	}
+
+	g_ready = true;
+	return true;
+}
+
+void quic_client_global_free(void)
+{
+	if(!g_ready)
+		return;
+	SSL_CTX_free(g_qctx);
+	g_qctx = NULL;
+	g_ready = false;
+}
+
 struct quic_pool *quic_pool_new(const struct upstream_uri *u, int max_conns)
 {
-	if(u == NULL || max_conns < 1)
+	if(!g_ready || u == NULL || max_conns < 1)
 		return NULL;
 	struct quic_pool *p = calloc(1, sizeof(*p));
 	if(p == NULL)
@@ -59,25 +178,650 @@ void quic_pool_free(struct quic_pool *p)
 	free(p);
 }
 
-// The QUIC/nghttp3 exchange is not implemented yet: the pool is armed so an
-// h3:// upstream gets its loopback listener and routing, but until the transport
-// is wired up every exchange fails closed. The trivial body is a const-folding
-// candidate, so silence -Wsuggest-attribute here (the attribute cannot be
-// applied - the real implementation has side effects). clang lacks the warning.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
-#endif
+// ---------------------------------------------------------------------------
+// One QUIC/HTTP3 exchange
+// ---------------------------------------------------------------------------
+
+// Streams we track: the request bidi stream, our three local uni streams (control
+// + QPACK encoder/decoder), and the three the server opens back. Cap covers all.
+#define QUIC_MAX_STREAMS 16
+
+struct qstream {
+	int64_t id;
+	SSL *ssl;         // OpenSSL QUIC child stream object
+	bool local_uni;   // a control/QPACK stream we created (write-only)
+	bool read_done;   // FIN or reset seen, no more reads
+};
+
+// Per-exchange transfer state, reached from the nghttp3 callbacks via the
+// connection user data.
+struct quic_xfer {
+	int64_t req_sid;        // the request stream id
+	const uint8_t *query;   // request body (the padded DNS query)
+	size_t qlen;            // request body length
+	size_t qoff;            // bytes already handed to nghttp3
+	uint8_t *answer;        // caller's answer buffer
+	size_t answer_sz;       // its capacity
+	size_t answer_len;      // response body bytes collected so far
+	int status;             // parsed :status (0 until seen)
+	bool overflow;          // response body exceeded answer_sz
+	bool done;              // request stream closed
+	bool failed;            // request stream closed with an error
+};
+
+// One QUIC connection plus its HTTP/3 session and stream table, for one exchange.
+struct quic_client_conn {
+	SSL *ssl;                              // QUIC connection object
+	nghttp3_conn *h3;
+	struct qstream streams[QUIC_MAX_STREAMS];
+	int nstreams;
+	struct quic_xfer x;
+};
+
+static struct qstream *find_stream(struct quic_client_conn *c, int64_t id)
+{
+	for(int i = 0; i < c->nstreams; i++)
+		if(c->streams[i].id == id)
+			return &c->streams[i];
+	return NULL;
+}
+
+// Register a QUIC stream object in the connection's table. Returns false (and does
+// not take ownership) when the table is full.
+static bool add_stream(struct quic_client_conn *c, SSL *ssl, bool local_uni)
+{
+	if(c->nstreams >= QUIC_MAX_STREAMS)
+		return false;
+	struct qstream *s = &c->streams[c->nstreams++];
+	s->ssl = ssl;
+	s->local_uni = local_uni;
+	s->read_done = false;
+	s->id = (int64_t)SSL_get_stream_id(ssl);
+	return true;
+}
+
+// nghttp3 data reader: hand the whole padded DNS query to nghttp3 as the POST body
+// in one vec. The caller's query buffer is stable for the exchange (safe to retain).
+static nghttp3_ssize quic_req_read(nghttp3_conn *h3, int64_t stream_id,
+                                   nghttp3_vec *vec, size_t veccnt,
+                                   uint32_t *pflags, void *conn_user_data,
+                                   void *stream_user_data)
+{
+	(void)h3; (void)stream_id; (void)stream_user_data;
+	struct quic_client_conn *c = conn_user_data;
+	if(veccnt < 1)
+		return NGHTTP3_ERR_CALLBACK_FAILURE;
+	vec[0].base = (uint8_t *)(uintptr_t)(c->x.query + c->x.qoff);
+	vec[0].len = c->x.qlen - c->x.qoff;
+	c->x.qoff = c->x.qlen;
+	*pflags = NGHTTP3_DATA_FLAG_EOF;
+	return 1;
+}
+
+// Capture the :status pseudo-header of the response.
+static int quic_cb_recv_header(nghttp3_conn *h3, int64_t stream_id, int32_t token,
+                               nghttp3_rcbuf *name, nghttp3_rcbuf *value,
+                               uint8_t flags, void *conn_user_data,
+                               void *stream_user_data)
+{
+	(void)h3; (void)token; (void)flags; (void)stream_user_data;
+	struct quic_client_conn *c = conn_user_data;
+	if(stream_id != c->x.req_sid)
+		return 0;
+	const nghttp3_vec n = nghttp3_rcbuf_get_buf(name);
+	const nghttp3_vec v = nghttp3_rcbuf_get_buf(value);
+	if(n.len == 7 && memcmp(n.base, ":status", 7) == 0)
+	{
+		int s = 0;
+		// A :status is exactly three digits; cap the loop so a hostile upstream's
+		// long digit run cannot overflow the int accumulator (undefined behaviour).
+		for(size_t i = 0; i < v.len && i < 3 && v.base[i] >= '0' && v.base[i] <= '9'; i++)
+			s = s * 10 + (v.base[i] - '0');
+		c->x.status = s;
+	}
+	return 0;
+}
+
+// Collect response DATA into the answer buffer. Overrunning the bounded buffer is
+// a hard failure (fail closed): flag it and abort the read so the exchange -1s.
+static int quic_cb_recv_data(nghttp3_conn *h3, int64_t stream_id,
+                             const uint8_t *data, size_t datalen,
+                             void *conn_user_data, void *stream_user_data)
+{
+	(void)h3; (void)stream_user_data;
+	struct quic_client_conn *c = conn_user_data;
+	if(stream_id != c->x.req_sid)
+		return 0;
+	if(datalen > c->x.answer_sz - c->x.answer_len)
+	{
+		c->x.overflow = true;
+		return NGHTTP3_ERR_CALLBACK_FAILURE;
+	}
+	memcpy(c->x.answer + c->x.answer_len, data, datalen);
+	c->x.answer_len += datalen;
+	return 0;
+}
+
+// The request stream closed: a non-zero application error code means it was reset
+// rather than completed cleanly.
+static int quic_cb_stream_close(nghttp3_conn *h3, int64_t stream_id,
+                                uint64_t app_error_code, void *conn_user_data,
+                                void *stream_user_data)
+{
+	(void)h3; (void)stream_user_data;
+	struct quic_client_conn *c = conn_user_data;
+	if(stream_id != c->x.req_sid)
+		return 0;
+	c->x.done = true;
+	if(app_error_code != 0)
+		c->x.failed = true;
+	return 0;
+}
+
+static const nghttp3_callbacks quic_callbacks = {
+	.stream_close = quic_cb_stream_close,
+	.recv_data    = quic_cb_recv_data,
+	.recv_header  = quic_cb_recv_header,
+};
+
+// Fill one nghttp3_nv from NUL-terminated name/value strings.
+static nghttp3_nv quic_nv(const char *name, const char *value)
+{
+	nghttp3_nv nv;
+	nv.name = (const uint8_t *)name;
+	nv.value = (const uint8_t *)value;
+	nv.namelen = strlen(name);
+	nv.valuelen = strlen(value);
+	nv.flags = NGHTTP3_NV_FLAG_NONE;
+	return nv;
+}
+
+// Resolve host:port and open a connected, non-blocking UDP socket, returning the fd
+// and peer address (for SSL_set1_initial_peer_addr). Connect budget spans all records.
+static bool udp_connect(const char *host, int port, uint64_t deadline,
+                        int *out_fd, BIO_ADDR **out_peer)
+{
+	char portstr[8];
+	snprintf(portstr, sizeof(portstr), "%d", port);
+
+	struct addrinfo hints = { 0 };
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_DGRAM;
+	hints.ai_protocol = IPPROTO_UDP;
+
+	struct addrinfo *res = NULL;
+	if(getaddrinfo(host, portstr, &hints, &res) != 0)
+		return false;
+
+	bool ok = false;
+	for(struct addrinfo *cur = res; cur != NULL && !ok; cur = cur->ai_next)
+	{
+		if(now_ms() >= deadline)
+			break;
+		// SOCK_CLOEXEC so a connected upstream socket is not inherited across
+		// FTL's execvp() self-restart.
+		const int fd = socket(cur->ai_family, cur->ai_socktype | SOCK_CLOEXEC, cur->ai_protocol);
+		if(fd < 0)
+			continue;
+		// A connected UDP socket lets the kernel drop stray datagrams from other
+		// peers before OpenSSL ever sees them. connect() on UDP does not block.
+		if(connect(fd, cur->ai_addr, cur->ai_addrlen) != 0)
+		{
+			close(fd);
+			continue;
+		}
+		const int flags = fcntl(fd, F_GETFL, 0);
+		if(flags >= 0)
+			fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+		BIO_ADDR *peer = BIO_ADDR_new();
+		if(peer == NULL)
+		{
+			close(fd);
+			break;
+		}
+		// Copy into aligned storage before reading family-specific fields;
+		// ai_addr has only sockaddr alignment, so a direct cast trips -Wcast-align.
+		struct sockaddr_storage ss;
+		memcpy(&ss, cur->ai_addr, cur->ai_addrlen < sizeof(ss) ? cur->ai_addrlen : sizeof(ss));
+		unsigned short nport = 0;
+		const void *raw = NULL;
+		size_t rawlen = 0;
+		if(cur->ai_family == AF_INET)
+		{
+			struct sockaddr_in sin;
+			memcpy(&sin, &ss, sizeof(sin));
+			nport = sin.sin_port;          // already network byte order
+			raw = &((struct sockaddr_in *)&ss)->sin_addr;
+			rawlen = sizeof(sin.sin_addr);
+		}
+		else if(cur->ai_family == AF_INET6)
+		{
+			struct sockaddr_in6 sin6;
+			memcpy(&sin6, &ss, sizeof(sin6));
+			nport = sin6.sin6_port;
+			raw = &((struct sockaddr_in6 *)&ss)->sin6_addr;
+			rawlen = sizeof(sin6.sin6_addr);
+		}
+		if(raw != NULL &&
+		   BIO_ADDR_rawmake(peer, cur->ai_family, raw, rawlen, nport) == 1)
+		{
+			*out_fd = fd;
+			*out_peer = peer;
+			ok = true;
+		}
+		else
+		{
+			BIO_ADDR_free(peer);
+			close(fd);
+		}
+	}
+
+	freeaddrinfo(res);
+	return ok;
+}
+
+// Wait for the QUIC socket to be ready or an OpenSSL timer to fire, bounded by the
+// deadline - OpenSSL drives its own timers, so we wake to run loss recovery too.
+static void quic_wait(SSL *ssl, int fd, uint64_t deadline)
+{
+	struct pollfd pfd = { .fd = fd, .events = 0, .revents = 0 };
+	if(SSL_net_read_desired(ssl))
+		pfd.events |= POLLIN;
+	if(SSL_net_write_desired(ssl))
+		pfd.events |= POLLOUT;
+
+	int tmo = ms_left(deadline, 1000);
+	struct timeval tv;
+	int is_infinite = 0;
+	if(SSL_get_event_timeout(ssl, &tv, &is_infinite) == 1 && !is_infinite)
+	{
+		int ev = (int)(tv.tv_sec * 1000 + tv.tv_usec / 1000);
+		if(ev < 0)
+			ev = 0;
+		if(ev < tmo)
+			tmo = ev;
+	}
+	poll(pfd.events != 0 ? &pfd : NULL, pfd.events != 0 ? 1 : 0, tmo);
+}
+
+// Drive the QUIC handshake to completion (non-blocking), bounded by the deadline.
+// A verification failure surfaces as a hard SSL_connect() error (fail-closed).
+static bool quic_do_handshake(SSL *ssl, int fd, uint64_t deadline)
+{
+	for(;;)
+	{
+		const int rc = SSL_connect(ssl);
+		if(rc == 1)
+			return true;
+		const int err = SSL_get_error(ssl, rc);
+		if(err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE)
+			return false;
+		if(now_ms() >= deadline)
+			return false;
+		quic_wait(ssl, fd, deadline);
+	}
+}
+
+// Read all currently available bytes from a readable stream and feed them to
+// nghttp3. Returns 0 normally, -1 on a fatal nghttp3 error.
+static int stream_pump_read(struct quic_client_conn *c, struct qstream *s)
+{
+	uint8_t buf[16384];
+	for(;;)
+	{
+		size_t nread = 0;
+		const int r = SSL_read_ex(s->ssl, buf, sizeof(buf), &nread);
+		if(r == 1 && nread > 0)
+		{
+			if(nghttp3_conn_read_stream2(c->h3, s->id, buf, nread, 0, h3_now()) < 0)
+				return -1;
+			continue;
+		}
+		const int err = SSL_get_error(s->ssl, r);
+		if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
+			return 0;
+		if(err == SSL_ERROR_ZERO_RETURN)
+		{
+			// Clean end of the receiving side: feed FIN to nghttp3 only for a
+			// graceful finish; a reset just stops reads.
+			s->read_done = true;
+			if(SSL_get_stream_read_state(s->ssl) == SSL_STREAM_STATE_FINISHED)
+			{
+				if(nghttp3_conn_read_stream2(c->h3, s->id, NULL, 0, 1, h3_now()) < 0)
+					return -1;
+				// Tell nghttp3 the QUIC stream has closed so it runs the
+				// stream_close callback - which is what completes the exchange.
+				// nghttp3 does not derive that from the FIN alone, so without this
+				// a fully received response never finishes and the exchange times
+				// out. Our bidi request stream's send side is already concluded.
+				if(nghttp3_conn_close_stream(c->h3, s->id, 0) < 0)
+					return -1;
+			}
+			else if(s->id == c->x.req_sid)
+				// Receive side ended without a clean FIN: fail the exchange now
+				// instead of spinning to the deadline.
+				c->x.done = c->x.failed = true;
+			return 0;
+		}
+		// Reset or connection-level error: stop reading this stream. If it is the
+		// request stream, fail the exchange promptly rather than waiting out the
+		// deadline (a hostile/buggy upstream reset would otherwise pin the worker).
+		s->read_done = true;
+		if(s->id == c->x.req_sid)
+			c->x.done = c->x.failed = true;
+		return 0;
+	}
+}
+
+// Drain nghttp3's pending stream writes to the QUIC streams. Returns 0 or -1.
+static int conn_pump_write(struct quic_client_conn *c)
+{
+	for(;;)
+	{
+		nghttp3_vec vec[16];
+		int64_t sid = -1;
+		int fin = 0;
+		const nghttp3_ssize n = nghttp3_conn_writev_stream(c->h3, &sid, &fin, vec, 16);
+		if(n < 0)
+			return -1;
+		if(n == 0 && sid == -1)
+			break; // nothing more to write right now
+
+		struct qstream *s = find_stream(c, sid);
+		if(s == NULL)
+		{
+			// Unknown stream: acknowledge zero progress and stop for now.
+			nghttp3_conn_add_write_offset(c->h3, sid, 0);
+			break;
+		}
+
+		size_t total = 0;
+		bool blocked = false;
+		for(nghttp3_ssize i = 0; i < n && !blocked; i++)
+		{
+			size_t off = 0;
+			while(off < vec[i].len)
+			{
+				size_t written = 0;
+				const int r = SSL_write_ex(s->ssl, vec[i].base + off,
+				                           vec[i].len - off, &written);
+				if(r == 1)
+				{
+					off += written;
+					total += written;
+				}
+				else
+				{
+					const int err = SSL_get_error(s->ssl, r);
+					if(err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE)
+						return -1; // fatal (e.g. STOP_SENDING / conn error): fail fast
+					// Stream send buffer full / not yet writable: retry later.
+					blocked = true;
+					break;
+				}
+			}
+		}
+
+		if(nghttp3_conn_add_write_offset(c->h3, sid, total) != 0)
+			return -1;
+		// OpenSSL owns retransmission once bytes are accepted, so nghttp3 may
+		// release its copy immediately.
+		if(total > 0 && nghttp3_conn_add_ack_offset(c->h3, sid, total) != 0)
+			return -1;
+
+		if(fin && !blocked)
+			SSL_stream_conclude(s->ssl, 0); // send FIN once all data is flushed
+		if(blocked)
+			break;
+	}
+	return 0;
+}
+
+// Accept any server-initiated streams (its control + QPACK streams) into the
+// table so their bytes can be fed to nghttp3.
+static void conn_accept_streams(struct quic_client_conn *c)
+{
+	for(;;)
+	{
+		SSL *st = SSL_accept_stream(c->ssl, SSL_ACCEPT_STREAM_NO_BLOCK);
+		if(st == NULL)
+			break;
+		if(!add_stream(c, st, false))
+		{
+			SSL_free(st);
+			break;
+		}
+	}
+}
+
+// Tear down the HTTP/3 session, every stream object and the QUIC connection.
+static void conn_teardown(struct quic_client_conn *c)
+{
+	if(c->ssl != NULL)
+		// Best-effort immediate close so the server does not wait on us; do not
+		// block the worker flushing it.
+		SSL_shutdown_ex(c->ssl, SSL_SHUTDOWN_FLAG_RAPID | SSL_SHUTDOWN_FLAG_NO_BLOCK,
+		                NULL, 0);
+	if(c->h3 != NULL)
+		nghttp3_conn_del(c->h3);
+	for(int i = 0; i < c->nstreams; i++)
+		if(c->streams[i].ssl != NULL)
+			SSL_free(c->streams[i].ssl);
+	if(c->ssl != NULL)
+		SSL_free(c->ssl); // frees the datagram BIO and closes the UDP fd
+}
+
+// Set up nghttp3 and the mandatory local control / QPACK streams on a freshly
+// handshaked QUIC connection. Returns true on success.
+static bool conn_setup_h3(struct quic_client_conn *c)
+{
+	nghttp3_settings settings;
+	nghttp3_settings_default(&settings);
+	if(nghttp3_conn_client_new(&c->h3, &quic_callbacks, &settings, NULL, c) != 0)
+		return false;
+
+	SSL *ctrl = SSL_new_stream(c->ssl, SSL_STREAM_FLAG_UNI);
+	SSL *qenc = SSL_new_stream(c->ssl, SSL_STREAM_FLAG_UNI);
+	SSL *qdec = SSL_new_stream(c->ssl, SSL_STREAM_FLAG_UNI);
+	if(ctrl == NULL || qenc == NULL || qdec == NULL)
+	{
+		if(ctrl != NULL) SSL_free(ctrl);
+		if(qenc != NULL) SSL_free(qenc);
+		if(qdec != NULL) SSL_free(qdec);
+		return false;
+	}
+	if(!add_stream(c, ctrl, true) || !add_stream(c, qenc, true) || !add_stream(c, qdec, true))
+		return false; // objects are now owned by the table, freed in teardown
+
+	const int64_t cid = c->streams[0].id, eid = c->streams[1].id, did = c->streams[2].id;
+	if(nghttp3_conn_bind_control_stream(c->h3, cid) != 0 ||
+	   nghttp3_conn_bind_qpack_streams(c->h3, eid, did) != 0)
+		return false;
+	return true;
+}
+
+// Open the request stream and submit the DoH POST. Returns true on success.
+static bool conn_submit_request(struct quic_client_conn *c, const struct upstream_uri *u,
+                                const uint8_t *query, size_t qlen,
+                                uint8_t *answer, size_t answer_sz)
+{
+	SSL *req = SSL_new_stream(c->ssl, 0); // client-initiated bidirectional
+	if(req == NULL)
+		return false;
+	if(!add_stream(c, req, false))
+	{
+		SSL_free(req);
+		return false;
+	}
+	const int64_t sid = (int64_t)SSL_get_stream_id(req);
+
+	c->x.req_sid = sid;
+	c->x.query = query;
+	c->x.qlen = qlen;
+	c->x.answer = answer;
+	c->x.answer_sz = answer_sz;
+
+	// An IPv6-literal authority must be bracketed; a hostname never contains ':'.
+	char authority[UURI_HOST_MAX + 2];
+	if(strchr(u->verify_name, ':') != NULL)
+		snprintf(authority, sizeof(authority), "[%s]", u->verify_name);
+	else
+		snprintf(authority, sizeof(authority), "%s", u->verify_name);
+
+	char clen[16];
+	snprintf(clen, sizeof(clen), "%zu", qlen);
+
+	// RFC 8484: POST the DNS wire message with media type application/dns-message.
+	const nghttp3_nv nva[] = {
+		quic_nv(":method", "POST"),
+		quic_nv(":scheme", "https"),
+		quic_nv(":authority", authority),
+		quic_nv(":path", u->doh_path),
+		quic_nv("content-type", "application/dns-message"),
+		quic_nv("accept", "application/dns-message"),
+		quic_nv("content-length", clen),
+	};
+	const nghttp3_data_reader dr = { quic_req_read };
+	return nghttp3_conn_submit_request(c->h3, sid, nva, sizeof(nva) / sizeof(nva[0]),
+	                                   &dr, c) == 0;
+}
+
 ssize_t quic_pool_exchange(struct quic_pool *p, const uint8_t *query, size_t qlen,
                            uint8_t *answer, size_t answer_sz)
 {
-	(void)p; (void)query; (void)qlen; (void)answer; (void)answer_sz;
-	return -1;
+	if(!g_ready || p == NULL || query == NULL || answer == NULL)
+		return -1;
+	if(qlen == 0 || qlen > DNS_MSG_MAX)
+		return -1;
+
+	const struct upstream_uri *u = &p->u;
+	const uint64_t deadline = now_ms() + QUIC_EXCHANGE_TIMEOUT_MS;
+
+	// 1. Connected, non-blocking UDP socket to the upstream.
+	int fd = -1;
+	BIO_ADDR *peer = NULL;
+	if(!udp_connect(u->connect_host, u->port, deadline, &fd, &peer))
+	{
+		log_warn("dotdoh: DoH3 connect to %s#%d failed", u->connect_host, u->port);
+		return -1;
+	}
+
+	// 2. QUIC connection object over that socket.
+	struct quic_client_conn c;
+	memset(&c, 0, sizeof(c));
+	c.ssl = SSL_new(g_qctx);
+	BIO *bio = c.ssl != NULL ? BIO_new_dgram(fd, BIO_CLOSE) : NULL;
+	if(c.ssl == NULL || bio == NULL)
+	{
+		// SSL_set_bio() has not run, so the SSL does not own the fd: a BIO (BIO_CLOSE)
+		// closes it on BIO_free(), else close it directly; SSL_free() alone leaks it.
+		if(bio != NULL)
+			BIO_free(bio);
+		else
+			close(fd);
+		if(c.ssl != NULL)
+			SSL_free(c.ssl);
+		BIO_ADDR_free(peer);
+		return -1;
+	}
+	SSL_set_bio(c.ssl, bio, bio); // SSL owns the BIO (and the fd via BIO_CLOSE)
+
+	// ALPN "h3" (opts into HTTP/3), the initial peer address, non-blocking mode
+	// and manual stream control - we accept and drive every stream by hand.
+	static const unsigned char alpn_h3[] = { 2, 'h', '3' };
+	SSL_set_alpn_protos(c.ssl, alpn_h3, sizeof(alpn_h3));
+	SSL_set1_initial_peer_addr(c.ssl, peer);
+	BIO_ADDR_free(peer);
+	SSL_set_blocking_mode(c.ssl, 0);
+	SSL_set_default_stream_mode(c.ssl, SSL_DEFAULT_STREAM_MODE_NONE);
+
+	// Verification name: a bare-IP upstream is checked against iPAddress SANs (and
+	// RFC 6066 forbids an IP literal as SNI); a hostname is checked against
+	// dNSName/CN and doubles as the SNI. A failed set is fatal (fail-closed).
+	struct in_addr v4;
+	struct in6_addr v6;
+	bool vok;
+	if(inet_pton(AF_INET, u->verify_name, &v4) == 1 ||
+	   inet_pton(AF_INET6, u->verify_name, &v6) == 1)
+		vok = X509_VERIFY_PARAM_set1_ip_asc(SSL_get0_param(c.ssl), u->verify_name) == 1;
+	else
+	{
+		vok = X509_VERIFY_PARAM_set1_host(SSL_get0_param(c.ssl), u->verify_name, 0) == 1;
+		if(vok)
+			SSL_set_tlsext_host_name(c.ssl, u->verify_name);
+	}
+
+	ssize_t rv = -1;
+	bool connected = false;
+
+	// 3. Handshake (fail-closed: bad chain/hostname aborts here).
+	if(vok && quic_do_handshake(c.ssl, fd, deadline))
+	{
+		connected = true;
+		// 4. HTTP/3 session + control/QPACK streams, then submit the request.
+		if(conn_setup_h3(&c) &&
+		   conn_submit_request(&c, u, query, qlen, answer, answer_sz))
+		{
+			// 5. Drive the exchange until the request stream closes or we run out
+			// of time.
+			for(;;)
+			{
+				if(conn_pump_write(&c) < 0)
+					break;
+				SSL_handle_events(c.ssl);
+				conn_accept_streams(&c);
+				bool read_err = false;
+				for(int i = 0; i < c.nstreams; i++)
+				{
+					struct qstream *s = &c.streams[i];
+					if(s->local_uni || s->read_done)
+						continue;
+					if(stream_pump_read(&c, s) < 0)
+					{
+						read_err = true;
+						break;
+					}
+				}
+				if(read_err)
+					break;
+				// Reading may have produced control/QPACK output (and acks); flush.
+				if(conn_pump_write(&c) < 0)
+					break;
+				SSL_handle_events(c.ssl);
+				if(c.x.done)
+					break;
+				if(now_ms() >= deadline)
+					break;
+				quic_wait(c.ssl, fd, deadline);
+			}
+
+			// A cleanly closed request stream carrying a 200 with a non-empty body
+			// is the only success; anything else fails closed.
+			if(c.x.done && !c.x.failed && !c.x.overflow &&
+			   c.x.status == 200 && c.x.answer_len > 0)
+				rv = (ssize_t)c.x.answer_len;
+		}
+	}
+
+	// 6. Accounting + teardown.
+	pthread_mutex_lock(&p->lock);
+	if(connected)
+	{
+		p->stats.conns_opened++;
+		p->stats.handshakes_fresh_cold++; // QUIC exchange = one fresh connection
+		p->stats.sessions_closed++;
+		p->stats.queries_per_session_sum += (rv >= 0) ? 1u : 0u;
+		if(rv >= 0 && p->stats.queries_per_session_max < 1)
+			p->stats.queries_per_session_max = 1;
+	}
+	if(rv >= 0)
+		p->stats.queries_total++;
+	pthread_mutex_unlock(&p->lock);
+
+	conn_teardown(&c);
+	return rv;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 void quic_pool_get_stats(struct quic_pool *p, struct dotdoh_stats *out)
 {
@@ -90,16 +834,17 @@ void quic_pool_get_stats(struct quic_pool *p, struct dotdoh_stats *out)
 
 #else // no QUIC / HTTP3 support in this build
 
-// Without OpenSSL QUIC + nghttp3 there is no DoH3 transport. The pool cannot be
-// created and every exchange fails closed; the config layer refuses to arm an
-// h3:// upstream when quic_pool_new() returns NULL. These trivial stubs are
-// const-folding candidates, so silence the GCC-only attribute suggestion (the
-// malloc attribute on quic_pool_new() also conflicts with -Wsuggest-attribute).
+// Without OpenSSL QUIC + nghttp3 there is no DoH3 transport: the pool cannot be
+// created and every exchange fails closed (the config layer refuses an h3://
+// upstream when quic_pool_new() returns NULL). These trivial stubs are const-
+// folding candidates, so silence the GCC-only -Wsuggest-attribute suggestions.
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
 #endif
+bool quic_client_global_init(const char *ca_file) { (void)ca_file; return false; }
+void quic_client_global_free(void) { }
 struct quic_pool *quic_pool_new(const struct upstream_uri *u, int max_conns)
 {
 	(void)u; (void)max_conns;

--- a/src/dotdoh/quic_client.h
+++ b/src/dotdoh/quic_client.h
@@ -24,24 +24,26 @@
 #include <sys/types.h>
 
 #include "upstream_uri.h"
-// struct dotdoh_stats is shared with the TCP client so the proxy can report both
-// transports through one summary path.
+// struct dotdoh_stats is shared with the TCP client (one summary path).
 #include "tls_client.h"
 
-// Per-upstream QUIC connection pool. Opaque: all connection and concurrency
-// state lives inside the implementation.
+// Per-upstream QUIC connection pool; all state lives in the implementation.
 struct quic_pool; // opaque
 
-// Create / destroy a per-upstream DoH3 pool. max_conns bounds the concurrent
-// QUIC connections to this upstream. The pool copies *u. Returns NULL on failure
-// (e.g. this build has no QUIC/nghttp3 support).
+// Build / tear down the shared QUIC SSL_CTX (trust store, ca_file NULL = system
+// bundle; fail-closed verify), mirroring tls_client_global_init(). Idempotent;
+// returns false in a build without OpenSSL QUIC + nghttp3. Call before quic_pool_new.
+bool quic_client_global_init(const char *ca_file);
+void quic_client_global_free(void);
+
+// Create / destroy a per-upstream DoH3 pool. max_conns bounds concurrent QUIC
+// connections; the pool copies *u. Returns NULL on failure (e.g. no QUIC build).
 struct quic_pool *quic_pool_new(const struct upstream_uri *u, int max_conns) __attribute__((malloc));
 void quic_pool_free(struct quic_pool *p);
 
 // Perform one DNS exchange over HTTP/3. query/qlen is the DNS wire message; the
 // answer is written into answer[answer_sz]. Returns the answer length, or -1 on
-// any failure (the caller drops the query so dnsmasq fails over). Thread-safe.
-// Fail-closed.
+// failure (caller drops the query, dnsmasq fails over). Thread-safe, fail-closed.
 ssize_t quic_pool_exchange(struct quic_pool *p, const uint8_t *query, size_t qlen,
                            uint8_t *answer, size_t answer_sz);
 

--- a/src/dotdoh/quic_client.h
+++ b/src/dotdoh/quic_client.h
@@ -1,0 +1,51 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Outbound QUIC client for DoH3 upstreams (HTTP/3 over QUIC)
+*
+*  Public interface of the DoH3 client: it mirrors the tls_client pool API so the
+*  proxy can route an h3:// upstream through it exactly as it routes DoT/DoH
+*  through the TCP pool. The transport underneath is OpenSSL QUIC + nghttp3; the
+*  handshake is fail-closed (chain + hostname verification) just like the TCP
+*  path, and a failed exchange returns -1 so the query is dropped and FTL fails
+*  over rather than downgrading.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef DOTDOH_QUIC_CLIENT_H
+#define DOTDOH_QUIC_CLIENT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#include "upstream_uri.h"
+// struct dotdoh_stats is shared with the TCP client so the proxy can report both
+// transports through one summary path.
+#include "tls_client.h"
+
+// Per-upstream QUIC connection pool. Opaque: all connection and concurrency
+// state lives inside the implementation.
+struct quic_pool; // opaque
+
+// Create / destroy a per-upstream DoH3 pool. max_conns bounds the concurrent
+// QUIC connections to this upstream. The pool copies *u. Returns NULL on failure
+// (e.g. this build has no QUIC/nghttp3 support).
+struct quic_pool *quic_pool_new(const struct upstream_uri *u, int max_conns) __attribute__((malloc));
+void quic_pool_free(struct quic_pool *p);
+
+// Perform one DNS exchange over HTTP/3. query/qlen is the DNS wire message; the
+// answer is written into answer[answer_sz]. Returns the answer length, or -1 on
+// any failure (the caller drops the query so dnsmasq fails over). Thread-safe.
+// Fail-closed.
+ssize_t quic_pool_exchange(struct quic_pool *p, const uint8_t *query, size_t qlen,
+                           uint8_t *answer, size_t answer_sz);
+
+// Snapshot this pool's diagnostic counters into *out.
+void quic_pool_get_stats(struct quic_pool *p, struct dotdoh_stats *out);
+
+#endif // DOTDOH_QUIC_CLIENT_H

--- a/src/dotdoh/tls_client.c
+++ b/src/dotdoh/tls_client.c
@@ -27,6 +27,10 @@
 #ifdef HAVE_TLS
 
 #include "framing.h"
+#ifdef HAVE_HTTP2
+// DoH: an https:// upstream that negotiates "h2" via ALPN is driven by nghttp2.
+#include <nghttp2/nghttp2.h>
+#endif
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
@@ -92,6 +96,10 @@ struct tls_conn {
 	unsigned queries_served;                        // exchanges on this connection
 	uint8_t req[DNS_MSG_MAX + 512];                 // framed request we send
 	uint8_t rbuf[DNS_MSG_MAX + DOH_HEADER_MAX];     // response accumulation buffer
+#ifdef HAVE_HTTP2
+	bool is_h2;                                     // ALPN negotiated "h2" (DoH only)
+	nghttp2_session *h2;                            // persistent client session, lazy
+#endif
 };
 
 // Per-upstream pool: a bounded set of connections plus the shared resumption
@@ -300,6 +308,13 @@ static bool ssl_io_wait(int fd, int ssl_err, uint64_t deadline)
 // not touch pool bookkeeping.
 static void conn_teardown(struct tls_conn *c)
 {
+#ifdef HAVE_HTTP2
+	if(c->h2 != NULL)
+	{
+		nghttp2_session_del(c->h2);
+		c->h2 = NULL;
+	}
+#endif
 	if(c->ssl != NULL)
 	{
 		if(c->connected)
@@ -388,6 +403,17 @@ static bool conn_connect(struct tls_pool *p, struct tls_conn *c,
 	if(SSL_set_fd(c->ssl, c->fd) != 1)
 		goto fail;
 
+#ifdef HAVE_HTTP2
+	// DoH offers "h2" then "http/1.1" and lets the server choose; if h2 is not
+	// selected we fall back to HTTP/1.1 framing. DoT does not use ALPN.
+	if(u->type == UST_DOH)
+	{
+		static const unsigned char alpn[] =
+			{ 2, 'h', '2', 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+		SSL_set_alpn_protos(c->ssl, alpn, sizeof(alpn));
+	}
+#endif
+
 	// Non-blocking handshake: SSL_connect yields WANT_READ/WANT_WRITE and we poll
 	// with the remaining budget, so a slow-drip peer cannot outlast the deadline.
 	// A verification failure returns a hard error here - fail-closed.
@@ -408,6 +434,19 @@ static bool conn_connect(struct tls_pool *p, struct tls_conn *c,
 			goto fail;
 		}
 	}
+
+#ifdef HAVE_HTTP2
+	// Record the negotiated protocol; the nghttp2 session is created lazily in conn_do_h2().
+	c->is_h2 = false;
+	if(u->type == UST_DOH)
+	{
+		const unsigned char *proto = NULL;
+		unsigned int plen = 0;
+		SSL_get0_alpn_selected(c->ssl, &proto, &plen);
+		if(proto != NULL && plen == 2 && memcmp(proto, "h2", 2) == 0)
+			c->is_h2 = true;
+	}
+#endif
 
 	*outcome = SSL_session_reused(c->ssl) ? HS_RESUMED
 	         : (tried_resume ? HS_FULL_FALLBACK : HS_FRESH_COLD);
@@ -444,12 +483,258 @@ static bool ssl_write_all(struct tls_conn *c, const uint8_t *buf, size_t len, ui
 	return true;
 }
 
+#ifdef HAVE_HTTP2
+// --- DoH over HTTP/2 (nghttp2) ---------------------------------------------
+//
+// Driven when an https:// upstream selected "h2" via ALPN. The pool serialises
+// exchanges, so one request stream is in flight at a time; the nghttp2 session
+// persists across exchanges (preface sent once). Any error maps to -1 so the
+// caller tears down the connection and fails over.
+
+// Per-exchange state, on the worker stack for the duration of conn_do_h2().
+// Reached from the nghttp2 callbacks via the stream user data.
+struct h2_xfer {
+	const uint8_t *query;   // request body (the padded DNS query)
+	size_t qlen;            // request body length
+	size_t qoff;            // bytes already pulled by the data provider
+	uint8_t *answer;        // caller's answer buffer
+	size_t answer_sz;       // its capacity
+	size_t answer_len;      // response body bytes collected so far
+	int status;             // parsed :status (0 until seen)
+	bool overflow;          // response body exceeded answer_sz
+	bool closed;            // stream has closed
+	bool failed;            // stream closed with an error (RST/GOAWAY)
+};
+
+// nghttp2 data provider: hand the padded DNS query to nghttp2 as the POST body.
+static nghttp2_ssize h2_req_read(nghttp2_session *session, int32_t stream_id,
+                                 uint8_t *buf, size_t length, uint32_t *data_flags,
+                                 nghttp2_data_source *source, void *user_data)
+{
+	(void)session; (void)stream_id; (void)user_data;
+	struct h2_xfer *x = source->ptr;
+	const size_t avail = x->qlen - x->qoff;
+	const size_t n = avail < length ? avail : length;
+	if(n > 0)
+	{
+		memcpy(buf, x->query + x->qoff, n);
+		x->qoff += n;
+	}
+	if(x->qoff >= x->qlen)
+		*data_flags |= NGHTTP2_DATA_FLAG_EOF;
+	return (nghttp2_ssize)n;
+}
+
+// Capture the :status pseudo-header of the response.
+static int h2_on_header(nghttp2_session *session, const nghttp2_frame *frame,
+                        const uint8_t *name, size_t namelen,
+                        const uint8_t *value, size_t valuelen,
+                        uint8_t flags, void *user_data)
+{
+	(void)flags; (void)user_data;
+	if(frame->hd.type != NGHTTP2_HEADERS)
+		return 0;
+	struct h2_xfer *x = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+	if(x == NULL)
+		return 0;
+	if(namelen == 7 && memcmp(name, ":status", 7) == 0)
+	{
+		int s = 0;
+		// A :status is exactly three digits; cap the loop so a hostile upstream's
+		// long digit run cannot overflow the int accumulator (undefined behaviour).
+		for(size_t i = 0; i < valuelen && i < 3 && value[i] >= '0' && value[i] <= '9'; i++)
+			s = s * 10 + (value[i] - '0');
+		x->status = s;
+	}
+	return 0;
+}
+
+// Collect response DATA into the answer buffer. Overrunning the bounded buffer
+// is a hard failure (fail closed): abort the session so the exchange returns -1.
+static int h2_on_data_chunk(nghttp2_session *session, uint8_t flags, int32_t stream_id,
+                            const uint8_t *data, size_t len, void *user_data)
+{
+	(void)flags; (void)user_data;
+	struct h2_xfer *x = nghttp2_session_get_stream_user_data(session, stream_id);
+	if(x == NULL)
+		return 0;
+	if(len > x->answer_sz - x->answer_len)
+	{
+		x->overflow = true;
+		return NGHTTP2_ERR_CALLBACK_FAILURE;
+	}
+	memcpy(x->answer + x->answer_len, data, len);
+	x->answer_len += len;
+	return 0;
+}
+
+// Mark the stream done; a non-zero error code means it was reset, not completed.
+static int h2_on_stream_close(nghttp2_session *session, int32_t stream_id,
+                              uint32_t error_code, void *user_data)
+{
+	(void)user_data;
+	struct h2_xfer *x = nghttp2_session_get_stream_user_data(session, stream_id);
+	if(x == NULL)
+		return 0;
+	x->closed = true;
+	if(error_code != NGHTTP2_NO_ERROR)
+		x->failed = true;
+	return 0;
+}
+
+// Create the persistent nghttp2 client session on first use and queue the
+// connection preface (SETTINGS). Returns true once c->h2 is ready.
+static bool h2_session_init(struct tls_conn *c)
+{
+	if(c->h2 != NULL)
+		return true;
+
+	nghttp2_session_callbacks *cbs = NULL;
+	if(nghttp2_session_callbacks_new(&cbs) != 0)
+		return false;
+	nghttp2_session_callbacks_set_on_header_callback(cbs, h2_on_header);
+	nghttp2_session_callbacks_set_on_data_chunk_recv_callback(cbs, h2_on_data_chunk);
+	nghttp2_session_callbacks_set_on_stream_close_callback(cbs, h2_on_stream_close);
+	const int rv = nghttp2_session_client_new(&c->h2, cbs, c);
+	nghttp2_session_callbacks_del(cbs);
+	if(rv != 0)
+	{
+		c->h2 = NULL;
+		return false;
+	}
+	// The connection preface is the 24-byte magic (auto-emitted) plus a SETTINGS
+	// frame we submit; an empty SETTINGS is valid. Flushed with the first request.
+	if(nghttp2_submit_settings(c->h2, NGHTTP2_FLAG_NONE, NULL, 0) != 0)
+	{
+		nghttp2_session_del(c->h2);
+		c->h2 = NULL;
+		return false;
+	}
+	return true;
+}
+
+// Flush all frames nghttp2 has queued to the TLS connection.
+static bool h2_send(struct tls_conn *c, uint64_t deadline)
+{
+	for(;;)
+	{
+		const uint8_t *data = NULL;
+		const nghttp2_ssize n = nghttp2_session_mem_send2(c->h2, &data);
+		if(n < 0)
+			return false;
+		if(n == 0)
+			return true;
+		if(!ssl_write_all(c, data, (size_t)n, deadline))
+			return false;
+	}
+}
+
+// Fill one nghttp2_nv from NUL-terminated name/value strings.
+static nghttp2_nv h2_nv(const char *name, const char *value)
+{
+	nghttp2_nv nv;
+	nv.name = (uint8_t *)name;
+	nv.namelen = strlen(name);
+	nv.value = (uint8_t *)value;
+	nv.valuelen = strlen(value);
+	nv.flags = NGHTTP2_NV_FLAG_NONE;
+	return nv;
+}
+
+// Perform one DoH exchange over HTTP/2 on an established, h2-negotiated
+// connection. Returns the answer length, or -1 on any error.
+static ssize_t conn_do_h2(struct tls_conn *c, const struct upstream_uri *u,
+                          const uint8_t *query, size_t qlen,
+                          uint8_t *answer, size_t answer_sz, uint64_t deadline)
+{
+	if(qlen == 0 || qlen > DNS_MSG_MAX)
+		return -1;
+	if(!h2_session_init(c))
+		return -1;
+
+	struct h2_xfer x = { .query = query, .qlen = qlen,
+	                     .answer = answer, .answer_sz = answer_sz };
+
+	// An IPv6-literal authority must be bracketed; a hostname never contains ':'.
+	char authority[UURI_HOST_MAX + 2];
+	if(strchr(u->verify_name, ':') != NULL)
+		snprintf(authority, sizeof(authority), "[%s]", u->verify_name);
+	else
+		snprintf(authority, sizeof(authority), "%s", u->verify_name);
+
+	char clen[16];
+	snprintf(clen, sizeof(clen), "%zu", qlen);
+
+	// RFC 8484: POST the DNS wire message with media type application/dns-message.
+	const nghttp2_nv nva[] = {
+		h2_nv(":method", "POST"),
+		h2_nv(":scheme", "https"),
+		h2_nv(":authority", authority),
+		h2_nv(":path", u->doh_path),
+		h2_nv("content-type", "application/dns-message"),
+		h2_nv("accept", "application/dns-message"),
+		h2_nv("content-length", clen),
+	};
+
+	nghttp2_data_provider2 prd = { .source.ptr = &x, .read_callback = h2_req_read };
+	const int32_t sid = nghttp2_submit_request2(c->h2, NULL, nva,
+	                                            sizeof(nva) / sizeof(nva[0]), &prd, &x);
+	if(sid < 0)
+		return -1;
+
+	// Drive the single in-flight request until the stream closes or the deadline
+	// passes. The read scratch reuses c->rbuf (unused on the h2 path).
+	while(!x.closed)
+	{
+		if(!h2_send(c, deadline))
+			return -1;
+		if(x.closed)
+			break;
+		if(!nghttp2_session_want_read(c->h2) && !nghttp2_session_want_write(c->h2))
+			break;
+		if(now_ms() >= deadline)
+			return -1;
+		const int r = SSL_read(c->ssl, c->rbuf, (int)sizeof(c->rbuf));
+		if(r <= 0)
+		{
+			const int err = SSL_get_error(c->ssl, r);
+			// Block in poll() until readable/writable or the deadline passes,
+			// instead of spinning the CPU re-reading the non-blocking socket
+			// (mirrors conn_do()); the deadline is still enforced at the top.
+			if((err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) &&
+			   ssl_io_wait(c->fd, err, deadline))
+				continue;
+			return -1;
+		}
+		if(nghttp2_session_mem_recv2(c->h2, c->rbuf, (size_t)r) < 0)
+			return -1;
+	}
+
+	// Flush frames the final recv queued (SETTINGS ACK, WINDOW_UPDATE) to leave a
+	// reused keep-alive connection clean. Best-effort - the answer is in hand.
+	(void)h2_send(c, deadline);
+
+	// A cleanly closed stream carrying a 200 with a non-empty body is the only
+	// success; anything else fails closed.
+	if(x.failed || x.overflow || x.status != 200 || x.answer_len == 0)
+		return -1;
+	return (ssize_t)x.answer_len;
+}
+#endif // HAVE_HTTP2
+
 // Send one query and read back the framed answer over an established connection.
 // Returns the answer length, or -1 on any protocol/transport error.
 static ssize_t conn_do(struct tls_conn *c, const struct upstream_uri *u,
                        const uint8_t *query, size_t qlen,
                        uint8_t *answer, size_t answer_sz, uint64_t deadline)
 {
+#ifdef HAVE_HTTP2
+	// A DoH upstream that negotiated "h2" uses the nghttp2 path; DoT and the
+	// HTTP/1.1 DoH fallback continue below unchanged.
+	if(u->type == UST_DOH && c->is_h2)
+		return conn_do_h2(c, u, query, qlen, answer, answer_sz, deadline);
+#endif
+
 	// Frame the request: DoT prepends a 2-byte length, DoH wraps it in a POST.
 	ssize_t reqlen;
 	if(u->type == UST_DOT)

--- a/src/dotdoh/upstream_uri.c
+++ b/src/dotdoh/upstream_uri.c
@@ -76,6 +76,8 @@ static int __attribute__((pure)) parse_port(const char *s)
 // tls://[<ipv6>][#<port>]               DoT to a bracketed IPv6 literal
 // https://<host>[#<port>][/<path>]      DoH, default port 443, path /dns-query
 // https://<verify>@<ip>[#<port>][/<path>]
+// h3://<host>[#<port>][/<path>]         DoH3 (HTTP/3 over QUIC), same defaults
+// h3://<verify>@<ip>[#<port>][/<path>]
 //
 // Rejects control characters (incl. CR/LF), empty host, invalid/oversized
 // fields, and unknown schemes.
@@ -112,17 +114,23 @@ bool parse_upstream_uri(const char *in, struct upstream_uri *out)
 		out->type = UST_DOT;
 	else if(schemelen == 5 && strncmp(in, "https", 5) == 0)
 		out->type = UST_DOH;
+	else if(schemelen == 2 && strncmp(in, "h3", 2) == 0)
+		out->type = UST_DOH3;
 	else
 		return false; // unknown scheme
 
+	// DoH over TCP (h1.1/h2) and DoH3 over QUIC share the same authority/path
+	// grammar and defaults; only the transport differs.
+	const bool is_doh = (out->type == UST_DOH || out->type == UST_DOH3);
+
 	const char *rest = sep + 3;
 	// 853 is the DoT default port (RFC 7858 Sec. 3.1); 443 is HTTPS for
-	// DoH.
+	// DoH and the default UDP port for DoH3/QUIC.
 	const int default_port = (out->type == UST_DOT) ? 853 : 443;
 
-	// For DoH, split off the path at the first '/'.
+	// For DoH(3), split off the path at the first '/'.
 	const char *authority_end = rest + strlen(rest);
-	if(out->type == UST_DOH)
+	if(is_doh)
 	{
 		const char *slash = strchr(rest, '/');
 		if(slash != NULL)

--- a/src/dotdoh/upstream_uri.h
+++ b/src/dotdoh/upstream_uri.h
@@ -16,7 +16,9 @@
 
 #include <stdbool.h>
 
-enum ustype { UST_PLAIN = 0, UST_DOT, UST_DOH };
+// UST_DOH is DoH over a TCP TLS connection (HTTP/1.1, auto-upgraded to HTTP/2
+// via ALPN); UST_DOH3 is DoH over QUIC (HTTP/3), selected by the h3:// scheme.
+enum ustype { UST_PLAIN = 0, UST_DOT, UST_DOH, UST_DOH3 };
 
 #define UURI_HOST_MAX 256
 #define UURI_PATH_MAX 256

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -1095,6 +1095,17 @@ static void resolveUpstreams(const bool onlynew)
 		size_t ippos = upstream->ippos;
 		size_t oldnamepos = upstream->namepos;
 
+		// Encrypted (DoT/DoH) upstreams are recorded by their scheme URL, e.g.
+		// "https://dns.quad9.net@9.9.9.9/dns-query", not a bare IP. They have no
+		// PTR to look up, so skip them: resolveHostname() would otherwise read the
+		// "://" as an IPv6 address and warn about it on every refresh.
+		if(strstr(getstr(ippos), "://") != NULL)
+		{
+			upstream->flags.new = false;
+			unlock_shm();
+			continue;
+		}
+
 		// Only try to resolve host names of upstream servers which were recently active
 		// Limit for a "recently active" upstream server is two hours ago
 		if(upstream->lastQuery < now - 2*60*60)

--- a/src/webserver/CMakeLists.txt
+++ b/src/webserver/CMakeLists.txt
@@ -14,6 +14,8 @@ set(sources
         json_macros.h
         lua_web.c
         lua_web.h
+        terminator.c
+        terminator.h
         webserver.c
         webserver.h
         x509.c

--- a/src/webserver/civetweb/CMakeLists.txt
+++ b/src/webserver/civetweb/CMakeLists.txt
@@ -19,15 +19,16 @@ set(sources
 
 add_library(civetweb OBJECT ${sources})
 target_compile_options(civetweb PRIVATE -Wno-unused-but-set-variable -Wno-unused-variable)
-# We can remove the NO_SSL later on. It adds additional constraints to the build system (availablity of libSSL-dev)
 # NO_CGI = no CGI support (we don't need it)
-# NO_SSL_DL NO_SSL = no SSL support (for now)
+# NO_SSL = no TLS in civetweb: the in-process front terminator terminates TLS
+#          and civetweb only ever serves plain HTTP/1.1 on the loopback backend,
+#          so civetweb's whole SSL layer is dead code and compiled out.
 # USE_IPV6: add IPv6 support
 # USE_LUA: add Lua support
 # TIMER_RESOLUTION: set timer resolution to 1000ms (default is 10ms) in an attempt to reduce CPU load
 target_compile_definitions(civetweb PRIVATE NO_CGI
                                             NO_DLOPEN
-                                            NO_SSL_DL
+                                            NO_SSL
                                             USE_IPV6
                                             USE_LUA
                                             TIMER_RESOLUTION=1000)

--- a/src/webserver/civetweb/CMakeLists.txt
+++ b/src/webserver/civetweb/CMakeLists.txt
@@ -25,12 +25,16 @@ target_compile_options(civetweb PRIVATE -Wno-unused-but-set-variable -Wno-unused
 #          so civetweb's whole SSL layer is dead code and compiled out.
 # USE_IPV6: add IPv6 support
 # USE_LUA: add Lua support
+# USE_STACK_SIZE: pin worker-thread stack to 1 MiB. Without it, threads inherit
+#          the platform default (~8 MiB on glibc, but only ~128 KiB on musl/Alpine),
+#          which is too tight for Lua pages, the recursive config API and Teleporter I/O.
 # TIMER_RESOLUTION: set timer resolution to 1000ms (default is 10ms) in an attempt to reduce CPU load
 target_compile_definitions(civetweb PRIVATE NO_CGI
                                             NO_DLOPEN
                                             NO_SSL
                                             USE_IPV6
                                             USE_LUA
+                                            USE_STACK_SIZE=1048576
                                             TIMER_RESOLUTION=1000)
 
 include_directories(${PROJECT_SOURCE_DIR}/src/lua)

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -20318,6 +20318,112 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
 #endif /* ALTERNATIVE_QUEUE */
 
 
+/* Pi-hole: parse a PROXY protocol v2 header on a fresh connection coming from
+ * the in-process TLS terminator (which reaches CivetWeb on the loopback
+ * backend), and replace the remote address with the real client the header
+ * announces. This keeps client-IP-based logging and authentication accurate
+ * behind the terminator. Only loopback connections are trusted, so a plain-HTTP
+ * client on a public port cannot spoof its address this way; a no-op if no
+ * PROXY header is present (e.g. a direct localhost request). */
+static void
+parse_proxy_protocol_v2(struct mg_connection *conn)
+{
+	static const unsigned char sig[12] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
+	                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+	struct pollfd pfd;
+	unsigned char hdr[16];
+	unsigned char buf[16 + 216]; /* 216 = largest v2 address block */
+	size_t addr_len, total, got;
+	int have;
+	const unsigned char *a;
+
+	/* Only trust the header on loopback connections (from the terminator). */
+	if (conn->client.lsa.sa.sa_family == AF_INET) {
+		if (conn->client.lsa.sin.sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
+			return;
+		}
+#if defined(USE_IPV6)
+	} else if (conn->client.lsa.sa.sa_family == AF_INET6) {
+		if (!IN6_IS_ADDR_LOOPBACK(&conn->client.lsa.sin6.sin6_addr)) {
+			return;
+		}
+#endif
+	} else {
+		return;
+	}
+
+	/* Peek the fixed 16-byte v2 header. Retry until 16 bytes are available, or
+	 * bail as soon as the available prefix already fails to match the
+	 * signature (i.e. this is a normal request, not a PROXY header). */
+	have = 0;
+	while (have < 16) {
+		int n;
+		pfd.fd = conn->client.sock;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 1000) <= 0) {
+			return;
+		}
+		n = (int)recv(conn->client.sock, hdr, sizeof(hdr), MSG_PEEK);
+		if (n <= 0) {
+			return;
+		}
+		if (memcmp(hdr, sig, (n < 12) ? (size_t)n : (size_t)12) != 0) {
+			return;
+		}
+		have = n;
+	}
+	if ((hdr[12] & 0xF0) != 0x20) {
+		return; /* not version 2 */
+	}
+
+	addr_len = ((size_t)hdr[14] << 8) | (size_t)hdr[15];
+	total = 16 + addr_len;
+	if (total > sizeof(buf)) {
+		return;
+	}
+
+	/* Consume the whole header for real so the HTTP request follows it. */
+	got = 0;
+	while (got < total) {
+		int n;
+		pfd.fd = conn->client.sock;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 1000) <= 0) {
+			return;
+		}
+		n = (int)recv(conn->client.sock, buf + got, total - got, 0);
+		if (n <= 0) {
+			return;
+		}
+		got += (size_t)n;
+	}
+
+	/* Only the PROXY command (0x01) carries a real address; LOCAL (0x00) keeps
+	 * the original one. */
+	if ((hdr[12] & 0x0F) != 0x01) {
+		return;
+	}
+
+	a = buf + 16;
+	if (hdr[13] == 0x11 && addr_len >= 12) { /* TCP over IPv4 */
+		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
+		conn->client.rsa.sin.sin_family = AF_INET;
+		memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
+		memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
+	}
+#if defined(USE_IPV6)
+	else if (hdr[13] == 0x21 && addr_len >= 36) { /* TCP over IPv6 */
+		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
+		conn->client.rsa.sin6.sin6_family = AF_INET6;
+		memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
+		memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
+	}
+#endif
+}
+
+
 static void
 worker_thread_run(struct mg_connection *conn)
 {
@@ -20402,6 +20508,10 @@ worker_thread_run(struct mg_connection *conn)
 		conn->conn_close_time = 0;
 #endif
 		conn->conn_birth_time = time(NULL);
+
+		/* Pi-hole: adopt the real client address from a PROXY protocol v2
+		 * header if this connection comes from the loopback TLS terminator. */
+		parse_proxy_protocol_v2(conn);
 
 		/* Fill in IP, port info early so even if SSL setup below fails,
 		 * error handler would have the corresponding info.

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -2105,6 +2105,7 @@ enum {
 #endif
 	ADDITIONAL_HEADER,
 	ALLOW_INDEX_SCRIPT_SUB_RES,
+	PROXY_PROTOCOL_SECRET,
 
 	NUM_OPTIONS
 };
@@ -2271,6 +2272,7 @@ static const struct mg_option config_options[] = {
 #endif
     {"additional_header", MG_CONFIG_TYPE_STRING_MULTILINE, NULL},
     {"allow_index_script_resource", MG_CONFIG_TYPE_BOOLEAN, "no"},
+    {"proxy_protocol_secret", MG_CONFIG_TYPE_STRING, NULL},
 
     {NULL, MG_CONFIG_TYPE_UNKNOWN, NULL}};
 
@@ -2607,6 +2609,8 @@ struct mg_connection {
 	char *path_info;          /* PATH_INFO part of the URL */
 
 	int must_close;       /* 1 if connection must be closed */
+	unsigned char proxy_is_ssl; /* Pi-hole: PROXY v2 announced a TLS-terminated
+	                             * client (PP2_TYPE_SSL), so treat as HTTPS */
 	int accept_gzip;      /* 1 if gzip encoding is accepted */
 	int in_error_handler; /* 1 if in handler for user defined error
 	                       * pages */
@@ -20318,110 +20322,10 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
 #endif /* ALTERNATIVE_QUEUE */
 
 
-/* Pi-hole: parse a PROXY protocol v2 header on a fresh connection coming from
- * the in-process TLS terminator (which reaches CivetWeb on the loopback
- * backend), and replace the remote address with the real client the header
- * announces. This keeps client-IP-based logging and authentication accurate
- * behind the terminator. Only loopback connections are trusted, so a plain-HTTP
- * client on a public port cannot spoof its address this way; a no-op if no
- * PROXY header is present (e.g. a direct localhost request). */
-static void
-parse_proxy_protocol_v2(struct mg_connection *conn)
-{
-	static const unsigned char sig[12] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
-	                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
-	struct pollfd pfd;
-	unsigned char hdr[16];
-	unsigned char buf[16 + 216]; /* 216 = largest v2 address block */
-	size_t addr_len, total, got;
-	int have;
-	const unsigned char *a;
-
-	/* Only trust the header on loopback connections (from the terminator). */
-	if (conn->client.lsa.sa.sa_family == AF_INET) {
-		if (conn->client.lsa.sin.sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
-			return;
-		}
-#if defined(USE_IPV6)
-	} else if (conn->client.lsa.sa.sa_family == AF_INET6) {
-		if (!IN6_IS_ADDR_LOOPBACK(&conn->client.lsa.sin6.sin6_addr)) {
-			return;
-		}
-#endif
-	} else {
-		return;
-	}
-
-	/* Peek the fixed 16-byte v2 header. Retry until 16 bytes are available, or
-	 * bail as soon as the available prefix already fails to match the
-	 * signature (i.e. this is a normal request, not a PROXY header). */
-	have = 0;
-	while (have < 16) {
-		int n;
-		pfd.fd = conn->client.sock;
-		pfd.events = POLLIN;
-		pfd.revents = 0;
-		if (poll(&pfd, 1, 1000) <= 0) {
-			return;
-		}
-		n = (int)recv(conn->client.sock, hdr, sizeof(hdr), MSG_PEEK);
-		if (n <= 0) {
-			return;
-		}
-		if (memcmp(hdr, sig, (n < 12) ? (size_t)n : (size_t)12) != 0) {
-			return;
-		}
-		have = n;
-	}
-	if ((hdr[12] & 0xF0) != 0x20) {
-		return; /* not version 2 */
-	}
-
-	addr_len = ((size_t)hdr[14] << 8) | (size_t)hdr[15];
-	total = 16 + addr_len;
-	if (total > sizeof(buf)) {
-		return;
-	}
-
-	/* Consume the whole header for real so the HTTP request follows it. */
-	got = 0;
-	while (got < total) {
-		int n;
-		pfd.fd = conn->client.sock;
-		pfd.events = POLLIN;
-		pfd.revents = 0;
-		if (poll(&pfd, 1, 1000) <= 0) {
-			return;
-		}
-		n = (int)recv(conn->client.sock, buf + got, total - got, 0);
-		if (n <= 0) {
-			return;
-		}
-		got += (size_t)n;
-	}
-
-	/* Only the PROXY command (0x01) carries a real address; LOCAL (0x00) keeps
-	 * the original one. */
-	if ((hdr[12] & 0x0F) != 0x01) {
-		return;
-	}
-
-	a = buf + 16;
-	if (hdr[13] == 0x11 && addr_len >= 12) { /* TCP over IPv4 */
-		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
-		conn->client.rsa.sin.sin_family = AF_INET;
-		memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
-		memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
-	}
-#if defined(USE_IPV6)
-	else if (hdr[13] == 0x21 && addr_len >= 36) { /* TCP over IPv6 */
-		memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
-		conn->client.rsa.sin6.sin6_family = AF_INET6;
-		memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
-		memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
-	}
-#endif
-}
+/* Pi-hole: adopt the real client address from a PROXY protocol v2 header sent
+ * by the loopback TLS terminator. Kept in its own unit to keep this patch
+ * small; parse_proxy_protocol_v2() is defined there. */
+#include "proxy_v2.inl"
 
 
 static void
@@ -20531,7 +20435,9 @@ worker_thread_run(struct mg_connection *conn)
 		            (conn->client.is_ssl ? "SSL " : ""),
 		            conn->request_info.remote_addr);
 
-		conn->request_info.is_ssl = conn->client.is_ssl;
+		/* Pi-hole: a PROXY v2 header from the TLS terminator can mark an
+		 * otherwise-plaintext loopback connection as HTTPS (PP2_TYPE_SSL). */
+		conn->request_info.is_ssl = conn->client.is_ssl || conn->proxy_is_ssl;
 
 		if (conn->client.is_ssl) {
 

--- a/src/webserver/civetweb/proxy_v2.inl
+++ b/src/webserver/civetweb/proxy_v2.inl
@@ -1,0 +1,225 @@
+/* PROXY protocol v2 support.
+ *
+ * When the "proxy_protocol_secret" option is set, civetweb parses a PROXY
+ * protocol v2 header at the start of each new connection. The header is trusted
+ * only if it carries a custom TLV whose value equals the configured secret; a
+ * trusted header's announced client address (and TLS status, via the standard
+ * PP2_TYPE_SSL TLV) then replaces the transport peer. The shared secret lets a
+ * trusted upstream terminator or L4 proxy authenticate itself where source-
+ * address trust is not possible (a loopback backend, a sidecar, a shared host).
+ * With no secret configured the parser is a no-op, so normal requests are
+ * unaffected.
+ *
+ * Kept in a separate unit that civetweb.c #includes, so that when this is
+ * vendored the change to civetweb.c stays a one-line include plus the two call
+ * sites. */
+
+/* Custom PROXY v2 TLV (in the PP2_TYPE_MIN_CUSTOM 0xE0-0xEF range) carrying the
+ * shared secret that authenticates the header. */
+#define PP2_TYPE_PROXY_SECRET 0xE0
+/* Standard PROXY v2 TLV announcing the client spoke TLS to the proxy. */
+#define PP2_TYPE_SSL 0x20
+#define PP2_CLIENT_SSL 0x01
+
+static int
+proxy_v2_hexdigit(char c)
+{
+	if (c >= '0' && c <= '9') {
+		return c - '0';
+	}
+	if (c >= 'a' && c <= 'f') {
+		return c - 'a' + 10;
+	}
+	if (c >= 'A' && c <= 'F') {
+		return c - 'A' + 10;
+	}
+	return -1;
+}
+
+/* Decode the hex string `hex` into up to out_sz bytes of `out`. Returns the
+ * number of bytes decoded, or -1 on an odd length or a non-hex character. */
+static int
+proxy_v2_hex_decode(const char *hex, unsigned char *out, size_t out_sz)
+{
+	size_t n = 0;
+	while (hex[0] != '\0') {
+		int hi, lo;
+		if (hex[1] == '\0' || n >= out_sz) {
+			return -1;
+		}
+		hi = proxy_v2_hexdigit(hex[0]);
+		lo = proxy_v2_hexdigit(hex[1]);
+		if (hi < 0 || lo < 0) {
+			return -1;
+		}
+		out[n++] = (unsigned char)((hi << 4) | lo);
+		hex += 2;
+	}
+	return (int)n;
+}
+
+/* Parse a PROXY protocol v2 header on a fresh connection and, if it is trusted
+ * (carries the configured secret), replace the remote address with the real
+ * client the header announces. A no-op when the feature is disabled or no PROXY
+ * header is present. */
+static void
+parse_proxy_protocol_v2(struct mg_connection *conn)
+{
+	static const unsigned char sig[12] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
+	                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+	const char *secret_hex;
+	unsigned char secret[64];
+	int secret_len;
+	struct pollfd pfd;
+	unsigned char hdr[16];
+	unsigned char buf[16 + 216]; /* 216 = largest v2 address block */
+	size_t addr_len, total, got, addr_size = 0;
+	int have;
+	const unsigned char *a;
+
+	/* Worker connection structs are reused across connections, so clear any
+	 * TLS-terminated marker from a previous connection before every early
+	 * return below - otherwise a later plaintext request on the same worker
+	 * would inherit a stale proxy_is_ssl and be mislabelled as HTTPS. */
+	conn->proxy_is_ssl = 0;
+
+	/* Opt-in: with no configured secret there is nothing to trust, so do not
+	 * touch the connection at all. */
+	secret_hex = (conn->dom_ctx != NULL)
+	                 ? conn->dom_ctx->config[PROXY_PROTOCOL_SECRET]
+	                 : NULL;
+	if (secret_hex == NULL || secret_hex[0] == '\0') {
+		return;
+	}
+	secret_len = proxy_v2_hex_decode(secret_hex, secret, sizeof(secret));
+	if (secret_len <= 0) {
+		return; /* misconfigured secret */
+	}
+
+	/* Peek the fixed 16-byte v2 header. Retry until 16 bytes are available, or
+	 * bail as soon as the available prefix already fails to match the
+	 * signature (i.e. this is a normal request, not a PROXY header). */
+	have = 0;
+	while (have < 16) {
+		int n;
+		pfd.fd = conn->client.sock;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 1000) <= 0) {
+			return;
+		}
+		n = (int)recv(conn->client.sock, hdr, sizeof(hdr), MSG_PEEK);
+		if (n <= 0) {
+			return;
+		}
+		if (memcmp(hdr, sig, (n < 12) ? (size_t)n : (size_t)12) != 0) {
+			return;
+		}
+		/* MSG_PEEK does not consume, so poll() keeps reporting the same bytes
+		 * readable: if the peeked count did not grow since the last iteration
+		 * the peer has stalled mid-signature. Bail instead of spinning at 100%
+		 * CPU (a real proxy writes all 16 bytes in one segment). */
+		if (n <= have) {
+			return;
+		}
+		have = n;
+	}
+	if ((hdr[12] & 0xF0) != 0x20) {
+		return; /* not version 2 */
+	}
+
+	addr_len = ((size_t)hdr[14] << 8) | (size_t)hdr[15];
+	total = 16 + addr_len;
+	if (total > sizeof(buf)) {
+		return;
+	}
+
+	/* Consume the whole header for real so the HTTP request follows it. */
+	got = 0;
+	while (got < total) {
+		int n;
+		pfd.fd = conn->client.sock;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 1000) <= 0) {
+			return;
+		}
+		n = (int)recv(conn->client.sock, buf + got, total - got, 0);
+		if (n <= 0) {
+			return;
+		}
+		got += (size_t)n;
+	}
+
+	/* Only the PROXY command (0x01) carries a real address; LOCAL (0x00) keeps
+	 * the original one. */
+	if ((hdr[12] & 0x0F) != 0x01) {
+		return;
+	}
+
+	a = buf + 16;
+	/* Note the address family/size but do NOT adopt the address yet - the header
+	 * must first prove it is trusted via the secret TLV below. */
+	if (hdr[13] == 0x11 && addr_len >= 12) { /* TCP over IPv4 */
+		addr_size = 12;
+	}
+#if defined(USE_IPV6)
+	else if (hdr[13] == 0x21 && addr_len >= 36) { /* TCP over IPv6 */
+		addr_size = 36;
+	}
+#endif
+	if (addr_size == 0) {
+		return; /* unsupported/short address block */
+	}
+
+	/* Walk the TLVs that follow the address block. Require the shared secret
+	 * (PP2_TYPE_PROXY_SECRET) before trusting the header, and note a
+	 * PP2_TYPE_SSL with PP2_CLIENT_SSL set (the client used TLS to the proxy). */
+	{
+		int token_ok = 0, ssl_flag = 0;
+		size_t off = addr_size;
+		while (off + 3 <= addr_len) {
+			const unsigned char t = a[off];
+			const size_t l = ((size_t)a[off + 1] << 8) | (size_t)a[off + 2];
+			off += 3;
+			if (off + l > addr_len) {
+				break;
+			}
+			if (t == PP2_TYPE_PROXY_SECRET && l == (size_t)secret_len) {
+				/* Constant-time compare so a co-resident process cannot time
+				 * byte-wise matching to recover the secret. */
+				unsigned char diff = 0;
+				size_t i;
+				for (i = 0; i < (size_t)secret_len; i++) {
+					diff |= (unsigned char)(a[off + i] ^ secret[i]);
+				}
+				if (diff == 0) {
+					token_ok = 1;
+				}
+			} else if (t == PP2_TYPE_SSL && l >= 1 && (a[off] & PP2_CLIENT_SSL)) {
+				ssl_flag = 1;
+			}
+			off += l;
+		}
+		if (!token_ok) {
+			return; /* secret missing or wrong - ignore the header */
+		}
+
+		/* Trusted: adopt the real client address and TLS status. */
+		if (hdr[13] == 0x11) { /* TCP over IPv4 */
+			memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
+			conn->client.rsa.sin.sin_family = AF_INET;
+			memcpy(&conn->client.rsa.sin.sin_addr, a, 4);
+			memcpy(&conn->client.rsa.sin.sin_port, a + 8, 2);
+		}
+#if defined(USE_IPV6)
+		else { /* TCP over IPv6 */
+			memset(&conn->client.rsa, 0, sizeof(conn->client.rsa));
+			conn->client.rsa.sin6.sin6_family = AF_INET6;
+			memcpy(&conn->client.rsa.sin6.sin6_addr, a, 16);
+			memcpy(&conn->client.rsa.sin6.sin6_port, a + 32, 2);
+		}
+#endif
+		conn->proxy_is_ssl = ssl_flag ? 1 : 0;
+	}
+}

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -3,14 +3,15 @@
 *  Network-wide ad blocking via your own hardware.
 *
 *  FTL Engine
-*  In-process TLS front terminator (HTTP/1.1)
+*  In-process TLS front terminator (HTTP/1.1, HTTP/2, HTTP/3)
 *
-*  Milestone M1: bind the public TLS port, terminate TLS, and forward the plain
-*  HTTP/1.1 byte stream to the CivetWeb backend on the loopback interface. TLS is
-*  the only thing this layer understands; everything above it (HTTP framing,
-*  keep-alive, routing, Lua, auth) stays in CivetWeb, which now speaks plain
-*  HTTP/1.1 on loopback. HTTP/2 (nghttp2) and HTTP/3 (nghttp3/QUIC) are added on
-*  top of this in later milestones.
+*  Bind the public TLS port, terminate TLS, and forward plain HTTP/1.1 to the
+*  CivetWeb backend on the loopback interface. TLS is the only thing this layer
+*  understands for HTTP/1.1; everything above it (HTTP framing, keep-alive,
+*  routing, Lua, auth) stays in CivetWeb, which now speaks plain HTTP/1.1 on
+*  loopback. On top of the same public port the terminator also gateways HTTP/2
+*  (nghttp2, ALPN "h2", over TLS/TCP) and HTTP/3 (nghttp3 over OpenSSL QUIC,
+*  ALPN "h3", over UDP), bridging both to the same HTTP/1.1 backend.
 *
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
@@ -25,6 +26,21 @@
 
 #ifdef HAVE_HTTP2
 #include <nghttp2/nghttp2.h>
+#endif
+
+#ifdef HAVE_HTTP3
+#include <openssl/quic.h>
+#include <openssl/bio.h>
+#include <openssl/opensslv.h>
+#include <nghttp3/nghttp3.h>
+#include <time.h>
+// The HTTP/3 gateway forwards the real client IP to the backend via
+// SSL_get_peer_addr(), a per-connection QUIC peer getter added in OpenSSL 4.0.
+// Refuse to build HTTP/3 against an older OpenSSL rather than silently
+// attributing every request to the loopback terminator.
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+#error "HTTP/3 requires OpenSSL >= 4.0, which provides SSL_get_peer_addr() for QUIC (needed to forward the real client IP). Upgrade OpenSSL to 4.0 or later, or build without nghttp3 to disable HTTP/3."
+#endif
 #endif
 
 #include <sys/socket.h>
@@ -53,6 +69,17 @@ static int backend_port = 0;
 static volatile bool running = false;
 static pthread_t accept_tid;
 static bool accept_tid_valid = false;
+
+#ifdef HAVE_HTTP3
+// HTTP/3 (QUIC) listener state. The QUIC side runs a dedicated event-loop
+// thread that owns one UDP socket, one OpenSSL QUIC listener, and every QUIC
+// connection and stream on top of it (see the HAVE_HTTP3 section below).
+static SSL_CTX *quic_ctx = NULL;
+static int quic_fd = -1;
+static pthread_t quic_tid;
+static bool quic_tid_valid = false;
+static volatile bool quic_running = false;
+#endif
 
 // Log the pending OpenSSL error queue at error level, prefixed with context.
 static void log_ssl_errors(const char *context)
@@ -238,37 +265,36 @@ static int write_all_ssl(SSL *ssl, const char *buf, size_t len)
 // bytes. Returns 0 and the header length in *out_len, or -1 for an unsupported
 // address family. CivetWeb parses this header and attributes the request to the
 // actual client instead of the loopback terminator, so client-IP-based logging
-// and auth stay correct.
-static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
+// and auth stay correct. This variant takes the addresses directly, so callers
+// without a client socket fd (e.g., the QUIC/HTTP3 gateway) can reuse it.
+static int build_proxy_v2_sa(const struct sockaddr_storage *src,
+                             const struct sockaddr_storage *dst,
+                             unsigned char *hdr, size_t *out_len)
 {
-	struct sockaddr_storage src, dst;
-	socklen_t sl = sizeof(src), dl = sizeof(dst);
-	if(getpeername(client_fd, (struct sockaddr *)&src, &sl) != 0 ||
-	   getsockname(client_fd, (struct sockaddr *)&dst, &dl) != 0)
-		return -1;
-
 	static const unsigned char sig[12] =
 		{ 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A };
 	memcpy(hdr, sig, sizeof(sig));
 	hdr[12] = 0x21; // version 2, PROXY command
+	memset(hdr + 16, 0, 36); // clear the address block (dst may be partial)
 	size_t len = 0;
 
-	if(src.ss_family == AF_INET)
+	if(src->ss_family == AF_INET)
 	{
-		const struct sockaddr_in *s = (const struct sockaddr_in *)&src;
-		const struct sockaddr_in *d = (const struct sockaddr_in *)&dst;
+		const struct sockaddr_in *s = (const struct sockaddr_in *)src;
+		const struct sockaddr_in *d = (const struct sockaddr_in *)dst;
 		hdr[13] = 0x11; // TCP over IPv4
 		hdr[14] = 0; hdr[15] = 12;
 		memcpy(hdr + 16, &s->sin_addr, 4);
-		memcpy(hdr + 20, &d->sin_addr, 4);
+		if(dst->ss_family == AF_INET)
+			memcpy(hdr + 20, &d->sin_addr, 4);
 		memcpy(hdr + 24, &s->sin_port, 2);
 		memcpy(hdr + 26, &d->sin_port, 2);
 		len = 16 + 12;
 	}
-	else if(src.ss_family == AF_INET6)
+	else if(src->ss_family == AF_INET6)
 	{
-		const struct sockaddr_in6 *s = (const struct sockaddr_in6 *)&src;
-		const struct sockaddr_in6 *d = (const struct sockaddr_in6 *)&dst;
+		const struct sockaddr_in6 *s = (const struct sockaddr_in6 *)src;
+		const struct sockaddr_in6 *d = (const struct sockaddr_in6 *)dst;
 		// The listener is dual-stack, so IPv4 clients arrive as v4-mapped IPv6;
 		// emit them as IPv4 for a faithful, compact header.
 		if(IN6_IS_ADDR_V4MAPPED(&s->sin6_addr))
@@ -276,7 +302,7 @@ static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
 			hdr[13] = 0x11;
 			hdr[14] = 0; hdr[15] = 12;
 			memcpy(hdr + 16, s->sin6_addr.s6_addr + 12, 4);
-			if(IN6_IS_ADDR_V4MAPPED(&d->sin6_addr))
+			if(dst->ss_family == AF_INET6 && IN6_IS_ADDR_V4MAPPED(&d->sin6_addr))
 				memcpy(hdr + 20, d->sin6_addr.s6_addr + 12, 4);
 			memcpy(hdr + 24, &s->sin6_port, 2);
 			memcpy(hdr + 26, &d->sin6_port, 2);
@@ -287,7 +313,8 @@ static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
 			hdr[13] = 0x21; // TCP over IPv6
 			hdr[14] = 0; hdr[15] = 36;
 			memcpy(hdr + 16, &s->sin6_addr, 16);
-			memcpy(hdr + 32, &d->sin6_addr, 16);
+			if(dst->ss_family == AF_INET6)
+				memcpy(hdr + 32, &d->sin6_addr, 16);
 			memcpy(hdr + 48, &s->sin6_port, 2);
 			memcpy(hdr + 50, &d->sin6_port, 2);
 			len = 16 + 36;
@@ -298,6 +325,18 @@ static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
 
 	*out_len = len;
 	return 0;
+}
+
+// Same, but derive the source/destination addresses from a connected client
+// socket via getpeername()/getsockname().
+static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
+{
+	struct sockaddr_storage src, dst;
+	socklen_t sl = sizeof(src), dl = sizeof(dst);
+	if(getpeername(client_fd, (struct sockaddr *)&src, &sl) != 0 ||
+	   getsockname(client_fd, (struct sockaddr *)&dst, &dl) != 0)
+		return -1;
+	return build_proxy_v2_sa(&src, &dst, hdr, out_len);
 }
 
 // Announce the real client to the backend by writing a PROXY protocol v2 header
@@ -376,37 +415,13 @@ static void relay(SSL *ssl, int client_fd, int be_fd)
 	}
 }
 
-#ifdef HAVE_HTTP2
+#if defined(HAVE_HTTP2) || defined(HAVE_HTTP3)
 // ---------------------------------------------------------------------------
-// HTTP/2 gateway (ALPN "h2")
-//
-// Runs an nghttp2 server session on the TLS connection and bridges every request
-// stream to a plain HTTP/1.1 request against the CivetWeb backend, translating
-// the response back to HTTP/2. CivetWeb keeps speaking HTTP/1.1 and never sees
-// HTTP/2.
-//
-// The gateway streams and multiplexes: each request stream gets its own
-// non-blocking backend connection, the request body is streamed to the backend
-// as it arrives (respecting HTTP/2 flow control), and the HTTP/1.1 response is
-// parsed incrementally and pulled back into HTTP/2 DATA frames on demand via an
-// nghttp2 data provider. A single poll() loop drives the client TLS socket and
-// every active backend socket, so many streams make progress concurrently and
-// no single stream blocks the whole session.
+// Helpers shared by the HTTP/2 and HTTP/3 gateways. Both terminate an upgraded
+// protocol on the public port and bridge every request to a plain HTTP/1.1
+// request against the CivetWeb backend, so the non-blocking backend socket, the
+// growing byte buffer, and the hop-by-hop header filter are common ground.
 // ---------------------------------------------------------------------------
-
-#define H2_REQHDR_MAX 8192u
-#define H2_MAX_HDRS 64u
-// Response header block size cap before we give up parsing.
-#define H2_RESP_HDR_MAX 65536u
-// Per-stream decoded response body high-water mark: once this much undelivered
-// body is buffered we stop reading the backend, applying backpressure toward the
-// (slower) client.
-#define H2_BODY_HIGH_WATER (256u * 1024u)
-// Soft cap on the outbound TLS buffer; we stop pulling more frames out of
-// nghttp2 once this much is queued for SSL_write().
-#define H2_WBUF_SOFT_CAP (512u * 1024u)
-// Maximum PROXY protocol v2 header size (16 fixed + 36 for IPv6).
-#define H2_PROXY_MAX 52u
 
 // EAGAIN and EWOULDBLOCK are the same value on Linux; test both only where they
 // actually differ so -Wlogical-op stays quiet.
@@ -415,83 +430,6 @@ static void relay(SSL *ssl, int client_fd, int be_fd)
 #else
 #define WOULDBLOCK(e) ((e) == EAGAIN)
 #endif
-
-// Request body framing towards the HTTP/1.1 backend.
-enum { REQ_NONE, REQ_RAW, REQ_CHUNKED };
-// Response body framing from the HTTP/1.1 backend.
-enum { BODY_NONE, BODY_LENGTH, BODY_CHUNKED, BODY_CLOSE };
-// Incremental Transfer-Encoding: chunked decoder states.
-enum { CH_SIZE, CH_EXT, CH_SIZE_LF, CH_DATA, CH_DATA_CR, CH_DATA_LF, CH_TRAILER, CH_DONE };
-
-struct h2_conn;
-
-struct h2_stream {
-	struct h2_stream *next;
-	struct h2_conn *conn;
-	int32_t stream_id;
-
-	// Request pseudo-headers and the reconstructed HTTP/1.1 header block
-	char method[16];
-	char authority[256];
-	char path[2048];
-	char reqhdr[H2_REQHDR_MAX];
-	size_t reqhdr_len;
-	bool content_length_seen;
-
-	// Backend connection (non-blocking)
-	int be_fd;
-	bool be_connecting;
-
-	// Outbound request buffer (PROXY header + HTTP/1.1 head + body), drained to
-	// the backend from [req_out_off, req_out_len)
-	char *req_out;
-	size_t req_out_len, req_out_off, req_out_cap;
-	int req_mode;
-	bool req_started;
-	// Client DATA bytes appended but not yet acknowledged to nghttp2's flow
-	// control; credited once they have been flushed to the backend.
-	size_t body_uncredited;
-
-	// Response header accumulation and parse state
-	bool resp_headers_parsed;
-	bool resp_headers_sent;
-	char *resp_hdr;
-	size_t resp_hdr_len, resp_hdr_cap;
-
-	// Response body framing / decoder state
-	int body_mode;
-	size_t body_remaining;   // BODY_LENGTH: bytes still expected
-	int chunk_state;
-	size_t chunk_size;       // chunked: size being accumulated
-	size_t chunk_remaining;  // chunked: bytes left in the current chunk
-	size_t trailer_line_len; // chunked: length of the current trailer line
-
-	// Decoded response body ready for the nghttp2 data provider, served from
-	// [body_off, body_len)
-	char *body_buf;
-	size_t body_len, body_off, body_cap;
-	bool resp_complete;      // full response body has been decoded
-	bool resp_deferred;      // data provider is parked on NGHTTP2_ERR_DEFERRED
-	bool error;              // gateway error: backend torn down, stream ending
-};
-
-struct h2_conn {
-	SSL *ssl;
-	int client_fd;
-	nghttp2_session *session;
-	struct h2_stream *streams; // singly linked list of active streams
-
-	// Outbound TLS buffer: serialized nghttp2 frames awaiting SSL_write(),
-	// pending in [woff, wlen)
-	char *wbuf;
-	size_t wlen, woff, wcap;
-	bool ssl_want_write;       // last SSL_write() returned WANT_WRITE
-
-	// Reused poll() scratch buffers (pfds[0] is always the client fd)
-	struct pollfd *pfds;
-	struct h2_stream **pmap;
-	size_t pcap;
-};
 
 // Put fd into non-blocking mode. Returns 0 or -1.
 static int set_nonblocking(int fd)
@@ -505,8 +443,9 @@ static int set_nonblocking(int fd)
 // Open a non-blocking plaintext TCP socket to the CivetWeb backend on loopback.
 // Sets *connected to true if the connection completed immediately (the common
 // case on loopback), false if it is still in progress (EINPROGRESS). Returns the
-// fd or -1.
-static int connect_backend_nb(bool *connected)
+// fd or -1. Shared by the streaming gateways; marked inline so a build with only
+// one of HTTP/2 / HTTP/3 does not warn when the other's caller is absent.
+static inline int connect_backend_nb(bool *connected)
 {
 	const int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
 	if(fd < 0)
@@ -552,8 +491,9 @@ static int buf_append(char **buf, size_t *len, size_t *cap, const char *data, si
 	return 0;
 }
 
-// Hop-by-hop / pseudo-reconstructed headers that must not be forwarded.
-static bool h2_skip_header(const char *name, size_t len)
+// Hop-by-hop / pseudo-reconstructed headers that must not be forwarded between
+// the upgraded protocol and the HTTP/1.1 backend, in either direction.
+static bool hbh_skip_header(const char *name, size_t len)
 {
 	static const char *const skip[] = {
 		"connection", "keep-alive", "proxy-connection", "transfer-encoding",
@@ -565,31 +505,281 @@ static bool h2_skip_header(const char *name, size_t len)
 	return false;
 }
 
+// Request body framing towards the HTTP/1.1 backend.
+enum { REQ_NONE, REQ_RAW, REQ_CHUNKED };
+// Response body framing from the HTTP/1.1 backend.
+enum { BODY_NONE, BODY_LENGTH, BODY_CHUNKED, BODY_CLOSE };
+// Incremental Transfer-Encoding: chunked decoder states.
+enum { CH_SIZE, CH_EXT, CH_SIZE_LF, CH_DATA, CH_DATA_CR, CH_DATA_LF, CH_TRAILER, CH_DONE };
+
+// Protocol-agnostic HTTP/1.1 backend-bridge state. Each streaming gateway embeds
+// one of these per request stream and drives it through the be_* helpers below:
+// an outbound request buffer, an incrementally parsed response-header
+// accumulator, the response body de-framing (Content-Length / chunked / close)
+// state machine, and a decoded-body buffer for the protocol's data provider.
+struct be_bridge {
+	// Outbound request buffer (PROXY header + HTTP/1.1 head + body), drained to
+	// the backend from [req_out_off, req_out_len)
+	char *req_out;
+	size_t req_out_len, req_out_off, req_out_cap;
+	int req_mode;
+	bool req_started;
+
+	// Response header accumulation and parse state
+	char *resp_hdr;
+	size_t resp_hdr_len, resp_hdr_cap;
+	bool resp_headers_parsed;
+
+	// Response body framing / decoder state
+	int body_mode;
+	size_t body_remaining;   // BODY_LENGTH: bytes still expected
+	int chunk_state;
+	size_t chunk_size;       // chunked: size being accumulated
+	size_t chunk_remaining;  // chunked: bytes left in the current chunk
+	size_t trailer_line_len; // chunked: length of the current trailer line
+
+	// Decoded response body ready for the data provider, served from
+	// [body_off, body_len)
+	char *body_buf;
+	size_t body_len, body_off, body_cap;
+	bool resp_complete;      // full response body has been decoded
+};
+
+// The be_* helpers below are marked inline so a build with only one of the two
+// streaming gateways does not warn about the ones the other gateway would call.
+
 // Queue bytes to send to the backend, compacting already-sent data first so the
 // buffer does not grow without bound. Returns 0 or -1.
-static int h2_req_push(struct h2_stream *s, const char *data, size_t n)
+static inline int be_req_push(struct be_bridge *b, const char *data, size_t n)
 {
-	if(s->req_out_off > 0)
+	if(b->req_out_off > 0)
 	{
-		memmove(s->req_out, s->req_out + s->req_out_off, s->req_out_len - s->req_out_off);
-		s->req_out_len -= s->req_out_off;
-		s->req_out_off = 0;
+		memmove(b->req_out, b->req_out + b->req_out_off, b->req_out_len - b->req_out_off);
+		b->req_out_len -= b->req_out_off;
+		b->req_out_off = 0;
 	}
-	return buf_append(&s->req_out, &s->req_out_len, &s->req_out_cap, data, n);
+	return buf_append(&b->req_out, &b->req_out_len, &b->req_out_cap, data, n);
 }
 
 // Queue decoded response body bytes for the data provider, compacting already-
 // delivered data first. Returns 0 or -1.
-static int h2_body_push(struct h2_stream *s, const char *data, size_t n)
+static inline int be_body_push(struct be_bridge *b, const char *data, size_t n)
 {
-	if(s->body_off > 0)
+	if(b->body_off > 0)
 	{
-		memmove(s->body_buf, s->body_buf + s->body_off, s->body_len - s->body_off);
-		s->body_len -= s->body_off;
-		s->body_off = 0;
+		memmove(b->body_buf, b->body_buf + b->body_off, b->body_len - b->body_off);
+		b->body_len -= b->body_off;
+		b->body_off = 0;
 	}
-	return buf_append(&s->body_buf, &s->body_len, &s->body_cap, data, n);
+	return buf_append(&b->body_buf, &b->body_len, &b->body_cap, data, n);
 }
+
+// Incrementally de-chunk a Transfer-Encoding: chunked response body, appending
+// decoded bytes to the bridge body buffer. State persists across calls. Returns
+// 0 or -1.
+static inline int be_feed_chunked(struct be_bridge *b, const char *data, size_t n)
+{
+	size_t i = 0;
+	while(i < n && b->chunk_state != CH_DONE)
+	{
+		const char c = data[i];
+		switch(b->chunk_state)
+		{
+			case CH_SIZE:
+				if(c >= '0' && c <= '9') { b->chunk_size = b->chunk_size * 16u + (size_t)(c - '0'); i++; }
+				else if(c >= 'a' && c <= 'f') { b->chunk_size = b->chunk_size * 16u + (size_t)(c - 'a' + 10); i++; }
+				else if(c >= 'A' && c <= 'F') { b->chunk_size = b->chunk_size * 16u + (size_t)(c - 'A' + 10); i++; }
+				else if(c == ';') { b->chunk_state = CH_EXT; i++; }
+				else if(c == '\r') { b->chunk_state = CH_SIZE_LF; i++; }
+				else i++; // tolerate stray bytes
+				break;
+			case CH_EXT: // chunk extension: skip to end of line
+				if(c == '\r') b->chunk_state = CH_SIZE_LF;
+				i++;
+				break;
+			case CH_SIZE_LF:
+				i++; // consume '\n'
+				if(b->chunk_size == 0) { b->chunk_state = CH_TRAILER; b->trailer_line_len = 0; }
+				else { b->chunk_remaining = b->chunk_size; b->chunk_state = CH_DATA; }
+				break;
+			case CH_DATA:
+			{
+				const size_t avail = n - i;
+				const size_t take = (avail < b->chunk_remaining) ? avail : b->chunk_remaining;
+				if(take > 0)
+				{
+					if(be_body_push(b, data + i, take) != 0)
+						return -1;
+					i += take;
+					b->chunk_remaining -= take;
+				}
+				if(b->chunk_remaining == 0)
+					b->chunk_state = CH_DATA_CR;
+				break;
+			}
+			case CH_DATA_CR:
+				if(c == '\r') b->chunk_state = CH_DATA_LF;
+				i++;
+				break;
+			case CH_DATA_LF:
+				if(c == '\n') { b->chunk_size = 0; b->chunk_state = CH_SIZE; }
+				i++;
+				break;
+			case CH_TRAILER: // optional trailers terminated by a blank line
+				if(c == '\n') { if(b->trailer_line_len == 0) b->chunk_state = CH_DONE; else b->trailer_line_len = 0; }
+				else if(c != '\r') b->trailer_line_len++;
+				i++;
+				break;
+		}
+	}
+	if(b->chunk_state == CH_DONE)
+		b->resp_complete = true;
+	return 0;
+}
+
+// Decode response body bytes according to the negotiated framing and append the
+// result to the bridge body buffer. Returns 0 or -1.
+static inline int be_feed_body(struct be_bridge *b, const char *data, size_t n)
+{
+	switch(b->body_mode)
+	{
+		case BODY_NONE:
+			return 0;
+		case BODY_LENGTH:
+		{
+			const size_t take = (n < b->body_remaining) ? n : b->body_remaining;
+			if(take > 0 && be_body_push(b, data, take) != 0)
+				return -1;
+			b->body_remaining -= take;
+			if(b->body_remaining == 0)
+				b->resp_complete = true;
+			return 0;
+		}
+		case BODY_CHUNKED:
+			return be_feed_chunked(b, data, n);
+		case BODY_CLOSE:
+		default:
+			if(n > 0 && be_body_push(b, data, n) != 0)
+				return -1;
+			return 0; // completion is signalled by the backend closing
+	}
+}
+
+// True if the response body framing is known and has not reached its end, i.e.
+// an early backend close or read error would truncate it. Close-delimited
+// (BODY_CLOSE) and body-less (BODY_NONE) responses end legitimately on close.
+static inline bool be_body_truncated(const struct be_bridge *b)
+{
+	if(b->body_mode == BODY_LENGTH)
+		return b->body_remaining > 0;
+	if(b->body_mode == BODY_CHUNKED)
+		return b->chunk_state != CH_DONE;
+	return false;
+}
+
+// Format the plain HTTP/1.1 request head (request line + reconstructed headers)
+// for the backend into out. The backend is asked to close after the response
+// (Connection: close), so responses are cleanly delimited. extra_headers, if
+// non-NULL, is inserted verbatim after the reconstructed headers (e.g. a framing
+// header such as Transfer-Encoding or Content-Length). Returns the snprintf()
+// result: the would-be length, negative on error, >= outcap if truncated.
+static inline int be_format_request_head(char *out, size_t outcap,
+                                         const char *method, const char *path,
+                                         const char *authority, const char *reqhdr,
+                                         size_t reqhdr_len, const char *extra_headers)
+{
+	return snprintf(out, outcap,
+	                "%s %s HTTP/1.1\r\nHost: %s\r\n%.*s%sConnection: close\r\n\r\n",
+	                method[0] ? method : "GET",
+	                path[0] ? path : "/",
+	                authority[0] ? authority : "pi.hole",
+	                (int)reqhdr_len, reqhdr,
+	                extra_headers ? extra_headers : "");
+}
+#endif /* HAVE_HTTP2 || HAVE_HTTP3 */
+
+#ifdef HAVE_HTTP2
+// ---------------------------------------------------------------------------
+// HTTP/2 gateway (ALPN "h2")
+//
+// Runs an nghttp2 server session on the TLS connection and bridges every request
+// stream to a plain HTTP/1.1 request against the CivetWeb backend, translating
+// the response back to HTTP/2. CivetWeb keeps speaking HTTP/1.1 and never sees
+// HTTP/2.
+//
+// The gateway streams and multiplexes: each request stream gets its own
+// non-blocking backend connection, the request body is streamed to the backend
+// as it arrives (respecting HTTP/2 flow control), and the HTTP/1.1 response is
+// parsed incrementally and pulled back into HTTP/2 DATA frames on demand via an
+// nghttp2 data provider. A single poll() loop drives the client TLS socket and
+// every active backend socket, so many streams make progress concurrently and
+// no single stream blocks the whole session.
+// ---------------------------------------------------------------------------
+
+#define H2_REQHDR_MAX 8192u
+#define H2_MAX_HDRS 64u
+// Response header block size cap before we give up parsing.
+#define H2_RESP_HDR_MAX 65536u
+// Per-stream decoded response body high-water mark: once this much undelivered
+// body is buffered we stop reading the backend, applying backpressure toward the
+// (slower) client.
+#define H2_BODY_HIGH_WATER (256u * 1024u)
+// Soft cap on the outbound TLS buffer; we stop pulling more frames out of
+// nghttp2 once this much is queued for SSL_write().
+#define H2_WBUF_SOFT_CAP (512u * 1024u)
+// Maximum PROXY protocol v2 header size (16 fixed + 36 for IPv6).
+#define H2_PROXY_MAX 52u
+
+struct h2_conn;
+
+struct h2_stream {
+	struct h2_stream *next;
+	struct h2_conn *conn;
+	int32_t stream_id;
+
+	// Request pseudo-headers and the reconstructed HTTP/1.1 header block
+	char method[16];
+	char authority[256];
+	char path[2048];
+	char reqhdr[H2_REQHDR_MAX];
+	size_t reqhdr_len;
+	bool content_length_seen;
+
+	// Backend connection (non-blocking)
+	int be_fd;
+	bool be_connecting;
+
+	// Shared HTTP/1.1 backend-bridge state: request-out buffer, response-header
+	// accumulator, body de-framing, and the decoded-body buffer.
+	struct be_bridge be;
+
+	// Client DATA bytes appended but not yet acknowledged to nghttp2's flow
+	// control; credited once they have been flushed to the backend.
+	size_t body_uncredited;
+
+	// Response submission / data-provider state (nghttp2-specific)
+	bool resp_headers_sent;
+	bool resp_deferred;      // data provider is parked on NGHTTP2_ERR_DEFERRED
+	bool error;              // gateway error: backend torn down, stream ending
+};
+
+struct h2_conn {
+	SSL *ssl;
+	int client_fd;
+	nghttp2_session *session;
+	struct h2_stream *streams; // singly linked list of active streams
+
+	// Outbound TLS buffer: serialized nghttp2 frames awaiting SSL_write(),
+	// pending in [woff, wlen)
+	char *wbuf;
+	size_t wlen, woff, wcap;
+	bool ssl_want_write;       // last SSL_write() returned WANT_WRITE
+
+	// Reused poll() scratch buffers (pfds[0] is always the client fd)
+	struct pollfd *pfds;
+	struct h2_stream **pmap;
+	size_t pcap;
+};
 
 static void h2_stream_link(struct h2_conn *c, struct h2_stream *s)
 {
@@ -617,9 +807,9 @@ static void h2_stream_free(struct h2_stream *s)
 		return;
 	if(s->be_fd >= 0)
 		close(s->be_fd);
-	free(s->req_out);
-	free(s->resp_hdr);
-	free(s->body_buf);
+	free(s->be.req_out);
+	free(s->be.resp_hdr);
+	free(s->be.body_buf);
 	free(s);
 }
 
@@ -649,7 +839,7 @@ static void h2_gateway_error(struct h2_stream *s, const char *status3)
 {
 	h2_be_close(s);
 	s->error = true;
-	s->resp_complete = true;
+	s->be.resp_complete = true;
 	if(s->resp_headers_sent)
 	{
 		nghttp2_submit_rst_stream(s->conn->session, NGHTTP2_FLAG_NONE,
@@ -670,11 +860,11 @@ static void h2_gateway_error(struct h2_stream *s, const char *status3)
 static void h2_start_backend(struct h2_stream *s, bool has_body)
 {
 	if(!has_body)
-		s->req_mode = REQ_NONE;
+		s->be.req_mode = REQ_NONE;
 	else if(s->content_length_seen)
-		s->req_mode = REQ_RAW;      // length known: forward the body verbatim
+		s->be.req_mode = REQ_RAW;      // length known: forward the body verbatim
 	else
-		s->req_mode = REQ_CHUNKED;  // unknown length: chunk it to the backend
+		s->be.req_mode = REQ_CHUNKED;  // unknown length: chunk it to the backend
 
 	bool connected = false;
 	s->be_fd = connect_backend_nb(&connected);
@@ -688,26 +878,23 @@ static void h2_start_backend(struct h2_stream *s, bool has_body)
 	unsigned char ph[H2_PROXY_MAX];
 	size_t phlen = 0;
 	if(build_proxy_v2(s->conn->client_fd, ph, &phlen) != 0 ||
-	   h2_req_push(s, (const char *)ph, phlen) != 0)
+	   be_req_push(&s->be, (const char *)ph, phlen) != 0)
 	{
 		h2_gateway_error(s, "502");
 		return;
 	}
 
 	char head[H2_REQHDR_MAX + 4096];
-	const int hl = snprintf(head, sizeof(head),
-	                        "%s %s HTTP/1.1\r\nHost: %s\r\n%.*s%sConnection: close\r\n\r\n",
-	                        s->method[0] ? s->method : "GET",
-	                        s->path[0] ? s->path : "/",
-	                        s->authority[0] ? s->authority : "pi.hole",
-	                        (int)s->reqhdr_len, s->reqhdr,
-	                        s->req_mode == REQ_CHUNKED ? "Transfer-Encoding: chunked\r\n" : "");
-	if(hl < 0 || (size_t)hl >= sizeof(head) || h2_req_push(s, head, (size_t)hl) != 0)
+	const int hl = be_format_request_head(head, sizeof(head), s->method, s->path,
+	                                      s->authority, s->reqhdr, s->reqhdr_len,
+	                                      s->be.req_mode == REQ_CHUNKED ?
+	                                          "Transfer-Encoding: chunked\r\n" : "");
+	if(hl < 0 || (size_t)hl >= sizeof(head) || be_req_push(&s->be, head, (size_t)hl) != 0)
 	{
 		h2_gateway_error(s, "500");
 		return;
 	}
-	s->req_started = true;
+	s->be.req_started = true;
 }
 
 // nghttp2 data provider: hand decoded response body bytes to nghttp2 on demand.
@@ -720,10 +907,10 @@ static nghttp2_ssize h2_body_read(nghttp2_session *session, int32_t stream_id,
 	struct h2_stream *s = (struct h2_stream *)source->ptr;
 	(void)session; (void)stream_id; (void)user_data;
 
-	const size_t avail = s->body_len - s->body_off;
+	const size_t avail = s->be.body_len - s->be.body_off;
 	if(avail == 0)
 	{
-		if(s->resp_complete)
+		if(s->be.resp_complete)
 		{
 			*data_flags |= NGHTTP2_DATA_FLAG_EOF;
 			return 0;
@@ -733,11 +920,11 @@ static nghttp2_ssize h2_body_read(nghttp2_session *session, int32_t stream_id,
 	}
 
 	const size_t n = (avail < length) ? avail : length;
-	memcpy(buf, s->body_buf + s->body_off, n);
-	s->body_off += n;
-	if(s->body_off == s->body_len)
-		s->body_off = s->body_len = 0;
-	if(s->resp_complete && s->body_len == 0)
+	memcpy(buf, s->be.body_buf + s->be.body_off, n);
+	s->be.body_off += n;
+	if(s->be.body_off == s->be.body_len)
+		s->be.body_off = s->be.body_len = 0;
+	if(s->be.resp_complete && s->be.body_len == 0)
 		*data_flags |= NGHTTP2_DATA_FLAG_EOF;
 	return (nghttp2_ssize)n;
 }
@@ -805,7 +992,7 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 					clen = (size_t)strtoull(val, NULL, 10);
 					h2_add_nv(nva, &nvlen, line, val);
 				}
-				else if(nlen > 0 && !h2_skip_header(line, nlen))
+				else if(nlen > 0 && !hbh_skip_header(line, nlen))
 				{
 					h2_add_nv(nva, &nvlen, line, val);
 				}
@@ -825,24 +1012,24 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 		no_body = true;
 
 	if(no_body)
-		s->body_mode = BODY_NONE;
+		s->be.body_mode = BODY_NONE;
 	else if(chunked)
 	{
-		s->body_mode = BODY_CHUNKED;
-		s->chunk_state = CH_SIZE;
+		s->be.body_mode = BODY_CHUNKED;
+		s->be.chunk_state = CH_SIZE;
 	}
 	else if(have_clen)
 	{
-		s->body_mode = BODY_LENGTH;
-		s->body_remaining = clen;
+		s->be.body_mode = BODY_LENGTH;
+		s->be.body_remaining = clen;
 	}
 	else
-		s->body_mode = BODY_CLOSE; // length delimited by the backend closing
+		s->be.body_mode = BODY_CLOSE; // length delimited by the backend closing
 
-	s->resp_headers_parsed = true;
+	s->be.resp_headers_parsed = true;
 
-	const bool empty = (s->body_mode == BODY_NONE) ||
-	                   (s->body_mode == BODY_LENGTH && s->body_remaining == 0);
+	const bool empty = (s->be.body_mode == BODY_NONE) ||
+	                   (s->be.body_mode == BODY_LENGTH && s->be.body_remaining == 0);
 	nghttp2_data_provider2 prd;
 	prd.source.ptr = s;
 	prd.read_callback = h2_body_read;
@@ -850,126 +1037,35 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 	                                        nva, nvlen, empty ? NULL : &prd);
 	s->resp_headers_sent = true;
 	if(empty)
-		s->resp_complete = true;
+		s->be.resp_complete = true;
 	return (rv == 0) ? 0 : -1;
-}
-
-// Incrementally de-chunk a Transfer-Encoding: chunked response body, appending
-// decoded bytes to the stream body buffer. State persists across calls. Returns
-// 0 or -1.
-static int h2_feed_chunked(struct h2_stream *s, const char *data, size_t n)
-{
-	size_t i = 0;
-	while(i < n && s->chunk_state != CH_DONE)
-	{
-		const char c = data[i];
-		switch(s->chunk_state)
-		{
-			case CH_SIZE:
-				if(c >= '0' && c <= '9') { s->chunk_size = s->chunk_size * 16u + (size_t)(c - '0'); i++; }
-				else if(c >= 'a' && c <= 'f') { s->chunk_size = s->chunk_size * 16u + (size_t)(c - 'a' + 10); i++; }
-				else if(c >= 'A' && c <= 'F') { s->chunk_size = s->chunk_size * 16u + (size_t)(c - 'A' + 10); i++; }
-				else if(c == ';') { s->chunk_state = CH_EXT; i++; }
-				else if(c == '\r') { s->chunk_state = CH_SIZE_LF; i++; }
-				else i++; // tolerate stray bytes
-				break;
-			case CH_EXT: // chunk extension: skip to end of line
-				if(c == '\r') s->chunk_state = CH_SIZE_LF;
-				i++;
-				break;
-			case CH_SIZE_LF:
-				i++; // consume '\n'
-				if(s->chunk_size == 0) { s->chunk_state = CH_TRAILER; s->trailer_line_len = 0; }
-				else { s->chunk_remaining = s->chunk_size; s->chunk_state = CH_DATA; }
-				break;
-			case CH_DATA:
-			{
-				const size_t avail = n - i;
-				const size_t take = (avail < s->chunk_remaining) ? avail : s->chunk_remaining;
-				if(take > 0)
-				{
-					if(h2_body_push(s, data + i, take) != 0)
-						return -1;
-					i += take;
-					s->chunk_remaining -= take;
-				}
-				if(s->chunk_remaining == 0)
-					s->chunk_state = CH_DATA_CR;
-				break;
-			}
-			case CH_DATA_CR:
-				if(c == '\r') s->chunk_state = CH_DATA_LF;
-				i++;
-				break;
-			case CH_DATA_LF:
-				if(c == '\n') { s->chunk_size = 0; s->chunk_state = CH_SIZE; }
-				i++;
-				break;
-			case CH_TRAILER: // optional trailers terminated by a blank line
-				if(c == '\n') { if(s->trailer_line_len == 0) s->chunk_state = CH_DONE; else s->trailer_line_len = 0; }
-				else if(c != '\r') s->trailer_line_len++;
-				i++;
-				break;
-		}
-	}
-	if(s->chunk_state == CH_DONE)
-		s->resp_complete = true;
-	return 0;
-}
-
-// Decode response body bytes according to the negotiated framing and append the
-// result to the stream body buffer. Returns 0 or -1.
-static int h2_feed_body(struct h2_stream *s, const char *data, size_t n)
-{
-	switch(s->body_mode)
-	{
-		case BODY_NONE:
-			return 0;
-		case BODY_LENGTH:
-		{
-			const size_t take = (n < s->body_remaining) ? n : s->body_remaining;
-			if(take > 0 && h2_body_push(s, data, take) != 0)
-				return -1;
-			s->body_remaining -= take;
-			if(s->body_remaining == 0)
-				s->resp_complete = true;
-			return 0;
-		}
-		case BODY_CHUNKED:
-			return h2_feed_chunked(s, data, n);
-		case BODY_CLOSE:
-		default:
-			if(n > 0 && h2_body_push(s, data, n) != 0)
-				return -1;
-			return 0; // completion is signalled by the backend closing
-	}
 }
 
 // Feed raw bytes read from the backend socket: accumulate and parse the response
 // header block first, then decode the body incrementally. Returns 0 or -1.
 static int h2_feed(struct h2_stream *s, const char *data, size_t n)
 {
-	if(s->resp_headers_parsed)
-		return h2_feed_body(s, data, n);
+	if(s->be.resp_headers_parsed)
+		return be_feed_body(&s->be, data, n);
 
-	if(buf_append(&s->resp_hdr, &s->resp_hdr_len, &s->resp_hdr_cap, data, n) != 0)
+	if(buf_append(&s->be.resp_hdr, &s->be.resp_hdr_len, &s->be.resp_hdr_cap, data, n) != 0)
 		return -1;
-	char *end = memmem(s->resp_hdr, s->resp_hdr_len, "\r\n\r\n", 4);
+	char *end = memmem(s->be.resp_hdr, s->be.resp_hdr_len, "\r\n\r\n", 4);
 	if(end == NULL)
-		return (s->resp_hdr_len > H2_RESP_HDR_MAX) ? -1 : 0; // need more headers
+		return (s->be.resp_hdr_len > H2_RESP_HDR_MAX) ? -1 : 0; // need more headers
 
-	const size_t hdrlen = (size_t)(end - s->resp_hdr);
+	const size_t hdrlen = (size_t)(end - s->be.resp_hdr);
 	const size_t consumed = hdrlen + 4;
-	if(h2_parse_and_submit(s, s->resp_hdr, hdrlen) != 0)
+	if(h2_parse_and_submit(s, s->be.resp_hdr, hdrlen) != 0)
 		return -1;
 	// Any bytes past the header terminator are the start of the body. Copy them
-	// out (h2_body_push copies) before freeing the header buffer.
-	const size_t leftover = s->resp_hdr_len - consumed;
-	if(leftover > 0 && h2_feed_body(s, s->resp_hdr + consumed, leftover) != 0)
+	// out (be_body_push copies) before freeing the header buffer.
+	const size_t leftover = s->be.resp_hdr_len - consumed;
+	if(leftover > 0 && be_feed_body(&s->be, s->be.resp_hdr + consumed, leftover) != 0)
 		return -1;
-	free(s->resp_hdr);
-	s->resp_hdr = NULL;
-	s->resp_hdr_len = s->resp_hdr_cap = 0;
+	free(s->be.resp_hdr);
+	s->be.resp_hdr = NULL;
+	s->be.resp_hdr_len = s->be.resp_hdr_cap = 0;
 	return 0;
 }
 
@@ -992,12 +1088,12 @@ static void h2_be_writable(struct h2_stream *s)
 		}
 		s->be_connecting = false;
 	}
-	while(s->req_out_off < s->req_out_len)
+	while(s->be.req_out_off < s->be.req_out_len)
 	{
-		const ssize_t w = write(s->be_fd, s->req_out + s->req_out_off,
-		                        s->req_out_len - s->req_out_off);
+		const ssize_t w = write(s->be_fd, s->be.req_out + s->be.req_out_off,
+		                        s->be.req_out_len - s->be.req_out_off);
 		if(w > 0)
-			s->req_out_off += (size_t)w;
+			s->be.req_out_off += (size_t)w;
 		else if(w < 0 && errno == EINTR)
 			continue;
 		else if(w < 0 && WOULDBLOCK(errno))
@@ -1008,9 +1104,9 @@ static void h2_be_writable(struct h2_stream *s)
 			return;
 		}
 	}
-	if(s->req_out_off == s->req_out_len)
+	if(s->be.req_out_off == s->be.req_out_len)
 	{
-		s->req_out_off = s->req_out_len = 0;
+		s->be.req_out_off = s->be.req_out_len = 0;
 		if(s->body_uncredited > 0)
 		{
 			nghttp2_session_consume(s->conn->session, s->stream_id, s->body_uncredited);
@@ -1037,22 +1133,24 @@ static void h2_be_readable(struct h2_stream *s)
 				h2_gateway_error(s, "502");
 				return;
 			}
-			if(s->resp_complete)
+			if(s->be.resp_complete)
 				break;
-			if((s->body_len - s->body_off) >= H2_BODY_HIGH_WATER)
+			if((s->be.body_len - s->be.body_off) >= H2_BODY_HIGH_WATER)
 				break; // backpressure: let the client drain first
 			continue;
 		}
 		if(r == 0)
 		{
 			// Backend closed. For close-delimited bodies this is the normal end;
-			// for framed bodies it truncates, but we still finish the stream.
-			if(!s->resp_headers_parsed)
+			// for a length/chunked-framed body that has not reached its end it is
+			// a truncation, which we signal to the client with RST_STREAM rather
+			// than delivering a silently short body as if complete.
+			if(!s->be.resp_headers_parsed || be_body_truncated(&s->be))
 			{
 				h2_gateway_error(s, "502");
 				return;
 			}
-			s->resp_complete = true;
+			s->be.resp_complete = true;
 			h2_be_close(s);
 			break;
 		}
@@ -1060,22 +1158,22 @@ static void h2_be_readable(struct h2_stream *s)
 			continue;
 		if(WOULDBLOCK(errno))
 			break;
-		// Fatal read error
-		if(!s->resp_headers_parsed)
+		// Fatal read error: never a legitimate end of a framed body.
+		if(!s->be.resp_headers_parsed || be_body_truncated(&s->be))
 		{
 			h2_gateway_error(s, "502");
 			return;
 		}
-		s->resp_complete = true;
+		s->be.resp_complete = true;
 		h2_be_close(s);
 		break;
 	}
 
 	// The response is fully decoded; the backend socket is no longer needed.
-	if(s->resp_complete && s->be_fd >= 0)
+	if(s->be.resp_complete && s->be_fd >= 0)
 		h2_be_close(s);
 	// Wake a parked data provider now that there is progress (more body or EOF).
-	if(s->resp_deferred && ((s->body_len - s->body_off) > 0 || s->resp_complete))
+	if(s->resp_deferred && ((s->be.body_len - s->be.body_off) > 0 || s->be.resp_complete))
 	{
 		s->resp_deferred = false;
 		nghttp2_session_resume_data(s->conn->session, s->stream_id);
@@ -1122,10 +1220,8 @@ static int h2_on_header(nghttp2_session *session, const nghttp2_frame *frame,
 		return 0;
 	}
 
-	if(h2_skip_header(n, namelen))
+	if(hbh_skip_header(n, namelen))
 		return 0;
-	if(namelen == 14 && strncasecmp(n, "content-length", 14) == 0)
-		s->content_length_seen = true;
 
 	const size_t need = namelen + 2 + valuelen + 2;
 	if(s->reqhdr_len + need < sizeof(s->reqhdr))
@@ -1136,6 +1232,11 @@ static int h2_on_header(nghttp2_session *session, const nghttp2_frame *frame,
 		memcpy(p, v, valuelen); p += valuelen;
 		*p++ = '\r'; *p++ = '\n';
 		s->reqhdr_len += need;
+		// Only trust a Content-Length we actually forwarded: if the header did
+		// not fit and was dropped, the request must instead be framed as chunked
+		// (see h2_start_backend()), so leave content_length_seen false.
+		if(namelen == 14 && strncasecmp(n, "content-length", 14) == 0)
+			s->content_length_seen = true;
 	}
 	return 0;
 }
@@ -1156,21 +1257,21 @@ static int h2_on_data_chunk(nghttp2_session *session, uint8_t flags, int32_t str
 		return 0;
 	}
 	s->body_uncredited += len;
-	if(s->req_mode == REQ_CHUNKED)
+	if(s->be.req_mode == REQ_CHUNKED)
 	{
 		if(len > 0)
 		{
 			char hdr[32];
 			const int hn = snprintf(hdr, sizeof(hdr), "%zx\r\n", len);
-			if(hn < 0 || h2_req_push(s, hdr, (size_t)hn) != 0 ||
-			   h2_req_push(s, (const char *)data, len) != 0 ||
-			   h2_req_push(s, "\r\n", 2) != 0)
+			if(hn < 0 || be_req_push(&s->be, hdr, (size_t)hn) != 0 ||
+			   be_req_push(&s->be, (const char *)data, len) != 0 ||
+			   be_req_push(&s->be, "\r\n", 2) != 0)
 				return NGHTTP2_ERR_CALLBACK_FAILURE;
 		}
 	}
 	else if(len > 0)
 	{
-		if(h2_req_push(s, (const char *)data, len) != 0)
+		if(be_req_push(&s->be, (const char *)data, len) != 0)
 			return NGHTTP2_ERR_CALLBACK_FAILURE;
 	}
 	return 0;
@@ -1191,8 +1292,8 @@ static int h2_on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame
 	   (frame->hd.type == NGHTTP2_HEADERS || frame->hd.type == NGHTTP2_DATA))
 	{
 		struct h2_stream *s = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
-		if(s != NULL && !s->error && s->req_mode == REQ_CHUNKED && s->be_fd >= 0)
-			h2_req_push(s, "0\r\n\r\n", 5);
+		if(s != NULL && !s->error && s->be.req_mode == REQ_CHUNKED && s->be_fd >= 0)
+			be_req_push(&s->be, "0\r\n\r\n", 5);
 	}
 	return 0;
 }
@@ -1382,9 +1483,9 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 				ev |= POLLOUT; // wait for connect() to complete
 			else
 			{
-				if(s->req_out_off < s->req_out_len)
+				if(s->be.req_out_off < s->be.req_out_len)
 					ev |= POLLOUT; // request bytes still to flush
-				if(!s->resp_complete && (s->body_len - s->body_off) < H2_BODY_HIGH_WATER)
+				if(!s->be.resp_complete && (s->be.body_len - s->be.body_off) < H2_BODY_HIGH_WATER)
 					ev |= POLLIN;  // room for more response body
 			}
 			if(ev == 0)
@@ -1396,7 +1497,15 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 			nfds++;
 		}
 
-		const int pr = poll(conn.pfds, nfds, IO_TIMEOUT_SEC * 1000);
+		// If nghttp2 still has data to send that the H2_WBUF_SOFT_CAP throttle
+		// deferred, and the outbound TLS buffer is already drained, do not block:
+		// poll with a zero timeout so the next loop iteration pumps the next
+		// batch. Otherwise a large or aggregated response would stall until the
+		// idle timeout and be truncated. When the buffer is not yet drained the
+		// pollfds carry POLLOUT and we wait for the client to accept more.
+		const bool more_to_pump = conn.wlen == conn.woff && !conn.ssl_want_write &&
+		                          nghttp2_session_want_write(conn.session);
+		const int pr = poll(conn.pfds, nfds, more_to_pump ? 0 : (IO_TIMEOUT_SEC * 1000));
 		if(pr < 0)
 		{
 			if(errno == EINTR)
@@ -1441,6 +1550,1290 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 	free(conn.pmap);
 }
 #endif /* HAVE_HTTP2 */
+
+#ifdef HAVE_HTTP3
+// ---------------------------------------------------------------------------
+// HTTP/3 gateway (ALPN "h3") over OpenSSL 3.5 native QUIC.
+//
+// A single dedicated thread owns one UDP socket, one OpenSSL QUIC listener, and
+// every QUIC connection and HTTP/3 stream on top of it. OpenSSL performs the
+// QUIC transport (packetisation, congestion control, loss recovery, per-stream
+// flow control); nghttp3 performs the HTTP/3 layer (QPACK, framing) on top of
+// the per-stream byte streams that OpenSSL exposes as child SSL objects.
+//
+// Each HTTP/3 request is bridged to a plain HTTP/1.1 request against the
+// CivetWeb backend, exactly like the HTTP/2 gateway, and the response is
+// translated back to HTTP/3. The bridge is non-blocking and streaming, mirroring
+// the HTTP/2 gateway and reusing the same shared HTTP/1.1 backend-bridge helpers:
+// each request stream gets its own non-blocking backend connection, the request
+// body is streamed to the backend as it arrives, and the HTTP/1.1 response is
+// parsed incrementally and pulled back into HTTP/3 DATA frames on demand via an
+// nghttp3 data reader (defer with NGHTTP3_ERR_WOULDBLOCK, resume with
+// nghttp3_conn_resume_stream). The single QUIC event-loop poll() set covers the
+// UDP socket plus every active backend socket, so a slow backend never blocks
+// QUIC processing for the other live HTTP/3 connections.
+//
+// Client-IP note: each backend request carries a PROXY protocol v2 header with
+// the real client address, obtained from SSL_get_peer_addr() (OpenSSL 4.0's QUIC
+// per-connection peer getter), identical to the TCP and HTTP/2 paths.
+// ---------------------------------------------------------------------------
+
+#define H3_REQHDR_MAX 8192u
+#define H3_MAX_HDRS 64u
+// Response header block size cap before we give up parsing.
+#define H3_RESP_HDR_MAX 65536u
+// Per-stream decoded response body high-water mark: once this much undelivered
+// body is buffered we stop reading the backend, applying backpressure toward the
+// (slower) client.
+#define H3_BODY_HIGH_WATER (256u * 1024u)
+// Outbound request buffer high-water mark: once this much request body is queued
+// for a backend that has not drained it, we stop reading the client stream so
+// QUIC flow control backpressures the client.
+#define H3_REQ_HIGH_WATER (256u * 1024u)
+// Maximum PROXY protocol v2 header size (16 fixed + 36 for IPv6).
+#define H3_PROXY_MAX 52u
+
+struct h3_conn;
+
+struct h3_stream {
+	struct h3_stream *next;
+	struct h3_conn *conn;
+	int64_t id;
+	SSL *ssl;              // OpenSSL QUIC child stream object
+	bool uni_local;        // control/QPACK stream we created (write-only)
+	bool read_done;        // FIN (or reset) seen, no more reads
+
+	// Request reconstruction (bidi request streams only)
+	char method[16];
+	char authority[256];
+	char path[2048];
+	char reqhdr[H3_REQHDR_MAX];
+	size_t reqhdr_len;
+	bool content_length_seen;
+
+	// Backend connection (non-blocking)
+	int be_fd;
+	bool be_connecting;
+	bool be_started;         // backend opened and request head queued
+
+	// Shared HTTP/1.1 backend-bridge state: request-out buffer, response-header
+	// accumulator, body de-framing, and the decoded-body buffer.
+	struct be_bridge be;
+
+	// Response submission / data-reader state (nghttp3-specific)
+	bool resp_headers_sent;
+	bool resp_deferred;      // data reader parked on NGHTTP3_ERR_WOULDBLOCK
+	bool error;              // gateway error: backend torn down, stream ending
+	bool reset;              // QUIC RESET_STREAM sent, stop writing this stream
+};
+
+struct h3_conn {
+	struct h3_conn *next;
+	SSL *ssl;              // OpenSSL QUIC connection object
+	nghttp3_conn *h3;
+	struct h3_stream *streams;
+	bool dead;             // scheduled for teardown
+	// Real QUIC client (source) and local UDP (destination) addresses, captured
+	// at accept time so each backend request can carry a PROXY v2 header.
+	struct sockaddr_storage client_addr;
+	struct sockaddr_storage server_addr;
+	bool have_client_addr;
+};
+
+// Monotonic timestamp in nanoseconds for nghttp3's rate limiter / bookkeeping.
+static nghttp3_tstamp h3_now(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (nghttp3_tstamp)ts.tv_sec * 1000000000ull + (nghttp3_tstamp)ts.tv_nsec;
+}
+
+static struct h3_stream *h3_find_stream(struct h3_conn *c, int64_t id)
+{
+	for(struct h3_stream *s = c->streams; s != NULL; s = s->next)
+		if(s->id == id)
+			return s;
+	return NULL;
+}
+
+static struct h3_stream *h3_stream_new(struct h3_conn *c, SSL *ssl, bool uni_local)
+{
+	struct h3_stream *s = calloc(1, sizeof(*s));
+	if(s == NULL)
+		return NULL;
+	s->conn = c;
+	s->ssl = ssl;
+	s->uni_local = uni_local;
+	s->be_fd = -1;
+	s->id = (int64_t)SSL_get_stream_id(ssl);
+	s->next = c->streams;
+	c->streams = s;
+	return s;
+}
+
+// Close the backend socket. QUIC flow control is handled by OpenSSL as we
+// SSL_read the request stream, so there is no window credit to reclaim here.
+static void h3_be_close(struct h3_stream *s)
+{
+	if(s->be_fd >= 0)
+	{
+		close(s->be_fd);
+		s->be_fd = -1;
+	}
+	s->be_connecting = false;
+}
+
+// Reset the QUIC stream (send RESET_STREAM) and tell nghttp3 to stop writing it.
+// Used when a framed response body is truncated by an early backend close.
+static void h3_reset_stream(struct h3_stream *s)
+{
+	if(s->reset)
+		return;
+	const SSL_STREAM_RESET_ARGS rargs = { NGHTTP3_H3_INTERNAL_ERROR };
+	SSL_stream_reset(s->ssl, &rargs, sizeof(rargs));
+	nghttp3_conn_shutdown_stream_write(s->conn->h3, s->id);
+	s->reset = true;
+	s->be.resp_complete = true;
+}
+
+// nghttp3 data reader: hand decoded response body bytes to nghttp3 on demand,
+// zero-copy from the bridge body buffer. Returns NGHTTP3_ERR_WOULDBLOCK when the
+// backend has not produced more body yet; h3_be_readable() resumes the stream
+// once it does. The buffer stays stable while nghttp3 references it because the
+// event loop only reads more backend data (which may reallocate the buffer) once
+// nghttp3 has flushed everything produced so far (nghttp3_conn_is_stream_flushed).
+static nghttp3_ssize h3_read_data(nghttp3_conn *h3, int64_t stream_id,
+                                  nghttp3_vec *vec, size_t veccnt,
+                                  uint32_t *pflags, void *conn_user_data,
+                                  void *stream_user_data)
+{
+	(void)h3; (void)veccnt; (void)stream_user_data;
+	struct h3_conn *c = (struct h3_conn *)conn_user_data;
+	struct h3_stream *s = h3_find_stream(c, stream_id);
+	if(s == NULL)
+	{
+		*pflags |= NGHTTP3_DATA_FLAG_EOF;
+		return 0;
+	}
+	const size_t avail = s->be.body_len - s->be.body_off;
+	if(avail == 0)
+	{
+		if(s->be.resp_complete)
+		{
+			*pflags |= NGHTTP3_DATA_FLAG_EOF;
+			return 0;
+		}
+		s->resp_deferred = true;
+		return NGHTTP3_ERR_WOULDBLOCK;
+	}
+	vec[0].base = (uint8_t *)s->be.body_buf + s->be.body_off;
+	vec[0].len = avail;
+	s->be.body_off += avail;
+	if(s->be.resp_complete && s->be.body_off == s->be.body_len)
+		*pflags |= NGHTTP3_DATA_FLAG_EOF;
+	return 1;
+}
+
+// Submit a status-only HTTP/3 response (used for gateway errors and bodiless
+// responses). The empty data reader signals EOF immediately.
+static void h3_submit_status(struct h3_stream *s, const char *status3)
+{
+	nghttp3_nv nv = {
+		(uint8_t *)":status", (uint8_t *)status3, 7, strlen(status3),
+		NGHTTP3_NV_FLAG_NONE
+	};
+	const nghttp3_data_reader dr = { h3_read_data };
+	s->be.resp_complete = true;
+	s->be.body_len = s->be.body_off = 0;
+	nghttp3_conn_submit_response(s->conn->h3, s->id, &nv, 1, &dr);
+	s->resp_headers_sent = true;
+}
+
+// Fail a stream at the gateway: tear down its backend socket and either submit a
+// status-only response (if nothing has been sent yet) or reset the QUIC stream
+// (if the response head is already on the wire).
+static void h3_gateway_error(struct h3_stream *s, const char *status3)
+{
+	h3_be_close(s);
+	s->error = true;
+	if(s->resp_headers_sent)
+		h3_reset_stream(s);
+	else
+		h3_submit_status(s, status3);
+}
+
+// Once the request headers are complete, decide the request body framing, open
+// the non-blocking backend connection, and queue the PROXY header and HTTP/1.1
+// request head. Mirrors h2_start_backend().
+static void h3_start_backend(struct h3_stream *s, bool has_body)
+{
+	s->be_started = true;
+
+	if(!has_body)
+		s->be.req_mode = REQ_NONE;
+	else if(s->content_length_seen)
+		s->be.req_mode = REQ_RAW;      // length known: forward the body verbatim
+	else
+		s->be.req_mode = REQ_CHUNKED;  // unknown length: chunk it to the backend
+
+	bool connected = false;
+	s->be_fd = connect_backend_nb(&connected);
+	if(s->be_fd < 0)
+	{
+		h3_gateway_error(s, "502");
+		return;
+	}
+	s->be_connecting = !connected;
+
+	// Announce the real client to the backend (PROXY v2) using the address we
+	// captured at accept time, mirroring the TCP and HTTP/2 paths.
+	if(s->conn->have_client_addr)
+	{
+		unsigned char ph[H3_PROXY_MAX];
+		size_t phlen = 0;
+		if(build_proxy_v2_sa(&s->conn->client_addr, &s->conn->server_addr,
+		                     ph, &phlen) != 0 ||
+		   be_req_push(&s->be, (const char *)ph, phlen) != 0)
+		{
+			h3_gateway_error(s, "502");
+			return;
+		}
+	}
+
+	char head[H3_REQHDR_MAX + 4096];
+	const int hl = be_format_request_head(head, sizeof(head), s->method, s->path,
+	                                      s->authority, s->reqhdr, s->reqhdr_len,
+	                                      s->be.req_mode == REQ_CHUNKED ?
+	                                          "Transfer-Encoding: chunked\r\n" : "");
+	if(hl < 0 || (size_t)hl >= sizeof(head) || be_req_push(&s->be, head, (size_t)hl) != 0)
+	{
+		h3_gateway_error(s, "500");
+		return;
+	}
+	s->be.req_started = true;
+}
+
+// Parse the HTTP/1.1 response header block hdr[0..hdrlen) (the bytes before the
+// terminating CRLFCRLF), determine the body framing, and submit the HTTP/3
+// response headers with a streaming data reader. nghttp3 copies the header list,
+// so the in-place-parsed hdr buffer can be freed afterwards. Returns 0 or -1.
+static int h3_parse_and_submit(struct h3_stream *s, char *hdr, size_t hdrlen)
+{
+	hdr[hdrlen] = '\0';
+
+	char status3[4] = "502";
+	const char *sp = memchr(hdr, ' ', hdrlen);
+	if(sp != NULL && sp[1] && sp[2] && sp[3])
+	{
+		status3[0] = sp[1]; status3[1] = sp[2]; status3[2] = sp[3]; status3[3] = '\0';
+	}
+
+	nghttp3_nv nva[H3_MAX_HDRS];
+	size_t nvlen = 0;
+	nva[nvlen].name = (uint8_t *)":status"; nva[nvlen].namelen = 7;
+	nva[nvlen].value = (uint8_t *)status3;  nva[nvlen].valuelen = 3;
+	nva[nvlen].flags = NGHTTP3_NV_FLAG_NONE; nvlen++;
+
+	bool chunked = false, have_clen = false;
+	size_t clen = 0;
+	char *line = strstr(hdr, "\r\n"); // skip the status line
+	if(line != NULL)
+	{
+		line += 2;
+		while(*line != '\0' && nvlen < H3_MAX_HDRS)
+		{
+			char *eol = strstr(line, "\r\n");
+			if(eol != NULL)
+				*eol = '\0';
+			char *colon = strchr(line, ':');
+			if(colon != NULL)
+			{
+				*colon = '\0';
+				char *val = colon + 1;
+				while(*val == ' ') val++;
+				const size_t nlen = strlen(line);
+				if(nlen == 17 && strncasecmp(line, "transfer-encoding", 17) == 0)
+				{
+					if(strcasestr(val, "chunked") != NULL)
+						chunked = true; // decoded here, not forwarded
+				}
+				else if(nlen == 14 && strncasecmp(line, "content-length", 14) == 0)
+				{
+					have_clen = true;
+					clen = (size_t)strtoull(val, NULL, 10);
+					// Content-Length is not forwarded: HTTP/3 frames the body by
+					// stream FIN, and the terminator may de-chunk, changing the
+					// length. nghttp3 rejects a content-length that does not match
+					// what it observes, so leave it out.
+				}
+				else if(nlen > 0 && !hbh_skip_header(line, nlen))
+				{
+					// QPACK requires lowercase field names.
+					for(char *ch = line; *ch != '\0'; ch++)
+						*ch = (char)tolower((unsigned char)*ch);
+					nva[nvlen].name = (uint8_t *)line; nva[nvlen].namelen = nlen;
+					nva[nvlen].value = (uint8_t *)val; nva[nvlen].valuelen = strlen(val);
+					nva[nvlen].flags = NGHTTP3_NV_FLAG_NONE; nvlen++;
+				}
+			}
+			if(eol == NULL)
+				break;
+			line = eol + 2;
+		}
+	}
+
+	// Determine the response body framing. HEAD requests and 1xx/204/304
+	// responses carry no body regardless of any length header.
+	bool no_body = false;
+	if(strcasecmp(s->method, "HEAD") == 0)
+		no_body = true;
+	else if(status3[0] == '1' || strcmp(status3, "204") == 0 || strcmp(status3, "304") == 0)
+		no_body = true;
+
+	if(no_body)
+		s->be.body_mode = BODY_NONE;
+	else if(chunked)
+	{
+		s->be.body_mode = BODY_CHUNKED;
+		s->be.chunk_state = CH_SIZE;
+	}
+	else if(have_clen)
+	{
+		s->be.body_mode = BODY_LENGTH;
+		s->be.body_remaining = clen;
+	}
+	else
+		s->be.body_mode = BODY_CLOSE; // length delimited by the backend closing
+
+	s->be.resp_headers_parsed = true;
+
+	const bool empty = (s->be.body_mode == BODY_NONE) ||
+	                   (s->be.body_mode == BODY_LENGTH && s->be.body_remaining == 0);
+	const nghttp3_data_reader dr = { h3_read_data };
+	const int rv = nghttp3_conn_submit_response(s->conn->h3, s->id, nva, nvlen, &dr);
+	s->resp_headers_sent = true;
+	if(empty)
+		s->be.resp_complete = true;
+	return (rv == 0) ? 0 : -1;
+}
+
+// Feed raw bytes read from the backend socket: accumulate and parse the response
+// header block first, then decode the body incrementally. Returns 0 or -1.
+static int h3_feed(struct h3_stream *s, const char *data, size_t n)
+{
+	if(s->be.resp_headers_parsed)
+		return be_feed_body(&s->be, data, n);
+
+	if(buf_append(&s->be.resp_hdr, &s->be.resp_hdr_len, &s->be.resp_hdr_cap, data, n) != 0)
+		return -1;
+	char *end = memmem(s->be.resp_hdr, s->be.resp_hdr_len, "\r\n\r\n", 4);
+	if(end == NULL)
+		return (s->be.resp_hdr_len > H3_RESP_HDR_MAX) ? -1 : 0; // need more headers
+
+	const size_t hdrlen = (size_t)(end - s->be.resp_hdr);
+	const size_t consumed = hdrlen + 4;
+	if(h3_parse_and_submit(s, s->be.resp_hdr, hdrlen) != 0)
+		return -1;
+	// Any bytes past the header terminator are the start of the body. Copy them
+	// out (be_body_push copies) before freeing the header buffer.
+	const size_t leftover = s->be.resp_hdr_len - consumed;
+	if(leftover > 0 && be_feed_body(&s->be, s->be.resp_hdr + consumed, leftover) != 0)
+		return -1;
+	free(s->be.resp_hdr);
+	s->be.resp_hdr = NULL;
+	s->be.resp_hdr_len = s->be.resp_hdr_cap = 0;
+	return 0;
+}
+
+// Backend socket became writable: finish a pending non-blocking connect() and
+// flush as much of the queued request as the socket accepts.
+static void h3_be_writable(struct h3_stream *s)
+{
+	if(s->be_fd < 0)
+		return;
+	if(s->be_connecting)
+	{
+		int err = 0;
+		socklen_t el = sizeof(err);
+		if(getsockopt(s->be_fd, SOL_SOCKET, SO_ERROR, &err, &el) != 0 || err != 0)
+		{
+			h3_gateway_error(s, "502");
+			return;
+		}
+		s->be_connecting = false;
+	}
+	while(s->be.req_out_off < s->be.req_out_len)
+	{
+		const ssize_t w = write(s->be_fd, s->be.req_out + s->be.req_out_off,
+		                        s->be.req_out_len - s->be.req_out_off);
+		if(w > 0)
+			s->be.req_out_off += (size_t)w;
+		else if(w < 0 && errno == EINTR)
+			continue;
+		else if(w < 0 && WOULDBLOCK(errno))
+			break;
+		else
+		{
+			h3_gateway_error(s, "502");
+			return;
+		}
+	}
+	if(s->be.req_out_off == s->be.req_out_len)
+		s->be.req_out_off = s->be.req_out_len = 0;
+}
+
+// Backend socket became readable: pull response bytes, feed the parser/decoder,
+// and resume the stream's data reader if it was parked. Stops early at the body
+// high-water mark to apply backpressure toward the client.
+static void h3_be_readable(struct h3_stream *s)
+{
+	if(s->be_fd < 0)
+		return;
+	char tmp[16384];
+	for(;;)
+	{
+		const ssize_t r = read(s->be_fd, tmp, sizeof(tmp));
+		if(r > 0)
+		{
+			if(h3_feed(s, tmp, (size_t)r) != 0)
+			{
+				h3_gateway_error(s, "502");
+				return;
+			}
+			if(s->be.resp_complete)
+				break;
+			if((s->be.body_len - s->be.body_off) >= H3_BODY_HIGH_WATER)
+				break; // backpressure: let the client drain first
+			continue;
+		}
+		if(r == 0)
+		{
+			// Backend closed. For close-delimited bodies this is the normal end;
+			// for a length/chunked-framed body that has not reached its end it is
+			// a truncation, which we signal to the client with RESET_STREAM rather
+			// than delivering a silently short body as if complete.
+			if(!s->be.resp_headers_parsed || be_body_truncated(&s->be))
+			{
+				h3_gateway_error(s, "502");
+				return;
+			}
+			s->be.resp_complete = true;
+			h3_be_close(s);
+			break;
+		}
+		if(errno == EINTR)
+			continue;
+		if(WOULDBLOCK(errno))
+			break;
+		// Fatal read error: never a legitimate end of a framed body.
+		if(!s->be.resp_headers_parsed || be_body_truncated(&s->be))
+		{
+			h3_gateway_error(s, "502");
+			return;
+		}
+		s->be.resp_complete = true;
+		h3_be_close(s);
+		break;
+	}
+
+	// The response is fully decoded; the backend socket is no longer needed.
+	if(s->be.resp_complete && s->be_fd >= 0)
+		h3_be_close(s);
+	// Wake a parked data reader now that there is progress (more body or EOF).
+	if(s->resp_deferred && ((s->be.body_len - s->be.body_off) > 0 || s->be.resp_complete))
+	{
+		s->resp_deferred = false;
+		nghttp3_conn_resume_stream(s->conn->h3, s->id);
+	}
+}
+
+// --- nghttp3 server callbacks ---------------------------------------------
+
+static int h3_cb_recv_header(nghttp3_conn *h3, int64_t stream_id, int32_t token,
+                             nghttp3_rcbuf *name, nghttp3_rcbuf *value,
+                             uint8_t flags, void *conn_user_data,
+                             void *stream_user_data)
+{
+	(void)h3; (void)token; (void)flags; (void)stream_user_data;
+	struct h3_conn *c = (struct h3_conn *)conn_user_data;
+	struct h3_stream *s = h3_find_stream(c, stream_id);
+	if(s == NULL)
+		return 0;
+	const nghttp3_vec nv = nghttp3_rcbuf_get_buf(name);
+	const nghttp3_vec vv = nghttp3_rcbuf_get_buf(value);
+	const char *n = (const char *)nv.base;
+	const char *v = (const char *)vv.base;
+	const size_t nl = nv.len, vl = vv.len;
+
+	if(nl > 0 && n[0] == ':')
+	{
+		if(nl == 7 && memcmp(n, ":method", 7) == 0)
+			snprintf(s->method, sizeof(s->method), "%.*s", (int)vl, v);
+		else if(nl == 5 && memcmp(n, ":path", 5) == 0)
+			snprintf(s->path, sizeof(s->path), "%.*s", (int)vl, v);
+		else if(nl == 10 && memcmp(n, ":authority", 10) == 0)
+			snprintf(s->authority, sizeof(s->authority), "%.*s", (int)vl, v);
+		// :scheme is always https at the terminator and is not forwarded
+		return 0;
+	}
+
+	if(hbh_skip_header(n, nl))
+		return 0;
+
+	const size_t need = nl + 2 + vl + 2;
+	if(s->reqhdr_len + need < sizeof(s->reqhdr))
+	{
+		char *p = s->reqhdr + s->reqhdr_len;
+		memcpy(p, n, nl); p += nl;
+		*p++ = ':'; *p++ = ' ';
+		memcpy(p, v, vl); p += vl;
+		*p++ = '\r'; *p++ = '\n';
+		s->reqhdr_len += need;
+		// Only trust a Content-Length we actually forwarded: if the header did not
+		// fit and was dropped, the request must instead be framed as chunked (see
+		// h3_start_backend()), so leave content_length_seen false in that case.
+		if(nl == 14 && strncasecmp(n, "content-length", 14) == 0)
+			s->content_length_seen = true;
+	}
+	return 0;
+}
+
+// The HTTP field section has ended: all request headers are in, so open the
+// backend and queue the request head. |fin| is nonzero if the request has no
+// body (the stream ends with the header section).
+static int h3_cb_end_headers(nghttp3_conn *h3, int64_t stream_id, int fin,
+                             void *conn_user_data, void *stream_user_data)
+{
+	(void)h3; (void)stream_user_data;
+	struct h3_conn *c = (struct h3_conn *)conn_user_data;
+	struct h3_stream *s = h3_find_stream(c, stream_id);
+	if(s != NULL && !s->uni_local && !s->be_started && !s->error)
+		h3_start_backend(s, fin == 0);
+	return 0;
+}
+
+static int h3_cb_recv_data(nghttp3_conn *h3, int64_t stream_id,
+                           const uint8_t *data, size_t datalen,
+                           void *conn_user_data, void *stream_user_data)
+{
+	(void)h3; (void)stream_user_data;
+	struct h3_conn *c = (struct h3_conn *)conn_user_data;
+	struct h3_stream *s = h3_find_stream(c, stream_id);
+	if(s == NULL)
+		return 0;
+	// The backend is gone (gateway error) or never opened: discard the body.
+	// OpenSSL manages QUIC flow control as we SSL_read the stream, so there is no
+	// separate credit to return here.
+	if(s->error || s->be_fd < 0)
+		return 0;
+	// Stream the request body to the backend, framing it as the negotiated mode.
+	if(s->be.req_mode == REQ_CHUNKED)
+	{
+		if(datalen > 0)
+		{
+			char hdr[32];
+			const int hn = snprintf(hdr, sizeof(hdr), "%zx\r\n", datalen);
+			if(hn < 0 || be_req_push(&s->be, hdr, (size_t)hn) != 0 ||
+			   be_req_push(&s->be, (const char *)data, datalen) != 0 ||
+			   be_req_push(&s->be, "\r\n", 2) != 0)
+				return NGHTTP3_ERR_CALLBACK_FAILURE;
+		}
+	}
+	else if(datalen > 0)
+	{
+		if(be_req_push(&s->be, (const char *)data, datalen) != 0)
+			return NGHTTP3_ERR_CALLBACK_FAILURE;
+	}
+	return 0;
+}
+
+static int h3_cb_end_stream(nghttp3_conn *h3, int64_t stream_id,
+                            void *conn_user_data, void *stream_user_data)
+{
+	(void)h3; (void)stream_user_data;
+	struct h3_conn *c = (struct h3_conn *)conn_user_data;
+	struct h3_stream *s = h3_find_stream(c, stream_id);
+	if(s == NULL)
+		return 0;
+	// End of the request body: finish a chunked request with the terminator.
+	if(!s->error && s->be.req_mode == REQ_CHUNKED && s->be_fd >= 0)
+		be_req_push(&s->be, "0\r\n\r\n", 5);
+	return 0;
+}
+
+static int h3_cb_stream_close(nghttp3_conn *h3, int64_t stream_id,
+                              uint64_t app_error_code, void *conn_user_data,
+                              void *stream_user_data)
+{
+	(void)h3; (void)app_error_code; (void)stream_user_data;
+	struct h3_conn *c = (struct h3_conn *)conn_user_data;
+	struct h3_stream *s = h3_find_stream(c, stream_id);
+	if(s != NULL)
+	{
+		// nghttp3 is done with the stream: release the HTTP buffers and the
+		// backend socket. The node and its QUIC stream object are reclaimed by
+		// h3_conn_reap_streams() once the send part is concluded/reset.
+		h3_be_close(s);
+		free(s->be.req_out); s->be.req_out = NULL;
+		s->be.req_out_len = s->be.req_out_off = s->be.req_out_cap = 0;
+		free(s->be.resp_hdr); s->be.resp_hdr = NULL;
+		s->be.resp_hdr_len = s->be.resp_hdr_cap = 0;
+		free(s->be.body_buf); s->be.body_buf = NULL;
+		s->be.body_len = s->be.body_off = s->be.body_cap = 0;
+	}
+	return 0;
+}
+
+// Read all currently available bytes from a stream and feed them to nghttp3.
+// Returns 0 normally, -1 on a fatal nghttp3 error (connection must be torn down).
+static int h3_stream_pump_read(struct h3_stream *s)
+{
+	uint8_t buf[16384];
+	for(;;)
+	{
+		size_t nread = 0;
+		const int r = SSL_read_ex(s->ssl, buf, sizeof(buf), &nread);
+		if(r == 1 && nread > 0)
+		{
+			if(nghttp3_conn_read_stream2(s->conn->h3, s->id, buf, nread, 0,
+			                             h3_now()) < 0)
+				return -1;
+			continue;
+		}
+		const int err = SSL_get_error(s->ssl, r);
+		if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
+			return 0;
+		if(err == SSL_ERROR_ZERO_RETURN)
+		{
+			// Clean end of the receiving side. Feed FIN to nghttp3 only for a
+			// graceful finish; a reset just stops reads.
+			s->read_done = true;
+			if(SSL_get_stream_read_state(s->ssl) == SSL_STREAM_STATE_FINISHED &&
+			   nghttp3_conn_read_stream2(s->conn->h3, s->id, NULL, 0, 1,
+			                             h3_now()) < 0)
+				return -1;
+			return 0;
+		}
+		// Reset or connection-level error: stop reading this stream.
+		s->read_done = true;
+		return 0;
+	}
+}
+
+// Drain nghttp3's pending stream writes to the QUIC streams. Returns 0 or -1.
+static int h3_conn_pump_write(struct h3_conn *c)
+{
+	for(;;)
+	{
+		nghttp3_vec vec[16];
+		int64_t sid = -1;
+		int fin = 0;
+		const nghttp3_ssize n = nghttp3_conn_writev_stream(c->h3, &sid, &fin,
+		                                                   vec, 16);
+		if(n < 0)
+			return -1;
+		if(n == 0 && sid == -1)
+			break; // nothing more to write right now
+
+		struct h3_stream *s = h3_find_stream(c, sid);
+		if(s == NULL)
+		{
+			// Unknown stream: acknowledge zero progress and stop for now.
+			nghttp3_conn_add_write_offset(c->h3, sid, 0);
+			break;
+		}
+
+		size_t total = 0;
+		bool blocked = false;
+		for(nghttp3_ssize i = 0; i < n && !blocked; i++)
+		{
+			size_t off = 0;
+			while(off < vec[i].len)
+			{
+				size_t written = 0;
+				const int r = SSL_write_ex(s->ssl, vec[i].base + off,
+				                           vec[i].len - off, &written);
+				if(r == 1)
+				{
+					off += written;
+					total += written;
+				}
+				else
+				{
+					// Stream send buffer full or not yet writable: retry later.
+					blocked = true;
+					break;
+				}
+			}
+		}
+
+		if(nghttp3_conn_add_write_offset(c->h3, sid, total) != 0)
+			return -1;
+		// OpenSSL owns retransmission once bytes are accepted, so nghttp3 may
+		// release its copy immediately.
+		if(total > 0 && nghttp3_conn_add_ack_offset(c->h3, sid, total) != 0)
+			return -1;
+
+		if(fin && !blocked)
+			SSL_stream_conclude(s->ssl, 0); // send FIN once all data is flushed
+		if(blocked)
+			break;
+	}
+	return 0;
+}
+
+// Accept any newly arrived streams on a connection into the stream list.
+static void h3_accept_streams(struct h3_conn *c)
+{
+	for(;;)
+	{
+		SSL *st = SSL_accept_stream(c->ssl, SSL_ACCEPT_STREAM_NO_BLOCK);
+		if(st == NULL)
+			break;
+		if(h3_stream_new(c, st, false) == NULL)
+		{
+			SSL_free(st);
+			break;
+		}
+	}
+}
+
+static const nghttp3_callbacks h3_callbacks = {
+	.stream_close = h3_cb_stream_close,
+	.recv_data    = h3_cb_recv_data,
+	.recv_header  = h3_cb_recv_header,
+	.end_headers  = h3_cb_end_headers,
+	.end_stream   = h3_cb_end_stream,
+};
+
+// Set up nghttp3 and the mandatory outgoing control / QPACK streams for a freshly
+// accepted QUIC connection. Returns the connection state or NULL on failure.
+static struct h3_conn *h3_conn_new(SSL *cssl)
+{
+	struct h3_conn *c = calloc(1, sizeof(*c));
+	if(c == NULL)
+		return NULL;
+	c->ssl = cssl;
+
+	// Capture the real client address so each backend request can announce it
+	// via PROXY v2, mirroring the TCP and HTTP/2 paths. OpenSSL hands us the
+	// peer as a BIO_ADDR (network byte order for the raw port); convert it to a
+	// sockaddr and remember the local UDP address as the PROXY destination.
+	BIO_ADDR *ba = BIO_ADDR_new();
+	if(ba != NULL && SSL_get_peer_addr(cssl, ba) == 1)
+	{
+		const int fam = BIO_ADDR_family(ba);
+		if(fam == AF_INET)
+		{
+			struct sockaddr_in *sin = (struct sockaddr_in *)&c->client_addr;
+			size_t al = sizeof(sin->sin_addr);
+			sin->sin_family = AF_INET;
+			if(BIO_ADDR_rawaddress(ba, &sin->sin_addr, &al) == 1)
+			{
+				sin->sin_port = BIO_ADDR_rawport(ba);
+				c->have_client_addr = true;
+			}
+		}
+		else if(fam == AF_INET6)
+		{
+			struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&c->client_addr;
+			size_t al = sizeof(sin6->sin6_addr);
+			sin6->sin6_family = AF_INET6;
+			if(BIO_ADDR_rawaddress(ba, &sin6->sin6_addr, &al) == 1)
+			{
+				sin6->sin6_port = BIO_ADDR_rawport(ba);
+				c->have_client_addr = true;
+			}
+		}
+	}
+	BIO_ADDR_free(ba);
+	if(c->have_client_addr)
+	{
+		socklen_t dl = sizeof(c->server_addr);
+		if(getsockname(quic_fd, (struct sockaddr *)&c->server_addr, &dl) != 0)
+			c->server_addr.ss_family = AF_UNSPEC;
+	}
+
+	SSL_set_blocking_mode(cssl, 0);
+	// We accept and drive streams by hand; do not auto-create a default stream.
+	SSL_set_default_stream_mode(cssl, SSL_DEFAULT_STREAM_MODE_NONE);
+	SSL_set_incoming_stream_policy(cssl, SSL_INCOMING_STREAM_POLICY_ACCEPT, 0);
+
+	nghttp3_settings settings;
+	nghttp3_settings_default(&settings);
+	if(nghttp3_conn_server_new(&c->h3, &h3_callbacks, &settings, NULL, c) != 0)
+	{
+		free(c);
+		return NULL;
+	}
+
+	SSL *ctrl = SSL_new_stream(cssl, SSL_STREAM_FLAG_UNI);
+	SSL *qenc = SSL_new_stream(cssl, SSL_STREAM_FLAG_UNI);
+	SSL *qdec = SSL_new_stream(cssl, SSL_STREAM_FLAG_UNI);
+	struct h3_stream *sc = ctrl ? h3_stream_new(c, ctrl, true) : NULL;
+	struct h3_stream *se = qenc ? h3_stream_new(c, qenc, true) : NULL;
+	struct h3_stream *sd = qdec ? h3_stream_new(c, qdec, true) : NULL;
+	if(sc == NULL || se == NULL || sd == NULL ||
+	   nghttp3_conn_bind_control_stream(c->h3, sc->id) != 0 ||
+	   nghttp3_conn_bind_qpack_streams(c->h3, se->id, sd->id) != 0)
+	{
+		// h3_conn_free() frees whatever streams were linked; free any that were
+		// created but not yet linked to avoid leaking them.
+		if(ctrl && sc == NULL) SSL_free(ctrl);
+		if(qenc && se == NULL) SSL_free(qenc);
+		if(qdec && sd == NULL) SSL_free(qdec);
+		nghttp3_conn_del(c->h3);
+		for(struct h3_stream *s = c->streams; s != NULL; )
+		{
+			struct h3_stream *nx = s->next;
+			SSL_free(s->ssl);
+			free(s);
+			s = nx;
+		}
+		free(c);
+		return NULL;
+	}
+	return c;
+}
+
+static void h3_conn_free(struct h3_conn *c)
+{
+	if(c == NULL)
+		return;
+	if(c->h3 != NULL)
+		nghttp3_conn_del(c->h3);
+	for(struct h3_stream *s = c->streams; s != NULL; )
+	{
+		struct h3_stream *nx = s->next;
+		if(s->ssl != NULL)
+			SSL_free(s->ssl);
+		if(s->be_fd >= 0)
+			close(s->be_fd);
+		free(s->be.req_out);
+		free(s->be.resp_hdr);
+		free(s->be.body_buf);
+		free(s);
+		s = nx;
+	}
+	if(c->ssl != NULL)
+		SSL_free(c->ssl);
+	free(c);
+}
+
+// A finished request stream may be reclaimed once its QUIC send part has been
+// concluded or reset. SSL_free() only resets stream parts that were NOT already
+// concluded/reset, and a concluded send part keeps being flushed reliably by the
+// parent connection after the stream object is freed, so reaping here loses no
+// response data. For a normal finish we also wait for the receive part to end so
+// we do not STOP_SENDING a request body still in flight; a reset stream is torn
+// down regardless. Control/QPACK streams live for the whole connection.
+static bool h3_stream_reapable(const struct h3_stream *s)
+{
+	if(s->uni_local)
+		return false;
+	const int ws = SSL_get_stream_write_state(s->ssl);
+	if(ws == SSL_STREAM_STATE_OK || ws == SSL_STREAM_STATE_NONE ||
+	   ws == SSL_STREAM_STATE_WRONG_DIR)
+		return false; // send part still open: freeing now would truncate it
+	if(ws == SSL_STREAM_STATE_FINISHED && !s->read_done)
+		return false;
+	return true;
+}
+
+// Reclaim completed request streams so per-connection memory and the event-loop
+// scan do not grow with the number of requests served over a long-lived HTTP/3
+// connection. Without this, browsers multiplexing thousands of requests on one
+// connection accumulate a node (and QUIC stream object) each.
+static void h3_conn_reap_streams(struct h3_conn *c)
+{
+	struct h3_stream **pp = &c->streams;
+	while(*pp != NULL)
+	{
+		struct h3_stream *s = *pp;
+		if(!h3_stream_reapable(s))
+		{
+			pp = &s->next;
+			continue;
+		}
+		// Tell nghttp3 the stream is closed so it drops its per-stream state;
+		// this also fires h3_cb_stream_close(), releasing the bridge buffers.
+		nghttp3_conn_close_stream(c->h3, s->id, 0);
+		*pp = s->next;
+		h3_be_close(s);
+		free(s->be.req_out);
+		free(s->be.resp_hdr);
+		free(s->be.body_buf);
+		if(s->ssl != NULL)
+			SSL_free(s->ssl);
+		free(s);
+	}
+}
+
+// Compute how long poll() may sleep before an OpenSSL QUIC timer needs service,
+// capped so a stopping terminator is noticed promptly.
+static int h3_event_timeout_ms(SSL *listener, struct h3_conn *conns)
+{
+	int best = 1000; // cap in milliseconds
+	struct timeval tv;
+	int is_infinite = 0;
+	if(SSL_get_event_timeout(listener, &tv, &is_infinite) == 1 && !is_infinite)
+	{
+		int ms = (int)(tv.tv_sec * 1000 + tv.tv_usec / 1000);
+		if(ms < best) best = ms;
+	}
+	for(struct h3_conn *c = conns; c != NULL; c = c->next)
+	{
+		if(SSL_get_event_timeout(c->ssl, &tv, &is_infinite) == 1 && !is_infinite)
+		{
+			int ms = (int)(tv.tv_sec * 1000 + tv.tv_usec / 1000);
+			if(ms < 0) ms = 0;
+			if(ms < best) best = ms;
+		}
+	}
+	return best;
+}
+
+// HTTP/3 event-loop thread: own the UDP socket, the QUIC listener, and every
+// connection and stream. One poll() over the shared UDP socket drives OpenSSL's
+// event handling; the rest is bookkeeping to bridge HTTP/3 to the backend.
+static void *quic_accept_loop(void *arg)
+{
+	(void)arg;
+	prctl(PR_SET_NAME, "terminator-h3", 0, 0, 0);
+
+	SSL *listener = SSL_new_listener(quic_ctx, 0);
+	if(listener == NULL)
+	{
+		log_ssl_errors("SSL_new_listener() failed");
+		return NULL;
+	}
+	BIO *dbio = BIO_new_dgram(quic_fd, BIO_NOCLOSE);
+	if(dbio == NULL)
+	{
+		log_ssl_errors("BIO_new_dgram() failed");
+		SSL_free(listener);
+		return NULL;
+	}
+	SSL_set_bio(listener, dbio, dbio); // listener takes ownership of dbio
+	SSL_set_blocking_mode(listener, 0);
+	if(SSL_listen(listener) <= 0)
+	{
+		log_ssl_errors("SSL_listen() failed");
+		SSL_free(listener);
+		return NULL;
+	}
+
+	// poll() scratch: index 0 is always the shared UDP socket, the rest are the
+	// active per-stream backend sockets. pmap[i] maps pfds[i] back to its stream.
+	struct pollfd *pfds = NULL;
+	struct h3_stream **pmap = NULL;
+	size_t pcap = 0;
+
+	struct h3_conn *conns = NULL;
+	while(quic_running)
+	{
+		// Size the poll set: the UDP socket plus every active backend socket.
+		size_t need = 1;
+		for(struct h3_conn *c = conns; c != NULL; c = c->next)
+			for(struct h3_stream *s = c->streams; s != NULL; s = s->next)
+				if(s->be_fd >= 0)
+					need++;
+		if(need > pcap)
+		{
+			struct pollfd *np = realloc(pfds, need * sizeof(*np));
+			struct h3_stream **nm = realloc(pmap, need * sizeof(*nm));
+			if(np != NULL) pfds = np;
+			if(nm != NULL) pmap = nm;
+			if(np != NULL && nm != NULL)
+				pcap = need;
+			// On a transient allocation failure keep the old capacity and poll
+			// only what fits this round; the backend fds that do not fit are
+			// serviced on a later iteration. Never tear down live connections
+			// over a momentary memory spike.
+		}
+		if(pcap == 0)
+		{
+			// Cannot poll the UDP socket yet (allocation failed at startup).
+			const struct timespec ts = { 0, 20 * 1000 * 1000 };
+			nanosleep(&ts, NULL);
+			continue;
+		}
+
+		pfds[0].fd = quic_fd;
+		pfds[0].events = POLLIN;
+		pfds[0].revents = 0;
+		pmap[0] = NULL;
+		if(SSL_net_write_desired(listener))
+			pfds[0].events |= POLLOUT;
+		for(struct h3_conn *c = conns; c != NULL; c = c->next)
+			if(SSL_net_write_desired(c->ssl))
+				pfds[0].events |= POLLOUT;
+
+		nfds_t nfds = 1;
+		for(struct h3_conn *c = conns; c != NULL; c = c->next)
+		{
+			for(struct h3_stream *s = c->streams; s != NULL; s = s->next)
+			{
+				if(s->be_fd < 0)
+					continue;
+				short ev = 0;
+				if(s->be_connecting || s->be.req_out_off < s->be.req_out_len)
+					ev |= POLLOUT; // finish connect() or flush request bytes
+				// Read more response only when there is buffer room and nghttp3 has
+				// flushed everything produced so far, so the decoded-body buffer is
+				// not reallocated while nghttp3 still references it.
+				if(!s->be.resp_complete &&
+				   (s->be.body_len - s->be.body_off) < H3_BODY_HIGH_WATER &&
+				   (!s->be.resp_headers_parsed ||
+				    nghttp3_conn_is_stream_flushed(c->h3, s->id)))
+					ev |= POLLIN;
+				if(ev == 0)
+					continue;
+				if((size_t)nfds >= pcap)
+					break; // no room this round (grow failed): serve next loop
+				pfds[nfds].fd = s->be_fd;
+				pfds[nfds].events = ev;
+				pfds[nfds].revents = 0;
+				pmap[nfds] = s;
+				nfds++;
+			}
+			if((size_t)nfds >= pcap)
+				break;
+		}
+
+		const int pr = poll(pfds, nfds, h3_event_timeout_ms(listener, conns));
+		if(pr < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			break;
+		}
+
+		// Let OpenSSL process incoming datagrams and fire timers.
+		SSL_handle_events(listener);
+		for(struct h3_conn *c = conns; c != NULL; c = c->next)
+			SSL_handle_events(c->ssl);
+
+		// Accept any freshly handshaked connections.
+		for(;;)
+		{
+			SSL *cs = SSL_accept_connection(listener, SSL_ACCEPT_CONNECTION_NO_BLOCK);
+			if(cs == NULL)
+				break;
+			struct h3_conn *c = h3_conn_new(cs);
+			if(c != NULL)
+			{
+				c->next = conns;
+				conns = c;
+			}
+			else
+				SSL_free(cs);
+		}
+
+		// Service the backend sockets first. Streams are reaped only at the end of
+		// the iteration (h3_conn_reap_streams), so the pmap stays valid here; this
+		// may parse a response and submit it, or resume a parked data reader.
+		for(nfds_t i = 1; i < nfds; i++)
+		{
+			struct h3_stream *s = pmap[i];
+			if(s == NULL || s->be_fd < 0)
+				continue;
+			if(pfds[i].revents & POLLOUT)
+				h3_be_writable(s);
+			if(pfds[i].revents & (POLLIN | POLLHUP | POLLERR))
+				h3_be_readable(s);
+		}
+
+		// Service each connection: accept new streams, pump client reads (which
+		// open backends and stream request bodies), then flush HTTP/3 writes.
+		for(struct h3_conn *c = conns; c != NULL; c = c->next)
+		{
+			if(c->dead)
+				continue;
+			h3_accept_streams(c);
+			for(struct h3_stream *s = c->streams; s != NULL; s = s->next)
+			{
+				if(s->uni_local || s->read_done)
+					continue;
+				// Backpressure: stop reading the request stream while its backend
+				// has a large unflushed request backlog, letting QUIC flow control
+				// throttle the client.
+				if(s->be_fd >= 0 &&
+				   (s->be.req_out_len - s->be.req_out_off) >= H3_REQ_HIGH_WATER)
+					continue;
+				if(h3_stream_pump_read(s) < 0)
+				{
+					c->dead = true;
+					break;
+				}
+			}
+			if(c->dead)
+				continue;
+			if(h3_conn_pump_write(c) < 0)
+				c->dead = true;
+			else
+				h3_conn_reap_streams(c); // reclaim finished request streams
+		}
+
+		// Reap dead or closed connections.
+		struct h3_conn **pp = &conns;
+		while(*pp != NULL)
+		{
+			struct h3_conn *c = *pp;
+			SSL_CONN_CLOSE_INFO info;
+			const bool closed = SSL_get_conn_close_info(c->ssl, &info, sizeof(info)) == 1;
+			if(c->dead || closed)
+			{
+				*pp = c->next;
+				h3_conn_free(c);
+			}
+			else
+				pp = &(*pp)->next;
+		}
+	}
+
+	while(conns != NULL)
+	{
+		struct h3_conn *c = conns;
+		conns = c->next;
+		h3_conn_free(c);
+	}
+	free(pfds);
+	free(pmap);
+	SSL_free(listener);
+	return NULL;
+}
+
+// ALPN selection on the QUIC side: accept only "h3". QUIC mandates ALPN, so a
+// client that does not offer "h3" is rejected outright.
+static int alpn_select_h3_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+                             const unsigned char *in, unsigned int inlen, void *arg)
+{
+	(void)ssl;
+	(void)arg;
+	for(unsigned int i = 0; i + 1 <= inlen; )
+	{
+		const unsigned int l = in[i];
+		if(i + 1 + l > inlen)
+			break;
+		if(l == 2 && memcmp(&in[i + 1], "h3", 2) == 0)
+		{
+			*out = &in[i + 1];
+			*outlen = 2;
+			return SSL_TLSEXT_ERR_OK;
+		}
+		i += 1 + l;
+	}
+	return SSL_TLSEXT_ERR_ALERT_FATAL;
+}
+
+// Build the QUIC server SSL_CTX (certificate/key + ALPN "h3" only).
+static SSL_CTX *create_quic_server_ctx(const char *cert_path)
+{
+	SSL_CTX *c = SSL_CTX_new(OSSL_QUIC_server_method());
+	if(c == NULL)
+	{
+		log_ssl_errors("QUIC SSL_CTX_new() failed");
+		return NULL;
+	}
+	if(SSL_CTX_use_certificate_chain_file(c, cert_path) != 1 ||
+	   SSL_CTX_use_PrivateKey_file(c, cert_path, SSL_FILETYPE_PEM) != 1 ||
+	   SSL_CTX_check_private_key(c) != 1)
+	{
+		log_ssl_errors("loading QUIC TLS certificate/key failed");
+		SSL_CTX_free(c);
+		return NULL;
+	}
+	SSL_CTX_set_alpn_select_cb(c, alpn_select_h3_cb, NULL);
+	return c;
+}
+
+// Bind a dual-stack UDP socket on the given port for the QUIC listener.
+static int bind_udp(int port)
+{
+	const int fd = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+	if(fd < 0)
+	{
+		log_err("Terminator: QUIC socket() failed: %s", strerror(errno));
+		return -1;
+	}
+	const int on = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+	const int off = 0;
+	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
+
+	struct sockaddr_in6 sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sin6_family = AF_INET6;
+	sa.sin6_addr = in6addr_any;
+	sa.sin6_port = htons((uint16_t)port);
+	if(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+	{
+		log_err("Terminator: QUIC bind() to port %d failed: %s", port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if(set_nonblocking(fd) != 0)
+	{
+		log_err("Terminator: QUIC set_nonblocking() failed: %s", strerror(errno));
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+// Start the HTTP/3 listener alongside the TCP terminator. HTTP/3 is optional, so
+// a failure here is logged and the terminator keeps serving HTTP/1.1 and HTTP/2.
+static void terminator_quic_start(int public_port, const char *cert_path)
+{
+	quic_ctx = create_quic_server_ctx(cert_path);
+	if(quic_ctx == NULL)
+		return;
+	quic_fd = bind_udp(public_port);
+	if(quic_fd < 0)
+	{
+		SSL_CTX_free(quic_ctx);
+		quic_ctx = NULL;
+		return;
+	}
+	quic_running = true;
+	if(pthread_create(&quic_tid, NULL, quic_accept_loop, NULL) != 0)
+	{
+		log_err("Terminator: failed to start HTTP/3 thread: %s", strerror(errno));
+		quic_running = false;
+		close(quic_fd);
+		quic_fd = -1;
+		SSL_CTX_free(quic_ctx);
+		quic_ctx = NULL;
+		return;
+	}
+	quic_tid_valid = true;
+	log_info("HTTP/3 (QUIC) listening on UDP port %d", public_port);
+}
+
+static void terminator_quic_stop(void)
+{
+	if(quic_running)
+	{
+		quic_running = false;
+		if(quic_tid_valid)
+		{
+			pthread_join(quic_tid, NULL);
+			quic_tid_valid = false;
+		}
+	}
+	if(quic_fd >= 0)
+	{
+		close(quic_fd);
+		quic_fd = -1;
+	}
+	if(quic_ctx != NULL)
+	{
+		SSL_CTX_free(quic_ctx);
+		quic_ctx = NULL;
+	}
+}
+#endif /* HAVE_HTTP3 */
 
 // Per-connection handler, run in a detached thread.
 static void *handle_conn(void *arg)
@@ -1583,11 +2976,21 @@ bool terminator_start(int public_port, int be_port, const char *cert_path)
 
 	log_info("TLS terminator listening on port %d, forwarding to 127.0.0.1:%d",
 	         public_port, be_port);
+
+#ifdef HAVE_HTTP3
+	// Serve HTTP/3 over QUIC on the same public port (UDP). Optional: on failure
+	// the terminator keeps serving HTTP/1.1 and (if built) HTTP/2 over TCP.
+	terminator_quic_start(public_port, cert_path);
+#endif
 	return true;
 }
 
 void terminator_stop(void)
 {
+#ifdef HAVE_HTTP3
+	terminator_quic_stop();
+#endif
+
 	if(!running && listen_fd < 0 && ssl_ctx == NULL)
 		return;
 

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -1848,6 +1848,7 @@ struct h3_stream {
 	bool resp_deferred;      // data reader parked on NGHTTP3_ERR_WOULDBLOCK
 	bool error;              // gateway error: backend torn down, stream ending
 	bool reset;              // QUIC RESET_STREAM sent, stop writing this stream
+	bool send_concluded;     // response FIN queued (SSL_stream_conclude called)
 };
 
 struct h3_conn {
@@ -2503,7 +2504,10 @@ static int h3_conn_pump_write(struct h3_conn *c)
 			return -1;
 
 		if(fin && !blocked)
+		{
 			SSL_stream_conclude(s->ssl, 0); // send FIN once all data is flushed
+			s->send_concluded = true;
+		}
 		if(blocked)
 			break;
 	}
@@ -2656,19 +2660,15 @@ static bool h3_stream_reapable(const struct h3_stream *s)
 {
 	if(s->uni_local)
 		return false;
-	// A remote unidirectional stream (the client's control and QPACK streams) is
-	// receive-only: it has no QUIC send part, so SSL_get_stream_write_state()
-	// below does not apply to it (querying it dereferences a NULL send-stream).
-	// These live for the whole connection anyway, so keep them.
-	if(SSL_get_stream_type(s->ssl) == SSL_STREAM_TYPE_READ)
-		return false;
-	const int ws = SSL_get_stream_write_state(s->ssl);
-	if(ws == SSL_STREAM_STATE_OK || ws == SSL_STREAM_STATE_NONE ||
-	   ws == SSL_STREAM_STATE_WRONG_DIR)
-		return false; // send part still open: freeing now would truncate it
-	if(ws == SSL_STREAM_STATE_FINISHED && !s->read_done)
-		return false;
-	return true;
+	// Decide from our own state, never SSL_get_stream_write_state(): once we
+	// conclude the send part OpenSSL may release its send-stream, and querying the
+	// write state then dereferences NULL. A reset stream is done and can go;
+	// otherwise wait until we have queued the response FIN (OpenSSL keeps flushing
+	// it after the node is freed) and the receive side has ended. Receive-only
+	// remote streams (control/QPACK) never conclude a send, so are never reaped.
+	if(s->reset)
+		return true;
+	return s->send_concluded && s->read_done;
 }
 
 // Reclaim completed request streams so per-connection memory and the event-loop

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -21,6 +21,12 @@
 // log_err(), log_info(), log_warn()
 #include "log.h"
 
+// The terminator is entirely OpenSSL-based; without TLS it does not exist. Guard
+// the whole body (like tls_client.c) so a no-TLS build still compiles. webserver.c
+// guards every terminator_start()/stop() call with HAVE_TLS; only the token
+// accessor (referenced unconditionally by the civetweb PROXY parser) needs a stub.
+#ifdef HAVE_TLS
+
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
@@ -34,10 +40,9 @@
 #include <openssl/opensslv.h>
 #include <nghttp3/nghttp3.h>
 #include <time.h>
-// The HTTP/3 gateway forwards the real client IP to the backend via
-// SSL_get_peer_addr(), a per-connection QUIC peer getter added in OpenSSL 4.0.
-// Refuse to build HTTP/3 against an older OpenSSL rather than silently
-// attributing every request to the loopback terminator.
+// HTTP/3 forwards the real client IP via SSL_get_peer_addr(), a per-connection
+// QUIC peer getter added in OpenSSL 4.0; refuse to build against older OpenSSL
+// rather than attributing every request to the loopback terminator.
 #if OPENSSL_VERSION_NUMBER < 0x40000000L
 #error "HTTP/3 requires OpenSSL >= 4.0, which provides SSL_get_peer_addr() for QUIC (needed to forward the real client IP). Upgrade OpenSSL to 4.0 or later, or build without nghttp3 to disable HTTP/3."
 #endif
@@ -45,6 +50,7 @@
 
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <sys/prctl.h>
 #include <pthread.h>
 #include <poll.h>
@@ -55,11 +61,89 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 
 // Bidirectional relay buffer size (per direction, per iteration).
 #define RELAY_BUF 16384u
 // Socket send/receive timeout so a stuck peer cannot pin a handler thread.
 #define IO_TIMEOUT_SEC 30
+// Cap on concurrent handler threads so a connection flood on the public TLS port
+// cannot exhaust the FTL process (threads, fds, memory). A browser needs only a
+// handful thanks to keep-alive and h2/h3 multiplexing, so this is generous for the
+// admin UI yet fatal to a flood; connections beyond it are dropped immediately.
+#define TERMINATOR_MAX_HANDLERS 256
+// Same cap for concurrent HTTP/3 connections. The QUIC gateway runs on one thread
+// and holds per-connection OpenSSL/nghttp3 state (plus a backend fd per request
+// stream), so an uncapped handshake flood would exhaust memory/fds; connections
+// beyond this are accepted and immediately closed, mirroring the TCP handler cap.
+#define TERMINATOR_MAX_H3_CONNS 256
+// Absolute wall-clock budget for the whole TLS handshake, independent of the
+// per-recv SO_RCVTIMEO (which a byte-at-a-time peer resets on every recv).
+#define HANDSHAKE_TIMEOUT_SEC 15
+
+// Number of live handler threads, for the cap above.
+static atomic_int active_handlers = 0;
+
+// A per-boot secret carried in a custom PROXY v2 TLV so the loopback CivetWeb
+// backend can tell a genuine terminator->backend header apart from one forged by
+// another local process (the loopback bind is the only other trust gate, and the
+// backend port is locally reachable). PP2_TYPE_MIN_CUSTOM..MAX_CUSTOM is 0xE0-EF.
+#define PP2_TYPE_FTL_TOKEN 0xE0u
+#define PROXY_TOKEN_LEN 16u
+// Largest PROXY v2 header we emit: 16 header + 36 IPv6 address block + 8 SSL TLV
+// + (3 + PROXY_TOKEN_LEN) token TLV.
+#define PROXY_V2_MAX (16u + 36u + 8u + 3u + PROXY_TOKEN_LEN)
+static unsigned char g_proxy_token[PROXY_TOKEN_LEN];
+static bool g_proxy_token_ready = false;
+// FTL's secure RNG (getrandom with a /dev/urandom fallback); declared here to
+// avoid pulling the whole config/password.h (and its config types) into this TU.
+extern bool get_secure_randomness(uint8_t *buffer, const size_t length);
+
+// Generate the per-boot backend-auth token once; idempotent. A restart (e.g.
+// cert renewal) must not rewrite it while leftover detached handlers may still
+// be reading it. Returns false only if the RNG fails.
+static bool ensure_proxy_token(void)
+{
+	if(g_proxy_token_ready)
+		return true;
+	if(!get_secure_randomness(g_proxy_token, sizeof(g_proxy_token)))
+		return false;
+	g_proxy_token_ready = true;
+	return true;
+}
+
+// Hex-encode the per-boot token into out (needs 2*PROXY_TOKEN_LEN+1 bytes),
+// generating it if necessary. webserver.c passes this to the loopback backend
+// as its "proxy_protocol_secret", the shared secret the backend uses to
+// authenticate our PROXY headers. Returns false if out is too small or the RNG
+// fails.
+bool terminator_proxy_token_hex(char *out, size_t outsz)
+{
+	static const char hex[] = "0123456789abcdef";
+	size_t i;
+	if(outsz < 2 * PROXY_TOKEN_LEN + 1 || !ensure_proxy_token())
+		return false;
+	for(i = 0; i < PROXY_TOKEN_LEN; i++)
+	{
+		out[2 * i]     = hex[g_proxy_token[i] >> 4];
+		out[2 * i + 1] = hex[g_proxy_token[i] & 0x0F];
+	}
+	out[2 * PROXY_TOKEN_LEN] = '\0';
+	return true;
+}
+
+// Passed to each detached handler: the client fd plus our own reference to the
+// SSL_CTX, taken while it is live, so terminator_stop() can free the context
+// without racing a handler that has not yet reached SSL_new().
+struct handler_arg { int client_fd; SSL_CTX *ctx; };
+
+// Monotonic milliseconds, for wall-clock deadlines.
+static uint64_t mono_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
 
 // Terminator state. There is a single terminator instance for the whole
 // process, mirroring the single CivetWeb context in webserver.c.
@@ -71,9 +155,8 @@ static pthread_t accept_tid;
 static bool accept_tid_valid = false;
 
 #ifdef HAVE_HTTP3
-// HTTP/3 (QUIC) listener state. The QUIC side runs a dedicated event-loop
-// thread that owns one UDP socket, one OpenSSL QUIC listener, and every QUIC
-// connection and stream on top of it (see the HAVE_HTTP3 section below).
+// HTTP/3 (QUIC) listener state, owned by the dedicated event-loop thread below
+// (one UDP socket, one OpenSSL QUIC listener, all connections and streams).
 static SSL_CTX *quic_ctx = NULL;
 static int quic_fd = -1;
 static pthread_t quic_tid;
@@ -93,9 +176,8 @@ static void log_ssl_errors(const char *context)
 	}
 }
 
-// ALPN selection: pick our most-preferred protocol that the client offers.
-// "h2" is preferred when HTTP/2 support is compiled in, otherwise (and as the
-// fallback) "http/1.1". Selection is done by hand to avoid the confusing
+// ALPN selection: pick our most-preferred protocol the client offers ("h2" when
+// HTTP/2 is compiled in, else "http/1.1"). Done by hand to avoid the confusing
 // server/client argument order of SSL_select_next_proto().
 static int alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
                           const unsigned char *in, unsigned int inlen, void *arg)
@@ -155,7 +237,35 @@ static SSL_CTX *create_server_ctx(const char *cert_path)
 
 // Bind a dual-stack (IPv4 + IPv6) TCP listener on the given port, all
 // interfaces. Returns the fd or -1.
-static int bind_listener(int port)
+// Fill a dual-stack sockaddr_in6 for the given bind address and port. addr may be
+// NULL or empty (bind all interfaces), an IPv6 literal, or an IPv4 literal (bound
+// as a v4-mapped address on the IPv6 socket, honouring IPV6_V6ONLY=off). Returns
+// false on an unparsable address so the caller fails closed rather than silently
+// widening the scope to all interfaces.
+static bool fill_bind_addr(struct sockaddr_in6 *sa, const char *addr, int port)
+{
+	memset(sa, 0, sizeof(*sa));
+	sa->sin6_family = AF_INET6;
+	sa->sin6_port = htons((uint16_t)port);
+	if(addr == NULL || addr[0] == '\0')
+	{
+		sa->sin6_addr = in6addr_any;
+		return true;
+	}
+	if(inet_pton(AF_INET6, addr, &sa->sin6_addr) == 1)
+		return true;
+	struct in_addr v4;
+	if(inet_pton(AF_INET, addr, &v4) == 1)
+	{
+		sa->sin6_addr.s6_addr[10] = 0xff; // ::ffff:a.b.c.d
+		sa->sin6_addr.s6_addr[11] = 0xff;
+		memcpy(&sa->sin6_addr.s6_addr[12], &v4, sizeof(v4));
+		return true;
+	}
+	return false;
+}
+
+static int bind_listener(const char *addr, int port)
 {
 	// SOCK_CLOEXEC so the fd is not inherited across FTL's execvp() self-restart,
 	// where it would keep the port busy and make the new process fail to re-bind.
@@ -173,13 +283,16 @@ static int bind_listener(int port)
 	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
 
 	struct sockaddr_in6 sa;
-	memset(&sa, 0, sizeof(sa));
-	sa.sin6_family = AF_INET6;
-	sa.sin6_addr = in6addr_any;
-	sa.sin6_port = htons((uint16_t)port);
+	if(!fill_bind_addr(&sa, addr, port))
+	{
+		log_err("Terminator: invalid bind address '%s'", addr);
+		close(fd);
+		return -1;
+	}
 	if(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
 	{
-		log_err("Terminator: bind() to port %d failed: %s", port, strerror(errno));
+		log_err("Terminator: bind() to %s#%d failed: %s",
+		        (addr && addr[0]) ? addr : "*", port, strerror(errno));
 		close(fd);
 		return -1;
 	}
@@ -239,8 +352,14 @@ static int write_all_fd(int fd, const char *buf, size_t len)
 }
 
 // Write the full buffer to the TLS connection (blocking socket). Returns 0 or -1.
+// The socket carries SO_SNDTIMEO, so each SSL_write() waits at most IO_TIMEOUT_SEC
+// for the peer to accept data; a WANT_WRITE then means a full timeout elapsed with
+// no progress. Bound the total no-progress time so a client that stops reading a
+// large response cannot pin this handler thread (and its active_handlers slot)
+// forever. Any forward progress resets the budget, so a slow-but-live reader is fine.
 static int write_all_ssl(SSL *ssl, const char *buf, size_t len)
 {
+	uint64_t deadline = mono_ms() + (uint64_t)IO_TIMEOUT_SEC * 1000u;
 	while(len > 0)
 	{
 		const int n = SSL_write(ssl, buf, (int)len);
@@ -248,25 +367,26 @@ static int write_all_ssl(SSL *ssl, const char *buf, size_t len)
 		{
 			buf += n;
 			len -= (size_t)n;
+			deadline = mono_ms() + (uint64_t)IO_TIMEOUT_SEC * 1000u;
 		}
 		else
 		{
 			const int err = SSL_get_error(ssl, n);
-			if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
-				continue;
-			return -1;
+			if(err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE)
+				return -1;
+			if(mono_ms() >= deadline)
+				return -1;
 		}
 	}
 	return 0;
 }
 
-// Fill a PROXY protocol v2 header describing the real client (source) and the
-// local accepting socket (destination) into hdr, which must hold at least 52
-// bytes. Returns 0 and the header length in *out_len, or -1 for an unsupported
-// address family. CivetWeb parses this header and attributes the request to the
-// actual client instead of the loopback terminator, so client-IP-based logging
-// and auth stay correct. This variant takes the addresses directly, so callers
-// without a client socket fd (e.g., the QUIC/HTTP3 gateway) can reuse it.
+// Build a PROXY protocol v2 header (real client as source, local socket as
+// destination) into hdr, which must hold at least PROXY_V2_MAX bytes. Returns 0 with the
+// length in *out_len, or -1 for an unsupported family. CivetWeb parses it and
+// attributes the request to the real client, not the loopback terminator, so
+// client-IP logging and auth stay correct. Takes the addresses directly so
+// callers without a client fd (the QUIC/HTTP3 gateway) can reuse it.
 static int build_proxy_v2_sa(const struct sockaddr_storage *src,
                              const struct sockaddr_storage *dst,
                              unsigned char *hdr, size_t *out_len)
@@ -323,6 +443,28 @@ static int build_proxy_v2_sa(const struct sockaddr_storage *src,
 	else
 		return -1;
 
+	// Announce that we terminated TLS via PP2_TYPE_SSL (0x20), value {client=
+	// PP2_CLIENT_SSL (0x01), verify=0}. Without it the plaintext loopback hop
+	// makes every request look like plain HTTP (no Secure cookie, wrong scheme).
+	static const unsigned char ssl_tlv[8] =
+		{ 0x20, 0x00, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00 };
+	memcpy(hdr + len, ssl_tlv, sizeof(ssl_tlv));
+	len += sizeof(ssl_tlv);
+
+	// Authenticate this header to the backend with the per-boot token TLV, so a
+	// PROXY header forged by another local process (which lacks the token) is
+	// ignored rather than adopted as the client address / TLS status.
+	hdr[len++] = PP2_TYPE_FTL_TOKEN;
+	hdr[len++] = 0x00;
+	hdr[len++] = (unsigned char)PROXY_TOKEN_LEN;
+	memcpy(hdr + len, g_proxy_token, PROXY_TOKEN_LEN);
+	len += PROXY_TOKEN_LEN;
+
+	// Rewrite the v2 length field to cover the address block plus the TLVs.
+	const size_t block = len - 16;
+	hdr[14] = (unsigned char)(block >> 8);
+	hdr[15] = (unsigned char)(block & 0xFF);
+
 	*out_len = len;
 	return 0;
 }
@@ -344,7 +486,7 @@ static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
 // Returns 0 on success, -1 on error.
 static int send_proxy_v2(int be_fd, int client_fd)
 {
-	unsigned char hdr[16 + 36];
+	unsigned char hdr[PROXY_V2_MAX]; // address block + SSL + token TLVs
 	size_t len = 0;
 	if(build_proxy_v2(client_fd, hdr, &len) != 0)
 		return -1;
@@ -352,9 +494,8 @@ static int send_proxy_v2(int be_fd, int client_fd)
 }
 
 // Relay bytes both ways between the TLS'd client and the plaintext backend until
-// either side closes. TLS is transparent here: CivetWeb sees a normal HTTP/1.1
-// stream, so keep-alive, chunked bodies, ranges, etc. all work unchanged. The
-// real client address was already announced to the backend via send_proxy_v2().
+// either side closes. CivetWeb sees a normal HTTP/1.1 stream, so keep-alive,
+// chunked bodies, ranges, etc. all work unchanged.
 static void relay(SSL *ssl, int client_fd, int be_fd)
 {
 	char buf[RELAY_BUF];
@@ -417,10 +558,9 @@ static void relay(SSL *ssl, int client_fd, int be_fd)
 
 #if defined(HAVE_HTTP2) || defined(HAVE_HTTP3)
 // ---------------------------------------------------------------------------
-// Helpers shared by the HTTP/2 and HTTP/3 gateways. Both terminate an upgraded
-// protocol on the public port and bridge every request to a plain HTTP/1.1
-// request against the CivetWeb backend, so the non-blocking backend socket, the
-// growing byte buffer, and the hop-by-hop header filter are common ground.
+// Helpers shared by the HTTP/2 and HTTP/3 gateways. Both bridge every request to
+// a plain HTTP/1.1 request against the CivetWeb backend, so the non-blocking
+// backend socket, growing byte buffer, and hop-by-hop header filter are common.
 // ---------------------------------------------------------------------------
 
 // EAGAIN and EWOULDBLOCK are the same value on Linux; test both only where they
@@ -441,11 +581,9 @@ static int set_nonblocking(int fd)
 }
 
 // Open a non-blocking plaintext TCP socket to the CivetWeb backend on loopback.
-// Sets *connected to true if the connection completed immediately (the common
-// case on loopback), false if it is still in progress (EINPROGRESS). Returns the
-// fd or -1. Shared by the streaming gateways; marked inline so a build with only
-// one of HTTP/2 / HTTP/3 does not warn when the other's caller is absent.
-static inline int connect_backend_nb(bool *connected)
+// Sets *connected to true if connect() completed immediately (common on
+// loopback), false if still in progress (EINPROGRESS). Returns the fd or -1.
+static int connect_backend_nb(bool *connected)
 {
 	const int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
 	if(fd < 0)
@@ -497,7 +635,10 @@ static bool hbh_skip_header(const char *name, size_t len)
 {
 	static const char *const skip[] = {
 		"connection", "keep-alive", "proxy-connection", "transfer-encoding",
-		"upgrade", "te", "host", "http2-settings"
+		"upgrade", "te", "host", "http2-settings",
+		// "expect" (100-continue) is dropped: the gateway does not relay interim
+		// 1xx responses, and h2/h3 clients send the body via flow control anyway.
+		"expect"
 	};
 	for(size_t i = 0; i < sizeof(skip) / sizeof(skip[0]); i++)
 		if(len == strlen(skip[i]) && strncasecmp(name, skip[i], len) == 0)
@@ -513,10 +654,9 @@ enum { BODY_NONE, BODY_LENGTH, BODY_CHUNKED, BODY_CLOSE };
 enum { CH_SIZE, CH_EXT, CH_SIZE_LF, CH_DATA, CH_DATA_CR, CH_DATA_LF, CH_TRAILER, CH_DONE };
 
 // Protocol-agnostic HTTP/1.1 backend-bridge state. Each streaming gateway embeds
-// one of these per request stream and drives it through the be_* helpers below:
-// an outbound request buffer, an incrementally parsed response-header
-// accumulator, the response body de-framing (Content-Length / chunked / close)
-// state machine, and a decoded-body buffer for the protocol's data provider.
+// one per request stream and drives it through the be_* helpers: outbound
+// request buffer, response-header accumulator, body de-framing state machine
+// (Content-Length / chunked / close), and a decoded-body buffer.
 struct be_bridge {
 	// Outbound request buffer (PROXY header + HTTP/1.1 head + body), drained to
 	// the backend from [req_out_off, req_out_len)
@@ -545,12 +685,9 @@ struct be_bridge {
 	bool resp_complete;      // full response body has been decoded
 };
 
-// The be_* helpers below are marked inline so a build with only one of the two
-// streaming gateways does not warn about the ones the other gateway would call.
-
 // Queue bytes to send to the backend, compacting already-sent data first so the
 // buffer does not grow without bound. Returns 0 or -1.
-static inline int be_req_push(struct be_bridge *b, const char *data, size_t n)
+static int be_req_push(struct be_bridge *b, const char *data, size_t n)
 {
 	if(b->req_out_off > 0)
 	{
@@ -563,7 +700,7 @@ static inline int be_req_push(struct be_bridge *b, const char *data, size_t n)
 
 // Queue decoded response body bytes for the data provider, compacting already-
 // delivered data first. Returns 0 or -1.
-static inline int be_body_push(struct be_bridge *b, const char *data, size_t n)
+static int be_body_push(struct be_bridge *b, const char *data, size_t n)
 {
 	if(b->body_off > 0)
 	{
@@ -577,7 +714,7 @@ static inline int be_body_push(struct be_bridge *b, const char *data, size_t n)
 // Incrementally de-chunk a Transfer-Encoding: chunked response body, appending
 // decoded bytes to the bridge body buffer. State persists across calls. Returns
 // 0 or -1.
-static inline int be_feed_chunked(struct be_bridge *b, const char *data, size_t n)
+static int be_feed_chunked(struct be_bridge *b, const char *data, size_t n)
 {
 	size_t i = 0;
 	while(i < n && b->chunk_state != CH_DONE)
@@ -639,7 +776,7 @@ static inline int be_feed_chunked(struct be_bridge *b, const char *data, size_t 
 
 // Decode response body bytes according to the negotiated framing and append the
 // result to the bridge body buffer. Returns 0 or -1.
-static inline int be_feed_body(struct be_bridge *b, const char *data, size_t n)
+static int be_feed_body(struct be_bridge *b, const char *data, size_t n)
 {
 	switch(b->body_mode)
 	{
@@ -668,7 +805,7 @@ static inline int be_feed_body(struct be_bridge *b, const char *data, size_t n)
 // True if the response body framing is known and has not reached its end, i.e.
 // an early backend close or read error would truncate it. Close-delimited
 // (BODY_CLOSE) and body-less (BODY_NONE) responses end legitimately on close.
-static inline bool be_body_truncated(const struct be_bridge *b)
+static bool be_body_truncated(const struct be_bridge *b)
 {
 	if(b->body_mode == BODY_LENGTH)
 		return b->body_remaining > 0;
@@ -677,13 +814,43 @@ static inline bool be_body_truncated(const struct be_bridge *b)
 	return false;
 }
 
+// Release the bridge's heap buffers. FTL's free() warns on NULL, so only free
+// what was actually allocated (an unused stream leaves some fields NULL).
+static void be_free(struct be_bridge *b)
+{
+	// Idempotent by construction: FTL's free() macro NULLs each pointer, and we
+	// skip already-NULL ones, so calling this twice on the same bridge is safe
+	// (the h3 reap path frees once in the nghttp3 stream_close callback and again
+	// after nghttp3_conn_close_stream()), and control/QPACK streams that never
+	// allocated a buffer do not trip FTLfree()'s NULL-pointer warning.
+	if(b->req_out != NULL)
+		free(b->req_out);
+	if(b->resp_hdr != NULL)
+		free(b->resp_hdr);
+	if(b->body_buf != NULL)
+		free(b->body_buf);
+}
+
+// Copy an h2/h3 request pseudo-header value into a fixed buffer. If it does not
+// fit, set *oversize so the caller rejects the request with 414 instead of
+// silently forwarding a truncated (i.e. different) request target to the backend.
+static void copy_pseudo_header(char *dst, size_t cap, const char *v, size_t vlen, bool *oversize)
+{
+	if(vlen >= cap)
+	{
+		*oversize = true;
+		return;
+	}
+	memcpy(dst, v, vlen);
+	dst[vlen] = '\0';
+}
+
 // Format the plain HTTP/1.1 request head (request line + reconstructed headers)
-// for the backend into out. The backend is asked to close after the response
-// (Connection: close), so responses are cleanly delimited. extra_headers, if
-// non-NULL, is inserted verbatim after the reconstructed headers (e.g. a framing
-// header such as Transfer-Encoding or Content-Length). Returns the snprintf()
-// result: the would-be length, negative on error, >= outcap if truncated.
-static inline int be_format_request_head(char *out, size_t outcap,
+// into out. Connection: close is added so responses are cleanly delimited.
+// extra_headers, if non-NULL, is inserted verbatim (e.g. a framing header such
+// as Transfer-Encoding). Returns the snprintf() result: the would-be length,
+// negative on error, >= outcap if truncated.
+static int be_format_request_head(char *out, size_t outcap,
                                          const char *method, const char *path,
                                          const char *authority, const char *reqhdr,
                                          size_t reqhdr_len, const char *extra_headers)
@@ -704,16 +871,14 @@ static inline int be_format_request_head(char *out, size_t outcap,
 //
 // Runs an nghttp2 server session on the TLS connection and bridges every request
 // stream to a plain HTTP/1.1 request against the CivetWeb backend, translating
-// the response back to HTTP/2. CivetWeb keeps speaking HTTP/1.1 and never sees
-// HTTP/2.
+// the response back to HTTP/2. CivetWeb never sees HTTP/2.
 //
-// The gateway streams and multiplexes: each request stream gets its own
-// non-blocking backend connection, the request body is streamed to the backend
-// as it arrives (respecting HTTP/2 flow control), and the HTTP/1.1 response is
-// parsed incrementally and pulled back into HTTP/2 DATA frames on demand via an
-// nghttp2 data provider. A single poll() loop drives the client TLS socket and
-// every active backend socket, so many streams make progress concurrently and
-// no single stream blocks the whole session.
+// Streams and multiplexes: each request stream gets its own non-blocking backend
+// connection, the request body is streamed to the backend as it arrives
+// (respecting HTTP/2 flow control), and the HTTP/1.1 response is parsed
+// incrementally and pulled into HTTP/2 DATA frames on demand via an nghttp2 data
+// provider. A single poll() loop drives the client TLS socket and every backend
+// socket, so streams progress concurrently and none blocks the session.
 // ---------------------------------------------------------------------------
 
 #define H2_REQHDR_MAX 8192u
@@ -724,11 +889,17 @@ static inline int be_format_request_head(char *out, size_t outcap,
 // body is buffered we stop reading the backend, applying backpressure toward the
 // (slower) client.
 #define H2_BODY_HIGH_WATER (256u * 1024u)
+// Aggregate cap on decoded response body buffered across ALL streams of one
+// connection. The per-stream high-water alone lets MAX_CONCURRENT_STREAMS x 256
+// KiB accumulate in a single handler thread if a client stalls; this bounds the
+// total so a slow/hostile multiplexed client cannot exhaust memory on a small
+// device. Legit clients drain quickly and never reach it.
+#define H2_CONN_BODY_CAP (4u * 1024u * 1024u)
 // Soft cap on the outbound TLS buffer; we stop pulling more frames out of
 // nghttp2 once this much is queued for SSL_write().
 #define H2_WBUF_SOFT_CAP (512u * 1024u)
 // Maximum PROXY protocol v2 header size (16 fixed + 36 for IPv6).
-#define H2_PROXY_MAX 52u
+#define H2_PROXY_MAX PROXY_V2_MAX
 
 struct h2_conn;
 
@@ -744,6 +915,7 @@ struct h2_stream {
 	char reqhdr[H2_REQHDR_MAX];
 	size_t reqhdr_len;
 	bool content_length_seen;
+	bool oversize;           // a pseudo-header did not fit -> answer 414, do not forward
 
 	// Backend connection (non-blocking)
 	int be_fd;
@@ -801,15 +973,22 @@ static void h2_stream_unlink(struct h2_conn *c, struct h2_stream *s)
 	}
 }
 
+// Total decoded response body buffered across all of a connection's streams.
+static size_t __attribute__((pure)) h2_conn_buffered(const struct h2_conn *c)
+{
+	size_t total = 0;
+	for(const struct h2_stream *s = c->streams; s != NULL; s = s->next)
+		total += s->be.body_len - s->be.body_off;
+	return total;
+}
+
 static void h2_stream_free(struct h2_stream *s)
 {
 	if(s == NULL)
 		return;
 	if(s->be_fd >= 0)
 		close(s->be_fd);
-	free(s->be.req_out);
-	free(s->be.resp_hdr);
-	free(s->be.body_buf);
+	be_free(&s->be);
 	free(s);
 }
 
@@ -859,6 +1038,13 @@ static void h2_gateway_error(struct h2_stream *s, const char *status3)
 // the backend connection, and queue the PROXY header and HTTP/1.1 request head.
 static void h2_start_backend(struct h2_stream *s, bool has_body)
 {
+	// A pseudo-header that did not fit its buffer would forward a truncated
+	// request target; reject cleanly instead of serving the wrong resource.
+	if(s->oversize)
+	{
+		h2_gateway_error(s, "414");
+		return;
+	}
 	if(!has_body)
 		s->be.req_mode = REQ_NONE;
 	else if(s->content_length_seen)
@@ -965,6 +1151,7 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 
 	bool chunked = false, have_clen = false;
 	size_t clen = 0;
+	char *clen_name = NULL, *clen_val = NULL; // Content-Length, forwarded after framing
 	char *line = strstr(hdr, "\r\n"); // skip the status line
 	if(line != NULL)
 	{
@@ -990,7 +1177,9 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 				{
 					have_clen = true;
 					clen = (size_t)strtoull(val, NULL, 10);
-					h2_add_nv(nva, &nvlen, line, val);
+					// Defer forwarding until the body framing is known: a
+					// de-chunked body makes the original length wrong.
+					clen_name = line; clen_val = val;
 				}
 				else if(nlen > 0 && !hbh_skip_header(line, nlen))
 				{
@@ -1025,6 +1214,12 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 	}
 	else
 		s->be.body_mode = BODY_CLOSE; // length delimited by the backend closing
+
+	// Forward Content-Length unless the terminator de-chunked the body, in which
+	// case the original length no longer matches the DATA the client receives
+	// (the HTTP/3 path drops it unconditionally for the same reason).
+	if(!chunked && clen_name != NULL && nvlen < H2_MAX_HDRS)
+		h2_add_nv(nva, &nvlen, clen_name, clen_val);
 
 	s->be.resp_headers_parsed = true;
 
@@ -1122,6 +1317,10 @@ static void h2_be_readable(struct h2_stream *s)
 {
 	if(s->be_fd < 0)
 		return;
+	// Body already buffered by the OTHER streams on this connection (fixed for the
+	// duration of this call), so the per-connection cap can be enforced with a
+	// single walk rather than one per read.
+	const size_t conn_other = h2_conn_buffered(s->conn) - (s->be.body_len - s->be.body_off);
 	char tmp[16384];
 	for(;;)
 	{
@@ -1136,15 +1335,16 @@ static void h2_be_readable(struct h2_stream *s)
 			if(s->be.resp_complete)
 				break;
 			if((s->be.body_len - s->be.body_off) >= H2_BODY_HIGH_WATER)
-				break; // backpressure: let the client drain first
+				break; // per-stream backpressure: let the client drain first
+			if(conn_other + (s->be.body_len - s->be.body_off) >= H2_CONN_BODY_CAP)
+				break; // per-connection backpressure: aggregate body cap reached
 			continue;
 		}
 		if(r == 0)
 		{
-			// Backend closed. For close-delimited bodies this is the normal end;
-			// for a length/chunked-framed body that has not reached its end it is
-			// a truncation, which we signal to the client with RST_STREAM rather
-			// than delivering a silently short body as if complete.
+			// Backend closed. Normal end for close-delimited bodies; for a
+			// length/chunked body short of its end it is a truncation, signalled
+			// to the client with RST_STREAM rather than a silently short body.
 			if(!s->be.resp_headers_parsed || be_body_truncated(&s->be))
 			{
 				h2_gateway_error(s, "502");
@@ -1211,11 +1411,11 @@ static int h2_on_header(nghttp2_session *session, const nghttp2_frame *frame,
 	if(namelen > 0 && n[0] == ':')
 	{
 		if(namelen == 7 && memcmp(n, ":method", 7) == 0)
-			snprintf(s->method, sizeof(s->method), "%.*s", (int)valuelen, v);
+			copy_pseudo_header(s->method, sizeof(s->method), v, valuelen, &s->oversize);
 		else if(namelen == 5 && memcmp(n, ":path", 5) == 0)
-			snprintf(s->path, sizeof(s->path), "%.*s", (int)valuelen, v);
+			copy_pseudo_header(s->path, sizeof(s->path), v, valuelen, &s->oversize);
 		else if(namelen == 10 && memcmp(n, ":authority", 10) == 0)
-			snprintf(s->authority, sizeof(s->authority), "%.*s", (int)valuelen, v);
+			copy_pseudo_header(s->authority, sizeof(s->authority), v, valuelen, &s->oversize);
 		// :scheme is always https at the terminator and is not forwarded
 		return 0;
 	}
@@ -1305,6 +1505,12 @@ static int h2_on_stream_close(nghttp2_session *session, int32_t stream_id, uint3
 	struct h2_stream *s = nghttp2_session_get_stream_user_data(session, stream_id);
 	if(s != NULL)
 	{
+		// Return any request-body bytes still charged against the connection
+		// window (e.g. a stream reset mid-body before the backend flushed): the
+		// session is still alive here, and h2_stream_free() would not reclaim
+		// them. h2_be_close() is a no-op if already reclaimed (body_uncredited
+		// zeroed).
+		h2_be_close(s);
 		h2_stream_unlink(conn, s);
 		h2_stream_free(s);
 		nghttp2_session_set_stream_user_data(session, stream_id, NULL);
@@ -1473,6 +1679,8 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 		conn.pfds[0].revents = 0;
 		conn.pmap[0] = NULL;
 
+		// Aggregate body buffered across the connection, for the per-connection cap.
+		const size_t conn_buffered = h2_conn_buffered(&conn);
 		nfds_t nfds = 1;
 		for(struct h2_stream *s = conn.streams; s != NULL; s = s->next)
 		{
@@ -1485,8 +1693,10 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 			{
 				if(s->be.req_out_off < s->be.req_out_len)
 					ev |= POLLOUT; // request bytes still to flush
-				if(!s->be.resp_complete && (s->be.body_len - s->be.body_off) < H2_BODY_HIGH_WATER)
-					ev |= POLLIN;  // room for more response body
+				if(!s->be.resp_complete &&
+				   (s->be.body_len - s->be.body_off) < H2_BODY_HIGH_WATER &&
+				   conn_buffered < H2_CONN_BODY_CAP)
+					ev |= POLLIN;  // room for more response body (per-stream + per-conn)
 			}
 			if(ev == 0)
 				continue;
@@ -1497,12 +1707,11 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 			nfds++;
 		}
 
-		// If nghttp2 still has data to send that the H2_WBUF_SOFT_CAP throttle
-		// deferred, and the outbound TLS buffer is already drained, do not block:
-		// poll with a zero timeout so the next loop iteration pumps the next
-		// batch. Otherwise a large or aggregated response would stall until the
-		// idle timeout and be truncated. When the buffer is not yet drained the
-		// pollfds carry POLLOUT and we wait for the client to accept more.
+		// If nghttp2 still has data the H2_WBUF_SOFT_CAP throttle deferred and
+		// the outbound TLS buffer is drained, poll with a zero timeout so the
+		// next iteration pumps the next batch; otherwise a large response would
+		// stall until the idle timeout and be truncated. When the buffer is not
+		// drained the pollfds carry POLLOUT and we wait for the client.
 		const bool more_to_pump = conn.wlen == conn.woff && !conn.ssl_want_write &&
 		                          nghttp2_session_want_write(conn.session);
 		const int pr = poll(conn.pfds, nfds, more_to_pump ? 0 : (IO_TIMEOUT_SEC * 1000));
@@ -1535,9 +1744,8 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 		}
 	}
 
-	// nghttp2_session_del() closes any remaining streams (invoking
-	// on_stream_close, which unlinks and frees them); drain defensively in case
-	// this version does not, then release the connection buffers.
+	// nghttp2_session_del() closes remaining streams via on_stream_close (which
+	// frees them); drain defensively in case it does not, then free the buffers.
 	nghttp2_session_del(conn.session);
 	while(conn.streams != NULL)
 	{
@@ -1557,25 +1765,22 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 //
 // A single dedicated thread owns one UDP socket, one OpenSSL QUIC listener, and
 // every QUIC connection and HTTP/3 stream on top of it. OpenSSL performs the
-// QUIC transport (packetisation, congestion control, loss recovery, per-stream
-// flow control); nghttp3 performs the HTTP/3 layer (QPACK, framing) on top of
-// the per-stream byte streams that OpenSSL exposes as child SSL objects.
+// QUIC transport (congestion control, loss recovery, per-stream flow control);
+// nghttp3 performs the HTTP/3 layer (QPACK, framing) over the per-stream byte
+// streams OpenSSL exposes as child SSL objects.
 //
-// Each HTTP/3 request is bridged to a plain HTTP/1.1 request against the
-// CivetWeb backend, exactly like the HTTP/2 gateway, and the response is
-// translated back to HTTP/3. The bridge is non-blocking and streaming, mirroring
-// the HTTP/2 gateway and reusing the same shared HTTP/1.1 backend-bridge helpers:
-// each request stream gets its own non-blocking backend connection, the request
-// body is streamed to the backend as it arrives, and the HTTP/1.1 response is
-// parsed incrementally and pulled back into HTTP/3 DATA frames on demand via an
-// nghttp3 data reader (defer with NGHTTP3_ERR_WOULDBLOCK, resume with
-// nghttp3_conn_resume_stream). The single QUIC event-loop poll() set covers the
-// UDP socket plus every active backend socket, so a slow backend never blocks
-// QUIC processing for the other live HTTP/3 connections.
+// Each request is bridged to a plain HTTP/1.1 request against the CivetWeb
+// backend and translated back, exactly like the HTTP/2 gateway and reusing the
+// same be_* helpers: a per-stream non-blocking backend connection, the request
+// body streamed as it arrives, and the HTTP/1.1 response parsed incrementally
+// and pulled into HTTP/3 DATA frames on demand via an nghttp3 data reader (defer
+// with NGHTTP3_ERR_WOULDBLOCK, resume with nghttp3_conn_resume_stream). One
+// poll() set covers the UDP socket plus every backend socket, so a slow backend
+// never blocks QUIC processing for the other connections.
 //
-// Client-IP note: each backend request carries a PROXY protocol v2 header with
-// the real client address, obtained from SSL_get_peer_addr() (OpenSSL 4.0's QUIC
-// per-connection peer getter), identical to the TCP and HTTP/2 paths.
+// Client-IP note: each backend request carries a PROXY v2 header with the real
+// client address from SSL_get_peer_addr() (OpenSSL 4.0's QUIC peer getter),
+// identical to the TCP and HTTP/2 paths.
 // ---------------------------------------------------------------------------
 
 #define H3_REQHDR_MAX 8192u
@@ -1591,7 +1796,7 @@ static void terminator_h2_serve(SSL *ssl, int client_fd)
 // QUIC flow control backpressures the client.
 #define H3_REQ_HIGH_WATER (256u * 1024u)
 // Maximum PROXY protocol v2 header size (16 fixed + 36 for IPv6).
-#define H3_PROXY_MAX 52u
+#define H3_PROXY_MAX PROXY_V2_MAX
 
 struct h3_conn;
 
@@ -1608,6 +1813,7 @@ struct h3_stream {
 	char authority[256];
 	char path[2048];
 	char reqhdr[H3_REQHDR_MAX];
+	bool oversize;           // a pseudo-header did not fit -> answer 414, do not forward
 	size_t reqhdr_len;
 	bool content_length_seen;
 
@@ -1648,7 +1854,7 @@ static nghttp3_tstamp h3_now(void)
 	return (nghttp3_tstamp)ts.tv_sec * 1000000000ull + (nghttp3_tstamp)ts.tv_nsec;
 }
 
-static struct h3_stream *h3_find_stream(struct h3_conn *c, int64_t id)
+static struct h3_stream *__attribute__((pure)) h3_find_stream(struct h3_conn *c, int64_t id)
 {
 	for(struct h3_stream *s = c->streams; s != NULL; s = s->next)
 		if(s->id == id)
@@ -1698,10 +1904,10 @@ static void h3_reset_stream(struct h3_stream *s)
 
 // nghttp3 data reader: hand decoded response body bytes to nghttp3 on demand,
 // zero-copy from the bridge body buffer. Returns NGHTTP3_ERR_WOULDBLOCK when the
-// backend has not produced more body yet; h3_be_readable() resumes the stream
-// once it does. The buffer stays stable while nghttp3 references it because the
-// event loop only reads more backend data (which may reallocate the buffer) once
-// nghttp3 has flushed everything produced so far (nghttp3_conn_is_stream_flushed).
+// backend has no more body yet; h3_be_readable() resumes the stream once it
+// does. The buffer stays stable while nghttp3 references it because the event
+// loop reads more backend data (which may realloc it) only after nghttp3 has
+// flushed everything so far (nghttp3_conn_is_stream_flushed).
 static nghttp3_ssize h3_read_data(nghttp3_conn *h3, int64_t stream_id,
                                   nghttp3_vec *vec, size_t veccnt,
                                   uint32_t *pflags, void *conn_user_data,
@@ -1769,6 +1975,13 @@ static void h3_start_backend(struct h3_stream *s, bool has_body)
 {
 	s->be_started = true;
 
+	// A pseudo-header that did not fit its buffer would forward a truncated
+	// request target; reject cleanly instead of serving the wrong resource.
+	if(s->oversize)
+	{
+		h3_gateway_error(s, "414");
+		return;
+	}
 	if(!has_body)
 		s->be.req_mode = REQ_NONE;
 	else if(s->content_length_seen)
@@ -2068,11 +2281,11 @@ static int h3_cb_recv_header(nghttp3_conn *h3, int64_t stream_id, int32_t token,
 	if(nl > 0 && n[0] == ':')
 	{
 		if(nl == 7 && memcmp(n, ":method", 7) == 0)
-			snprintf(s->method, sizeof(s->method), "%.*s", (int)vl, v);
+			copy_pseudo_header(s->method, sizeof(s->method), v, vl, &s->oversize);
 		else if(nl == 5 && memcmp(n, ":path", 5) == 0)
-			snprintf(s->path, sizeof(s->path), "%.*s", (int)vl, v);
+			copy_pseudo_header(s->path, sizeof(s->path), v, vl, &s->oversize);
 		else if(nl == 10 && memcmp(n, ":authority", 10) == 0)
-			snprintf(s->authority, sizeof(s->authority), "%.*s", (int)vl, v);
+			copy_pseudo_header(s->authority, sizeof(s->authority), v, vl, &s->oversize);
 		// :scheme is always https at the terminator and is not forwarded
 		return 0;
 	}
@@ -2174,11 +2387,9 @@ static int h3_cb_stream_close(nghttp3_conn *h3, int64_t stream_id,
 		// backend socket. The node and its QUIC stream object are reclaimed by
 		// h3_conn_reap_streams() once the send part is concluded/reset.
 		h3_be_close(s);
-		free(s->be.req_out); s->be.req_out = NULL;
+		be_free(&s->be);
 		s->be.req_out_len = s->be.req_out_off = s->be.req_out_cap = 0;
-		free(s->be.resp_hdr); s->be.resp_hdr = NULL;
 		s->be.resp_hdr_len = s->be.resp_hdr_cap = 0;
-		free(s->be.body_buf); s->be.body_buf = NULL;
 		s->be.body_len = s->be.body_off = s->be.body_cap = 0;
 	}
 	return 0;
@@ -2409,9 +2620,7 @@ static void h3_conn_free(struct h3_conn *c)
 			SSL_free(s->ssl);
 		if(s->be_fd >= 0)
 			close(s->be_fd);
-		free(s->be.req_out);
-		free(s->be.resp_hdr);
-		free(s->be.body_buf);
+		be_free(&s->be);
 		free(s);
 		s = nx;
 	}
@@ -2420,13 +2629,12 @@ static void h3_conn_free(struct h3_conn *c)
 	free(c);
 }
 
-// A finished request stream may be reclaimed once its QUIC send part has been
-// concluded or reset. SSL_free() only resets stream parts that were NOT already
-// concluded/reset, and a concluded send part keeps being flushed reliably by the
-// parent connection after the stream object is freed, so reaping here loses no
-// response data. For a normal finish we also wait for the receive part to end so
-// we do not STOP_SENDING a request body still in flight; a reset stream is torn
-// down regardless. Control/QPACK streams live for the whole connection.
+// A finished request stream may be reclaimed once its QUIC send part is
+// concluded or reset: a concluded send part keeps being flushed by the parent
+// connection after the stream object is freed, so reaping loses no response
+// data. For a normal finish we also wait for the receive part to end so we do
+// not STOP_SENDING a request body still in flight; a reset stream is reaped
+// regardless. Control/QPACK streams live for the whole connection.
 static bool h3_stream_reapable(const struct h3_stream *s)
 {
 	if(s->uni_local)
@@ -2441,9 +2649,8 @@ static bool h3_stream_reapable(const struct h3_stream *s)
 }
 
 // Reclaim completed request streams so per-connection memory and the event-loop
-// scan do not grow with the number of requests served over a long-lived HTTP/3
-// connection. Without this, browsers multiplexing thousands of requests on one
-// connection accumulate a node (and QUIC stream object) each.
+// scan do not grow with each request over a long-lived HTTP/3 connection (a
+// browser multiplexing thousands of requests would otherwise leak a node each).
 static void h3_conn_reap_streams(struct h3_conn *c)
 {
 	struct h3_stream **pp = &c->streams;
@@ -2460,9 +2667,7 @@ static void h3_conn_reap_streams(struct h3_conn *c)
 		nghttp3_conn_close_stream(c->h3, s->id, 0);
 		*pp = s->next;
 		h3_be_close(s);
-		free(s->be.req_out);
-		free(s->be.resp_hdr);
-		free(s->be.body_buf);
+		be_free(&s->be);
 		if(s->ssl != NULL)
 			SSL_free(s->ssl);
 		free(s);
@@ -2530,6 +2735,7 @@ static void *quic_accept_loop(void *arg)
 	size_t pcap = 0;
 
 	struct h3_conn *conns = NULL;
+	unsigned int h3_live = 0; // live connections on `conns`, capped below
 	while(quic_running)
 	{
 		// Size the poll set: the UDP socket plus every active backend socket.
@@ -2547,9 +2753,8 @@ static void *quic_accept_loop(void *arg)
 			if(np != NULL && nm != NULL)
 				pcap = need;
 			// On a transient allocation failure keep the old capacity and poll
-			// only what fits this round; the backend fds that do not fit are
-			// serviced on a later iteration. Never tear down live connections
-			// over a momentary memory spike.
+			// only what fits; the rest are serviced on a later iteration. Never
+			// tear down live connections over a momentary memory spike.
 		}
 		if(pcap == 0)
 		{
@@ -2620,11 +2825,19 @@ static void *quic_accept_loop(void *arg)
 			SSL *cs = SSL_accept_connection(listener, SSL_ACCEPT_CONNECTION_NO_BLOCK);
 			if(cs == NULL)
 				break;
+			// Over the cap: reject the connection but keep draining the accept
+			// queue so a flood cannot pile up inside OpenSSL either.
+			if(h3_live >= TERMINATOR_MAX_H3_CONNS)
+			{
+				SSL_free(cs);
+				continue;
+			}
 			struct h3_conn *c = h3_conn_new(cs);
 			if(c != NULL)
 			{
 				c->next = conns;
 				conns = c;
+				h3_live++;
 			}
 			else
 				SSL_free(cs);
@@ -2686,6 +2899,7 @@ static void *quic_accept_loop(void *arg)
 			{
 				*pp = c->next;
 				h3_conn_free(c);
+				h3_live--;
 			}
 			else
 				pp = &(*pp)->next;
@@ -2749,7 +2963,7 @@ static SSL_CTX *create_quic_server_ctx(const char *cert_path)
 }
 
 // Bind a dual-stack UDP socket on the given port for the QUIC listener.
-static int bind_udp(int port)
+static int bind_udp(const char *addr, int port)
 {
 	const int fd = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 	if(fd < 0)
@@ -2763,13 +2977,16 @@ static int bind_udp(int port)
 	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
 
 	struct sockaddr_in6 sa;
-	memset(&sa, 0, sizeof(sa));
-	sa.sin6_family = AF_INET6;
-	sa.sin6_addr = in6addr_any;
-	sa.sin6_port = htons((uint16_t)port);
+	if(!fill_bind_addr(&sa, addr, port))
+	{
+		log_err("Terminator: invalid QUIC bind address '%s'", addr);
+		close(fd);
+		return -1;
+	}
 	if(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
 	{
-		log_err("Terminator: QUIC bind() to port %d failed: %s", port, strerror(errno));
+		log_err("Terminator: QUIC bind() to %s#%d failed: %s",
+		        (addr && addr[0]) ? addr : "*", port, strerror(errno));
 		close(fd);
 		return -1;
 	}
@@ -2784,12 +3001,12 @@ static int bind_udp(int port)
 
 // Start the HTTP/3 listener alongside the TCP terminator. HTTP/3 is optional, so
 // a failure here is logged and the terminator keeps serving HTTP/1.1 and HTTP/2.
-static void terminator_quic_start(int public_port, const char *cert_path)
+static void terminator_quic_start(const char *bind_addr, int public_port, const char *cert_path)
 {
 	quic_ctx = create_quic_server_ctx(cert_path);
 	if(quic_ctx == NULL)
 		return;
-	quic_fd = bind_udp(public_port);
+	quic_fd = bind_udp(bind_addr, public_port);
 	if(quic_fd < 0)
 	{
 		SSL_CTX_free(quic_ctx);
@@ -2835,16 +3052,55 @@ static void terminator_quic_stop(void)
 }
 #endif /* HAVE_HTTP3 */
 
+// Drive SSL_accept to completion in non-blocking mode against an absolute
+// deadline, so a slow-drip client cannot pin a handler thread indefinitely
+// (SO_RCVTIMEO only bounds a single idle recv, which a dribbling peer resets on
+// every byte). Restores the fd's blocking mode on return for the post-handshake
+// relay/gateway code. Returns true iff the handshake completed in time.
+static bool terminator_handshake(SSL *ssl, int fd)
+{
+	const int fl = fcntl(fd, F_GETFL, 0);
+	if(fl >= 0)
+		fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+	const uint64_t deadline = mono_ms() + (uint64_t)HANDSHAKE_TIMEOUT_SEC * 1000u;
+	bool ok = false;
+	for(;;)
+	{
+		const int r = SSL_accept(ssl);
+		if(r == 1)
+		{
+			ok = true;
+			break;
+		}
+		const int err = SSL_get_error(ssl, r);
+		if(err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE)
+			break; // hard error or a plain-HTTP probe on the TLS port
+		const uint64_t now = mono_ms();
+		if(now >= deadline)
+			break;
+		struct pollfd pfd = { .fd = fd,
+		                      .events = (short)((err == SSL_ERROR_WANT_WRITE) ? POLLOUT : POLLIN),
+		                      .revents = 0 };
+		poll(&pfd, 1, (int)(deadline - now));
+	}
+	if(fl >= 0)
+		fcntl(fd, F_SETFL, fl); // restore blocking for relay()/h2/h3
+	return ok;
+}
+
 // Per-connection handler, run in a detached thread.
 static void *handle_conn(void *arg)
 {
-	const int client_fd = (int)(intptr_t)arg;
+	struct handler_arg *ha = arg;
+	const int client_fd = ha->client_fd;
+	SSL_CTX *const ctx = ha->ctx;
+	free(ha);
 
 	const struct timeval tv = { .tv_sec = IO_TIMEOUT_SEC, .tv_usec = 0 };
 	setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 	setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-	SSL *ssl = SSL_new(ssl_ctx);
+	SSL *ssl = SSL_new(ctx);
 	int be_fd = -1;
 	if(ssl == NULL)
 	{
@@ -2852,11 +3108,11 @@ static void *handle_conn(void *arg)
 		goto cleanup;
 	}
 	SSL_set_fd(ssl, client_fd);
-	if(SSL_accept(ssl) != 1)
+	if(!terminator_handshake(ssl, client_fd))
 	{
-		// A failed handshake (e.g. a plain-HTTP probe on the TLS port) is not
-		// worth an error; keep it at debug level to avoid log flooding.
-		log_debug(DEBUG_WEBSERVER, "Terminator: TLS handshake failed");
+		// A failed/slow handshake (e.g. a plain-HTTP probe on the TLS port) is
+		// not worth an error; keep it at debug level to avoid log flooding.
+		log_debug(DEBUG_WEBSERVER, "Terminator: TLS handshake failed or timed out");
 		goto cleanup;
 	}
 
@@ -2897,6 +3153,8 @@ cleanup:
 	if(be_fd >= 0)
 		close(be_fd);
 	close(client_fd);
+	SSL_CTX_free(ctx); // release our reference (keeps the ctx alive across stop)
+	atomic_fetch_sub(&active_handlers, 1);
 	return NULL;
 }
 
@@ -2924,12 +3182,37 @@ static void *accept_loop(void *arg)
 			continue;
 		}
 
-		// TODO(M1): bound the number of concurrent handler threads (a worker
-		// pool) instead of one detached thread per connection.
+		// Cap concurrent handlers so a connection flood cannot exhaust the
+		// process. fetch_add reserves a slot; drop the connection if over cap.
+		if(atomic_fetch_add(&active_handlers, 1) >= TERMINATOR_MAX_HANDLERS)
+		{
+			atomic_fetch_sub(&active_handlers, 1);
+			log_debug(DEBUG_WEBSERVER, "Terminator: handler cap reached, dropping connection");
+			close(client_fd);
+			continue;
+		}
+
+		// Hand the detached handler its own SSL_CTX reference, taken now while
+		// the context is live, so terminator_stop() can free it without racing a
+		// handler that has not yet reached SSL_new().
+		struct handler_arg *ha = malloc(sizeof(*ha));
+		if(ha == NULL)
+		{
+			atomic_fetch_sub(&active_handlers, 1);
+			close(client_fd);
+			continue;
+		}
+		ha->client_fd = client_fd;
+		SSL_CTX_up_ref(ssl_ctx);
+		ha->ctx = ssl_ctx;
+
 		pthread_t tid;
-		if(pthread_create(&tid, &attr, handle_conn, (void *)(intptr_t)client_fd) != 0)
+		if(pthread_create(&tid, &attr, handle_conn, ha) != 0)
 		{
 			log_err("Terminator: pthread_create() failed: %s", strerror(errno));
+			SSL_CTX_free(ha->ctx);
+			free(ha);
+			atomic_fetch_sub(&active_handlers, 1);
 			close(client_fd);
 		}
 	}
@@ -2938,7 +3221,7 @@ static void *accept_loop(void *arg)
 	return NULL;
 }
 
-bool terminator_start(int public_port, int be_port, const char *cert_path)
+bool terminator_start(const char *bind_addr, int public_port, int be_port, const char *cert_path)
 {
 	if(running)
 	{
@@ -2948,11 +3231,21 @@ bool terminator_start(int public_port, int be_port, const char *cert_path)
 	if(cert_path == NULL || public_port <= 0 || be_port <= 0)
 		return false;
 
+	// Per-boot secret authenticating our PROXY headers to the loopback backend.
+	// Usually already generated by webserver.c (it passes the hex form to the
+	// backend as proxy_protocol_secret); ensure it here too. Fail closed if the
+	// RNG fails: without it the backend would ignore every header.
+	if(!ensure_proxy_token())
+	{
+		log_err("Terminator: could not obtain secure randomness, cannot start");
+		return false;
+	}
+
 	ssl_ctx = create_server_ctx(cert_path);
 	if(ssl_ctx == NULL)
 		return false;
 
-	listen_fd = bind_listener(public_port);
+	listen_fd = bind_listener(bind_addr, public_port);
 	if(listen_fd < 0)
 	{
 		SSL_CTX_free(ssl_ctx);
@@ -2974,13 +3267,13 @@ bool terminator_start(int public_port, int be_port, const char *cert_path)
 	}
 	accept_tid_valid = true;
 
-	log_info("TLS terminator listening on port %d, forwarding to 127.0.0.1:%d",
-	         public_port, be_port);
+	log_info("TLS terminator listening on %s#%d, forwarding to 127.0.0.1:%d",
+	         (bind_addr && bind_addr[0]) ? bind_addr : "*", public_port, be_port);
 
 #ifdef HAVE_HTTP3
 	// Serve HTTP/3 over QUIC on the same public port (UDP). Optional: on failure
 	// the terminator keeps serving HTTP/1.1 and (if built) HTTP/2 over TCP.
-	terminator_quic_start(public_port, cert_path);
+	terminator_quic_start(bind_addr, public_port, cert_path);
 #endif
 	return true;
 }
@@ -3010,9 +3303,28 @@ void terminator_stop(void)
 	}
 	if(ssl_ctx != NULL)
 	{
+		// Drops our reference only. Each in-flight handler holds its own ref
+		// (taken in accept_loop before SSL_new()), so the context stays valid
+		// until the last handler exits - no use-after-free on SSL_new().
 		SSL_CTX_free(ssl_ctx);
 		ssl_ctx = NULL;
 	}
 	// Note: in-flight detached handler threads are not joined here; they finish
-	// on their own when their connection closes or times out (IO_TIMEOUT_SEC).
+	// on their own when their connection closes or times out (IO_TIMEOUT_SEC),
+	// then release their SSL_CTX reference.
 }
+
+#else // !HAVE_TLS
+
+// No-TLS build: the terminator does not exist. webserver.c still links
+// terminator_proxy_token_hex() (its call is guarded by terminator_port > 0,
+// which stays 0 here), so provide a stub. terminator_start()/stop() are only
+// ever called under HAVE_TLS, so they need no stubs.
+bool terminator_proxy_token_hex(char *out, size_t outsz)
+{
+	(void)out;
+	(void)outsz;
+	return false;
+}
+
+#endif // HAVE_TLS

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -2656,6 +2656,12 @@ static bool h3_stream_reapable(const struct h3_stream *s)
 {
 	if(s->uni_local)
 		return false;
+	// A remote unidirectional stream (the client's control and QPACK streams) is
+	// receive-only: it has no QUIC send part, so SSL_get_stream_write_state()
+	// below does not apply to it (querying it dereferences a NULL send-stream).
+	// These live for the whole connection anyway, so keep them.
+	if(SSL_get_stream_type(s->ssl) == SSL_STREAM_TYPE_READ)
+		return false;
 	const int ws = SSL_get_stream_write_state(s->ssl);
 	if(ws == SSL_STREAM_STATE_OK || ws == SSL_STREAM_STATE_NONE ||
 	   ws == SSL_STREAM_STATE_WRONG_DIR)

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -3340,8 +3340,11 @@ void terminator_stop(void)
 // ever called under HAVE_TLS, so they need no stubs.
 bool terminator_proxy_token_hex(char *out, size_t outsz)
 {
-	(void)out;
-	(void)outsz;
+	// No terminator here, so there is no token: return an empty string. The
+	// write also gives the stub a side effect, so it is not mistaken for a
+	// candidate for __attribute__((const)) under -Wsuggest-attribute=const.
+	if(outsz > 0)
+		out[0] = '\0';
 	return false;
 }
 

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -162,6 +162,9 @@ static int quic_fd = -1;
 static pthread_t quic_tid;
 static bool quic_tid_valid = false;
 static volatile bool quic_running = false;
+// Public UDP/TCP port the QUIC listener bound to, advertised to h2 clients via
+// Alt-Svc so h3-capable browsers upgrade to HTTP/3.
+static int quic_public_port = 0;
 #endif
 
 // Log the pending OpenSSL error queue at error level, prefixed with context.
@@ -1220,6 +1223,20 @@ static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
 	// (the HTTP/3 path drops it unconditionally for the same reason).
 	if(!chunked && clen_name != NULL && nvlen < H2_MAX_HDRS)
 		h2_add_nv(nva, &nvlen, clen_name, clen_val);
+
+#ifdef HAVE_HTTP3
+	// Advertise HTTP/3 so an h3-capable browser on this h2 connection upgrades to
+	// it, but only while the QUIC listener is actually up. h2_add_nv() lowercases
+	// the name in place, so both name and value must be writable; nghttp2 copies
+	// the nv, so these stack buffers only need to outlive the submit call below.
+	char altsvc_name[] = "alt-svc";
+	char altsvc[32];
+	if(quic_running && nvlen < H2_MAX_HDRS)
+	{
+		snprintf(altsvc, sizeof(altsvc), "h3=\":%d\"; ma=86400", quic_public_port);
+		h2_add_nv(nva, &nvlen, altsvc_name, altsvc);
+	}
+#endif
 
 	s->be.resp_headers_parsed = true;
 
@@ -3014,6 +3031,7 @@ static void terminator_quic_start(const char *bind_addr, int public_port, const 
 		return;
 	}
 	quic_running = true;
+	quic_public_port = public_port;
 	if(pthread_create(&quic_tid, NULL, quic_accept_loop, NULL) != 0)
 	{
 		log_err("Terminator: failed to start HTTP/3 thread: %s", strerror(errno));

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -23,13 +23,20 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+#ifdef HAVE_HTTP2
+#include <nghttp2/nghttp2.h>
+#endif
+
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/prctl.h>
 #include <pthread.h>
 #include <poll.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <string.h>
+#include <strings.h>
+#include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
 
@@ -59,18 +66,41 @@ static void log_ssl_errors(const char *context)
 	}
 }
 
-// ALPN: this milestone only serves HTTP/1.1. Offer nothing else so clients
-// negotiate http/1.1 (or fall back to it when they send no ALPN).
+// ALPN selection: pick our most-preferred protocol that the client offers.
+// "h2" is preferred when HTTP/2 support is compiled in, otherwise (and as the
+// fallback) "http/1.1". Selection is done by hand to avoid the confusing
+// server/client argument order of SSL_select_next_proto().
 static int alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
                           const unsigned char *in, unsigned int inlen, void *arg)
 {
-	static const unsigned char http11[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+	static const char *const prefs[] = {
+#ifdef HAVE_HTTP2
+		"h2",
+#endif
+		"http/1.1"
+	};
 	(void)ssl;
 	(void)arg;
-	if(SSL_select_next_proto((unsigned char **)out, outlen, http11, sizeof(http11),
-	                         in, inlen) != OPENSSL_NPN_NEGOTIATED)
-		return SSL_TLSEXT_ERR_NOACK;
-	return SSL_TLSEXT_ERR_OK;
+	for(size_t p = 0; p < sizeof(prefs) / sizeof(prefs[0]); p++)
+	{
+		const size_t plen = strlen(prefs[p]);
+		// The client's ALPN list is a sequence of (1-byte length, bytes) entries
+		for(unsigned int i = 0; i + 1 <= inlen; )
+		{
+			const unsigned int l = in[i];
+			if(i + 1 + l > inlen)
+				break;
+			if(l == plen && memcmp(&in[i + 1], prefs[p], plen) == 0)
+			{
+				*out = &in[i + 1];
+				*outlen = (unsigned char)l;
+				return SSL_TLSEXT_ERR_OK;
+			}
+			i += 1 + l;
+		}
+	}
+	// No overlap: decline ALPN, the client falls back to HTTP/1.1
+	return SSL_TLSEXT_ERR_NOACK;
 }
 
 // Build the server-side SSL_CTX from the combined PEM (certificate + key).
@@ -203,12 +233,13 @@ static int write_all_ssl(SSL *ssl, const char *buf, size_t len)
 	return 0;
 }
 
-// Announce the real client to the backend with a PROXY protocol v2 header,
-// written once at the very start of the backend connection (before any request
-// bytes). CivetWeb parses it and attributes the request to the actual client
-// instead of the loopback terminator, so client-IP-based logging and auth stay
-// correct. Returns 0 on success, -1 on error.
-static int send_proxy_v2(int be_fd, int client_fd)
+// Fill a PROXY protocol v2 header describing the real client (source) and the
+// local accepting socket (destination) into hdr, which must hold at least 52
+// bytes. Returns 0 and the header length in *out_len, or -1 for an unsupported
+// address family. CivetWeb parses this header and attributes the request to the
+// actual client instead of the loopback terminator, so client-IP-based logging
+// and auth stay correct.
+static int build_proxy_v2(int client_fd, unsigned char *hdr, size_t *out_len)
 {
 	struct sockaddr_storage src, dst;
 	socklen_t sl = sizeof(src), dl = sizeof(dst);
@@ -218,7 +249,6 @@ static int send_proxy_v2(int be_fd, int client_fd)
 
 	static const unsigned char sig[12] =
 		{ 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A };
-	unsigned char hdr[16 + 36];
 	memcpy(hdr, sig, sizeof(sig));
 	hdr[12] = 0x21; // version 2, PROXY command
 	size_t len = 0;
@@ -266,6 +296,19 @@ static int send_proxy_v2(int be_fd, int client_fd)
 	else
 		return -1;
 
+	*out_len = len;
+	return 0;
+}
+
+// Announce the real client to the backend by writing a PROXY protocol v2 header
+// once at the very start of the backend connection, before any request bytes.
+// Returns 0 on success, -1 on error.
+static int send_proxy_v2(int be_fd, int client_fd)
+{
+	unsigned char hdr[16 + 36];
+	size_t len = 0;
+	if(build_proxy_v2(client_fd, hdr, &len) != 0)
+		return -1;
 	return write_all_fd(be_fd, (const char *)hdr, len);
 }
 
@@ -333,6 +376,1072 @@ static void relay(SSL *ssl, int client_fd, int be_fd)
 	}
 }
 
+#ifdef HAVE_HTTP2
+// ---------------------------------------------------------------------------
+// HTTP/2 gateway (ALPN "h2")
+//
+// Runs an nghttp2 server session on the TLS connection and bridges every request
+// stream to a plain HTTP/1.1 request against the CivetWeb backend, translating
+// the response back to HTTP/2. CivetWeb keeps speaking HTTP/1.1 and never sees
+// HTTP/2.
+//
+// The gateway streams and multiplexes: each request stream gets its own
+// non-blocking backend connection, the request body is streamed to the backend
+// as it arrives (respecting HTTP/2 flow control), and the HTTP/1.1 response is
+// parsed incrementally and pulled back into HTTP/2 DATA frames on demand via an
+// nghttp2 data provider. A single poll() loop drives the client TLS socket and
+// every active backend socket, so many streams make progress concurrently and
+// no single stream blocks the whole session.
+// ---------------------------------------------------------------------------
+
+#define H2_REQHDR_MAX 8192u
+#define H2_MAX_HDRS 64u
+// Response header block size cap before we give up parsing.
+#define H2_RESP_HDR_MAX 65536u
+// Per-stream decoded response body high-water mark: once this much undelivered
+// body is buffered we stop reading the backend, applying backpressure toward the
+// (slower) client.
+#define H2_BODY_HIGH_WATER (256u * 1024u)
+// Soft cap on the outbound TLS buffer; we stop pulling more frames out of
+// nghttp2 once this much is queued for SSL_write().
+#define H2_WBUF_SOFT_CAP (512u * 1024u)
+// Maximum PROXY protocol v2 header size (16 fixed + 36 for IPv6).
+#define H2_PROXY_MAX 52u
+
+// EAGAIN and EWOULDBLOCK are the same value on Linux; test both only where they
+// actually differ so -Wlogical-op stays quiet.
+#if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
+#define WOULDBLOCK(e) ((e) == EAGAIN || (e) == EWOULDBLOCK)
+#else
+#define WOULDBLOCK(e) ((e) == EAGAIN)
+#endif
+
+// Request body framing towards the HTTP/1.1 backend.
+enum { REQ_NONE, REQ_RAW, REQ_CHUNKED };
+// Response body framing from the HTTP/1.1 backend.
+enum { BODY_NONE, BODY_LENGTH, BODY_CHUNKED, BODY_CLOSE };
+// Incremental Transfer-Encoding: chunked decoder states.
+enum { CH_SIZE, CH_EXT, CH_SIZE_LF, CH_DATA, CH_DATA_CR, CH_DATA_LF, CH_TRAILER, CH_DONE };
+
+struct h2_conn;
+
+struct h2_stream {
+	struct h2_stream *next;
+	struct h2_conn *conn;
+	int32_t stream_id;
+
+	// Request pseudo-headers and the reconstructed HTTP/1.1 header block
+	char method[16];
+	char authority[256];
+	char path[2048];
+	char reqhdr[H2_REQHDR_MAX];
+	size_t reqhdr_len;
+	bool content_length_seen;
+
+	// Backend connection (non-blocking)
+	int be_fd;
+	bool be_connecting;
+
+	// Outbound request buffer (PROXY header + HTTP/1.1 head + body), drained to
+	// the backend from [req_out_off, req_out_len)
+	char *req_out;
+	size_t req_out_len, req_out_off, req_out_cap;
+	int req_mode;
+	bool req_started;
+	// Client DATA bytes appended but not yet acknowledged to nghttp2's flow
+	// control; credited once they have been flushed to the backend.
+	size_t body_uncredited;
+
+	// Response header accumulation and parse state
+	bool resp_headers_parsed;
+	bool resp_headers_sent;
+	char *resp_hdr;
+	size_t resp_hdr_len, resp_hdr_cap;
+
+	// Response body framing / decoder state
+	int body_mode;
+	size_t body_remaining;   // BODY_LENGTH: bytes still expected
+	int chunk_state;
+	size_t chunk_size;       // chunked: size being accumulated
+	size_t chunk_remaining;  // chunked: bytes left in the current chunk
+	size_t trailer_line_len; // chunked: length of the current trailer line
+
+	// Decoded response body ready for the nghttp2 data provider, served from
+	// [body_off, body_len)
+	char *body_buf;
+	size_t body_len, body_off, body_cap;
+	bool resp_complete;      // full response body has been decoded
+	bool resp_deferred;      // data provider is parked on NGHTTP2_ERR_DEFERRED
+	bool error;              // gateway error: backend torn down, stream ending
+};
+
+struct h2_conn {
+	SSL *ssl;
+	int client_fd;
+	nghttp2_session *session;
+	struct h2_stream *streams; // singly linked list of active streams
+
+	// Outbound TLS buffer: serialized nghttp2 frames awaiting SSL_write(),
+	// pending in [woff, wlen)
+	char *wbuf;
+	size_t wlen, woff, wcap;
+	bool ssl_want_write;       // last SSL_write() returned WANT_WRITE
+
+	// Reused poll() scratch buffers (pfds[0] is always the client fd)
+	struct pollfd *pfds;
+	struct h2_stream **pmap;
+	size_t pcap;
+};
+
+// Put fd into non-blocking mode. Returns 0 or -1.
+static int set_nonblocking(int fd)
+{
+	const int fl = fcntl(fd, F_GETFL, 0);
+	if(fl < 0)
+		return -1;
+	return fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+}
+
+// Open a non-blocking plaintext TCP socket to the CivetWeb backend on loopback.
+// Sets *connected to true if the connection completed immediately (the common
+// case on loopback), false if it is still in progress (EINPROGRESS). Returns the
+// fd or -1.
+static int connect_backend_nb(bool *connected)
+{
+	const int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+	if(fd < 0)
+		return -1;
+
+	struct sockaddr_in sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons((uint16_t)backend_port);
+	sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	const int r = connect(fd, (struct sockaddr *)&sa, sizeof(sa));
+	if(r == 0)
+	{
+		*connected = true;
+		return fd;
+	}
+	if(errno == EINPROGRESS)
+	{
+		*connected = false;
+		return fd;
+	}
+	close(fd);
+	return -1;
+}
+
+// Append n bytes to a growing heap buffer. Returns 0 or -1.
+static int buf_append(char **buf, size_t *len, size_t *cap, const char *data, size_t n)
+{
+	if(*len + n > *cap)
+	{
+		size_t newcap = (*cap == 0) ? 8192 : *cap;
+		while(newcap < *len + n)
+			newcap *= 2;
+		char *nb = realloc(*buf, newcap);
+		if(nb == NULL)
+			return -1;
+		*buf = nb;
+		*cap = newcap;
+	}
+	memcpy(*buf + *len, data, n);
+	*len += n;
+	return 0;
+}
+
+// Hop-by-hop / pseudo-reconstructed headers that must not be forwarded.
+static bool h2_skip_header(const char *name, size_t len)
+{
+	static const char *const skip[] = {
+		"connection", "keep-alive", "proxy-connection", "transfer-encoding",
+		"upgrade", "te", "host", "http2-settings"
+	};
+	for(size_t i = 0; i < sizeof(skip) / sizeof(skip[0]); i++)
+		if(len == strlen(skip[i]) && strncasecmp(name, skip[i], len) == 0)
+			return true;
+	return false;
+}
+
+// Queue bytes to send to the backend, compacting already-sent data first so the
+// buffer does not grow without bound. Returns 0 or -1.
+static int h2_req_push(struct h2_stream *s, const char *data, size_t n)
+{
+	if(s->req_out_off > 0)
+	{
+		memmove(s->req_out, s->req_out + s->req_out_off, s->req_out_len - s->req_out_off);
+		s->req_out_len -= s->req_out_off;
+		s->req_out_off = 0;
+	}
+	return buf_append(&s->req_out, &s->req_out_len, &s->req_out_cap, data, n);
+}
+
+// Queue decoded response body bytes for the data provider, compacting already-
+// delivered data first. Returns 0 or -1.
+static int h2_body_push(struct h2_stream *s, const char *data, size_t n)
+{
+	if(s->body_off > 0)
+	{
+		memmove(s->body_buf, s->body_buf + s->body_off, s->body_len - s->body_off);
+		s->body_len -= s->body_off;
+		s->body_off = 0;
+	}
+	return buf_append(&s->body_buf, &s->body_len, &s->body_cap, data, n);
+}
+
+static void h2_stream_link(struct h2_conn *c, struct h2_stream *s)
+{
+	s->next = c->streams;
+	c->streams = s;
+}
+
+static void h2_stream_unlink(struct h2_conn *c, struct h2_stream *s)
+{
+	struct h2_stream **pp = &c->streams;
+	while(*pp != NULL)
+	{
+		if(*pp == s)
+		{
+			*pp = s->next;
+			return;
+		}
+		pp = &(*pp)->next;
+	}
+}
+
+static void h2_stream_free(struct h2_stream *s)
+{
+	if(s == NULL)
+		return;
+	if(s->be_fd >= 0)
+		close(s->be_fd);
+	free(s->req_out);
+	free(s->resp_hdr);
+	free(s->body_buf);
+	free(s);
+}
+
+// Close the backend socket and return any request-body bytes that were charged
+// against the flow-control window but never forwarded to the connection window.
+// With manual window management nghttp2 does not reclaim these on stream close,
+// so failing to do this would slowly shrink the shared connection window.
+static void h2_be_close(struct h2_stream *s)
+{
+	if(s->be_fd >= 0)
+	{
+		close(s->be_fd);
+		s->be_fd = -1;
+	}
+	s->be_connecting = false;
+	if(s->body_uncredited > 0)
+	{
+		nghttp2_session_consume_connection(s->conn->session, s->body_uncredited);
+		s->body_uncredited = 0;
+	}
+}
+
+// Fail a stream at the gateway: tear down its backend socket and either submit a
+// status-only response (if nothing has been sent yet) or reset the stream (if
+// the response head is already on the wire).
+static void h2_gateway_error(struct h2_stream *s, const char *status3)
+{
+	h2_be_close(s);
+	s->error = true;
+	s->resp_complete = true;
+	if(s->resp_headers_sent)
+	{
+		nghttp2_submit_rst_stream(s->conn->session, NGHTTP2_FLAG_NONE,
+		                          s->stream_id, NGHTTP2_INTERNAL_ERROR);
+	}
+	else
+	{
+		const nghttp2_nv nva[] = {
+			{ (uint8_t *)":status", (uint8_t *)status3, 7, 3, NGHTTP2_NV_FLAG_NONE }
+		};
+		nghttp2_submit_response2(s->conn->session, s->stream_id, nva, 1, NULL);
+		s->resp_headers_sent = true;
+	}
+}
+
+// Once the request headers are complete, decide the request body framing, open
+// the backend connection, and queue the PROXY header and HTTP/1.1 request head.
+static void h2_start_backend(struct h2_stream *s, bool has_body)
+{
+	if(!has_body)
+		s->req_mode = REQ_NONE;
+	else if(s->content_length_seen)
+		s->req_mode = REQ_RAW;      // length known: forward the body verbatim
+	else
+		s->req_mode = REQ_CHUNKED;  // unknown length: chunk it to the backend
+
+	bool connected = false;
+	s->be_fd = connect_backend_nb(&connected);
+	if(s->be_fd < 0)
+	{
+		h2_gateway_error(s, "502");
+		return;
+	}
+	s->be_connecting = !connected;
+
+	unsigned char ph[H2_PROXY_MAX];
+	size_t phlen = 0;
+	if(build_proxy_v2(s->conn->client_fd, ph, &phlen) != 0 ||
+	   h2_req_push(s, (const char *)ph, phlen) != 0)
+	{
+		h2_gateway_error(s, "502");
+		return;
+	}
+
+	char head[H2_REQHDR_MAX + 4096];
+	const int hl = snprintf(head, sizeof(head),
+	                        "%s %s HTTP/1.1\r\nHost: %s\r\n%.*s%sConnection: close\r\n\r\n",
+	                        s->method[0] ? s->method : "GET",
+	                        s->path[0] ? s->path : "/",
+	                        s->authority[0] ? s->authority : "pi.hole",
+	                        (int)s->reqhdr_len, s->reqhdr,
+	                        s->req_mode == REQ_CHUNKED ? "Transfer-Encoding: chunked\r\n" : "");
+	if(hl < 0 || (size_t)hl >= sizeof(head) || h2_req_push(s, head, (size_t)hl) != 0)
+	{
+		h2_gateway_error(s, "500");
+		return;
+	}
+	s->req_started = true;
+}
+
+// nghttp2 data provider: hand decoded response body bytes to nghttp2 on demand.
+// Returns NGHTTP2_ERR_DEFERRED when the backend has not produced more body yet;
+// h2_be_readable() resumes the stream once it does.
+static nghttp2_ssize h2_body_read(nghttp2_session *session, int32_t stream_id,
+                                  uint8_t *buf, size_t length, uint32_t *data_flags,
+                                  nghttp2_data_source *source, void *user_data)
+{
+	struct h2_stream *s = (struct h2_stream *)source->ptr;
+	(void)session; (void)stream_id; (void)user_data;
+
+	const size_t avail = s->body_len - s->body_off;
+	if(avail == 0)
+	{
+		if(s->resp_complete)
+		{
+			*data_flags |= NGHTTP2_DATA_FLAG_EOF;
+			return 0;
+		}
+		s->resp_deferred = true;
+		return NGHTTP2_ERR_DEFERRED;
+	}
+
+	const size_t n = (avail < length) ? avail : length;
+	memcpy(buf, s->body_buf + s->body_off, n);
+	s->body_off += n;
+	if(s->body_off == s->body_len)
+		s->body_off = s->body_len = 0;
+	if(s->resp_complete && s->body_len == 0)
+		*data_flags |= NGHTTP2_DATA_FLAG_EOF;
+	return (nghttp2_ssize)n;
+}
+
+// Lowercase the header name in place (HTTP/2 requires it) and append the
+// name/value pair to the nghttp2 header list.
+static void h2_add_nv(nghttp2_nv *nva, size_t *nvlen, char *name, char *value)
+{
+	for(char *c = name; *c != '\0'; c++)
+		*c = (char)tolower((unsigned char)*c);
+	nva[*nvlen].name = (uint8_t *)name; nva[*nvlen].namelen = strlen(name);
+	nva[*nvlen].value = (uint8_t *)value; nva[*nvlen].valuelen = strlen(value);
+	nva[*nvlen].flags = NGHTTP2_NV_FLAG_NONE;
+	(*nvlen)++;
+}
+
+// Parse the HTTP/1.1 response header block hdr[0..hdrlen) (the bytes before the
+// terminating CRLFCRLF), determine the body framing, and submit the HTTP/2
+// response headers with a streaming data provider. nghttp2 copies the header
+// list, so the in-place-parsed hdr buffer can be freed afterwards. Returns 0 or
+// -1.
+static int h2_parse_and_submit(struct h2_stream *s, char *hdr, size_t hdrlen)
+{
+	hdr[hdrlen] = '\0';
+
+	char status3[4] = "502";
+	const char *sp = strchr(hdr, ' ');
+	if(sp != NULL && sp[1] && sp[2] && sp[3])
+	{
+		status3[0] = sp[1]; status3[1] = sp[2]; status3[2] = sp[3]; status3[3] = '\0';
+	}
+
+	nghttp2_nv nva[H2_MAX_HDRS];
+	size_t nvlen = 0;
+	nva[nvlen].name = (uint8_t *)":status"; nva[nvlen].namelen = 7;
+	nva[nvlen].value = (uint8_t *)status3;  nva[nvlen].valuelen = 3;
+	nva[nvlen].flags = NGHTTP2_NV_FLAG_NONE; nvlen++;
+
+	bool chunked = false, have_clen = false;
+	size_t clen = 0;
+	char *line = strstr(hdr, "\r\n"); // skip the status line
+	if(line != NULL)
+	{
+		line += 2;
+		while(*line != '\0' && nvlen < H2_MAX_HDRS)
+		{
+			char *eol = strstr(line, "\r\n");
+			if(eol != NULL)
+				*eol = '\0';
+			char *colon = strchr(line, ':');
+			if(colon != NULL)
+			{
+				*colon = '\0';
+				char *val = colon + 1;
+				while(*val == ' ') val++;
+				const size_t nlen = strlen(line);
+				if(nlen == 17 && strncasecmp(line, "transfer-encoding", 17) == 0)
+				{
+					if(strcasestr(val, "chunked") != NULL)
+						chunked = true; // decoded here, not forwarded
+				}
+				else if(nlen == 14 && strncasecmp(line, "content-length", 14) == 0)
+				{
+					have_clen = true;
+					clen = (size_t)strtoull(val, NULL, 10);
+					h2_add_nv(nva, &nvlen, line, val);
+				}
+				else if(nlen > 0 && !h2_skip_header(line, nlen))
+				{
+					h2_add_nv(nva, &nvlen, line, val);
+				}
+			}
+			if(eol == NULL)
+				break;
+			line = eol + 2;
+		}
+	}
+
+	// Determine the response body framing. HEAD requests and 1xx/204/304
+	// responses carry no body regardless of any length header.
+	bool no_body = false;
+	if(strcasecmp(s->method, "HEAD") == 0)
+		no_body = true;
+	else if(status3[0] == '1' || strcmp(status3, "204") == 0 || strcmp(status3, "304") == 0)
+		no_body = true;
+
+	if(no_body)
+		s->body_mode = BODY_NONE;
+	else if(chunked)
+	{
+		s->body_mode = BODY_CHUNKED;
+		s->chunk_state = CH_SIZE;
+	}
+	else if(have_clen)
+	{
+		s->body_mode = BODY_LENGTH;
+		s->body_remaining = clen;
+	}
+	else
+		s->body_mode = BODY_CLOSE; // length delimited by the backend closing
+
+	s->resp_headers_parsed = true;
+
+	const bool empty = (s->body_mode == BODY_NONE) ||
+	                   (s->body_mode == BODY_LENGTH && s->body_remaining == 0);
+	nghttp2_data_provider2 prd;
+	prd.source.ptr = s;
+	prd.read_callback = h2_body_read;
+	const int rv = nghttp2_submit_response2(s->conn->session, s->stream_id,
+	                                        nva, nvlen, empty ? NULL : &prd);
+	s->resp_headers_sent = true;
+	if(empty)
+		s->resp_complete = true;
+	return (rv == 0) ? 0 : -1;
+}
+
+// Incrementally de-chunk a Transfer-Encoding: chunked response body, appending
+// decoded bytes to the stream body buffer. State persists across calls. Returns
+// 0 or -1.
+static int h2_feed_chunked(struct h2_stream *s, const char *data, size_t n)
+{
+	size_t i = 0;
+	while(i < n && s->chunk_state != CH_DONE)
+	{
+		const char c = data[i];
+		switch(s->chunk_state)
+		{
+			case CH_SIZE:
+				if(c >= '0' && c <= '9') { s->chunk_size = s->chunk_size * 16u + (size_t)(c - '0'); i++; }
+				else if(c >= 'a' && c <= 'f') { s->chunk_size = s->chunk_size * 16u + (size_t)(c - 'a' + 10); i++; }
+				else if(c >= 'A' && c <= 'F') { s->chunk_size = s->chunk_size * 16u + (size_t)(c - 'A' + 10); i++; }
+				else if(c == ';') { s->chunk_state = CH_EXT; i++; }
+				else if(c == '\r') { s->chunk_state = CH_SIZE_LF; i++; }
+				else i++; // tolerate stray bytes
+				break;
+			case CH_EXT: // chunk extension: skip to end of line
+				if(c == '\r') s->chunk_state = CH_SIZE_LF;
+				i++;
+				break;
+			case CH_SIZE_LF:
+				i++; // consume '\n'
+				if(s->chunk_size == 0) { s->chunk_state = CH_TRAILER; s->trailer_line_len = 0; }
+				else { s->chunk_remaining = s->chunk_size; s->chunk_state = CH_DATA; }
+				break;
+			case CH_DATA:
+			{
+				const size_t avail = n - i;
+				const size_t take = (avail < s->chunk_remaining) ? avail : s->chunk_remaining;
+				if(take > 0)
+				{
+					if(h2_body_push(s, data + i, take) != 0)
+						return -1;
+					i += take;
+					s->chunk_remaining -= take;
+				}
+				if(s->chunk_remaining == 0)
+					s->chunk_state = CH_DATA_CR;
+				break;
+			}
+			case CH_DATA_CR:
+				if(c == '\r') s->chunk_state = CH_DATA_LF;
+				i++;
+				break;
+			case CH_DATA_LF:
+				if(c == '\n') { s->chunk_size = 0; s->chunk_state = CH_SIZE; }
+				i++;
+				break;
+			case CH_TRAILER: // optional trailers terminated by a blank line
+				if(c == '\n') { if(s->trailer_line_len == 0) s->chunk_state = CH_DONE; else s->trailer_line_len = 0; }
+				else if(c != '\r') s->trailer_line_len++;
+				i++;
+				break;
+		}
+	}
+	if(s->chunk_state == CH_DONE)
+		s->resp_complete = true;
+	return 0;
+}
+
+// Decode response body bytes according to the negotiated framing and append the
+// result to the stream body buffer. Returns 0 or -1.
+static int h2_feed_body(struct h2_stream *s, const char *data, size_t n)
+{
+	switch(s->body_mode)
+	{
+		case BODY_NONE:
+			return 0;
+		case BODY_LENGTH:
+		{
+			const size_t take = (n < s->body_remaining) ? n : s->body_remaining;
+			if(take > 0 && h2_body_push(s, data, take) != 0)
+				return -1;
+			s->body_remaining -= take;
+			if(s->body_remaining == 0)
+				s->resp_complete = true;
+			return 0;
+		}
+		case BODY_CHUNKED:
+			return h2_feed_chunked(s, data, n);
+		case BODY_CLOSE:
+		default:
+			if(n > 0 && h2_body_push(s, data, n) != 0)
+				return -1;
+			return 0; // completion is signalled by the backend closing
+	}
+}
+
+// Feed raw bytes read from the backend socket: accumulate and parse the response
+// header block first, then decode the body incrementally. Returns 0 or -1.
+static int h2_feed(struct h2_stream *s, const char *data, size_t n)
+{
+	if(s->resp_headers_parsed)
+		return h2_feed_body(s, data, n);
+
+	if(buf_append(&s->resp_hdr, &s->resp_hdr_len, &s->resp_hdr_cap, data, n) != 0)
+		return -1;
+	char *end = memmem(s->resp_hdr, s->resp_hdr_len, "\r\n\r\n", 4);
+	if(end == NULL)
+		return (s->resp_hdr_len > H2_RESP_HDR_MAX) ? -1 : 0; // need more headers
+
+	const size_t hdrlen = (size_t)(end - s->resp_hdr);
+	const size_t consumed = hdrlen + 4;
+	if(h2_parse_and_submit(s, s->resp_hdr, hdrlen) != 0)
+		return -1;
+	// Any bytes past the header terminator are the start of the body. Copy them
+	// out (h2_body_push copies) before freeing the header buffer.
+	const size_t leftover = s->resp_hdr_len - consumed;
+	if(leftover > 0 && h2_feed_body(s, s->resp_hdr + consumed, leftover) != 0)
+		return -1;
+	free(s->resp_hdr);
+	s->resp_hdr = NULL;
+	s->resp_hdr_len = s->resp_hdr_cap = 0;
+	return 0;
+}
+
+// Backend socket became writable: finish a pending non-blocking connect() and
+// flush as much of the queued request as the socket accepts. Once the request
+// buffer fully drains, credit the request body bytes back to nghttp2's flow
+// control so the client may send more (backpressure follows the backend).
+static void h2_be_writable(struct h2_stream *s)
+{
+	if(s->be_fd < 0)
+		return;
+	if(s->be_connecting)
+	{
+		int err = 0;
+		socklen_t el = sizeof(err);
+		if(getsockopt(s->be_fd, SOL_SOCKET, SO_ERROR, &err, &el) != 0 || err != 0)
+		{
+			h2_gateway_error(s, "502");
+			return;
+		}
+		s->be_connecting = false;
+	}
+	while(s->req_out_off < s->req_out_len)
+	{
+		const ssize_t w = write(s->be_fd, s->req_out + s->req_out_off,
+		                        s->req_out_len - s->req_out_off);
+		if(w > 0)
+			s->req_out_off += (size_t)w;
+		else if(w < 0 && errno == EINTR)
+			continue;
+		else if(w < 0 && WOULDBLOCK(errno))
+			break;
+		else
+		{
+			h2_gateway_error(s, "502");
+			return;
+		}
+	}
+	if(s->req_out_off == s->req_out_len)
+	{
+		s->req_out_off = s->req_out_len = 0;
+		if(s->body_uncredited > 0)
+		{
+			nghttp2_session_consume(s->conn->session, s->stream_id, s->body_uncredited);
+			s->body_uncredited = 0;
+		}
+	}
+}
+
+// Backend socket became readable: pull response bytes, feed the parser/decoder,
+// and resume the stream's data provider if it was parked. Stops early at the
+// body high-water mark to apply backpressure toward the client.
+static void h2_be_readable(struct h2_stream *s)
+{
+	if(s->be_fd < 0)
+		return;
+	char tmp[16384];
+	for(;;)
+	{
+		const ssize_t r = read(s->be_fd, tmp, sizeof(tmp));
+		if(r > 0)
+		{
+			if(h2_feed(s, tmp, (size_t)r) != 0)
+			{
+				h2_gateway_error(s, "502");
+				return;
+			}
+			if(s->resp_complete)
+				break;
+			if((s->body_len - s->body_off) >= H2_BODY_HIGH_WATER)
+				break; // backpressure: let the client drain first
+			continue;
+		}
+		if(r == 0)
+		{
+			// Backend closed. For close-delimited bodies this is the normal end;
+			// for framed bodies it truncates, but we still finish the stream.
+			if(!s->resp_headers_parsed)
+			{
+				h2_gateway_error(s, "502");
+				return;
+			}
+			s->resp_complete = true;
+			h2_be_close(s);
+			break;
+		}
+		if(errno == EINTR)
+			continue;
+		if(WOULDBLOCK(errno))
+			break;
+		// Fatal read error
+		if(!s->resp_headers_parsed)
+		{
+			h2_gateway_error(s, "502");
+			return;
+		}
+		s->resp_complete = true;
+		h2_be_close(s);
+		break;
+	}
+
+	// The response is fully decoded; the backend socket is no longer needed.
+	if(s->resp_complete && s->be_fd >= 0)
+		h2_be_close(s);
+	// Wake a parked data provider now that there is progress (more body or EOF).
+	if(s->resp_deferred && ((s->body_len - s->body_off) > 0 || s->resp_complete))
+	{
+		s->resp_deferred = false;
+		nghttp2_session_resume_data(s->conn->session, s->stream_id);
+	}
+}
+
+static int h2_on_begin_headers(nghttp2_session *session, const nghttp2_frame *frame, void *user_data)
+{
+	struct h2_conn *conn = (struct h2_conn *)user_data;
+	if(frame->hd.type != NGHTTP2_HEADERS || frame->headers.cat != NGHTTP2_HCAT_REQUEST)
+		return 0;
+	struct h2_stream *s = calloc(1, sizeof(*s));
+	if(s == NULL)
+		return NGHTTP2_ERR_CALLBACK_FAILURE;
+	s->conn = conn;
+	s->stream_id = frame->hd.stream_id;
+	s->be_fd = -1;
+	h2_stream_link(conn, s);
+	nghttp2_session_set_stream_user_data(session, frame->hd.stream_id, s);
+	return 0;
+}
+
+static int h2_on_header(nghttp2_session *session, const nghttp2_frame *frame,
+                        const uint8_t *name, size_t namelen,
+                        const uint8_t *value, size_t valuelen,
+                        uint8_t flags, void *user_data)
+{
+	(void)flags; (void)user_data;
+	struct h2_stream *s = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+	if(s == NULL)
+		return 0;
+	const char *n = (const char *)name;
+	const char *v = (const char *)value;
+
+	if(namelen > 0 && n[0] == ':')
+	{
+		if(namelen == 7 && memcmp(n, ":method", 7) == 0)
+			snprintf(s->method, sizeof(s->method), "%.*s", (int)valuelen, v);
+		else if(namelen == 5 && memcmp(n, ":path", 5) == 0)
+			snprintf(s->path, sizeof(s->path), "%.*s", (int)valuelen, v);
+		else if(namelen == 10 && memcmp(n, ":authority", 10) == 0)
+			snprintf(s->authority, sizeof(s->authority), "%.*s", (int)valuelen, v);
+		// :scheme is always https at the terminator and is not forwarded
+		return 0;
+	}
+
+	if(h2_skip_header(n, namelen))
+		return 0;
+	if(namelen == 14 && strncasecmp(n, "content-length", 14) == 0)
+		s->content_length_seen = true;
+
+	const size_t need = namelen + 2 + valuelen + 2;
+	if(s->reqhdr_len + need < sizeof(s->reqhdr))
+	{
+		char *p = s->reqhdr + s->reqhdr_len;
+		memcpy(p, n, namelen); p += namelen;
+		*p++ = ':'; *p++ = ' ';
+		memcpy(p, v, valuelen); p += valuelen;
+		*p++ = '\r'; *p++ = '\n';
+		s->reqhdr_len += need;
+	}
+	return 0;
+}
+
+static int h2_on_data_chunk(nghttp2_session *session, uint8_t flags, int32_t stream_id,
+                            const uint8_t *data, size_t len, void *user_data)
+{
+	(void)flags; (void)user_data;
+	struct h2_stream *s = nghttp2_session_get_stream_user_data(session, stream_id);
+	if(s == NULL)
+		return 0;
+	// If the backend is gone (error, or it already responded and we closed the
+	// socket), discard the body but keep the flow-control window moving so the
+	// client is not stalled.
+	if(s->error || s->be_fd < 0)
+	{
+		nghttp2_session_consume(session, stream_id, len);
+		return 0;
+	}
+	s->body_uncredited += len;
+	if(s->req_mode == REQ_CHUNKED)
+	{
+		if(len > 0)
+		{
+			char hdr[32];
+			const int hn = snprintf(hdr, sizeof(hdr), "%zx\r\n", len);
+			if(hn < 0 || h2_req_push(s, hdr, (size_t)hn) != 0 ||
+			   h2_req_push(s, (const char *)data, len) != 0 ||
+			   h2_req_push(s, "\r\n", 2) != 0)
+				return NGHTTP2_ERR_CALLBACK_FAILURE;
+		}
+	}
+	else if(len > 0)
+	{
+		if(h2_req_push(s, (const char *)data, len) != 0)
+			return NGHTTP2_ERR_CALLBACK_FAILURE;
+	}
+	return 0;
+}
+
+static int h2_on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame, void *user_data)
+{
+	(void)user_data;
+	// All request headers are in: open the backend and queue the request head.
+	if(frame->hd.type == NGHTTP2_HEADERS && frame->headers.cat == NGHTTP2_HCAT_REQUEST)
+	{
+		struct h2_stream *s = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+		if(s != NULL && !s->error)
+			h2_start_backend(s, !(frame->hd.flags & NGHTTP2_FLAG_END_STREAM));
+	}
+	// End of the request body: finish a chunked request with the terminator.
+	if((frame->hd.flags & NGHTTP2_FLAG_END_STREAM) &&
+	   (frame->hd.type == NGHTTP2_HEADERS || frame->hd.type == NGHTTP2_DATA))
+	{
+		struct h2_stream *s = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+		if(s != NULL && !s->error && s->req_mode == REQ_CHUNKED && s->be_fd >= 0)
+			h2_req_push(s, "0\r\n\r\n", 5);
+	}
+	return 0;
+}
+
+static int h2_on_stream_close(nghttp2_session *session, int32_t stream_id, uint32_t error_code, void *user_data)
+{
+	(void)error_code;
+	struct h2_conn *conn = (struct h2_conn *)user_data;
+	struct h2_stream *s = nghttp2_session_get_stream_user_data(session, stream_id);
+	if(s != NULL)
+	{
+		h2_stream_unlink(conn, s);
+		h2_stream_free(s);
+		nghttp2_session_set_stream_user_data(session, stream_id, NULL);
+	}
+	return 0;
+}
+
+// Pull serialized frames out of nghttp2 into the outbound TLS buffer, up to the
+// soft cap. Returns 0 or -1. This may invoke the data provider and, on stream
+// completion, on_stream_close (which frees stream state).
+static int h2_pump_output(struct h2_conn *c)
+{
+	if(c->woff > 0)
+	{
+		memmove(c->wbuf, c->wbuf + c->woff, c->wlen - c->woff);
+		c->wlen -= c->woff;
+		c->woff = 0;
+	}
+	while((c->wlen - c->woff) < H2_WBUF_SOFT_CAP)
+	{
+		const uint8_t *data = NULL;
+		const nghttp2_ssize len = nghttp2_session_mem_send2(c->session, &data);
+		if(len < 0)
+			return -1;
+		if(len == 0)
+			break;
+		if(buf_append(&c->wbuf, &c->wlen, &c->wcap, (const char *)data, (size_t)len) != 0)
+			return -1;
+	}
+	return 0;
+}
+
+// Flush the outbound TLS buffer to the client. On WANT_WRITE we stop and wait
+// for the socket to become writable again (POLLOUT). Returns 0 or -1.
+static int h2_drain_tls(struct h2_conn *c)
+{
+	c->ssl_want_write = false;
+	while(c->woff < c->wlen)
+	{
+		const int n = SSL_write(c->ssl, c->wbuf + c->woff, (int)(c->wlen - c->woff));
+		if(n > 0)
+			c->woff += (size_t)n;
+		else
+		{
+			const int err = SSL_get_error(c->ssl, n);
+			if(err == SSL_ERROR_WANT_WRITE)
+			{
+				c->ssl_want_write = true;
+				break;
+			}
+			if(err == SSL_ERROR_WANT_READ)
+				break; // a read must happen before the write can proceed
+			return -1;
+		}
+	}
+	if(c->woff == c->wlen)
+		c->woff = c->wlen = 0;
+	return 0;
+}
+
+// Read all currently available TLS plaintext and hand it to nghttp2. Returns 0
+// on success (including "nothing more to read right now"), -1 on a closed or
+// broken connection. May free stream state via on_stream_close.
+static int h2_read_tls(struct h2_conn *c)
+{
+	char buf[16384];
+	for(;;)
+	{
+		const int n = SSL_read(c->ssl, buf, sizeof(buf));
+		if(n > 0)
+		{
+			if(nghttp2_session_mem_recv2(c->session, (const uint8_t *)buf, (size_t)n) < 0)
+				return -1;
+			continue;
+		}
+		const int err = SSL_get_error(c->ssl, n);
+		if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
+			return 0;
+		return -1; // clean shutdown or fatal error
+	}
+}
+
+// Serve one HTTP/2 connection: a single poll() loop over the client TLS socket
+// and every active backend socket, streaming requests to the backend and
+// responses back to the client with per-stream concurrency. Uses the
+// module-global backend_port.
+static void terminator_h2_serve(SSL *ssl, int client_fd)
+{
+	if(set_nonblocking(client_fd) != 0)
+		return;
+	// Allow partial writes and a moved buffer pointer, since the outbound TLS
+	// buffer is compacted between SSL_write() retries.
+	SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+
+	nghttp2_session_callbacks *cbs = NULL;
+	if(nghttp2_session_callbacks_new(&cbs) != 0)
+		return;
+	nghttp2_session_callbacks_set_on_begin_headers_callback(cbs, h2_on_begin_headers);
+	nghttp2_session_callbacks_set_on_header_callback(cbs, h2_on_header);
+	nghttp2_session_callbacks_set_on_data_chunk_recv_callback(cbs, h2_on_data_chunk);
+	nghttp2_session_callbacks_set_on_frame_recv_callback(cbs, h2_on_frame_recv);
+	nghttp2_session_callbacks_set_on_stream_close_callback(cbs, h2_on_stream_close);
+
+	struct h2_conn conn;
+	memset(&conn, 0, sizeof(conn));
+	conn.ssl = ssl;
+	conn.client_fd = client_fd;
+
+	nghttp2_option *opt = NULL;
+	if(nghttp2_option_new(&opt) != 0)
+	{
+		nghttp2_session_callbacks_del(cbs);
+		return;
+	}
+	// Manage flow-control windows by hand so request-body backpressure follows
+	// the backend's drain rate (see h2_be_writable()).
+	nghttp2_option_set_no_auto_window_update(opt, 1);
+	if(nghttp2_session_server_new2(&conn.session, cbs, &conn, opt) != 0)
+	{
+		nghttp2_option_del(opt);
+		nghttp2_session_callbacks_del(cbs);
+		return;
+	}
+	nghttp2_option_del(opt);
+	nghttp2_session_callbacks_del(cbs);
+
+	const nghttp2_settings_entry iv[1] = {
+		{ NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100 }
+	};
+	nghttp2_submit_settings(conn.session, NGHTTP2_FLAG_NONE, iv, 1);
+
+	for(;;)
+	{
+		if(h2_pump_output(&conn) != 0)
+			break;
+		if(h2_drain_tls(&conn) != 0)
+			break;
+
+		// The session is finished once nghttp2 wants neither read nor write, no
+		// streams remain, and the outbound buffer is empty.
+		if(!nghttp2_session_want_read(conn.session) &&
+		   !nghttp2_session_want_write(conn.session) &&
+		   conn.streams == NULL && conn.wlen == conn.woff)
+			break;
+
+		// Grow the poll scratch buffers to fit the client fd plus every backend.
+		size_t need = 1;
+		for(struct h2_stream *s = conn.streams; s != NULL; s = s->next)
+			if(s->be_fd >= 0)
+				need++;
+		if(need > conn.pcap)
+		{
+			struct pollfd *np = realloc(conn.pfds, need * sizeof(*np));
+			struct h2_stream **nm = realloc(conn.pmap, need * sizeof(*nm));
+			if(np != NULL) conn.pfds = np;
+			if(nm != NULL) conn.pmap = nm;
+			if(np == NULL || nm == NULL)
+				break;
+			conn.pcap = need;
+		}
+
+		conn.pfds[0].fd = client_fd;
+		conn.pfds[0].events = POLLIN;
+		if(conn.wlen > conn.woff || conn.ssl_want_write)
+			conn.pfds[0].events |= POLLOUT;
+		conn.pfds[0].revents = 0;
+		conn.pmap[0] = NULL;
+
+		nfds_t nfds = 1;
+		for(struct h2_stream *s = conn.streams; s != NULL; s = s->next)
+		{
+			if(s->be_fd < 0)
+				continue;
+			short ev = 0;
+			if(s->be_connecting)
+				ev |= POLLOUT; // wait for connect() to complete
+			else
+			{
+				if(s->req_out_off < s->req_out_len)
+					ev |= POLLOUT; // request bytes still to flush
+				if(!s->resp_complete && (s->body_len - s->body_off) < H2_BODY_HIGH_WATER)
+					ev |= POLLIN;  // room for more response body
+			}
+			if(ev == 0)
+				continue;
+			conn.pfds[nfds].fd = s->be_fd;
+			conn.pfds[nfds].events = ev;
+			conn.pfds[nfds].revents = 0;
+			conn.pmap[nfds] = s;
+			nfds++;
+		}
+
+		const int pr = poll(conn.pfds, nfds, IO_TIMEOUT_SEC * 1000);
+		if(pr < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			break;
+		}
+		if(pr == 0)
+			break; // idle timeout
+
+		// Service backend fds first. These never free stream state, so the pmap
+		// stays valid; the client read below may close and free streams.
+		for(nfds_t i = 1; i < nfds; i++)
+		{
+			struct h2_stream *s = conn.pmap[i];
+			if(s == NULL || s->be_fd < 0)
+				continue;
+			if(conn.pfds[i].revents & POLLOUT)
+				h2_be_writable(s);
+			if(conn.pfds[i].revents & (POLLIN | POLLHUP | POLLERR))
+				h2_be_readable(s);
+		}
+
+		if(conn.pfds[0].revents & (POLLIN | POLLHUP | POLLERR))
+		{
+			if(h2_read_tls(&conn) != 0)
+				break;
+		}
+	}
+
+	// nghttp2_session_del() closes any remaining streams (invoking
+	// on_stream_close, which unlinks and frees them); drain defensively in case
+	// this version does not, then release the connection buffers.
+	nghttp2_session_del(conn.session);
+	while(conn.streams != NULL)
+	{
+		struct h2_stream *s = conn.streams;
+		conn.streams = s->next;
+		h2_stream_free(s);
+	}
+	free(conn.wbuf);
+	free(conn.pfds);
+	free(conn.pmap);
+}
+#endif /* HAVE_HTTP2 */
+
 // Per-connection handler, run in a detached thread.
 static void *handle_conn(void *arg)
 {
@@ -358,6 +1467,21 @@ static void *handle_conn(void *arg)
 		goto cleanup;
 	}
 
+#ifdef HAVE_HTTP2
+	// If the client negotiated HTTP/2 via ALPN, run the HTTP/2 gateway.
+	{
+		const unsigned char *alpn = NULL;
+		unsigned int alpn_len = 0;
+		SSL_get0_alpn_selected(ssl, &alpn, &alpn_len);
+		if(alpn_len == 2 && memcmp(alpn, "h2", 2) == 0)
+		{
+			terminator_h2_serve(ssl, client_fd);
+			goto cleanup;
+		}
+	}
+#endif
+
+	// HTTP/1.1: terminate TLS and relay the byte stream to the backend.
 	be_fd = connect_backend();
 	if(be_fd < 0)
 		goto cleanup;

--- a/src/webserver/terminator.c
+++ b/src/webserver/terminator.c
@@ -1,0 +1,491 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  In-process TLS front terminator (HTTP/1.1)
+*
+*  Milestone M1: bind the public TLS port, terminate TLS, and forward the plain
+*  HTTP/1.1 byte stream to the CivetWeb backend on the loopback interface. TLS is
+*  the only thing this layer understands; everything above it (HTTP framing,
+*  keep-alive, routing, Lua, auth) stays in CivetWeb, which now speaks plain
+*  HTTP/1.1 on loopback. HTTP/2 (nghttp2) and HTTP/3 (nghttp3/QUIC) are added on
+*  top of this in later milestones.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "webserver/terminator.h"
+// log_err(), log_info(), log_warn()
+#include "log.h"
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <sys/prctl.h>
+#include <pthread.h>
+#include <poll.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+// Bidirectional relay buffer size (per direction, per iteration).
+#define RELAY_BUF 16384u
+// Socket send/receive timeout so a stuck peer cannot pin a handler thread.
+#define IO_TIMEOUT_SEC 30
+
+// Terminator state. There is a single terminator instance for the whole
+// process, mirroring the single CivetWeb context in webserver.c.
+static SSL_CTX *ssl_ctx = NULL;
+static int listen_fd = -1;
+static int backend_port = 0;
+static volatile bool running = false;
+static pthread_t accept_tid;
+static bool accept_tid_valid = false;
+
+// Log the pending OpenSSL error queue at error level, prefixed with context.
+static void log_ssl_errors(const char *context)
+{
+	unsigned long e;
+	while((e = ERR_get_error()) != 0)
+	{
+		char buf[256];
+		ERR_error_string_n(e, buf, sizeof(buf));
+		log_err("Terminator: %s: %s", context, buf);
+	}
+}
+
+// ALPN: this milestone only serves HTTP/1.1. Offer nothing else so clients
+// negotiate http/1.1 (or fall back to it when they send no ALPN).
+static int alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+                          const unsigned char *in, unsigned int inlen, void *arg)
+{
+	static const unsigned char http11[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+	(void)ssl;
+	(void)arg;
+	if(SSL_select_next_proto((unsigned char **)out, outlen, http11, sizeof(http11),
+	                         in, inlen) != OPENSSL_NPN_NEGOTIATED)
+		return SSL_TLSEXT_ERR_NOACK;
+	return SSL_TLSEXT_ERR_OK;
+}
+
+// Build the server-side SSL_CTX from the combined PEM (certificate + key).
+static SSL_CTX *create_server_ctx(const char *cert_path)
+{
+	SSL_CTX *c = SSL_CTX_new(TLS_server_method());
+	if(c == NULL)
+	{
+		log_ssl_errors("SSL_CTX_new() failed");
+		return NULL;
+	}
+	SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION);
+	// The PEM carries both the certificate (chain) and the private key.
+	if(SSL_CTX_use_certificate_chain_file(c, cert_path) != 1 ||
+	   SSL_CTX_use_PrivateKey_file(c, cert_path, SSL_FILETYPE_PEM) != 1 ||
+	   SSL_CTX_check_private_key(c) != 1)
+	{
+		log_ssl_errors("loading TLS certificate/key failed");
+		SSL_CTX_free(c);
+		return NULL;
+	}
+	SSL_CTX_set_alpn_select_cb(c, alpn_select_cb, NULL);
+	return c;
+}
+
+// Bind a dual-stack (IPv4 + IPv6) TCP listener on the given port, all
+// interfaces. Returns the fd or -1.
+static int bind_listener(int port)
+{
+	// SOCK_CLOEXEC so the fd is not inherited across FTL's execvp() self-restart,
+	// where it would keep the port busy and make the new process fail to re-bind.
+	const int fd = socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	if(fd < 0)
+	{
+		log_err("Terminator: socket() failed: %s", strerror(errno));
+		return -1;
+	}
+
+	const int on = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+	// Accept both IPv4 (as v4-mapped) and IPv6 on this single socket.
+	const int off = 0;
+	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
+
+	struct sockaddr_in6 sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sin6_family = AF_INET6;
+	sa.sin6_addr = in6addr_any;
+	sa.sin6_port = htons((uint16_t)port);
+	if(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+	{
+		log_err("Terminator: bind() to port %d failed: %s", port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if(listen(fd, SOMAXCONN) != 0)
+	{
+		log_err("Terminator: listen() on port %d failed: %s", port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+// Connect a fresh plaintext TCP socket to the CivetWeb backend on loopback.
+// Returns the fd or -1.
+static int connect_backend(void)
+{
+	const int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	if(fd < 0)
+		return -1;
+
+	const struct timeval tv = { .tv_sec = IO_TIMEOUT_SEC, .tv_usec = 0 };
+	setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+	struct sockaddr_in sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons((uint16_t)backend_port);
+	sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	if(connect(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0)
+	{
+		log_err("Terminator: connect to backend 127.0.0.1:%d failed: %s",
+		        backend_port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+// Write the full buffer to a plain fd (blocking socket). Returns 0 or -1.
+static int write_all_fd(int fd, const char *buf, size_t len)
+{
+	while(len > 0)
+	{
+		const ssize_t n = write(fd, buf, len);
+		if(n > 0)
+		{
+			buf += n;
+			len -= (size_t)n;
+		}
+		else if(n < 0 && errno == EINTR)
+			continue;
+		else
+			return -1;
+	}
+	return 0;
+}
+
+// Write the full buffer to the TLS connection (blocking socket). Returns 0 or -1.
+static int write_all_ssl(SSL *ssl, const char *buf, size_t len)
+{
+	while(len > 0)
+	{
+		const int n = SSL_write(ssl, buf, (int)len);
+		if(n > 0)
+		{
+			buf += n;
+			len -= (size_t)n;
+		}
+		else
+		{
+			const int err = SSL_get_error(ssl, n);
+			if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
+				continue;
+			return -1;
+		}
+	}
+	return 0;
+}
+
+// Announce the real client to the backend with a PROXY protocol v2 header,
+// written once at the very start of the backend connection (before any request
+// bytes). CivetWeb parses it and attributes the request to the actual client
+// instead of the loopback terminator, so client-IP-based logging and auth stay
+// correct. Returns 0 on success, -1 on error.
+static int send_proxy_v2(int be_fd, int client_fd)
+{
+	struct sockaddr_storage src, dst;
+	socklen_t sl = sizeof(src), dl = sizeof(dst);
+	if(getpeername(client_fd, (struct sockaddr *)&src, &sl) != 0 ||
+	   getsockname(client_fd, (struct sockaddr *)&dst, &dl) != 0)
+		return -1;
+
+	static const unsigned char sig[12] =
+		{ 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A };
+	unsigned char hdr[16 + 36];
+	memcpy(hdr, sig, sizeof(sig));
+	hdr[12] = 0x21; // version 2, PROXY command
+	size_t len = 0;
+
+	if(src.ss_family == AF_INET)
+	{
+		const struct sockaddr_in *s = (const struct sockaddr_in *)&src;
+		const struct sockaddr_in *d = (const struct sockaddr_in *)&dst;
+		hdr[13] = 0x11; // TCP over IPv4
+		hdr[14] = 0; hdr[15] = 12;
+		memcpy(hdr + 16, &s->sin_addr, 4);
+		memcpy(hdr + 20, &d->sin_addr, 4);
+		memcpy(hdr + 24, &s->sin_port, 2);
+		memcpy(hdr + 26, &d->sin_port, 2);
+		len = 16 + 12;
+	}
+	else if(src.ss_family == AF_INET6)
+	{
+		const struct sockaddr_in6 *s = (const struct sockaddr_in6 *)&src;
+		const struct sockaddr_in6 *d = (const struct sockaddr_in6 *)&dst;
+		// The listener is dual-stack, so IPv4 clients arrive as v4-mapped IPv6;
+		// emit them as IPv4 for a faithful, compact header.
+		if(IN6_IS_ADDR_V4MAPPED(&s->sin6_addr))
+		{
+			hdr[13] = 0x11;
+			hdr[14] = 0; hdr[15] = 12;
+			memcpy(hdr + 16, s->sin6_addr.s6_addr + 12, 4);
+			if(IN6_IS_ADDR_V4MAPPED(&d->sin6_addr))
+				memcpy(hdr + 20, d->sin6_addr.s6_addr + 12, 4);
+			memcpy(hdr + 24, &s->sin6_port, 2);
+			memcpy(hdr + 26, &d->sin6_port, 2);
+			len = 16 + 12;
+		}
+		else
+		{
+			hdr[13] = 0x21; // TCP over IPv6
+			hdr[14] = 0; hdr[15] = 36;
+			memcpy(hdr + 16, &s->sin6_addr, 16);
+			memcpy(hdr + 32, &d->sin6_addr, 16);
+			memcpy(hdr + 48, &s->sin6_port, 2);
+			memcpy(hdr + 50, &d->sin6_port, 2);
+			len = 16 + 36;
+		}
+	}
+	else
+		return -1;
+
+	return write_all_fd(be_fd, (const char *)hdr, len);
+}
+
+// Relay bytes both ways between the TLS'd client and the plaintext backend until
+// either side closes. TLS is transparent here: CivetWeb sees a normal HTTP/1.1
+// stream, so keep-alive, chunked bodies, ranges, etc. all work unchanged. The
+// real client address was already announced to the backend via send_proxy_v2().
+static void relay(SSL *ssl, int client_fd, int be_fd)
+{
+	char buf[RELAY_BUF];
+	for(;;)
+	{
+		struct pollfd fds[2];
+		fds[0].fd = client_fd;
+		fds[0].events = POLLIN;
+		fds[0].revents = 0;
+		fds[1].fd = be_fd;
+		fds[1].events = POLLIN;
+		fds[1].revents = 0;
+
+		// If OpenSSL has buffered, already-decrypted data, drain it without
+		// waiting in poll() (the socket may not be readable in that case).
+		const int timeout = SSL_pending(ssl) > 0 ? 0 : (IO_TIMEOUT_SEC * 1000);
+		const int pr = poll(fds, 2, timeout);
+		if(pr < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			break;
+		}
+		if(pr == 0)
+			break; // idle timeout
+
+		// client -> backend
+		if(SSL_pending(ssl) > 0 || (fds[0].revents & (POLLIN | POLLHUP | POLLERR)))
+		{
+			const int n = SSL_read(ssl, buf, sizeof(buf));
+			if(n > 0)
+			{
+				if(write_all_fd(be_fd, buf, (size_t)n) != 0)
+					break;
+			}
+			else
+			{
+				const int err = SSL_get_error(ssl, n);
+				if(err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE)
+					break; // clean close or fatal error
+			}
+		}
+
+		// backend -> client
+		if(fds[1].revents & (POLLIN | POLLHUP | POLLERR))
+		{
+			const ssize_t n = read(be_fd, buf, sizeof(buf));
+			if(n > 0)
+			{
+				if(write_all_ssl(ssl, buf, (size_t)n) != 0)
+					break;
+			}
+			else if(n == 0)
+				break; // backend closed
+			else if(errno != EINTR)
+				break;
+		}
+	}
+}
+
+// Per-connection handler, run in a detached thread.
+static void *handle_conn(void *arg)
+{
+	const int client_fd = (int)(intptr_t)arg;
+
+	const struct timeval tv = { .tv_sec = IO_TIMEOUT_SEC, .tv_usec = 0 };
+	setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+	SSL *ssl = SSL_new(ssl_ctx);
+	int be_fd = -1;
+	if(ssl == NULL)
+	{
+		log_ssl_errors("SSL_new() failed");
+		goto cleanup;
+	}
+	SSL_set_fd(ssl, client_fd);
+	if(SSL_accept(ssl) != 1)
+	{
+		// A failed handshake (e.g. a plain-HTTP probe on the TLS port) is not
+		// worth an error; keep it at debug level to avoid log flooding.
+		log_debug(DEBUG_WEBSERVER, "Terminator: TLS handshake failed");
+		goto cleanup;
+	}
+
+	be_fd = connect_backend();
+	if(be_fd < 0)
+		goto cleanup;
+
+	// Announce the real client to the backend before relaying any request bytes
+	if(send_proxy_v2(be_fd, client_fd) != 0)
+	{
+		log_debug(DEBUG_WEBSERVER, "Terminator: could not send PROXY header");
+		goto cleanup;
+	}
+
+	relay(ssl, client_fd, be_fd);
+
+cleanup:
+	if(ssl != NULL)
+	{
+		SSL_shutdown(ssl);
+		SSL_free(ssl);
+	}
+	if(be_fd >= 0)
+		close(be_fd);
+	close(client_fd);
+	return NULL;
+}
+
+// Accept loop thread: hand each accepted connection to a detached handler.
+static void *accept_loop(void *arg)
+{
+	(void)arg;
+	prctl(PR_SET_NAME, "terminator", 0, 0, 0);
+
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+	while(running)
+	{
+		const int client_fd = accept4(listen_fd, NULL, NULL, SOCK_CLOEXEC);
+		if(client_fd < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			if(!running)
+				break; // listener shut down by terminator_stop()
+			// Transient error (e.g. EMFILE); avoid a tight spin.
+			poll(NULL, 0, 100);
+			continue;
+		}
+
+		// TODO(M1): bound the number of concurrent handler threads (a worker
+		// pool) instead of one detached thread per connection.
+		pthread_t tid;
+		if(pthread_create(&tid, &attr, handle_conn, (void *)(intptr_t)client_fd) != 0)
+		{
+			log_err("Terminator: pthread_create() failed: %s", strerror(errno));
+			close(client_fd);
+		}
+	}
+
+	pthread_attr_destroy(&attr);
+	return NULL;
+}
+
+bool terminator_start(int public_port, int be_port, const char *cert_path)
+{
+	if(running)
+	{
+		log_warn("Terminator: already running");
+		return false;
+	}
+	if(cert_path == NULL || public_port <= 0 || be_port <= 0)
+		return false;
+
+	ssl_ctx = create_server_ctx(cert_path);
+	if(ssl_ctx == NULL)
+		return false;
+
+	listen_fd = bind_listener(public_port);
+	if(listen_fd < 0)
+	{
+		SSL_CTX_free(ssl_ctx);
+		ssl_ctx = NULL;
+		return false;
+	}
+
+	backend_port = be_port;
+	running = true;
+	if(pthread_create(&accept_tid, NULL, accept_loop, NULL) != 0)
+	{
+		log_err("Terminator: failed to start accept thread: %s", strerror(errno));
+		running = false;
+		close(listen_fd);
+		listen_fd = -1;
+		SSL_CTX_free(ssl_ctx);
+		ssl_ctx = NULL;
+		return false;
+	}
+	accept_tid_valid = true;
+
+	log_info("TLS terminator listening on port %d, forwarding to 127.0.0.1:%d",
+	         public_port, be_port);
+	return true;
+}
+
+void terminator_stop(void)
+{
+	if(!running && listen_fd < 0 && ssl_ctx == NULL)
+		return;
+
+	running = false;
+	// Break the blocking accept4() so the accept thread can exit.
+	if(listen_fd >= 0)
+		shutdown(listen_fd, SHUT_RDWR);
+	if(accept_tid_valid)
+	{
+		pthread_join(accept_tid, NULL);
+		accept_tid_valid = false;
+	}
+	if(listen_fd >= 0)
+	{
+		close(listen_fd);
+		listen_fd = -1;
+	}
+	if(ssl_ctx != NULL)
+	{
+		SSL_CTX_free(ssl_ctx);
+		ssl_ctx = NULL;
+	}
+	// Note: in-flight detached handler threads are not joined here; they finish
+	// on their own when their connection closes or times out (IO_TIMEOUT_SEC).
+}

--- a/src/webserver/terminator.h
+++ b/src/webserver/terminator.h
@@ -3,12 +3,11 @@
 *  Network-wide ad blocking via your own hardware.
 *
 *  FTL Engine
-*  In-process TLS front terminator (HTTP/1.1)
+*  In-process TLS front terminator (HTTP/1.1, HTTP/2, HTTP/3)
 *
 *  Terminates TLS on the public port and forwards plain HTTP/1.1 to the CivetWeb
-*  backend on the loopback interface. This is milestone M1 (HTTP/1.1 only); the
-*  terminator is the foundation for HTTP/2 (nghttp2) and HTTP/3 (nghttp3/QUIC),
-*  which are added in later milestones. CivetWeb itself stays HTTP/1.1-only.
+*  backend on the loopback interface. HTTP/2 (nghttp2) and HTTP/3 (nghttp3/QUIC)
+*  are bridged to the same backend; CivetWeb itself stays HTTP/1.1-only.
 *
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
@@ -17,15 +16,20 @@
 
 #include <stdbool.h>
 
-// Start the TLS terminator: bind public_port on all interfaces, terminate TLS
-// using the certificate (PEM with certificate and private key) at cert_path,
-// and forward accepted connections as plain HTTP/1.1 to 127.0.0.1:backend_port
-// (the CivetWeb backend). Spawns its own accept thread. Returns true on
-// success; on failure nothing is left running.
-bool terminator_start(int public_port, int backend_port, const char *cert_path);
+// Start the TLS terminator: bind public_port on bind_addr (NULL/"" = all
+// interfaces, else an IPv4/IPv6 literal), terminate TLS with the PEM (cert + key)
+// at cert_path, and forward accepted connections as plain HTTP/1.1 to
+// 127.0.0.1:backend_port. Spawns an accept thread. Returns true on success; on
+// failure nothing is left running.
+bool terminator_start(const char *bind_addr, int public_port, int backend_port, const char *cert_path);
 
-// Stop the terminator and release all resources. Safe to call even if the
-// terminator was never started or already stopped.
+// Stop the terminator and free all resources. Safe to call if never started or already stopped.
 void terminator_stop(void);
+
+// Hex-encode the per-boot token (generating it if needed) into out, which must
+// hold at least 33 bytes. webserver.c passes it to the loopback CivetWeb backend
+// as "proxy_protocol_secret", the shared secret the backend uses to authenticate
+// our PROXY v2 headers. Returns false if out is too small or the RNG fails.
+bool terminator_proxy_token_hex(char *out, size_t outsz);
 
 #endif // WEBSERVER_TERMINATOR_H

--- a/src/webserver/terminator.h
+++ b/src/webserver/terminator.h
@@ -15,6 +15,7 @@
 #define WEBSERVER_TERMINATOR_H
 
 #include <stdbool.h>
+#include <stddef.h> // size_t
 
 // Start the TLS terminator: bind public_port on bind_addr (NULL/"" = all
 // interfaces, else an IPv4/IPv6 literal), terminate TLS with the PEM (cert + key)

--- a/src/webserver/terminator.h
+++ b/src/webserver/terminator.h
@@ -1,0 +1,31 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  In-process TLS front terminator (HTTP/1.1)
+*
+*  Terminates TLS on the public port and forwards plain HTTP/1.1 to the CivetWeb
+*  backend on the loopback interface. This is milestone M1 (HTTP/1.1 only); the
+*  terminator is the foundation for HTTP/2 (nghttp2) and HTTP/3 (nghttp3/QUIC),
+*  which are added in later milestones. CivetWeb itself stays HTTP/1.1-only.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+#ifndef WEBSERVER_TERMINATOR_H
+#define WEBSERVER_TERMINATOR_H
+
+#include <stdbool.h>
+
+// Start the TLS terminator: bind public_port on all interfaces, terminate TLS
+// using the certificate (PEM with certificate and private key) at cert_path,
+// and forward accepted connections as plain HTTP/1.1 to 127.0.0.1:backend_port
+// (the CivetWeb backend). Spawns its own accept thread. Returns true on
+// success; on failure nothing is left running.
+bool terminator_start(int public_port, int backend_port, const char *cert_path);
+
+// Stop the terminator and release all resources. Safe to call even if the
+// terminator was never started or already stopped.
+void terminator_stop(void);
+
+#endif // WEBSERVER_TERMINATOR_H

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -116,6 +116,24 @@ char * __attribute__((pure)) get_api_uri(void)
 	return api_uri;
 }
 
+bool __attribute__((const)) webserver_have_http2(void)
+{
+#ifdef HAVE_HTTP2
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool __attribute__((const)) webserver_have_http3(void)
+{
+#ifdef HAVE_HTTP3
+	return true;
+#else
+	return false;
+#endif
+}
+
 static int redirect_root_handler(struct mg_connection *conn, void *input)
 {
 	// Get requested host
@@ -389,6 +407,13 @@ static struct serverports
 	int protocol; // 1 = IPv4, 3 = IPv6
 } server_ports[MAXPORTS] = { 0 };
 static in_port_t https_port = 0;
+// TLS terminator bookkeeping: the public TLS port it owns and the ephemeral
+// loopback backend port CivetWeb serves it on. Both 0 when TLS is off.
+static int terminator_port = 0;
+static int backend_port = 0;
+// The bind address the operator scoped the secure port to ("" = all interfaces),
+// so the terminator honours it instead of always binding every interface.
+static char terminator_addr[64] = "";
 /**
  * @brief Retrieves and logs the server ports configuration.
  *
@@ -418,55 +443,111 @@ static bool get_server_ports(void)
 		return false;
 	}
 
-	// Loop over all ports
-	for(unsigned int i = 0; i < (unsigned int)ports; i++)
+	// Rebuild the table from scratch (http_init may run again on a restart).
+	memset(server_ports, 0, sizeof(server_ports));
+
+	// Loop over all ports CivetWeb reports. In terminator mode CivetWeb binds the
+	// public plaintext port(s) plus an internal loopback backend; the public TLS
+	// port lives on the terminator. Hide the backend and mirror each public
+	// plaintext port with the terminator's TLS port on the same address.
+	log_info("Web server ports:");
+	unsigned int n = 0;
+	for(unsigned int i = 0; i < (unsigned int)ports && n < MAXPORTS; i++)
 	{
 		// Stop if no more ports are configured
 		if(mgports[i].protocol == 0)
 			break;
 
-		// Store port information
-		server_ports[i].port = mgports[i].port;
-		server_ports[i].is_secure = mgports[i].is_ssl;
-		server_ports[i].is_redirect = mgports[i].is_redirect;
-		server_ports[i].is_optional = mgports[i].is_optional;
-		server_ports[i].is_bound = mgports[i].is_bound;
-		// 1 = IPv4, 3 = IPv6 (can also be a combo-socker serving both),
-		// the documentation in civetweb.h is wrong
-		server_ports[i].protocol = mgports[i].protocol;
-
 		// Convert listening address to string
-		if(server_ports[i].protocol == 1)
-			inet_ntop(AF_INET, &mgports[i].addr.sa4.sin_addr, server_ports[i].addr, INET_ADDRSTRLEN);
-		else if(server_ports[i].protocol == 3)
+		// 1 = IPv4, 3 = IPv6 (can also be a combo-socket serving both),
+		// the documentation in civetweb.h is wrong
+		char addr[INET6_ADDRSTRLEN + 2] = { 0 };
+		if(mgports[i].protocol == 1)
+			inet_ntop(AF_INET, &mgports[i].addr.sa4.sin_addr, addr, INET_ADDRSTRLEN);
+		else if(mgports[i].protocol == 3)
 		{
 			char tmp[INET6_ADDRSTRLEN] = { 0 };
 			inet_ntop(AF_INET6, &mgports[i].addr.sa6.sin6_addr, tmp, INET6_ADDRSTRLEN);
 			// Enclose IPv6 address in square brackets
-			snprintf(server_ports[i].addr, sizeof(server_ports[i].addr), "[%s]", tmp);
+			snprintf(addr, sizeof(addr), "[%s]", tmp);
 		}
 		else
+		{
 			log_warn("Unsupported protocol for port %d", mgports[i].port);
+			continue;
+		}
 
-		// Store (first) HTTPS port if not already set
+		// The loopback plaintext backend the terminator forwards to is internal;
+		// remember its port for terminator_start() but do not advertise it.
+		if(terminator_port > 0 && !mgports[i].is_ssl &&
+		   strcmp(addr, "127.0.0.1") == 0)
+		{
+			backend_port = mgports[i].port;
+			continue;
+		}
+
+		// Store the public port
+		strncpy(server_ports[n].addr, addr, sizeof(server_ports[n].addr) - 1);
+		server_ports[n].port = mgports[i].port;
+		server_ports[n].is_secure = mgports[i].is_ssl;
+		server_ports[n].is_redirect = mgports[i].is_redirect;
+		server_ports[n].is_optional = mgports[i].is_optional;
+		server_ports[n].is_bound = mgports[i].is_bound;
+		server_ports[n].protocol = mgports[i].protocol;
 		if(mgports[i].is_ssl && https_port == 0)
 			https_port = mgports[i].port;
-
-		// Print port information
-		if(i == 0)
-			log_info("Web server ports:");
 		log_info("  - %s:%d (HTTP%s, IPv%s%s%s, %s)",
-		         server_ports[i].addr,
-		         server_ports[i].port,
-		         server_ports[i].is_secure ? "S" : "",
-		         server_ports[i].protocol == 1 ? "4" : "6",
-		         server_ports[i].is_redirect ? ", redirecting" : "",
-		         server_ports[i].is_optional ? ", optional" : "",
-		         server_ports[i].is_bound ? "OK" : "NOT bound");
+		         server_ports[n].addr, server_ports[n].port,
+		         server_ports[n].is_secure ? "S" : "",
+		         server_ports[n].protocol == 1 ? "4" : "6",
+		         server_ports[n].is_redirect ? ", redirecting" : "",
+		         server_ports[n].is_optional ? ", optional" : "",
+		         server_ports[n].is_bound ? "OK" : "NOT bound");
+		n++;
 
+		// Mirror each public plaintext (non-redirect) port with the terminator's
+		// TLS port on the same address.
+		if(terminator_port > 0 && !mgports[i].is_ssl &&
+		   !mgports[i].is_redirect && n < MAXPORTS)
+		{
+			server_ports[n] = server_ports[n - 1];
+			server_ports[n].port = terminator_port;
+			server_ports[n].is_secure = true;
+			server_ports[n].is_bound = true;
+			if(https_port == 0)
+				https_port = (in_port_t)terminator_port;
+			log_info("  - %s:%d (HTTPS, IPv%s%s, terminator)",
+			         server_ports[n].addr, server_ports[n].port,
+			         server_ports[n].protocol == 1 ? "4" : "6",
+			         server_ports[n].is_optional ? ", optional" : "");
+			n++;
+		}
 	}
 
-	return true;
+	// The terminator serves the public TLS port outside CivetWeb, so it is
+	// normally registered by mirroring a public plaintext port above. If there is
+	// no plaintext port to mirror - a TLS-only "443s" config, or only a redirect
+	// plaintext port ("80r,443s") - register it explicitly here. Otherwise
+	// get_server_ports() would report failure (aborting the whole web interface)
+	// or leave https_port at 0, which mis-reports the port in /info and skips
+	// certificate auto-renewal (letting an FTL-generated cert silently expire).
+	if(terminator_port > 0 && https_port == 0 && n < MAXPORTS)
+	{
+		memset(&server_ports[n], 0, sizeof(server_ports[n]));
+		strncpy(server_ports[n].addr,
+		        terminator_addr[0] != '\0' ? terminator_addr : "0.0.0.0",
+		        sizeof(server_ports[n].addr) - 1);
+		server_ports[n].port = (in_port_t)terminator_port;
+		server_ports[n].is_secure = true;
+		server_ports[n].is_bound = true;
+		server_ports[n].protocol = 1;
+		https_port = (in_port_t)terminator_port;
+		log_info("  - %s:%d (HTTPS, terminator)",
+		         server_ports[n].addr, server_ports[n].port);
+		n++;
+	}
+
+	return n > 0;
 }
 
 in_port_t __attribute__((pure)) get_https_port(void)
@@ -584,8 +665,13 @@ static void print_webserver_opts(const bool debug, const size_t idx, const char 
 {
 	for(size_t i = 0; i <= idx; i++)
 	{
-		char *escaped_key = escape_string(static_options[i * 2]);
-		char *escaped_value = escape_string(static_options[i * 2 + 1]);
+		const char *key = static_options[i * 2];
+		const char *value = static_options[i * 2 + 1];
+		// Never log the value of the per-boot backend-auth secret.
+		if(key != NULL && strcmp(key, "proxy_protocol_secret") == 0)
+			value = "<per-boot secret>";
+		char *escaped_key = escape_string(key);
+		char *escaped_value = escape_string(value);
 		if(debug)
 		{
 			if(i == idx)
@@ -614,15 +700,15 @@ static void print_webserver_opts(const bool debug, const size_t idx, const char 
 }
 
 #ifdef HAVE_TLS
-// Split the configured webserver port list for TLS-terminator mode. Every
-// secure ("...s") entry names a public TLS port the terminator will own, so it
-// is removed from the list handed to CivetWeb; a single loopback plaintext
-// backend (ephemeral port, read back after start) is appended instead. Returns
-// the first secure port found (the terminator's public port), or 0 if the list
-// has no TLS port.
-static int split_terminator_ports(const char *cfg, char *backend, size_t backend_len)
+// Split the webserver port list for TLS-terminator mode. Secure ("...s") entries
+// name public TLS ports the terminator owns, so they are dropped from CivetWeb's
+// list and a loopback plaintext backend (ephemeral port, read back after start)
+// is appended instead. Returns the first secure port, or 0 if none.
+static int split_terminator_ports(const char *cfg, char *backend, size_t backend_len,
+                                  char *tls_addr, size_t tls_addr_len)
 {
 	backend[0] = '\0';
+	tls_addr[0] = '\0';
 	int tls_port = 0;
 
 	char *copy = strdup(cfg);
@@ -632,22 +718,47 @@ static int split_terminator_ports(const char *cfg, char *backend, size_t backend
 	char *save = NULL;
 	for(char *tok = strtok_r(copy, ",", &save); tok != NULL; tok = strtok_r(NULL, ",", &save))
 	{
-		// Skip leading whitespace
-		while(*tok == ' ')
-			tok++;
-		if(*tok == '\0')
+		// Skip leading whitespace via a separate pointer so the loop variable
+		// itself is not modified in the body.
+		const char *ent = tok;
+		while(*ent == ' ')
+			ent++;
+		if(*ent == '\0')
 			continue;
 
 		// A secure entry (carries the 's' flag) is owned by the terminator
-		if(strchr(tok, 's') != NULL)
+		if(strchr(ent, 's') != NULL)
 		{
 			if(tls_port == 0)
 			{
-				// The port digits follow the last ':' (IP-prefixed entries such
-				// as "[::]:443os") or start the token ("443os"); atoi() stops at
-				// the flag letters.
-				const char *p = strrchr(tok, ':');
-				tls_port = atoi(p != NULL ? p + 1 : tok);
+				// Port digits follow the last ':' ("[::]:443os") or start the
+				// token ("443os"); atoi() stops at the flag letters.
+				const char *p = strrchr(ent, ':');
+				tls_port = atoi(p != NULL ? p + 1 : ent);
+				// Everything before that ':' is the bind address the operator
+				// scoped the port to; strip the [ ] around an IPv6 literal. No
+				// ':' means a bare port ("443s") -> all interfaces (empty addr).
+				if(p != NULL)
+				{
+					const char *astart = ent;
+					size_t alen = (size_t)(p - ent);
+					if(alen >= 2 && ent[0] == '[' && p[-1] == ']')
+					{
+						astart++;
+						alen -= 2;
+					}
+					if(alen > 0)
+					{
+						// An over-long address cannot be a valid IP literal;
+						// truncate it (rather than dropping it, which would
+						// silently fall back to all interfaces) so the terminator's
+						// fill_bind_addr() rejects it and fails closed.
+						if(alen >= tls_addr_len)
+							alen = tls_addr_len - 1;
+						memcpy(tls_addr, astart, alen);
+						tls_addr[alen] = '\0';
+					}
+				}
 			}
 			continue; // drop from the list handed to CivetWeb
 		}
@@ -655,7 +766,7 @@ static int split_terminator_ports(const char *cfg, char *backend, size_t backend
 		// Keep plaintext entries verbatim
 		if(backend[0] != '\0')
 			strncat(backend, ",", backend_len - strlen(backend) - 1);
-		strncat(backend, tok, backend_len - strlen(backend) - 1);
+		strncat(backend, ent, backend_len - strlen(backend) - 1);
 	}
 	free(copy);
 
@@ -666,22 +777,6 @@ static int split_terminator_ports(const char *cfg, char *backend, size_t backend
 	strncat(backend, "127.0.0.1:0", backend_len - strlen(backend) - 1);
 
 	return tls_port;
-}
-
-// After CivetWeb has started, find the ephemeral port it bound for the loopback
-// plaintext backend (the single non-secure listener on 127.0.0.1). Returns 0 if
-// not found.
-static int find_backend_port(void)
-{
-	for(unsigned int i = 0; i < MAXPORTS; i++)
-	{
-		if(server_ports[i].protocol == 0)
-			break;
-		if(!server_ports[i].is_secure &&
-		   strcmp(server_ports[i].addr, "127.0.0.1") == 0)
-			return server_ports[i].port;
-	}
-	return 0;
 }
 #endif /* HAVE_TLS */
 
@@ -761,19 +856,21 @@ void http_init(void)
 		strcat(webheaders, "\r\n");
 	}
 
-	// TLS is terminated by the in-process front terminator, not by CivetWeb.
-	// When the port list contains a secure port, hand CivetWeb a plaintext
-	// loopback backend instead and let the terminator own the public TLS port.
+	// TLS is terminated by the in-process front terminator, not CivetWeb: when the
+	// port list has a secure port, hand CivetWeb a plaintext loopback backend instead.
 	const char *listening_ports = config.webserver.port.v.s;
 #ifdef HAVE_TLS
 	const bool tls_used = config.webserver.port.v.s != NULL &&
 	                      strchr(config.webserver.port.v.s, 's') != NULL;
 	char backend_ports[256];
-	int terminator_port = 0;
+	terminator_port = 0;
+	backend_port = 0;
+	terminator_addr[0] = '\0';
 	if(tls_used)
 	{
 		terminator_port = split_terminator_ports(config.webserver.port.v.s,
-		                                          backend_ports, sizeof(backend_ports));
+		                                          backend_ports, sizeof(backend_ports),
+		                                          terminator_addr, sizeof(terminator_addr));
 		if(terminator_port > 0)
 			listening_ports = backend_ports;
 		else
@@ -799,7 +896,7 @@ void http_init(void)
 		NULL, NULL, // Optional slots for access control list (ACL)
 		NULL, NULL  // Termination of the array
 	};
-	const size_t opt_size = (ArraySize(static_options) / 2) + cJSON_GetArraySize(config.webserver.advancedOpts.v.json);
+	const size_t opt_size = (ArraySize(static_options) / 2) + cJSON_GetArraySize(config.webserver.advancedOpts.v.json) + 1; // +1: proxy_protocol_secret
 	// We allocate two additional slots for ACL and TLS configuration
 	// which are added later if configured
 	// The last NULL is for the NULL-termination of the array
@@ -819,8 +916,7 @@ void http_init(void)
 
 #ifdef HAVE_TLS
 	// Ensure the TLS certificate exists and matches the configured domain. The
-	// terminator (not CivetWeb) uses it to terminate TLS; CivetWeb serves plain
-	// HTTP/1.1 on the loopback backend, so no ssl_certificate option is passed.
+	// terminator (not CivetWeb) uses it; no ssl_certificate option is passed.
 	if(tls_used &&
 	   config.webserver.tls.cert.v.s != NULL &&
 	   strlen(config.webserver.tls.cert.v.s) > 0)
@@ -853,6 +949,24 @@ void http_init(void)
 			log_err("Webserver SSL/TLS certificate %s not found or not readable!",
 			        config.webserver.tls.cert.v.s);
 		}
+	}
+
+	// When the front terminator is active it reaches this loopback backend behind
+	// a PROXY v2 header; hand the backend the shared secret (the per-boot token,
+	// hex-encoded) so it authenticates the header and adopts the real client
+	// address. Generated here so it exists before mg_start2(); terminator_start()
+	// reuses the same token.
+	if(terminator_port > 0)
+	{
+		char secret_hex[33]; // 2 * 16-byte token + NUL
+		if(terminator_proxy_token_hex(secret_hex, sizeof(secret_hex)))
+		{
+			conf_opts[idx * 2] = strdup("proxy_protocol_secret");
+			conf_opts[idx * 2 + 1] = strdup(secret_hex);
+			idx++;
+		}
+		else
+			log_err("Terminator: could not derive proxy_protocol_secret; requests will log the loopback address");
 	}
 #endif
 	// Add access control list if configured (last two options)
@@ -1017,19 +1131,17 @@ void http_init(void)
 
 #ifdef HAVE_TLS
 	// Start the TLS terminator in front of the (now plaintext) CivetWeb backend.
-	// CivetWeb bound the loopback backend on an ephemeral port; read it back and
-	// forward the public TLS port to it. Record the public TLS port as the HTTPS
-	// port (civetweb no longer reports one) so the /api/info report and the
-	// certificate-expiry renewal loop in webserver_thread() keep working.
+	// get_server_ports() captured the ephemeral loopback port as backend_port and
+	// the public TLS port as https_port; forward the TLS port to that backend.
 	if(tls_used && terminator_port > 0)
 	{
-		const int be_port = find_backend_port();
-		if(be_port <= 0)
+		if(backend_port <= 0)
 			log_err("Could not determine the CivetWeb loopback backend port; TLS will not be available");
-		else if(terminator_start(terminator_port, be_port, config.webserver.tls.cert.v.s))
-			https_port = (in_port_t)terminator_port;
-		else
+		else if(!terminator_start(terminator_addr, terminator_port, backend_port, config.webserver.tls.cert.v.s))
+		{
 			log_err("Failed to start the TLS terminator on port %d", terminator_port);
+			https_port = 0; // TLS is not actually available
+		}
 	}
 #endif
 }

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -24,6 +24,8 @@
 #include "files.h"
 // generate_certificate()
 #include "webserver/x509.h"
+// terminator_start(), terminator_stop()
+#include "webserver/terminator.h"
 // allocate_lua(), free_lua(), init_lua(), request_handler()
 #include "webserver/lua_web.h"
 // log_certificate_domain_mismatch()
@@ -611,6 +613,78 @@ static void print_webserver_opts(const bool debug, const size_t idx, const char 
 	}
 }
 
+#ifdef HAVE_TLS
+// Split the configured webserver port list for TLS-terminator mode. Every
+// secure ("...s") entry names a public TLS port the terminator will own, so it
+// is removed from the list handed to CivetWeb; a single loopback plaintext
+// backend (ephemeral port, read back after start) is appended instead. Returns
+// the first secure port found (the terminator's public port), or 0 if the list
+// has no TLS port.
+static int split_terminator_ports(const char *cfg, char *backend, size_t backend_len)
+{
+	backend[0] = '\0';
+	int tls_port = 0;
+
+	char *copy = strdup(cfg);
+	if(copy == NULL)
+		return 0;
+
+	char *save = NULL;
+	for(char *tok = strtok_r(copy, ",", &save); tok != NULL; tok = strtok_r(NULL, ",", &save))
+	{
+		// Skip leading whitespace
+		while(*tok == ' ')
+			tok++;
+		if(*tok == '\0')
+			continue;
+
+		// A secure entry (carries the 's' flag) is owned by the terminator
+		if(strchr(tok, 's') != NULL)
+		{
+			if(tls_port == 0)
+			{
+				// The port digits follow the last ':' (IP-prefixed entries such
+				// as "[::]:443os") or start the token ("443os"); atoi() stops at
+				// the flag letters.
+				const char *p = strrchr(tok, ':');
+				tls_port = atoi(p != NULL ? p + 1 : tok);
+			}
+			continue; // drop from the list handed to CivetWeb
+		}
+
+		// Keep plaintext entries verbatim
+		if(backend[0] != '\0')
+			strncat(backend, ",", backend_len - strlen(backend) - 1);
+		strncat(backend, tok, backend_len - strlen(backend) - 1);
+	}
+	free(copy);
+
+	// Append the loopback plaintext backend CivetWeb serves the terminator on.
+	// Port 0 lets the kernel pick a free port; it is read back after mg_start2().
+	if(backend[0] != '\0')
+		strncat(backend, ",", backend_len - strlen(backend) - 1);
+	strncat(backend, "127.0.0.1:0", backend_len - strlen(backend) - 1);
+
+	return tls_port;
+}
+
+// After CivetWeb has started, find the ephemeral port it bound for the loopback
+// plaintext backend (the single non-secure listener on 127.0.0.1). Returns 0 if
+// not found.
+static int find_backend_port(void)
+{
+	for(unsigned int i = 0; i < MAXPORTS; i++)
+	{
+		if(server_ports[i].protocol == 0)
+			break;
+		if(!server_ports[i].is_secure &&
+		   strcmp(server_ports[i].addr, "127.0.0.1") == 0)
+			return server_ports[i].port;
+	}
+	return 0;
+}
+#endif /* HAVE_TLS */
+
 void http_init(void)
 {
 	// Don't start web server if port is not set
@@ -639,13 +713,11 @@ void http_init(void)
 
 	/* Initialize the library */
 	log_web("Initializing HTTP server on ports \"%s\"", config.webserver.port.v.s);
+	// No MG_FEATURES_TLS: civetweb is built without TLS (NO_SSL) and only serves
+	// plain HTTP/1.1 on the loopback backend; the front terminator does TLS.
 	unsigned int features = MG_FEATURES_FILES |
 	                        MG_FEATURES_IPV6 |
 	                        MG_FEATURES_CACHE;
-
-#ifdef HAVE_TLS
-	features |= MG_FEATURES_TLS;
-#endif
 
 	if(mg_init_library(features) == 0)
 	{
@@ -689,11 +761,32 @@ void http_init(void)
 		strcat(webheaders, "\r\n");
 	}
 
+	// TLS is terminated by the in-process front terminator, not by CivetWeb.
+	// When the port list contains a secure port, hand CivetWeb a plaintext
+	// loopback backend instead and let the terminator own the public TLS port.
+	const char *listening_ports = config.webserver.port.v.s;
+#ifdef HAVE_TLS
+	const bool tls_used = config.webserver.port.v.s != NULL &&
+	                      strchr(config.webserver.port.v.s, 's') != NULL;
+	char backend_ports[256];
+	int terminator_port = 0;
+	if(tls_used)
+	{
+		terminator_port = split_terminator_ports(config.webserver.port.v.s,
+		                                          backend_ports, sizeof(backend_ports));
+		if(terminator_port > 0)
+			listening_ports = backend_ports;
+		else
+			log_err("Could not extract a TLS port from '%s'; the web server will not offer TLS",
+			        config.webserver.port.v.s);
+	}
+#endif
+
 	// Prepare options for HTTP server (NULL-terminated list)
 	const char *static_options[] = {
 		"document_root", config.webserver.paths.webroot.v.s,
 		"error_pages", error_pages,
-		"listening_ports", config.webserver.port.v.s,
+		"listening_ports", listening_ports,
 		"decode_url", "yes",
 		"enable_directory_listing", "no",
 		"num_threads", num_threads,
@@ -725,16 +818,9 @@ void http_init(void)
 	}
 
 #ifdef HAVE_TLS
-	// Add TLS options if configured
-
-	// TLS is used when webserver.port contains "s" (e.g. "443s")
-	const bool tls_used = config.webserver.port.v.s != NULL &&
-	                      strchr(config.webserver.port.v.s, 's') != NULL;
-
-	// Check certificate domain if
-	// - TLS is used
-	// - A certificate is configured
-	// - The certificate is readable
+	// Ensure the TLS certificate exists and matches the configured domain. The
+	// terminator (not CivetWeb) uses it to terminate TLS; CivetWeb serves plain
+	// HTTP/1.1 on the loopback backend, so no ssl_certificate option is passed.
 	if(tls_used &&
 	   config.webserver.tls.cert.v.s != NULL &&
 	   strlen(config.webserver.tls.cert.v.s) > 0)
@@ -754,20 +840,13 @@ void http_init(void)
 			}
 		}
 
-		// Check if the certificate is readable (we may have just
-		// created it)
+		// Check if the certificate is readable (we may have just created it)
 		if(file_readable(config.webserver.tls.cert.v.s))
 		{
 			if(read_certificate(config.webserver.tls.cert.v.s, config.webserver.domain.v.s, false) != CERT_DOMAIN_MATCH)
 			{
 				log_certificate_domain_mismatch(config.webserver.tls.cert.v.s, config.webserver.domain.v.s);
 			}
-			conf_opts[idx * 2] = strdup("ssl_certificate");
-			conf_opts[idx * 2 + 1] = strdup(config.webserver.tls.cert.v.s);
-			idx++;
-
-			log_info("Using SSL/TLS certificate file %s",
-			         config.webserver.tls.cert.v.s);
 		}
 		else
 		{
@@ -935,6 +1014,24 @@ void http_init(void)
 
 	// Create CLI password (if enabled)
 	create_cli_password();
+
+#ifdef HAVE_TLS
+	// Start the TLS terminator in front of the (now plaintext) CivetWeb backend.
+	// CivetWeb bound the loopback backend on an ephemeral port; read it back and
+	// forward the public TLS port to it. Record the public TLS port as the HTTPS
+	// port (civetweb no longer reports one) so the /api/info report and the
+	// certificate-expiry renewal loop in webserver_thread() keep working.
+	if(tls_used && terminator_port > 0)
+	{
+		const int be_port = find_backend_port();
+		if(be_port <= 0)
+			log_err("Could not determine the CivetWeb loopback backend port; TLS will not be available");
+		else if(terminator_start(terminator_port, be_port, config.webserver.tls.cert.v.s))
+			https_port = (in_port_t)terminator_port;
+		else
+			log_err("Failed to start the TLS terminator on port %d", terminator_port);
+	}
+#endif
 }
 
 static char *append_to_path(char *path, const char *append)
@@ -1019,6 +1116,11 @@ void http_terminate(void)
 	// The server may have never been started
 	if(!ctx)
 		return;
+
+#ifdef HAVE_TLS
+	// Stop the TLS terminator before the backend it forwards to
+	terminator_stop();
+#endif
 
 	/* Stop the server */
 	mg_stop(ctx);

--- a/src/webserver/webserver.c
+++ b/src/webserver/webserver.c
@@ -444,7 +444,10 @@ static bool get_server_ports(void)
 	}
 
 	// Rebuild the table from scratch (http_init may run again on a restart).
+	// https_port is only ever assigned below when still 0, so clear it here too;
+	// otherwise a stale value from a previous run survives the rebuild.
 	memset(server_ports, 0, sizeof(server_ports));
+	https_port = 0;
 
 	// Loop over all ports CivetWeb reports. In terminator mode CivetWeb binds the
 	// public plaintext port(s) plus an internal loopback backend; the public TLS
@@ -700,6 +703,16 @@ static void print_webserver_opts(const bool debug, const size_t idx, const char 
 }
 
 #ifdef HAVE_TLS
+// Append src to dst (buffer size dstsz), keeping dst NUL-terminated. A no-op once
+// dst is full, so the length handed to strncat() can never underflow.
+static void str_append(char *dst, size_t dstsz, const char *src)
+{
+	const size_t used = strlen(dst);
+	if(used + 1 >= dstsz)
+		return;
+	strncat(dst, src, dstsz - used - 1);
+}
+
 // Split the webserver port list for TLS-terminator mode. Secure ("...s") entries
 // name public TLS ports the terminator owns, so they are dropped from CivetWeb's
 // list and a loopback plaintext backend (ephemeral port, read back after start)
@@ -765,16 +778,16 @@ static int split_terminator_ports(const char *cfg, char *backend, size_t backend
 
 		// Keep plaintext entries verbatim
 		if(backend[0] != '\0')
-			strncat(backend, ",", backend_len - strlen(backend) - 1);
-		strncat(backend, ent, backend_len - strlen(backend) - 1);
+			str_append(backend, backend_len, ",");
+		str_append(backend, backend_len, ent);
 	}
 	free(copy);
 
 	// Append the loopback plaintext backend CivetWeb serves the terminator on.
 	// Port 0 lets the kernel pick a free port; it is read back after mg_start2().
 	if(backend[0] != '\0')
-		strncat(backend, ",", backend_len - strlen(backend) - 1);
-	strncat(backend, "127.0.0.1:0", backend_len - strlen(backend) - 1);
+		str_append(backend, backend_len, ",");
+	str_append(backend, backend_len, "127.0.0.1:0");
 
 	return tls_port;
 }

--- a/src/webserver/webserver.h
+++ b/src/webserver/webserver.h
@@ -32,4 +32,10 @@ unsigned short get_api_string(char **buf, const bool domain);
 char *get_prefix_webhome(void) __attribute__((pure));
 char *get_api_uri(void) __attribute__((pure));
 
+// Compile-time protocol capabilities of the advanced TLS backend, exposed so
+// --version (compiled in core, which lacks the HTTP/2 and HTTP/3 build flags)
+// can report them.
+bool webserver_have_http2(void) __attribute__((const));
+bool webserver_have_http3(void) __attribute__((const));
+
 #endif // WEBSERVER_H

--- a/test/dotdoh.bats
+++ b/test/dotdoh.bats
@@ -176,6 +176,15 @@ teardown_file() {
   assert_success
 }
 
+@test "dotdoh-client: the DoH exchange uses HTTP/1.1" {
+  run bash -c "dig +short +tries=1 +time=5 @127.47.11.2 -p 5302 a.ftl"
+  assert_output --partial "192.168.1.1"
+  # The shim records the request-line HTTP version it received from FTL's DoH
+  # client. DoH-over-HTTP/2 and DoH3/DoQ are out of scope for this client.
+  run bash -c "grep -F 'doh-proto HTTP/1.1' \"$SHIM_PAD_LOG\""
+  assert_success
+}
+
 @test "dotdoh-client: many concurrent queries over the DoT proxy all resolve" {
   run run_concurrent DoT 25
   assert_success

--- a/test/dotdoh.bats
+++ b/test/dotdoh.bats
@@ -3,8 +3,10 @@
 #
 # Prerequisites, provided by test/run.sh:
 #   - pdns_recursor serving the .ftl test zone on 127.0.0.1:5555
-#   - test/dotdoh_shim.py running (DoT on :8853, DoH on :8443), terminating
-#     TLS with test/test.pem (CN/SAN "pi.hole", signed by test/test_ca.crt)
+#   - test/dotdoh_shim.py running, terminating TLS with test/test.pem (CN/SAN
+#     "pi.hole", signed by test/test_ca.crt):
+#       DoT   on :8853, DoH on :8443 (HTTP/2 via ALPN, else HTTP/1.1),
+#       DoH1  on :8445 (HTTP/1.1 only), and DoH3 on :8444 (HTTP/3, needs aioquic)
 #
 # dns.upstreams and dns.upstreamCA are RESTART_FTL settings. We switch both to
 # the encrypted test upstream in ONE atomic API request, so FTL restarts exactly
@@ -24,6 +26,15 @@ FTL_URL="http://127.0.0.1"
 # a standalone bats run works too; run.sh exports the same path.
 export SHIM_PAD_LOG="${SHIM_PAD_LOG:-/tmp/dotdoh_pad.log}"
 
+# The shim touches this file once its HTTP/3 (QUIC) listener is bound; the DoH3
+# test waits on it. Default so a standalone bats run works; run.sh exports it.
+export SHIM_H3_READY="${SHIM_H3_READY:-/tmp/dotdoh_h3_ready}"
+
+# The shim's own stdout/stderr, so the DoH3 test can show why the HTTP/3 listener
+# did not come up (aioquic missing, or an aioquic error). Default for a standalone
+# bats run; run.sh exports the same path.
+export SHIM_LOG="${SHIM_LOG:-/tmp/dotdoh_shim.log}"
+
 # PATCH the given dns config object ($1) in one atomic request and block until
 # the self-restart it triggers has produced the readiness marker ($2) past the
 # pre-change log offset, using pihole-FTL wait-for as the rest of the suite does.
@@ -41,7 +52,7 @@ api_patch_dns() {  # $1 = JSON object for "dns", $2 = readiness log marker
 
 ensure_shim() {
   if ! pgrep -f dotdoh_shim.py >/dev/null 2>&1; then
-    python3 test/dotdoh_shim.py &
+    python3 test/dotdoh_shim.py >"$SHIM_LOG" 2>&1 &
   fi
   # pgrep only proves the process exists, not that it is accepting yet. Wait
   # until both TLS ports actually accept a connection so setup_file cannot race
@@ -49,7 +60,7 @@ ensure_shim() {
   # if a port never comes up instead of letting it surface as a later, harder
   # to diagnose DNS failure.
   local port i ready
-  for port in 8853 8443; do
+  for port in 8853 8443 8445; do
     ready=""
     for i in $(seq 1 50); do
       if (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
@@ -64,6 +75,9 @@ ensure_shim() {
       return 1
     fi
   done
+  # The HTTP/3 (QUIC) listener readiness is checked by the DoH3 test itself, not
+  # here: gating the whole setup on it would drop the DoT/DoH/DoH2 tests (and
+  # their config writes) too. See the DoH3 test for the loud, no-skip requirement.
 }
 
 # Succeed if the shim recorded at least one query of the given transport whose
@@ -81,26 +95,27 @@ assert_padded() {  # $1 = transport (dot|doh)
   return 1
 }
 
-# The randomised loopback tuple the proxy actually bound for an upstream, read
-# from its "armed on <ip#port>" log line. Sets $tuple_ip and $tuple_port.
-armed_tuple() {  # $1 = DoT | DoH
+# dig target ("@IP -p PORT") of the Nth (1-based, config order) armed upstream,
+# read from FTL's log. The proxy binds a randomised loopback tuple per process
+# (127.0.0.0/8 + random port), so the port cannot be assumed - the deterministic
+# 5300+N is only a getrandom-failure fallback. The last four "armed on" lines are
+# this run's four upstreams (DoT, DoH/h2, DoH/h1.1, DoH3).
+proxy_at() {  # $1 = 1-based slot -> "@IP -p PORT"
   local t
-  t="$(grep -oE "dotdoh: $1 upstream [^ ]+ armed on 127(\.[0-9]+){3}#[0-9]+" /var/log/pihole/FTL.log \
-       | grep -oE '127(\.[0-9]+){3}#[0-9]+' | tail -1)"
-  tuple_ip="${t%#*}"
-  tuple_port="${t#*#}"
+  t=$(grep -oE "armed on 127\.[0-9.]+#[0-9]+" /var/log/pihole/FTL.log |
+      tail -n 4 | sed -n "${1}p" | grep -oE "127\.[0-9.]+#[0-9]+")
+  echo "@${t%#*} -p ${t#*#}"
 }
 
-# Fire $2 concurrent dig queries at the proxy's randomised listener and succeed
-# only if every one resolved to the expected answer. This is the meaningful
-# concurrency test: the worker pool and per-upstream connection pool must serve
-# many in-flight exchanges at once without racing or dropping.
-run_concurrent() {  # $1 = DoT|DoH, $2 = number of queries
-  local n="$2" tmp i ok=0 tuple_ip tuple_port
-  armed_tuple "$1"
+# Fire $2 concurrent dig queries at the Nth upstream's proxy listener and succeed
+# only if every one resolved. This exercises the worker pool and per-upstream
+# connection pool serving many in-flight exchanges at once without racing.
+run_concurrent() {  # $1 = 1-based slot (1=DoT, 2=DoH), $2 = number of queries
+  local idx="$1" n="$2" tmp i ok=0 at
+  at=$(proxy_at "$idx")
   tmp="$(mktemp -d)"
   for i in $(seq 1 "$n"); do
-    ( dig +short +tries=1 +time=8 "@${tuple_ip}" -p "$tuple_port" a.ftl > "${tmp}/${i}" 2>&1 ) &
+    ( dig +short +tries=1 +time=8 $at a.ftl > "${tmp}/${i}" 2>&1 ) &
   done
   wait
   for i in $(seq 1 "$n"); do
@@ -120,9 +135,17 @@ set_debug_dotdoh() {  # $1 = true|false
 
 setup_file() {
   ensure_shim || return 1
-  # The DoH upstream is armed last, so waiting for it means both listeners are up.
-  api_patch_dns "{\"upstreamCA\":\"$(pwd)/test/test_ca.crt\",\"upstreams\":[\"tls://pi.hole@127.0.0.1#8853\",\"https://pi.hole@127.0.0.1#8443/dns-query\"]}" \
-                "dotdoh: DoH upstream pi.hole armed"
+  # Arm four encrypted upstreams in a fixed order; each takes the next proxy slot,
+  # so proxy_at reads their randomised loopback tuples back in this order:
+  #   1  DoT           (tls://,   shim :8853)
+  #   2  DoH over h2   (https://, shim :8443, ALPN "h2")
+  #   3  DoH over h1.1 (https://, shim :8445, ALPN "http/1.1")
+  #   4  DoH3 over h3  (h3://,    shim :8444, QUIC)
+  # The h3:// upstream is armed last, so its (unique) armed marker means every
+  # listener is up. ensure_shim already required the h3 listener's readiness, so
+  # the DoH3 query is guaranteed to have a server to talk to.
+  api_patch_dns "{\"upstreamCA\":\"$(pwd)/test/test_ca.crt\",\"upstreams\":[\"tls://pi.hole@127.0.0.1#8853\",\"https://pi.hole@127.0.0.1#8443/dns-query\",\"https://pi.hole@127.0.0.1#8445/dns-query\",\"h3://pi.hole@127.0.0.1#8444/dns-query\"]}" \
+                "dotdoh: DoH3 upstream pi.hole armed"
 }
 
 teardown_file() {
@@ -149,60 +172,90 @@ teardown_file() {
 # UDP hop and, worse, .ftl is pinned to the plaintext recursor by a server=/ftl/
 # rule in 01-pihole-tests.conf, so it would never traverse the proxy at all.
 @test "dotdoh-client: a query resolves through the DoT proxy path" {
-  armed_tuple DoT
-  run bash -c "dig +short +tries=1 +time=5 @${tuple_ip} -p ${tuple_port} a.ftl"
+  run bash -c "dig +short +tries=1 +time=5 $(proxy_at 1) a.ftl"
   assert_output --partial "192.168.1.1"
 }
 
 @test "dotdoh-client: a query resolves through the DoH proxy path" {
-  armed_tuple DoH
-  run bash -c "dig +short +tries=1 +time=5 @${tuple_ip} -p ${tuple_port} a.ftl"
+  run bash -c "dig +short +tries=1 +time=5 $(proxy_at 2) a.ftl"
   assert_output --partial "192.168.1.1"
 }
 
 @test "dotdoh-client: the DoT-forwarded query is padded (RFC 8467)" {
-  armed_tuple DoT
-  run bash -c "dig +short +tries=1 +time=5 @${tuple_ip} -p ${tuple_port} a.ftl"
+  run bash -c "dig +short +tries=1 +time=5 $(proxy_at 1) a.ftl"
   assert_output --partial "192.168.1.1"
   run assert_padded dot
   assert_success
 }
 
 @test "dotdoh-client: the DoH-forwarded query is padded (RFC 8467)" {
-  armed_tuple DoH
-  run bash -c "dig +short +tries=1 +time=5 @${tuple_ip} -p ${tuple_port} a.ftl"
+  run bash -c "dig +short +tries=1 +time=5 $(proxy_at 2) a.ftl"
   assert_output --partial "192.168.1.1"
   run assert_padded doh
   assert_success
 }
 
-@test "dotdoh-client: the DoH exchange uses HTTP/1.1" {
-  run bash -c "dig +short +tries=1 +time=5 @127.47.11.2 -p 5302 a.ftl"
+@test "dotdoh-client: the DoH exchange negotiates HTTP/2 (ALPN h2)" {
+  run bash -c "dig +short +tries=1 +time=5 $(proxy_at 2) a.ftl"
   assert_output --partial "192.168.1.1"
-  # The shim records the request-line HTTP version it received from FTL's DoH
-  # client. DoH-over-HTTP/2 and DoH3/DoQ are out of scope for this client.
+  # The :8443 shim offers ALPN "h2,http/1.1"; FTL's DoH client offers the same,
+  # so the exchange upgrades to HTTP/2 and the shim records the negotiated
+  # protocol. This is the auto-negotiation path for existing https:// upstreams.
+  run bash -c "grep -F 'doh-proto HTTP/2' \"$SHIM_PAD_LOG\""
+  assert_success
+}
+
+@test "dotdoh-client: the DoH exchange falls back to HTTP/1.1" {
+  run bash -c "dig +short +tries=1 +time=5 $(proxy_at 3) a.ftl"
+  assert_output --partial "192.168.1.1"
+  # The :8445 shim offers only ALPN "http/1.1", so FTL's DoH client - which
+  # offers "h2,http/1.1" - falls back to the HTTP/1.1 framing. The shim records
+  # the request-line HTTP version it received.
   run bash -c "grep -F 'doh-proto HTTP/1.1' \"$SHIM_PAD_LOG\""
   assert_success
 }
 
+@test "dotdoh-client: a query resolves over the DoH3 (HTTP/3) proxy path" {
+  # HTTP/3 is required, never skipped: the shim publishes SHIM_H3_READY once its
+  # aioquic QUIC listener is bound (a UDP listener a TCP probe cannot observe).
+  # Wait for it and fail loudly if it never appears (e.g. aioquic missing from the
+  # image), so a missing dependency surfaces here instead of being silently
+  # skipped - without holding the DoT/DoH/DoH2 tests hostage in setup_file.
+  local ready=""
+  for _ in $(seq 1 50); do
+    [ -f "$SHIM_H3_READY" ] && { ready=1; break; }
+    sleep 0.2
+  done
+  if [ -z "$ready" ]; then
+    echo "DoH3 shim HTTP/3 listener never became ready. Shim log:" >&2
+    cat "$SHIM_LOG" >&2 2>/dev/null || echo "(no shim log at $SHIM_LOG)" >&2
+    false
+  fi
+  run bash -c "dig +short +tries=1 +time=8 $(proxy_at 4) a.ftl"
+  assert_output --partial "192.168.1.1"
+  run bash -c "grep -F 'doh3-proto HTTP/3' \"$SHIM_PAD_LOG\""
+  assert_success
+}
+
 @test "dotdoh-client: many concurrent queries over the DoT proxy all resolve" {
-  run run_concurrent DoT 25
+  run run_concurrent 1 25
   assert_success
   assert_output --partial "25/25 resolved"
 }
 
 @test "dotdoh-client: many concurrent queries over the DoH proxy all resolve" {
-  run run_concurrent DoH 25
+  run run_concurrent 2 25
   assert_success
   assert_output --partial "25/25 resolved"
 }
 
 @test "dotdoh-client: debug.dotdoh emits a per-upstream statistics summary" {
   set_debug_dotdoh true
-  # Generate some traffic so the counters are non-zero.
-  armed_tuple DoT
+  # Generate some traffic so the counters are non-zero. Never abort the test on a
+  # dig hiccup: the summary check below is the real assertion, and set_debug false
+  # must still run so debug.dotdoh is restored (and its write counted).
   for i in $(seq 1 10); do
-    dig +short +tries=1 +time=5 @"${tuple_ip}" -p "${tuple_port}" a.ftl >/dev/null 2>&1
+    dig +short +tries=1 +time=5 $(proxy_at 1) a.ftl >/dev/null 2>&1 || true
   done
   # The summary is emitted periodically (~10 s) by whichever worker is idle.
   # Wait for one that reflects our queries to appear in the log.

--- a/test/dotdoh.bats
+++ b/test/dotdoh.bats
@@ -141,9 +141,10 @@ setup_file() {
   #   2  DoH over h2   (https://, shim :8443, ALPN "h2")
   #   3  DoH over h1.1 (https://, shim :8445, ALPN "http/1.1")
   #   4  DoH3 over h3  (h3://,    shim :8444, QUIC)
-  # The h3:// upstream is armed last, so its (unique) armed marker means every
-  # listener is up. ensure_shim already required the h3 listener's readiness, so
-  # the DoH3 query is guaranteed to have a server to talk to.
+  # The h3:// upstream is armed last, so its (unique) armed marker means FTL
+  # accepted every upstream. This only arms the config; the shim's h3 listener is
+  # UDP and not covered by ensure_shim's TCP checks, so the DoH3 test itself waits
+  # on SHIM_H3_READY before querying.
   api_patch_dns "{\"upstreamCA\":\"$(pwd)/test/test_ca.crt\",\"upstreams\":[\"tls://pi.hole@127.0.0.1#8853\",\"https://pi.hole@127.0.0.1#8443/dns-query\",\"https://pi.hole@127.0.0.1#8445/dns-query\",\"h3://pi.hole@127.0.0.1#8444/dns-query\"]}" \
                 "dotdoh: DoH3 upstream pi.hole armed"
 }

--- a/test/dotdoh_regression.c
+++ b/test/dotdoh_regression.c
@@ -106,6 +106,12 @@ static void test_doh(void)
 	// sni@[ipv6] pinning, as emitted for the suggested DoH servers
 	ok("https://dns.google@[2001:4860:4860::8888]/dns-query", UST_DOH, "2001:4860:4860::8888", "dns.google", 443, "/dns-query");
 	ok("https://doh.example#8443/q",           UST_DOH, "doh.example", "doh.example", 8443, "/q");
+
+	// DoH3 (HTTP/3 over QUIC): same grammar and defaults as https://, only the scheme differs.
+	ok("h3://cloudflare-dns.com/dns-query", UST_DOH3, "cloudflare-dns.com", "cloudflare-dns.com", 443, "/dns-query");
+	ok("h3://cloudflare-dns.com",           UST_DOH3, "cloudflare-dns.com", "cloudflare-dns.com", 443, "/dns-query");
+	ok("h3://dns.google@[2001:4860:4860::8888]/dns-query", UST_DOH3, "2001:4860:4860::8888", "dns.google", 443, "/dns-query");
+	ok("h3://doh.example#8443/q",           UST_DOH3, "doh.example", "doh.example", 8443, "/q");
 }
 
 static void test_reject(void)
@@ -121,6 +127,9 @@ static void test_reject(void)
 	bad("ftp://x"); // unknown scheme
 	bad("tls://@1.1.1.1"); // empty verify name
 	bad("tls://name@"); // empty connect host
+	bad("h3://"); // empty host
+	bad("h3://ho st/dns-query"); // space in host
+	bad("h3://host#0"); // port 0
 	bad(NULL); // NULL input
 	bad(""); // empty input
 }

--- a/test/dotdoh_shim.py
+++ b/test/dotdoh_shim.py
@@ -16,8 +16,10 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 #
-#   DoT  : TLS  on 127.0.0.1:8853 (2-byte length-prefixed DNS)
-#   DoH  : HTTPS on 127.0.0.1:8443 (HTTP/1.1 POST /dns-query)
+#   DoT   : TLS   on 127.0.0.1:8853 (2-byte length-prefixed DNS)
+#   DoH   : HTTPS on 127.0.0.1:8443 (HTTP/2 via ALPN "h2", else HTTP/1.1)
+#   DoH1  : HTTPS on 127.0.0.1:8445 (HTTP/1.1 only - ALPN offers "http/1.1")
+#   DoH3  : QUIC  on 127.0.0.1:8444 (HTTP/3, only if aioquic is installed)
 #   backend: 127.0.0.1:5555 (pdns_recursor, UDP)
 
 import os
@@ -31,15 +33,19 @@ import time
 BACKEND = ("127.0.0.1", 5555)
 CERT = os.environ.get("SHIM_CERT", "test/test.pem")
 DOT_ADDR = ("127.0.0.1", 8853)
-DOH_ADDR = ("127.0.0.1", 8443)
+DOH_ADDR = ("127.0.0.1", 8443)     # HTTP/2-capable DoH (auto-negotiates via ALPN)
+DOH_H1_ADDR = ("127.0.0.1", 8445)  # HTTP/1.1-only DoH (exercises the h1 fallback)
+DOH3_ADDR = ("127.0.0.1", 8444)    # HTTP/3 (QUIC) DoH, optional (needs aioquic)
 # When set, append the on-the-wire length of every decrypted query here so the
 # padding E2E test can confirm FTL padded it. FTL pads encrypted queries to a
 # 128-octet boundary (RFC 8467), so a padded query arrives as a multiple of 128.
 PAD_LOG = os.environ.get("SHIM_PAD_LOG", "")
 _pad_lock = threading.Lock()
-# Optional per-response delay (ms). When set, each backend resolution sleeps this
-# long before replying, so a concurrency test can make in-flight exchanges
-# overlap (a serial client would take N*delay, a parallel one ~delay).
+# Touched once the (optional) HTTP/3 listener is actually bound and accepting, so
+# the bats suite can skip the DoH3 test cleanly when aioquic is not installed.
+H3_READY = os.environ.get("SHIM_H3_READY", "/tmp/dotdoh_h3_ready")
+# Optional per-response delay (ms): each backend resolution sleeps this long
+# before replying, so a concurrency test can overlap in-flight exchanges.
 try:
     DELAY_S = float(os.environ.get("SHIM_DELAY_MS", "0")) / 1000.0
 except ValueError:
@@ -79,9 +85,11 @@ def resolve(wire):
         s.close()
 
 
-def tls_context():
+def tls_context(alpn=None):
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(CERT)
+    if alpn:
+        ctx.set_alpn_protocols(alpn)
     return ctx
 
 
@@ -123,15 +131,34 @@ def dot_handle(ctx, raw):
 
 
 def doh_handle(ctx, raw):
+    """Terminate TLS for a DoH connection and dispatch on the negotiated ALPN.
+
+    If the client selected "h2" we serve the exchange over a minimal HTTP/2
+    session; otherwise we fall back to the HTTP/1.1 framing. FTL's DoH client
+    offers "h2,http/1.1", so an h2-capable context here upgrades it to HTTP/2,
+    while the http/1.1-only context keeps exercising the fallback path.
+    """
     try:
         conn = ctx.wrap_socket(raw, server_side=True)
     except Exception:
         raw.close()
         return
-    # Persistent HTTP/1.1 keep-alive, like a real DoH resolver (Cloudflare/Google
-    # keep the connection open for a long time): serve request after request on the
-    # same connection so FTL's connection pool actually reuses it. An idle timeout
-    # eventually closes it, matching a real server.
+    try:
+        if conn.selected_alpn_protocol() == "h2":
+            doh_http2(conn)
+        else:
+            doh_http1(conn)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def doh_http1(conn):
+    # Persistent HTTP/1.1 keep-alive, like a real DoH resolver: serve request
+    # after request on the same connection so FTL's connection pool reuses it.
+    # An idle timeout eventually closes it, matching a real server.
     conn.settimeout(30)
     buf = b""
     try:
@@ -147,8 +174,8 @@ def doh_handle(ctx, raw):
                     return
             head, _, rest = buf.partition(b"\r\n\r\n")
 
-            # Record the request-line HTTP version (FTL's DoH client speaks
-            # HTTP/1.1) so the suite can assert the DoH transport.
+            # Record the request-line HTTP version (FTL's HTTP/1.1 DoH client
+            # sends "HTTP/1.1") so the suite can assert the DoH transport.
             try:
                 req_line = head.split(b"\r\n", 1)[0].decode("latin-1")
                 note_proto("doh", req_line.rsplit(" ", 1)[-1])
@@ -156,8 +183,7 @@ def doh_handle(ctx, raw):
                 pass
 
             # Require a valid, positive Content-Length and read exactly that many
-            # body bytes. A malformed request fails closed (connection dropped, no
-            # answer) instead of being resolved with an empty or partial body.
+            # body bytes. A malformed request fails closed instead of resolving.
             content_len = None
             for line in head.split(b"\r\n")[1:]:
                 if line.lower().startswith(b"content-length:"):
@@ -187,11 +213,215 @@ def doh_handle(ctx, raw):
             conn.sendall(resp)
     except Exception:
         pass
-    finally:
+
+
+# --- Minimal HTTP/2 server -------------------------------------------------
+#
+# Just enough of RFC 7540 to serve the DoH exchange to FTL's nghttp2 client with
+# no third-party dependency. We never decode the request HPACK header block (we
+# only need the DATA payload) and hand-encode the response headers, which avoids
+# any HPACK dynamic-table state.
+
+H2_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+# Frame types
+H2_DATA, H2_HEADERS, H2_RST_STREAM = 0x0, 0x1, 0x3
+H2_SETTINGS, H2_PING, H2_GOAWAY, H2_CONTINUATION = 0x4, 0x6, 0x7, 0x9
+# Frame flags
+H2_END_STREAM, H2_END_HEADERS, H2_PADDED, H2_ACK = 0x1, 0x4, 0x8, 0x1
+
+
+def h2_encode_int(value, prefix_bits, first_byte):
+    """HPACK integer with the high (8 - prefix_bits) bits taken from first_byte."""
+    max_prefix = (1 << prefix_bits) - 1
+    if value < max_prefix:
+        return bytes([first_byte | value])
+    out = bytearray([first_byte | max_prefix])
+    value -= max_prefix
+    while value >= 0x80:
+        out.append((value & 0x7f) | 0x80)
+        value >>= 7
+    out.append(value)
+    return bytes(out)
+
+
+def h2_encode_str(s):
+    b = s.encode("latin-1")
+    return h2_encode_int(len(b), 7, 0x00) + b  # H=0 (no Huffman)
+
+
+def h2_literal_header(name, value):
+    # Literal header field without indexing, new name (first byte 0x00).
+    return b"\x00" + h2_encode_str(name) + h2_encode_str(value)
+
+
+def h2_frame(ftype, flags, stream_id, payload=b""):
+    return (struct.pack("!I", len(payload))[1:] +
+            bytes([ftype, flags]) +
+            struct.pack("!I", stream_id & 0x7fffffff) +
+            payload)
+
+
+def h2_respond(conn, stream_id, body):
+    note_query("doh", body)
+    answer = resolve(body)
+    headers = (b"\x88" +  # indexed :status 200 (static table index 8)
+               h2_literal_header("content-type", "application/dns-message") +
+               h2_literal_header("content-length", str(len(answer))))
+    conn.sendall(h2_frame(H2_HEADERS, H2_END_HEADERS, stream_id, headers))
+    conn.sendall(h2_frame(H2_DATA, H2_END_STREAM, stream_id, answer))
+
+
+def doh_http2(conn):
+    conn.settimeout(30)
+    pre = recvall(conn, len(H2_PREFACE))
+    if pre != H2_PREFACE:
+        return
+    # Server connection preface: an (empty) SETTINGS frame must come first.
+    conn.sendall(h2_frame(H2_SETTINGS, 0x0, 0))
+    proto_recorded = False
+    bodies = {}  # stream_id -> bytearray (accumulated request body)
+    try:
+        while True:
+            hdr = recvall(conn, 9)
+            if not hdr:
+                return
+            length = (hdr[0] << 16) | (hdr[1] << 8) | hdr[2]
+            ftype, flags = hdr[3], hdr[4]
+            stream_id = struct.unpack("!I", hdr[5:9])[0] & 0x7fffffff
+            payload = recvall(conn, length) if length else b""
+            if length and payload is None:
+                return
+
+            if ftype == H2_SETTINGS:
+                if not (flags & H2_ACK):
+                    conn.sendall(h2_frame(H2_SETTINGS, H2_ACK, 0))
+            elif ftype == H2_PING:
+                if not (flags & H2_ACK):
+                    conn.sendall(h2_frame(H2_PING, H2_ACK, 0, payload))
+            elif ftype == H2_GOAWAY:
+                return
+            elif ftype == H2_RST_STREAM:
+                bodies.pop(stream_id, None)
+            elif ftype == H2_HEADERS:
+                if not proto_recorded:
+                    note_proto("doh", "HTTP/2")
+                    proto_recorded = True
+                bodies.setdefault(stream_id, bytearray())
+                # We do not decode the header block; if it spans CONTINUATION
+                # frames, drain them until END_HEADERS so the framing stays in
+                # sync (their payloads are irrelevant to us).
+                if not (flags & H2_END_HEADERS):
+                    while True:
+                        chdr = recvall(conn, 9)
+                        if not chdr:
+                            return
+                        clen = (chdr[0] << 16) | (chdr[1] << 8) | chdr[2]
+                        ctype, cflags = chdr[3], chdr[4]
+                        if clen and recvall(conn, clen) is None:
+                            return
+                        if ctype == H2_CONTINUATION and (cflags & H2_END_HEADERS):
+                            break
+                if flags & H2_END_STREAM:  # request with no body (unusual for DoH)
+                    h2_respond(conn, stream_id, bytes(bodies.pop(stream_id, b"")))
+            elif ftype == H2_DATA:
+                data = payload
+                if flags & H2_PADDED and data:
+                    pad_len = data[0]
+                    data = data[1:len(data) - pad_len] if pad_len <= len(data) - 1 else data[1:]
+                bodies.setdefault(stream_id, bytearray()).extend(data)
+                if flags & H2_END_STREAM:
+                    h2_respond(conn, stream_id, bytes(bodies.pop(stream_id, b"")))
+            # WINDOW_UPDATE / PRIORITY / unknown frames are ignored: our response
+            # is small enough that no flow-control bookkeeping is needed.
+    except Exception:
+        pass
+
+
+# --- Optional HTTP/3 (QUIC) server via aioquic -----------------------------
+
+try:
+    import asyncio
+    from aioquic.asyncio import serve as quic_serve
+    from aioquic.asyncio.protocol import QuicConnectionProtocol
+    from aioquic.h3.connection import H3Connection
+    from aioquic.h3.events import DataReceived, HeadersReceived
+    from aioquic.quic.configuration import QuicConfiguration
+    from aioquic.quic.events import ProtocolNegotiated
+    HAVE_AIOQUIC = True
+    AIOQUIC_IMPORT_ERROR = None
+except Exception as exc:
+    HAVE_AIOQUIC = False
+    # Keep the reason so the disabled message can tell "aioquic not installed"
+    # apart from "installed but a submodule/API import failed".
+    AIOQUIC_IMPORT_ERROR = repr(exc)
+
+
+def start_h3_listener():
+    """Bring up the HTTP/3 DoH listener if aioquic is available.
+
+    Returns True once bound (and touches H3_READY), or False if aioquic is not
+    installed - in which case the DoH3 E2E test skips cleanly.
+    """
+    if not HAVE_AIOQUIC:
+        return False
+
+    class DoH3Protocol(QuicConnectionProtocol):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._http = None
+            self._bodies = {}
+
+        def quic_event_received(self, event):
+            if isinstance(event, ProtocolNegotiated):
+                self._http = H3Connection(self._quic)
+            if self._http is None:
+                return
+            for h3_event in self._http.handle_event(event):
+                if isinstance(h3_event, HeadersReceived):
+                    self._bodies.setdefault(h3_event.stream_id, bytearray())
+                    note_proto("doh3", "HTTP/3")
+                    if h3_event.stream_ended:
+                        self._reply(h3_event.stream_id)
+                elif isinstance(h3_event, DataReceived):
+                    self._bodies.setdefault(h3_event.stream_id, bytearray()).extend(h3_event.data)
+                    if h3_event.stream_ended:
+                        self._reply(h3_event.stream_id)
+
+        def _reply(self, stream_id):
+            body = bytes(self._bodies.pop(stream_id, b""))
+            note_query("doh3", body)
+            answer = resolve(body)
+            self._http.send_headers(stream_id, [
+                (b":status", b"200"),
+                (b"content-type", b"application/dns-message"),
+            ])
+            self._http.send_data(stream_id, answer, end_stream=True)
+            self.transmit()
+
+    async def _serve():
+        config = QuicConfiguration(is_client=False, alpn_protocols=["h3"])
+        config.load_cert_chain(CERT, CERT)
+        await quic_serve(DOH3_ADDR[0], DOH3_ADDR[1],
+                         configuration=config, create_protocol=DoH3Protocol)
+
+    def _run():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         try:
-            conn.close()
+            loop.run_until_complete(_serve())
+        except Exception as exc:
+            print("dotdoh_shim: HTTP/3 listener failed to start (%s)" % exc,
+                  file=sys.stderr)
+            return
+        try:
+            with open(H3_READY, "w") as fh:
+                fh.write("1\n")
         except Exception:
             pass
+        loop.run_forever()
+
+    threading.Thread(target=_run, daemon=True).start()
+    return True
 
 
 def make_listener(addr):
@@ -209,17 +439,36 @@ def accept_loop(srv, ctx, handler):
 
 
 if __name__ == "__main__":
-    ctx = tls_context()
-    # Bind both listeners up front so a port clash (e.g. a stale shim from an
+    # A stale readiness marker from an earlier run must not fool the suite into
+    # thinking HTTP/3 is up; drop it and only re-create it once we actually bind.
+    try:
+        os.unlink(H3_READY)
+    except OSError:
+        pass
+
+    dot_ctx = tls_context()                          # DoT: no ALPN
+    doh_ctx = tls_context(["h2", "http/1.1"])        # DoH: prefer HTTP/2
+    doh_h1_ctx = tls_context(["http/1.1"])           # DoH: HTTP/1.1 only
+
+    # Bind the TCP listeners up front so a port clash (e.g. a stale shim from an
     # interrupted run) makes us exit immediately instead of lingering half-alive.
     try:
         dot_srv = make_listener(DOT_ADDR)
         doh_srv = make_listener(DOH_ADDR)
+        doh_h1_srv = make_listener(DOH_H1_ADDR)
     except OSError as exc:
         print("dotdoh_shim: could not bind (%s); is another shim running?" % exc,
               file=sys.stderr)
         sys.exit(1)
-    threading.Thread(target=accept_loop, args=(dot_srv, ctx, dot_handle), daemon=True).start()
-    threading.Thread(target=accept_loop, args=(doh_srv, ctx, doh_handle), daemon=True).start()
+
+    # HTTP/3 needs aioquic. dotdoh.bats requires DoH3, so surface the exact
+    # reason (import error) rather than a bare "not available".
+    if not start_h3_listener():
+        print("dotdoh_shim: HTTP/3 (DoH3) listener disabled, aioquic import failed: %s"
+              % AIOQUIC_IMPORT_ERROR, file=sys.stderr)
+
+    threading.Thread(target=accept_loop, args=(dot_srv, dot_ctx, dot_handle), daemon=True).start()
+    threading.Thread(target=accept_loop, args=(doh_srv, doh_ctx, doh_handle), daemon=True).start()
+    threading.Thread(target=accept_loop, args=(doh_h1_srv, doh_h1_ctx, doh_handle), daemon=True).start()
     while True:
         time.sleep(3600)

--- a/test/dotdoh_shim.py
+++ b/test/dotdoh_shim.py
@@ -54,6 +54,17 @@ def note_query(transport, query):
             fh.write("%s %d\n" % (transport, len(query)))
 
 
+def note_proto(transport, proto):
+    # Record the wire protocol a request arrived on (e.g. "HTTP/1.1") so the test
+    # suite can assert the DoH transport. Written with a distinct "<t>-proto"
+    # label so it never collides with the "<t> <len>" padding records above.
+    if not PAD_LOG:
+        return
+    with _pad_lock:
+        with open(PAD_LOG, "a") as fh:
+            fh.write("%s-proto %s\n" % (transport, proto))
+
+
 def resolve(wire):
     """Forward a DNS wire message to the plaintext backend and return the reply."""
     if DELAY_S > 0:
@@ -135,6 +146,14 @@ def doh_handle(ctx, raw):
                 if len(buf) > 65536:
                     return
             head, _, rest = buf.partition(b"\r\n\r\n")
+
+            # Record the request-line HTTP version (FTL's DoH client speaks
+            # HTTP/1.1) so the suite can assert the DoH transport.
+            try:
+                req_line = head.split(b"\r\n", 1)[0].decode("latin-1")
+                note_proto("doh", req_line.rsplit(" ", 1)[-1])
+            except Exception:
+                pass
 
             # Require a valid, positive Content-Length and read exactly that many
             # body bytes. A malformed request fails closed (connection dropped, no

--- a/test/http2_test.sh
+++ b/test/http2_test.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Dedicated end-to-end test for the in-process TLS terminator.
+#
+# The terminator binds the public TLS port, terminates TLS (OpenSSL), advertises
+# ALPN "h2", and forwards plaintext HTTP/1.1 to CivetWeb on a loopback backend.
+# CivetWeb itself is built with NO_SSL now, so every TLS request - HTTP/2 and
+# HTTP/1.1 alike - goes through the terminator. The regular suite exercises the
+# plain HTTP/1.1 port; this script starts a throwaway FTL instance and covers
+# the terminator directly:
+#   - a body-less GET is served over HTTP/2 (version 2, status 200, JSON intact),
+#   - HTTP/1.1 clients keep working via ALPN fall-through,
+#   - a POST carrying a body is served over HTTP/2 and the body reaches the
+#     backend (wrong password -> a valid session response with valid=false),
+#   - the long default Content-Security-Policy header survives HPACK encoding,
+#   - the real client address is forwarded via PROXY protocol v2 (the JSON
+#     reflects 127.0.0.1, not an empty or garbage value).
+#
+# Run with:  ./build.sh ci test-http2   (after the regular test series)
+
+set -u
+
+RET=0
+BODY=$(mktemp)
+trap 'rm -f "${BODY}"' EXIT
+
+# Shared curl invocations. --resolve maps pi.hole to the loopback terminator
+# (curl does not use FTL as its resolver), --cacert trusts the repo test cert.
+COMMON=(--cacert /etc/pihole/test.crt --resolve pi.hole:443:127.0.0.1)
+H2=(curl -s --http2 "${COMMON[@]}")
+H1=(curl -s --http1.1 "${COMMON[@]}")
+
+# check <description> <expected> <actual>
+check() {
+  if [[ "$3" == "$2" ]]; then
+    printf 'PASS  %-52s -> %s\n' "$1" "$3"
+  else
+    printf 'FAIL  %-52s -> %s (wanted %s)\n' "$1" "$3" "$2"
+    RET=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Minimal environment setup (mirrors the essential parts of test/run.sh)
+# ---------------------------------------------------------------------------
+if ! id -u pihole &> /dev/null; then
+  useradd -m -s /usr/sbin/nologin pihole
+fi
+
+while pidof -s pihole-FTL > /dev/null; do
+  kill "$(pidof -s pihole-FTL)"; sleep 1
+done
+
+rm -rf /etc/pihole /etc/dnsmasq.d /var/log/pihole /dev/shm/FTL-*
+mkdir -p /home/pihole /etc/pihole /run/pihole /var/log/pihole /etc/pihole/config_backups /var/www/html
+: > /var/log/pihole/FTL.log
+: > /var/log/pihole/webserver.log
+touch /run/pihole-FTL.pid /etc/pihole/dhcp.leases
+chown -R pihole:pihole /etc/pihole /run/pihole /var/log/pihole
+chown pihole:pihole /run/pihole-FTL.pid
+
+cp ./pihole-FTL /home/pihole/pihole-FTL
+chmod +x /home/pihole/pihole-FTL
+setcap CAP_NET_BIND_SERVICE+eip /home/pihole/pihole-FTL
+
+./pihole-FTL sqlite3 /etc/pihole/gravity.db < test/gravity.db.sql
+./pihole-FTL sqlite3 /etc/pihole/pihole-FTL.db < test/pihole-FTL.db.sql
+chown pihole:pihole /etc/pihole/gravity.db /etc/pihole/pihole-FTL.db
+cp test/test.pem /etc/pihole/test.pem
+cp test/test.crt /etc/pihole/test.crt
+cp test/pihole.toml /etc/pihole/pihole.toml
+chown pihole:pihole /etc/pihole/pihole.toml
+
+# Set a known API password for this run only. /api/auth and /api/info/client do
+# not require authentication, but a configured password makes the POST-body test
+# unambiguous: a wrong password can only yield session.valid=false if the JSON
+# body actually reached the backend (an empty payload would instead be answered
+# with a "no password found in JSON payload" error).
+export FTLCONF_webserver_api_password="terminator-secret"
+
+# ---------------------------------------------------------------------------
+# Start FTL
+# ---------------------------------------------------------------------------
+if ! su pihole -s /bin/sh -c /home/pihole/pihole-FTL; then
+  echo "pihole-FTL failed to start"; exit 1
+fi
+sleep 2
+
+echo "=================== TLS terminator ==================="
+grep -a "TLS terminator listening" /var/log/pihole/FTL.log || true
+echo
+
+echo "======================== checks ========================="
+
+# (1) A body-less GET is served over HTTP/2. curl reports the negotiated
+# version and status; the body is captured for the JSON-integrity checks below.
+# A corrupt HEADERS block would make curl abort with an empty version.
+ver_code="$("${H2[@]}" -o "${BODY}" -w '%{http_version} %{http_code}' \
+            https://pi.hole/api/info/client)"
+check "GET /api/info/client over HTTP/2 (version + status)" "2 200" "${ver_code}"
+
+# The captured body must be well-formed JSON (proves the response survived the
+# h2 -> plaintext -> h2 round trip intact, not just the status line).
+if jq -e . "${BODY}" > /dev/null 2>&1; then
+  json="ok"
+else
+  json="broken"
+fi
+check "HTTP/2 response body is valid JSON" "ok" "${json}"
+
+# (5) Client-IP forwarding via PROXY protocol v2: the backend must see the real
+# client (127.0.0.1 over loopback), not an empty or garbage address. A broken
+# PROXY v2 header would leave remote_addr unset or corrupted.
+remote_addr="$(jq -r '.remote_addr // empty' "${BODY}" 2> /dev/null)"
+check "Client address forwarded via PROXY protocol v2" "127.0.0.1" "${remote_addr}"
+
+# (4) The default Content-Security-Policy header is long enough to need a
+# multi-byte HPACK string length. Require the full value (down to the trailing
+# form-action 'self') to survive over HTTP/2; a broken length prefix would
+# desync the HEADERS block and curl would abort.
+if "${H2[@]}" -D - -o /dev/null https://pi.hole/ \
+     | grep -qi "^content-security-policy:.*form-action 'self'"; then
+  csp="ok"
+else
+  csp="missing"
+fi
+check "Content-Security-Policy intact over HTTP/2" "ok" "${csp}"
+
+# (3) A POST carrying a body is served over HTTP/2 (not downgraded) and the body
+# reaches the backend. The wrong password yields a valid session response with
+# valid=false, which is only possible if the JSON body was forwarded and parsed.
+post_ver="$("${H2[@]}" -o "${BODY}" -w '%{http_version}' -X POST \
+            -d '{"password":"wrong"}' https://pi.hole/api/auth)"
+check "POST /api/auth served over HTTP/2 (not downgraded)" "2" "${post_ver}"
+valid="$(jq -r '.session.valid // empty' "${BODY}" 2> /dev/null)"
+check "POST body forwarded to backend (wrong password rejected)" "false" "${valid}"
+
+# (2) Plain HTTP/1.1 clients are unaffected (ALPN fall-through to http/1.1).
+check "HTTP/1.1 client still served (ALPN fall-through)" "1.1 200" \
+  "$("${H1[@]}" -o /dev/null -w '%{http_version} %{http_code}' \
+     https://pi.hole/api/info/client)"
+
+echo
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+kill "$(cat /run/pihole-FTL.pid 2> /dev/null)" 2> /dev/null
+rm -f /home/pihole/pihole-FTL
+
+echo "========================================================="
+if [[ ${RET} -eq 0 ]]; then
+  echo "TLS terminator test: PASS"
+else
+  echo "TLS terminator test: FAIL (see per-check results above)"
+fi
+exit ${RET}

--- a/test/http2_test.sh
+++ b/test/http2_test.sh
@@ -113,6 +113,17 @@ else
 fi
 check "Content-Security-Policy intact over HTTP/2" "ok" "${csp}"
 
+# The terminator advertises its HTTP/3 endpoint to h2 clients via Alt-Svc, so an
+# h3-capable browser upgrades from this h2 connection to HTTP/3 on the same port
+# (the h3 listener is up in this build, so the header must be present).
+if "${H2[@]}" -D - -o /dev/null https://pi.hole/ \
+     | grep -qiE "^alt-svc:.*h3="; then
+  altsvc="ok"
+else
+  altsvc="missing"
+fi
+check "Alt-Svc advertises HTTP/3 over HTTP/2" "ok" "${altsvc}"
+
 # (3) A POST with a body is served over HTTP/2 (not downgraded) and reaches the
 # backend: the wrong password yields valid=false only if the JSON body was parsed.
 post_ver="$("${H2[@]}" -o "${BODY}" -w '%{http_version}' -X POST \

--- a/test/http2_test.sh
+++ b/test/http2_test.sh
@@ -3,17 +3,10 @@
 #
 # The terminator binds the public TLS port, terminates TLS (OpenSSL), advertises
 # ALPN "h2", and forwards plaintext HTTP/1.1 to CivetWeb on a loopback backend.
-# CivetWeb itself is built with NO_SSL now, so every TLS request - HTTP/2 and
-# HTTP/1.1 alike - goes through the terminator. The regular suite exercises the
-# plain HTTP/1.1 port; this script starts a throwaway FTL instance and covers
-# the terminator directly:
-#   - a body-less GET is served over HTTP/2 (version 2, status 200, JSON intact),
-#   - HTTP/1.1 clients keep working via ALPN fall-through,
-#   - a POST carrying a body is served over HTTP/2 and the body reaches the
-#     backend (wrong password -> a valid session response with valid=false),
-#   - the long default Content-Security-Policy header survives HPACK encoding,
-#   - the real client address is forwarded via PROXY protocol v2 (the JSON
-#     reflects 127.0.0.1, not an empty or garbage value).
+# CivetWeb is built NO_SSL, so every TLS request goes through the terminator. The
+# regular suite covers the plain HTTP/1.1 port; this script starts a throwaway
+# FTL instance and covers the terminator directly (HTTP/2, HTTP/1.1 fall-through,
+# POST bodies, CSP header survival, PROXY-v2 client-IP, HTTP/1.0 and HTTP/3).
 #
 # Run with:  ./build.sh ci test-http2   (after the regular test series)
 
@@ -70,11 +63,9 @@ cp test/test.crt /etc/pihole/test.crt
 cp test/pihole.toml /etc/pihole/pihole.toml
 chown pihole:pihole /etc/pihole/pihole.toml
 
-# Set a known API password for this run only. /api/auth and /api/info/client do
-# not require authentication, but a configured password makes the POST-body test
-# unambiguous: a wrong password can only yield session.valid=false if the JSON
-# body actually reached the backend (an empty payload would instead be answered
-# with a "no password found in JSON payload" error).
+# Set a known API password for this run only, so the POST-body test is
+# unambiguous: a wrong password only yields session.valid=false if the JSON body
+# reached the backend (an empty payload gives a "no password found" error).
 export FTLCONF_webserver_api_password="terminator-secret"
 
 # ---------------------------------------------------------------------------
@@ -91,9 +82,8 @@ echo
 
 echo "======================== checks ========================="
 
-# (1) A body-less GET is served over HTTP/2. curl reports the negotiated
-# version and status; the body is captured for the JSON-integrity checks below.
-# A corrupt HEADERS block would make curl abort with an empty version.
+# (1) A body-less GET over HTTP/2: curl reports the negotiated version and
+# status, and the body is captured for the JSON-integrity checks below.
 ver_code="$("${H2[@]}" -o "${BODY}" -w '%{http_version} %{http_code}' \
             https://pi.hole/api/info/client)"
 check "GET /api/info/client over HTTP/2 (version + status)" "2 200" "${ver_code}"
@@ -108,15 +98,13 @@ fi
 check "HTTP/2 response body is valid JSON" "ok" "${json}"
 
 # (5) Client-IP forwarding via PROXY protocol v2: the backend must see the real
-# client (127.0.0.1 over loopback), not an empty or garbage address. A broken
-# PROXY v2 header would leave remote_addr unset or corrupted.
+# client (127.0.0.1), not an empty or garbage address from a broken v2 header.
 remote_addr="$(jq -r '.remote_addr // empty' "${BODY}" 2> /dev/null)"
 check "Client address forwarded via PROXY protocol v2" "127.0.0.1" "${remote_addr}"
 
 # (4) The default Content-Security-Policy header is long enough to need a
 # multi-byte HPACK string length. Require the full value (down to the trailing
-# form-action 'self') to survive over HTTP/2; a broken length prefix would
-# desync the HEADERS block and curl would abort.
+# form-action 'self') to survive HTTP/2; a broken length prefix desyncs HEADERS.
 if "${H2[@]}" -D - -o /dev/null https://pi.hole/ \
      | grep -qi "^content-security-policy:.*form-action 'self'"; then
   csp="ok"
@@ -125,19 +113,46 @@ else
 fi
 check "Content-Security-Policy intact over HTTP/2" "ok" "${csp}"
 
-# (3) A POST carrying a body is served over HTTP/2 (not downgraded) and the body
-# reaches the backend. The wrong password yields a valid session response with
-# valid=false, which is only possible if the JSON body was forwarded and parsed.
+# (3) A POST with a body is served over HTTP/2 (not downgraded) and reaches the
+# backend: the wrong password yields valid=false only if the JSON body was parsed.
 post_ver="$("${H2[@]}" -o "${BODY}" -w '%{http_version}' -X POST \
+            -H 'Content-Type: application/json' \
             -d '{"password":"wrong"}' https://pi.hole/api/auth)"
 check "POST /api/auth served over HTTP/2 (not downgraded)" "2" "${post_ver}"
-valid="$(jq -r '.session.valid // empty' "${BODY}" 2> /dev/null)"
+# Read the field directly: jq's // treats a literal false as empty, so
+# '.session.valid // empty' would blank out the false we are checking for. A
+# wrong password yields valid=false only when the JSON body reached the backend.
+valid="$(jq -r '.session.valid' "${BODY}" 2> /dev/null)"
 check "POST body forwarded to backend (wrong password rejected)" "false" "${valid}"
 
 # (2) Plain HTTP/1.1 clients are unaffected (ALPN fall-through to http/1.1).
 check "HTTP/1.1 client still served (ALPN fall-through)" "1.1 200" \
   "$("${H1[@]}" -o /dev/null -w '%{http_version} %{http_code}' \
      https://pi.hole/api/info/client)"
+
+# (6) HTTP/1.0 clients are served too: the terminator's HTTP/1.1 splice relay
+# forwards the older request unchanged (response version is up to the backend).
+h10_code="$(curl -s --http1.0 "${COMMON[@]}" -o "${BODY}" -w '%{http_code}' \
+            https://pi.hole/api/info/client)"
+check "HTTP/1.0 client served over TLS (status)" "200" "${h10_code}"
+if jq -e . "${BODY}" > /dev/null 2>&1; then j10="ok"; else j10="broken"; fi
+check "HTTP/1.0 response body is valid JSON" "ok" "${j10}"
+
+# (7) HTTP/3 (QUIC) over the terminator's UDP :443. Needs a curl built with
+# HTTP/3; where the image lacks it (the stock CI image does), skip these checks
+# rather than fail - the h3 server is still exercised by the DoH3 bats test and
+# by local runs with an HTTP/3-capable curl.
+if ! curl --version 2>/dev/null | grep -qiw HTTP3; then
+  echo "SKIP  HTTP/3 checks - curl in this image has no HTTP/3 support"
+else
+  h3="$(curl -s --http3 "${COMMON[@]}" -o "${BODY}" \
+        -w '%{http_version} %{http_code}' https://pi.hole/api/info/client 2>/dev/null)"
+  check "GET /api/info/client over HTTP/3 (version + status)" "3 200" "${h3}"
+  if jq -e . "${BODY}" > /dev/null 2>&1; then j3="ok"; else j3="broken"; fi
+  check "HTTP/3 response body is valid JSON" "ok" "${j3}"
+  h3addr="$(jq -r '.remote_addr // empty' "${BODY}" 2> /dev/null)"
+  check "Client address forwarded over HTTP/3 (PROXY v2)" "127.0.0.1" "${h3addr}"
+fi
 
 echo
 

--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -190,6 +190,16 @@ pdnsutil rrset add arpa. 2.1.168.192.in-addr.arpa. PTR a.ftl.
 pdnsutil rrset add arpa. 1.0.c.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. PTR ftl.
 pdnsutil rrset add arpa. 2.0.c.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. PTR aaaa.ftl.
 
+# Delegate the unsigned child zones from the locally-signed root. Both ftl and
+# arpa are children of the '.' zone we serve, so the root has to carry an NS
+# delegation for them; without it the signed root answers NXDOMAIN for their DS
+# query (rather than a proper "insecure delegation" NODATA proof) and
+# `pdnsutil zone check` reports "No delegation ... in parent '.'". They are
+# unsigned, so an NS record with no DS is the correct, secure-parent way to mark
+# them as an insecure delegation.
+pdnsutil rrset add . ftl.  NS ns1.ftl.
+pdnsutil rrset add . arpa. NS ns1.ftl.
+
 # Calculates the ‘ordername’ and ‘auth’ fields for all zones so they comply with
 # DNSSEC settings. Can be used to fix up migrated data. Can always safely be
 # run, it does no harm.

--- a/test/run.sh
+++ b/test/run.sh
@@ -80,7 +80,16 @@ pkill -f "${SHIM_PATTERN}" 2>/dev/null || true
 # Record decrypted query lengths so dotdoh.bats can confirm FTL padded them.
 export SHIM_PAD_LOG="/tmp/dotdoh_pad.log"
 rm -f "${SHIM_PAD_LOG}"
-python3 test/dotdoh_shim.py &
+# The shim touches this marker once its optional HTTP/3 listener is up; dotdoh.bats
+# skips the DoH3 test when it is absent. Clear any stale marker to avoid a false ready.
+export SHIM_H3_READY="/tmp/dotdoh_h3_ready"
+rm -f "${SHIM_H3_READY}"
+# Capture the shim's own output so a failure to bring up the HTTP/3 listener
+# (aioquic missing, or an aioquic error) is visible to dotdoh.bats, which dumps
+# this on the DoH3 test failure instead of leaving the reason on the console.
+export SHIM_LOG="/tmp/dotdoh_shim.log"
+rm -f "${SHIM_LOG}"
+python3 test/dotdoh_shim.py >"${SHIM_LOG}" 2>&1 &
 DOTDOH_SHIM_PID=$!
 # Stop the shim even if the script exits early (e.g. FTL fails to start below),
 # so a leftover process cannot hold ports 8853/8443 and make the next run flaky.

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1699,11 +1699,12 @@ setup() {
 @test "Test TLS/SSL server using self-signed certificate" {
   # -s: silent
   # -I: HEAD request
+  # --http1.1: force HTTP/1.1 (the terminator advertises h2 via ALPN, else curl negotiates HTTP/2)
   # --cacert: use this CA certificate to verify the server certificate
   # --resolve: resolve pi.hole:443 to 127.0.0.1
   #            we need this line because curl is not using FTL as resolver
   #            and would otherwise not be able to resolve pi.hole
-  run bash -c 'curl -sI --cacert /etc/pihole/test.crt --resolve pi.hole:443:127.0.0.1 https://pi.hole/'
+  run bash -c 'curl -sI --http1.1 --cacert /etc/pihole/test.crt --resolve pi.hole:443:127.0.0.1 https://pi.hole/'
   assert_line --partial --index 0 "HTTP/1.1 "
   run bash -c 'curl -I --cacert /etc/pihole/test.crt --resolve pi.hole:443:127.0.0.1 https://pi.hole/'
   assert_success
@@ -1841,7 +1842,8 @@ setup() {
   assert_success
   run bash -c 'grep -F "Webserver option 1/12: error_pages=/var/www/html/admin/" /var/log/pihole/FTL.log'
   assert_success
-  run bash -c 'grep -F "Webserver option 2/12: listening_ports=80o,443os,[::]:80o,[::]:443os" /var/log/pihole/FTL.log'
+  # The terminator owns the secure ports; CivetWeb gets the plaintext ports plus its loopback backend.
+  run bash -c 'grep -F "Webserver option 2/12: listening_ports=80o,[::]:80o,127.0.0.1:0" /var/log/pihole/FTL.log'
   assert_success
   run bash -c 'grep -F "Webserver option 3/12: decode_url=yes" /var/log/pihole/FTL.log'
   assert_success
@@ -1859,8 +1861,10 @@ setup() {
   assert_success
   run bash -c 'grep -F "Webserver option 10/12: keep_alive_timeout_ms=5000" /var/log/pihole/FTL.log'
   assert_success
-  run bash -c 'grep -F "Webserver option 11/12: ssl_certificate=/etc/pihole/test.pem" /var/log/pihole/FTL.log'
+  # The terminator's per-boot backend-auth secret; its value is redacted in the log.
+  run bash -c 'grep -F "Webserver option 11/12: proxy_protocol_secret=<per-boot secret>" /var/log/pihole/FTL.log'
   assert_success
+  # No ssl_certificate: CivetWeb runs plaintext behind the terminator, which owns the cert.
   run bash -c 'grep -F "Webserver option 12/12: <END OF OPTIONS>" /var/log/pihole/FTL.log'
   assert_success
 }


### PR DESCRIPTION
# What does this implement/fix?

An in-process TLS terminator fronting CivetWeb: it terminates TLS (OpenSSL) and serves HTTP/1.0, 1.1, 2 (`nghttp2`) and 3 (OpenSSL QUIC + `nghttp3`), forwarding plain HTTP/1.1 to the backend. It also adds DoH-over-HTTP/2 and DoH-over-HTTP/3 upstream clients to `dotdoh`.

The large `src/webserver/civetweb/` diff is *not* new code we we will have to carry/review: it is generic `PROXY-v2` support the backend needs so the terminator can hand the real client address (ultimately needed for client-aware blocking). That feature is proposed upstream as https://github.com/civetweb/civetweb/pull/1413; here we vendor it as `proxy_v2.inl` plus a ~9-line hook in `civetweb.c`, carried as a `patch/civetweb/` patch until upstream accepts it. civetweb/civetweb#1413 sits on civetweb/civetweb#1412 (a build and macOS-CI fix); the macOS-CI part there may end up folded into @yubiuser's build PR https://github.com/civetweb/civetweb/pull/1392.

## How to test the change during review

1. Build FTL and start it with a TLS port, e.g. `webserver.port = "80,443s"`. (Already included in the default set of parameters, so there is no change here visible to users and neither a need to change any configuration already present to get this running)
2. `curl -k --http1.1 https://<pi>/admin/`, then `--http2` and `--http3` - each returns the web UI; the plain-HTTP port is unaffected.
3. For encrypted upstreams, arm `tls://`, `https://` and `h3://` upstreams and confirm they resolve. The `dotdoh` and HTTP/2 paths are also extensively covered by new tests in `test/dotdoh.bats` and `test/http2_test.sh` in CI.

This PR also builds FTL with `-ffunction-sections -fdata-sections -Wl,--gc-sections`, letting the linker drop unreferenced code. On its own that only strips FTL's own dead code; the full effect - notably trimming the large unused parts of OpenSSL, about 815 KB off the stripped static binary - needs the bundled static libraries compiled with matching section flags, which is https://github.com/pi-hole/docker-base-images/pull/177. The two are independent and non-breaking: either can be merged on its own and everything keeps building unchanged; only together do they realise the size reduction.

Note that there is no explicit need to configure HTTP 1.1/2 for normal `https://` requests because negotiation via ALPN will automatically find out what the best protocol is supported by this server.

Follow-up pull requests will be
- the still-missing downstream (from my local clients to the pi-hole) direction for DoT, DoH-over-HTTP1/2/3
- extension to up- and downstream DoQ support, including DoQ-over-HTTP3. Pi-hole then really covers all standardized alternative DNS protocols for the foreseeable future

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.

