### PR TITLE
Validate internal PTR DNS responses

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -35,7 +35,7 @@ RUN rm -rf cmake && \
 # Start from clean counters so the statistics below describe this build alone
     ccache --zero-stats && \
 # Build and test FTL
-    bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache" ${BUILD_OPTS} && \
+    bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON -DBUILD_PTR_RESPONSE_REGRESSION=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache" ${BUILD_OPTS} && \
 # Report what the cache saved, so the CI log shows whether it is worth keeping
     ccache --show-stats && \
 # Copy FTL binary to root directory

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ pihole-FTL*
 # Generated standalone regression test binaries (built via ./build.sh test)
 /tar_regression
 /gzip_regression
+/dotdoh_regression
+/ptr_response_regression
 
 # Generated pihole.toml file
 pihole.toml

--- a/build.sh
+++ b/build.sh
@@ -113,9 +113,9 @@ fi
 # They are gated behind CMake options so ordinary builds do not produce them.
 if [[ -n "${test}" ]]; then
     if [[ -n "${cmake_args}" ]]; then
-        cmake_args="${cmake_args} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON"
+        cmake_args="${cmake_args} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON -DBUILD_PTR_RESPONSE_REGRESSION=ON"
     else
-        cmake_args="-DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON"
+        cmake_args="-DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON -DBUILD_PTR_RESPONSE_REGRESSION=ON"
     fi
 fi
 
@@ -212,7 +212,7 @@ echo "Copying compiled pihole-FTL binary to repository root"
 cp pihole-FTL ../
 # Copy the regression test binaries alongside it so the bats tests can run them
 # from the repo root.
-for regression_bin in tar_regression gzip_regression dotdoh_regression; do
+for regression_bin in tar_regression gzip_regression dotdoh_regression ptr_response_regression; do
     if [[ -f "${regression_bin}" ]]; then
         cp "${regression_bin}" ../
     fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -482,6 +482,14 @@ if(BUILD_PTR_RESPONSE_REGRESSION)
     target_include_directories(ptr_response_regression PRIVATE ${PROJECT_SOURCE_DIR}/src)
     target_compile_options(ptr_response_regression PRIVATE -fvisibility=hidden)
     target_link_libraries(ptr_response_regression Threads::Threads)
+
+    # Optional ASan/UBSan instrumentation for local runs:
+    #   ./build.sh "-DPTR_RESPONSE_REGRESSION_SANITIZE=ON" test
+    option(PTR_RESPONSE_REGRESSION_SANITIZE "Build the PTR response regression test with ASan/UBSan" OFF)
+    if(PTR_RESPONSE_REGRESSION_SANITIZE)
+        target_compile_options(ptr_response_regression PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(ptr_response_regression PRIVATE -fsanitize=address,undefined)
+    endif()
 endif()
 
 # Standalone regression harness for the in-memory gzip parser (zip/gzip.c).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -445,6 +445,16 @@ endif()
 #
 # Only built on request: `./build.sh test` enables it for local runs and the
 # CI Dockerfile passes -DBUILD_DOTDOH_REGRESSION=ON at build time.
+option(BUILD_PTR_RESPONSE_REGRESSION "Build the PTR response regression test harness" OFF)
+if(BUILD_PTR_RESPONSE_REGRESSION)
+    add_executable(ptr_response_regression
+            ${PROJECT_SOURCE_DIR}/test/ptr_response_regression.c
+            ${PROJECT_SOURCE_DIR}/src/resolve.c)
+    target_include_directories(ptr_response_regression PRIVATE ${PROJECT_SOURCE_DIR}/src)
+    target_compile_options(ptr_response_regression PRIVATE -fvisibility=hidden)
+    target_link_libraries(ptr_response_regression Threads::Threads)
+endif()
+
 option(BUILD_DOTDOH_REGRESSION "Build the dotdoh regression test harness" OFF)
 if(BUILD_DOTDOH_REGRESSION)
     add_executable(dotdoh_regression

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -445,16 +445,6 @@ endif()
 #
 # Only built on request: `./build.sh test` enables it for local runs and the
 # CI Dockerfile passes -DBUILD_DOTDOH_REGRESSION=ON at build time.
-option(BUILD_PTR_RESPONSE_REGRESSION "Build the PTR response regression test harness" OFF)
-if(BUILD_PTR_RESPONSE_REGRESSION)
-    add_executable(ptr_response_regression
-            ${PROJECT_SOURCE_DIR}/test/ptr_response_regression.c
-            ${PROJECT_SOURCE_DIR}/src/resolve.c)
-    target_include_directories(ptr_response_regression PRIVATE ${PROJECT_SOURCE_DIR}/src)
-    target_compile_options(ptr_response_regression PRIVATE -fvisibility=hidden)
-    target_link_libraries(ptr_response_regression Threads::Threads)
-endif()
-
 option(BUILD_DOTDOH_REGRESSION "Build the dotdoh regression test harness" OFF)
 if(BUILD_DOTDOH_REGRESSION)
     add_executable(dotdoh_regression
@@ -468,6 +458,30 @@ if(BUILD_DOTDOH_REGRESSION)
         target_compile_options(dotdoh_regression PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
         target_link_options(dotdoh_regression PRIVATE -fsanitize=address,undefined)
     endif()
+endif()
+
+# Standalone regression harness for the internal PTR resolver. It compiles
+# src/resolve.c a second time and stubs the FTL wrappers that file needs, so a
+# scripted DNS server can replay a stale response against the real resolver.
+# The "PTR stale-response regression harness" bats test runs the resulting
+# binary. Deliberately NOT given the strict EXTRAWARN/-Werror flags applied to
+# FTL code.
+#
+# -fvisibility=hidden is load-bearing here: with default visibility the entry
+# points of resolve.c are GC roots for -Wl,--gc-sections, so the linker keeps
+# resolveClients() and DNSclient_thread() and then fails on their references
+# into shared memory, the event queue and the thread helpers.
+#
+# Only built on request: `./build.sh test` enables it for local runs and the
+# CI Dockerfile passes -DBUILD_PTR_RESPONSE_REGRESSION=ON at build time.
+option(BUILD_PTR_RESPONSE_REGRESSION "Build the PTR response regression test harness" OFF)
+if(BUILD_PTR_RESPONSE_REGRESSION)
+    add_executable(ptr_response_regression
+            ${PROJECT_SOURCE_DIR}/test/ptr_response_regression.c
+            ${PROJECT_SOURCE_DIR}/src/resolve.c)
+    target_include_directories(ptr_response_regression PRIVATE ${PROJECT_SOURCE_DIR}/src)
+    target_compile_options(ptr_response_regression PRIVATE -fvisibility=hidden)
+    target_link_libraries(ptr_response_regression Threads::Threads)
 endif()
 
 # Standalone regression harness for the in-memory gzip parser (zip/gzip.c).

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -40,6 +40,10 @@
 // get_secure_randomness()
 #include "config/password.h"
 
+// Wall-clock budget for a single PTR lookup, used both as the socket-level
+// receive timeout and as the deadline bounding the receive loops below
+#define RESOLVER_TIMEOUT_MS 2000
+
 // Function Prototypes
 static size_t nameToDNS(unsigned char *dns, const size_t dnslen, const char *host, const size_t hostlen) __attribute__((nonnull(1,3)));
 static unsigned char *nameFromDNS(unsigned char *reader, unsigned char *buffer, const unsigned char *end, uint16_t *count) __attribute__((malloc)) __attribute__((nonnull(1,2,3,4)));
@@ -257,10 +261,10 @@ int create_socket(bool tcp, struct sockaddr_in *dest)
 		return -1;
 	}
 
-	// Set timeout for socket (2 seconds)
+	// Set timeout for socket
 	struct timeval tv;
-	tv.tv_sec = 2;
-	tv.tv_usec = 0;
+	tv.tv_sec = RESOLVER_TIMEOUT_MS / 1000;
+	tv.tv_usec = (RESOLVER_TIMEOUT_MS % 1000) * 1000;
 	if(setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0)
 	{
 		log_err("Unable to set DNS resolver socket timeout: %s", strerror(errno));
@@ -296,6 +300,72 @@ static int64_t resolver_monotonic_msec(void)
 		return -1;
 
 	return (int64_t)now.tv_sec * 1000LL + now.tv_nsec / 1000000LL;
+}
+
+// Receive exactly len bytes from a stream socket. recv() may return fewer
+// bytes than requested, so keep reading until the full amount has arrived,
+// bounded by one absolute deadline for the entire lookup.
+static bool recv_all(const int sock, void *target, const size_t len,
+                     const int64_t deadline, const char *what)
+{
+	size_t received = 0;
+	while(received < len)
+	{
+		const int64_t now = resolver_monotonic_msec();
+		if(now < 0)
+		{
+			log_err("Cannot read resolver monotonic clock: %s", strerror(errno));
+			return false;
+		}
+
+		const int64_t remaining = deadline - now;
+		if(remaining <= 0)
+		{
+			log_err("Cannot receive TCP DNS reply (%s): Timed out after %d ms",
+			        what, RESOLVER_TIMEOUT_MS);
+			return false;
+		}
+
+		struct pollfd pfd = {
+			.fd = sock,
+			.events = POLLIN,
+			.revents = 0,
+		};
+
+		const int ready = poll(&pfd, 1, (int)remaining);
+		if(ready < 0)
+		{
+			if(errno == EINTR)
+				continue;
+
+			log_err("Cannot wait for TCP DNS reply (%s): %s", what, strsockerr(errno));
+			return false;
+		}
+		if(ready == 0)
+		{
+			log_err("Cannot receive TCP DNS reply (%s): Timed out after %d ms",
+			        what, RESOLVER_TIMEOUT_MS);
+			return false;
+		}
+
+		const ssize_t bytes = recv(sock, (uint8_t *)target + received,
+		                           len - received, 0);
+		if(bytes < 0)
+		{
+			log_err("Cannot receive TCP DNS reply (%s): %s", what, strsockerr(errno));
+			return false;
+		}
+		if(bytes == 0)
+		{
+			log_err("Cannot receive TCP DNS reply (%s): connection closed after "
+			        "%zu of %zu bytes", what, received, len);
+			return false;
+		}
+
+		received += (size_t)bytes;
+	}
+
+	return true;
 }
 
 static bool validate_udp_ptr_response(uint8_t *buf, const size_t response_len,
@@ -441,7 +511,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 	log_debug(DEBUG_RESOLVER, "Resolving PTR \"%s\" on 127.0.0.1#%u (%s)",
 	          host, config.dns.port.v.u16, tcp ? "TCP" : "UDP");
 
-	ssize_t response_len = sizeof(buf);
+	ssize_t response_len = 0;
 	uint8_t *reader = NULL;
 	uint16_t prefix = 0;
 
@@ -465,7 +535,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
 			return false;
 		}
-		const int64_t deadline = start + 2000;
+		const int64_t deadline = start + RESOLVER_TIMEOUT_MS;
 
 		while(true)
 		{
@@ -480,7 +550,8 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 			const int64_t remaining = deadline - now;
 			if(remaining <= 0)
 			{
-				log_err("Cannot receive UDP DNS reply: Timed out after 2000 ms");
+				log_err("Cannot receive UDP DNS reply: Timed out after %d ms",
+				        RESOLVER_TIMEOUT_MS);
 				log_resolve_info(host, config.dns.port.v.u16, tcp);
 				return false;
 			}
@@ -503,7 +574,8 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 			}
 			if(ready == 0)
 			{
-				log_err("Cannot receive UDP DNS reply: Timed out after 2000 ms");
+				log_err("Cannot receive UDP DNS reply: Timed out after %d ms",
+				        RESOLVER_TIMEOUT_MS);
 				log_resolve_info(host, config.dns.port.v.u16, tcp);
 				return false;
 			}
@@ -514,7 +586,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 			                        (struct sockaddr *)&source, &source_len);
 			if(response_len < 0)
 			{
-				if(errno == EAGAIN || errno == EINTR)
+				if(errno == EAGAIN)
 					continue;
 
 				log_err("Cannot receive UDP DNS reply: %s", strsockerr(errno));
@@ -561,11 +633,19 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 			return false;
 		}
 
+		const int64_t start = resolver_monotonic_msec();
+		if(start < 0)
+		{
+			log_err("Cannot read resolver monotonic clock: %s", strerror(errno));
+			log_resolve_info(host, config.dns.port.v.u16, tcp);
+			return false;
+		}
+		const int64_t deadline = start + RESOLVER_TIMEOUT_MS;
+
 		// Receive the answer, first the length of the message ...
 		prefix = 0;
-		if(recv(sock, &prefix, sizeof(prefix), 0) < 0)
+		if(!recv_all(sock, &prefix, sizeof(prefix), deadline, "length prefix"))
 		{
-			log_err("Cannot receive TCP DNS reply (1): %s", strsockerr(errno));
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
 			return false;
 		}
@@ -582,34 +662,13 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		}
 		bzero(buf, prefix + 1);
 
-		// ... then the message itself. recv() on a stream socket may
-		// return fewer bytes than requested, so keep reading until the
-		// complete DNS message announced by prefix has arrived.
-		response_len = 0;
-		while((size_t)response_len < prefix)
+		// ... then the message itself
+		if(!recv_all(sock, buf, prefix, deadline, "message"))
 		{
-			const ssize_t received =
-			    recv(sock, buf + (size_t)response_len,
-			         prefix - (size_t)response_len, 0);
-			if(received < 0)
-			{
-				if(errno == EINTR)
-					continue;
-
-				log_err("Cannot receive TCP DNS reply (2): %s", strsockerr(errno));
-				log_resolve_info(host, config.dns.port.v.u16, tcp);
-				return false;
-			}
-			if(received == 0)
-			{
-				log_err("Cannot receive TCP DNS reply (2): connection closed after "
-				        "%zd of %u bytes", response_len, prefix);
-				log_resolve_info(host, config.dns.port.v.u16, tcp);
-				return false;
-			}
-
-			response_len += received;
+			log_resolve_info(host, config.dns.port.v.u16, tcp);
+			return false;
 		}
+		response_len = prefix;
 
 		memcpy(&dns, buf, sizeof(struct DNS_HEADER));
 		reader = &buf[len];

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -348,8 +348,10 @@ static bool recv_all(const int sock, void *target, const size_t len,
 			return false;
 		}
 
-		const ssize_t bytes = recv(sock, (uint8_t *)target + received,
-		                           len - received, 0);
+		// recv_nowarn() as the error is logged below with the name of
+		// the part we were reading
+		const ssize_t bytes = recv_nowarn(sock, (uint8_t *)target + received,
+		                                  len - received, 0);
 		if(bytes < 0)
 		{
 			log_err("Cannot receive TCP DNS reply (%s): %s", what, strsockerr(errno));

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -33,6 +33,8 @@
 #include "regex_r.h"
 // statis_assert()
 #include <assert.h>
+#include <poll.h>
+#include <time.h>
 // TCP_MAX_QUERIES
 #include "dnsmasq/config.h"
 // get_secure_randomness()
@@ -287,13 +289,98 @@ int create_socket(bool tcp, struct sockaddr_in *dest)
 // Helper macro to reduce code duplication
 #define log_resolve_info(host, port, tcp) { log_info("Tried to resolve PTR \"%s\" on 127.0.0.1#%u (%s)", host, port, tcp ? "TCP" : "UDP"); }
 
+static int64_t resolver_monotonic_msec(void)
+{
+	struct timespec now = { 0 };
+	if(clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+		return -1;
+
+	return (int64_t)now.tv_sec * 1000LL + now.tv_nsec / 1000000LL;
+}
+
+static bool validate_udp_ptr_response(uint8_t *buf, const size_t response_len,
+                                      const uint16_t request_id, const char *host,
+                                      struct DNS_HEADER *dns, uint8_t **answer)
+{
+	if(response_len < sizeof(struct DNS_HEADER))
+	{
+		log_debug(DEBUG_RESOLVER,
+		          "Discarding short UDP DNS reply while resolving PTR \"%s\" (%zu bytes)",
+		          host, response_len);
+		return false;
+	}
+
+	struct DNS_HEADER response = { 0 };
+	memcpy(&response, buf, sizeof(response));
+
+	if(response.id != request_id || response.qr != 1 || response.opcode != 0 ||
+	   ntohs(response.q_count) != 1)
+	{
+		log_debug(DEBUG_RESOLVER,
+		          "Discarding unrelated UDP DNS reply while resolving PTR \"%s\" "
+		          "(id %u, expected %u, qr %u, opcode %u, questions %u)",
+		          host, (unsigned int)ntohs(response.id),
+		          (unsigned int)ntohs(request_id), (unsigned int)response.qr,
+		          (unsigned int)response.opcode,
+		          (unsigned int)ntohs(response.q_count));
+		return false;
+	}
+
+	const unsigned char *bufend = buf + response_len;
+	uint8_t *reader = buf + sizeof(struct DNS_HEADER);
+	uint16_t consumed = 0;
+	unsigned char *question_name = nameFromDNS(reader, buf, bufend, &consumed);
+	if(question_name == NULL)
+	{
+		log_debug(DEBUG_RESOLVER,
+		          "Discarding malformed UDP DNS question while resolving PTR \"%s\"",
+		          host);
+		return false;
+	}
+
+	if(consumed > (size_t)(bufend - reader) ||
+	   sizeof(struct QUESTION) > (size_t)(bufend - reader - consumed))
+	{
+		free(question_name);
+		log_debug(DEBUG_RESOLVER,
+		          "Discarding truncated UDP DNS question while resolving PTR \"%s\"",
+		          host);
+		return false;
+	}
+
+	reader += consumed;
+	struct QUESTION question = { 0 };
+	memcpy(&question, reader, sizeof(question));
+
+	const bool matches =
+	    strcasecmp((const char *)question_name, host) == 0 &&
+	    ntohs(question.qtype) == T_PTR &&
+	    ntohs(question.qclass) == 1;
+
+	if(!matches)
+	{
+		log_debug(DEBUG_RESOLVER,
+		          "Discarding UDP DNS reply with mismatched question while resolving "
+		          "PTR \"%s\" (received \"%s\", type %u, class %u)",
+		          host, (const char *)question_name,
+		          (unsigned int)ntohs(question.qtype),
+		          (unsigned int)ntohs(question.qclass));
+		free(question_name);
+		return false;
+	}
+
+	free(question_name);
+	*dns = response;
+	*answer = reader + sizeof(struct QUESTION);
+	return true;
+}
+
 // Perform a name lookup by sending a packet to ourselves
 static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *dest,
                            char hostn[MAXDOMAINLEN], const char *host, const char *ipaddr, bool *truncated)
 {	
 	// Initialize request DNS header
 	struct DNS_HEADER dns = { 0 };
-
 	// Random query ID. This has to be unpredictable, as an off-path
 	// attacker who can guess it may forge a reply
 	uint16_t query_id = 0;
@@ -303,6 +390,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		return false;
 	}
 	dns.id = htons(query_id);
+	const uint16_t request_id = dns.id;
 	dns.qr = 0; // This is a query
 	dns.opcode = 0; // This is a standard query
 	dns.aa = 0; // Not Authoritative
@@ -325,7 +413,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 	if(hname == NULL)
 	{
 		log_err("Unable to allocate memory for hname");
-		return NULL;
+		return false;
 	}
 	strncpy(hname, host, hnamelen);
 	strncat(hname, ".", hnamelen - strlen(hname));
@@ -353,6 +441,10 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 	log_debug(DEBUG_RESOLVER, "Resolving PTR \"%s\" on 127.0.0.1#%u (%s)",
 	          host, config.dns.port.v.u16, tcp ? "TCP" : "UDP");
 
+	ssize_t response_len = sizeof(buf);
+	uint8_t *reader = NULL;
+	uint16_t prefix = 0;
+
 	// Send the query and receive the answer
 	if(!tcp)
 	{
@@ -363,15 +455,92 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		{
 			log_err("Cannot send UDP DNS query: %s", strsockerr(errno));
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return NULL;
+			return false;
 		}
 
-		// Receive the answer
-		if(recvfrom (sock, buf, sizeof(buf), 0, (struct sockaddr*)dest, &addrlen) < 0)
+		const int64_t start = resolver_monotonic_msec();
+		if(start < 0)
 		{
-			log_err("Cannot receive UDP DNS reply: %s", strsockerr(errno));
+			log_err("Cannot read resolver monotonic clock: %s", strerror(errno));
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return NULL;
+			return false;
+		}
+		const int64_t deadline = start + 2000;
+
+		while(true)
+		{
+			const int64_t now = resolver_monotonic_msec();
+			if(now < 0)
+			{
+				log_err("Cannot read resolver monotonic clock: %s", strerror(errno));
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+
+			const int64_t remaining = deadline - now;
+			if(remaining <= 0)
+			{
+				log_err("Cannot receive UDP DNS reply: Timed out after 2000 ms");
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+
+			struct pollfd pfd = {
+				.fd = sock,
+				.events = POLLIN,
+				.revents = 0,
+			};
+
+			const int ready = poll(&pfd, 1, (int)remaining);
+			if(ready < 0)
+			{
+				if(errno == EINTR)
+					continue;
+
+				log_err("Cannot wait for UDP DNS reply: %s", strsockerr(errno));
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+			if(ready == 0)
+			{
+				log_err("Cannot receive UDP DNS reply: Timed out after 2000 ms");
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+
+			struct sockaddr_in source = { 0 };
+			socklen_t source_len = sizeof(source);
+			response_len = recvfrom(sock, buf, sizeof(buf), MSG_DONTWAIT,
+			                        (struct sockaddr *)&source, &source_len);
+			if(response_len < 0)
+			{
+				if(errno == EAGAIN || errno == EINTR)
+					continue;
+
+				log_err("Cannot receive UDP DNS reply: %s", strsockerr(errno));
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+
+			if(source_len < (socklen_t)sizeof(source) ||
+			   source.sin_family != dest->sin_family ||
+			   source.sin_addr.s_addr != dest->sin_addr.s_addr ||
+			   source.sin_port != dest->sin_port)
+			{
+				log_debug(DEBUG_RESOLVER,
+				          "Discarding UDP DNS reply from unexpected source while "
+				          "resolving PTR \"%s\"",
+				          host);
+				continue;
+			}
+
+			if(!validate_udp_ptr_response(buf, (size_t)response_len,
+			                              request_id, host, &dns, &reader))
+				continue;
+
+			// Unrelated datagrams may keep the loop active until this request's
+			// deadline, but they cannot extend the original two-second wait.
+			break;
 		}
 	}
 	else
@@ -383,7 +552,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		// not sending messages (datagrams) but a continuous stream of
 		// bytes. We therefore need a way to tell the receiver about
 		// this length of the message.
-		uint16_t prefix = htons(len & 0xffffu);
+		prefix = htons(len & 0xffffu);
 		if(send(sock, &prefix, sizeof(prefix), 0) < 0 ||
 		   send(sock, buf, len, 0) < 0)
 		{
@@ -412,19 +581,39 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 			return false;
 		}
 		bzero(buf, prefix + 1);
-		// ... then the message itself
-		if(recv(sock, buf, sizeof(buf), 0) < 0)
-		{
-			log_err("Cannot receive TCP DNS reply (2): %s", strsockerr(errno));
-			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return false;
-		}
-	}
 
-	// Parse the reply
-	memcpy(&dns, buf, sizeof(struct DNS_HEADER));
-	// Move ahead of the dns header and the query field
-	uint8_t *reader = &buf[len];
+		// ... then the message itself. recv() on a stream socket may
+		// return fewer bytes than requested, so keep reading until the
+		// complete DNS message announced by prefix has arrived.
+		response_len = 0;
+		while((size_t)response_len < prefix)
+		{
+			const ssize_t received =
+			    recv(sock, buf + (size_t)response_len,
+			         prefix - (size_t)response_len, 0);
+			if(received < 0)
+			{
+				if(errno == EINTR)
+					continue;
+
+				log_err("Cannot receive TCP DNS reply (2): %s", strsockerr(errno));
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+			if(received == 0)
+			{
+				log_err("Cannot receive TCP DNS reply (2): connection closed after "
+				        "%zd of %u bytes", response_len, prefix);
+				log_resolve_info(host, config.dns.port.v.u16, tcp);
+				return false;
+			}
+
+			response_len += received;
+		}
+
+		memcpy(&dns, buf, sizeof(struct DNS_HEADER));
+		reader = &buf[len];
+	}
 
 	// Log the status of the query
 	log_debug(DEBUG_RESOLVER, "DNS query for PTR \"%s\" returned status %s (%i)",
@@ -436,14 +625,14 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		log_debug(DEBUG_RESOLVER, " --> DNS response truncated");
 		if(truncated != NULL)
 			*truncated = true;
-		return NULL;
+		return false;
 	}
 
 	// Start reading answers
 	uint16_t stop = 0;
 	bool have_name = false;
 	struct RES_RECORD answers[20] = { 0 };
-	const unsigned char *bufend = buf + sizeof(buf);
+	const unsigned char *bufend = buf + (size_t)response_len;
 	for(uint16_t i = 0; i < min(ntohs(dns.ans_count), ArraySize(answers)); i++)
 	{
 		// Ensure the read pointer still points within the receive

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -651,6 +651,15 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		}
 		prefix = ntohs(prefix);
 
+		// A reply shorter than the DNS header cannot be parsed, and the
+		// header copy below would otherwise take bytes that never arrived
+		if(prefix < sizeof(struct DNS_HEADER))
+		{
+			log_err("Received TCP DNS reply is too short (%u bytes)", prefix);
+			log_resolve_info(host, config.dns.port.v.u16, tcp);
+			return false;
+		}
+
 		// Sanity check the length of the message. Reject prefix == sizeof(buf)
 		// as well, otherwise the bzero(buf, prefix + 1) below writes one byte
 		// past the end of the buffer.

--- a/test/ptr_response_regression.c
+++ b/test/ptr_response_regression.c
@@ -1,0 +1,441 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "config/config.h"
+#include "log.h"
+#include "syscalls/syscalls.h"
+
+#define TEST_MAXDOMAINLEN 256
+#define DNS_HEADER_LEN 12
+#define DNS_TYPE_PTR 12
+#define DNS_CLASS_IN 1
+
+bool resolveHostname(const int sock, const bool tcp, struct sockaddr_in *dest,
+                     char hostn[TEST_MAXDOMAINLEN], const char *addr,
+                     const bool force, bool *truncated);
+
+struct config config = { 0 };
+bool debug_flags[DEBUG_MAX] = { false };
+bool only_testing = true;
+
+bool get_secure_randomness(uint8_t *buffer, const size_t length)
+{
+	// The production resolver obtains cryptographically secure query IDs.
+	// This standalone regression harness only needs distinct, reproducible
+	// IDs so stale replies can be correlated deterministically.
+	static uint8_t next = 1;
+
+	if(buffer == NULL)
+		return false;
+
+	for(size_t i = 0; i < length; i++)
+		buffer[i] = next++;
+
+	return true;
+}
+
+
+void _FTL_log(const int priority, const enum debug_flag flag, const char *format, ...)
+{
+	(void)priority;
+	(void)flag;
+	(void)format;
+}
+
+char *escape_string(const char *input)
+{
+	if(input == NULL)
+		return NULL;
+	const size_t len = strlen(input) + 1;
+	char *copy = malloc(len);
+	if(copy != NULL)
+		memcpy(copy, input, len);
+	return copy;
+}
+
+void log_hostname_warning(const char *ip, const char *name, const unsigned int pos)
+{
+	(void)ip;
+	(void)name;
+	(void)pos;
+}
+
+void *FTLcalloc(size_t n, size_t size, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return calloc(n, size);
+}
+
+bool FTLfree(void *ptr, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	free(ptr);
+	return true;
+}
+
+size_t FTLstrlen(const char *s, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return strlen(s);
+}
+
+char *FTLstrncpy(char *dest, const char *src, const size_t n, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return strncpy(dest, src, n);
+}
+
+char *FTLstrncat(char *dest, const char *src, const size_t n, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return strncat(dest, src, n);
+}
+
+void *FTLmemcpy(void *dest, const void *src, const size_t n, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return memcpy(dest, src, n);
+}
+
+void *FTLmemset(void *s, const int c, const size_t n, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return memset(s, c, n);
+}
+
+char *FTLstrstr(const char *haystack, const char *needle, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return strstr(haystack, needle);
+}
+
+int FTLstrcmp(const char *s1, const char *s2, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return strcmp(s1, s2);
+}
+
+int FTLstrcasecmp(const char *s1, const char *s2, const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return strcasecmp(s1, s2);
+}
+
+int FTLsnprintf(const char *file, const char *func, const int line,
+                char *buffer, const size_t maxlen, const char *format, ...)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	va_list args;
+	va_start(args, format);
+	const int result = vsnprintf(buffer, maxlen, format, args);
+	va_end(args);
+	return result;
+}
+
+ssize_t FTLsendto(int sockfd, void *buf, size_t len, int flags,
+                  const struct sockaddr *dest_addr, socklen_t addrlen,
+                  const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+ssize_t FTLrecvfrom(int sockfd, void *buf, size_t len, int flags,
+                    struct sockaddr *src_addr, socklen_t *addrlen,
+                    const char *file, const char *func, const int line)
+{
+	(void)file;
+	(void)func;
+	(void)line;
+	return recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+ssize_t FTLrecv(int sockfd, void *buf, size_t len, int flags, const bool warn,
+                const char *file, const char *func, const int line)
+{
+	(void)warn;
+	(void)file;
+	(void)func;
+	(void)line;
+	return recv(sockfd, buf, len, flags);
+}
+
+struct server_context {
+	int sock;
+	pthread_mutex_t mutex;
+	pthread_cond_t condition;
+	bool release_delayed_a;
+	bool success;
+};
+
+static bool dns_question_end(const uint8_t *query, const size_t query_len, size_t *end)
+{
+	if(query_len < DNS_HEADER_LEN + 1)
+		return false;
+
+	size_t pos = DNS_HEADER_LEN;
+	while(pos < query_len)
+	{
+		const uint8_t label_len = query[pos++];
+		if(label_len == 0)
+			break;
+		if(label_len > 63 || pos + label_len > query_len)
+			return false;
+		pos += label_len;
+	}
+
+	if(pos + 4 > query_len)
+		return false;
+
+	*end = pos + 4;
+	return true;
+}
+
+static bool encode_dns_name(uint8_t *out, const size_t out_len, const char *name, size_t *encoded_len)
+{
+	size_t used = 0;
+	const char *label = name;
+	while(*label != '\0')
+	{
+		const char *dot = strchr(label, '.');
+		const size_t len = dot == NULL ? strlen(label) : (size_t)(dot - label);
+		if(len == 0 || len > 63 || used + 1 + len >= out_len)
+			return false;
+		out[used++] = (uint8_t)len;
+		memcpy(out + used, label, len);
+		used += len;
+		if(dot == NULL)
+			break;
+		label = dot + 1;
+	}
+	if(used >= out_len)
+		return false;
+	out[used++] = 0;
+	*encoded_len = used;
+	return true;
+}
+
+static bool build_ptr_response(const uint8_t *query, const size_t query_len,
+                               const char *target, uint8_t *response,
+                               const size_t response_size, size_t *response_len)
+{
+	size_t question_end = 0;
+	if(!dns_question_end(query, query_len, &question_end) || question_end + 12 >= response_size)
+		return false;
+
+	memset(response, 0, response_size);
+	memcpy(response, query, question_end);
+	response[2] = 0x81;
+	response[3] = 0x80;
+	response[4] = 0x00;
+	response[5] = 0x01;
+	response[6] = 0x00;
+	response[7] = 0x01;
+	response[8] = 0x00;
+	response[9] = 0x00;
+	response[10] = 0x00;
+	response[11] = 0x00;
+
+	size_t pos = question_end;
+	response[pos++] = 0xc0;
+	response[pos++] = 0x0c;
+	response[pos++] = 0x00;
+	response[pos++] = DNS_TYPE_PTR;
+	response[pos++] = 0x00;
+	response[pos++] = DNS_CLASS_IN;
+	response[pos++] = 0x00;
+	response[pos++] = 0x00;
+	response[pos++] = 0x00;
+	response[pos++] = 0x00;
+
+	uint8_t encoded[256] = { 0 };
+	size_t encoded_len = 0;
+	if(!encode_dns_name(encoded, sizeof(encoded), target, &encoded_len) ||
+	   encoded_len > UINT16_MAX || pos + 2 + encoded_len > response_size)
+		return false;
+
+	response[pos++] = (uint8_t)(encoded_len >> 8);
+	response[pos++] = (uint8_t)(encoded_len & 0xffu);
+	memcpy(response + pos, encoded, encoded_len);
+	pos += encoded_len;
+	*response_len = pos;
+	return true;
+}
+
+static void *server_main(void *arg)
+{
+	struct server_context *ctx = arg;
+	uint8_t query_a[512] = { 0 };
+	uint8_t query_b[512] = { 0 };
+	uint8_t response[512] = { 0 };
+	struct sockaddr_in client = { 0 };
+	socklen_t client_len = sizeof(client);
+
+	const ssize_t a_len = recvfrom(ctx->sock, query_a, sizeof(query_a), 0,
+	                               (struct sockaddr *)&client, &client_len);
+	if(a_len <= 0)
+		return NULL;
+
+	pthread_mutex_lock(&ctx->mutex);
+	while(!ctx->release_delayed_a)
+		pthread_cond_wait(&ctx->condition, &ctx->mutex);
+	pthread_mutex_unlock(&ctx->mutex);
+
+	size_t response_len = 0;
+	if(!build_ptr_response(query_a, (size_t)a_len, "late-a.example",
+	                       response, sizeof(response), &response_len))
+		return NULL;
+	if(sendto(ctx->sock, response, response_len, 0,
+	          (const struct sockaddr *)&client, client_len) != (ssize_t)response_len)
+		return NULL;
+
+	client_len = sizeof(client);
+	const ssize_t b_len = recvfrom(ctx->sock, query_b, sizeof(query_b), 0,
+	                               (struct sockaddr *)&client, &client_len);
+	if(b_len <= 0)
+		return NULL;
+
+	if(!build_ptr_response(query_b, (size_t)b_len, "answer-b.example",
+	                       response, sizeof(response), &response_len))
+		return NULL;
+	if(sendto(ctx->sock, response, response_len, 0,
+	          (const struct sockaddr *)&client, client_len) != (ssize_t)response_len)
+		return NULL;
+
+	ctx->success = true;
+	return NULL;
+}
+
+int main(void)
+{
+	int server_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if(server_sock < 0)
+	{
+		perror("server socket");
+		return EXIT_FAILURE;
+	}
+
+	struct sockaddr_in server = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+		.sin_port = 0,
+	};
+	if(bind(server_sock, (const struct sockaddr *)&server, sizeof(server)) != 0)
+	{
+		perror("server bind");
+		close(server_sock);
+		return EXIT_FAILURE;
+	}
+
+	socklen_t server_len = sizeof(server);
+	if(getsockname(server_sock, (struct sockaddr *)&server, &server_len) != 0)
+	{
+		perror("getsockname");
+		close(server_sock);
+		return EXIT_FAILURE;
+	}
+
+	int client_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if(client_sock < 0)
+	{
+		perror("client socket");
+		close(server_sock);
+		return EXIT_FAILURE;
+	}
+
+	const struct timeval timeout = { .tv_sec = 2, .tv_usec = 0 };
+	if(setsockopt(client_sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0)
+	{
+		perror("setsockopt");
+		close(client_sock);
+		close(server_sock);
+		return EXIT_FAILURE;
+	}
+
+	config.dns.port.v.u16 = ntohs(server.sin_port);
+	struct server_context ctx = {
+		.sock = server_sock,
+		.mutex = PTHREAD_MUTEX_INITIALIZER,
+		.condition = PTHREAD_COND_INITIALIZER,
+		.release_delayed_a = false,
+		.success = false,
+	};
+	pthread_t thread;
+	if(pthread_create(&thread, NULL, server_main, &ctx) != 0)
+	{
+		perror("pthread_create");
+		close(client_sock);
+		close(server_sock);
+		return EXIT_FAILURE;
+	}
+
+	char host_a[TEST_MAXDOMAINLEN] = { 0 };
+	char host_b[TEST_MAXDOMAINLEN] = { 0 };
+	bool truncated = false;
+	const bool first_ok = resolveHostname(client_sock, false, &server, host_a,
+	                                      "192.0.2.10", true, &truncated);
+	pthread_mutex_lock(&ctx.mutex);
+	ctx.release_delayed_a = true;
+	pthread_cond_signal(&ctx.condition);
+	pthread_mutex_unlock(&ctx.mutex);
+	const bool second_ok = resolveHostname(client_sock, false, &server, host_b,
+	                                       "192.0.2.11", true, &truncated);
+
+	pthread_join(thread, NULL);
+	pthread_cond_destroy(&ctx.condition);
+	pthread_mutex_destroy(&ctx.mutex);
+	close(client_sock);
+	close(server_sock);
+
+	printf("FIRST_LOOKUP_TIMEOUT=%s\n", !first_ok ? "PASS" : "FAIL");
+	printf("SECOND_LOOKUP_RESULT=%s\n", second_ok ? host_b : "<failed>");
+	printf("SERVER_SEQUENCE=%s\n", ctx.success ? "PASS" : "FAIL");
+
+	if(first_ok || !second_ok || !ctx.success || strcmp(host_b, "answer-b.example") != 0)
+	{
+		printf("PTR_RESPONSE_REGRESSION=FAIL\n");
+		return EXIT_FAILURE;
+	}
+
+	printf("PTR_RESPONSE_REGRESSION=PASS\n");
+	return EXIT_SUCCESS;
+}

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1774,6 +1774,12 @@ setup() {
   assert_success
 }
 
+@test "PTR stale-response regression harness" {
+  run ./ptr_response_regression
+  assert_success
+  assert_output --partial "PTR_RESPONSE_REGRESSION=PASS"
+}
+
 @test "SHA256 checksum working" {
   run bash -c './pihole-FTL sha256sum test/test.pem'
   assert_line --index 0 "ce4c01340ef46bf3bc26831f7c53763d57c863528826aa795f1da5e16d6e7b2d  test/test.pem"


### PR DESCRIPTION
# What does this implement/fix?

The internal PTR resolver reuses one UDP socket across sequential lookups. If a lookup times out, a delayed response from that lookup can remain queued and be consumed while the resolver is waiting for the next lookup.

This change correlates received UDP DNS datagrams with the active PTR request before parsing them. It:

- validates the response source address and port;
- validates `QR`, opcode, transaction ID and `QDCOUNT`;
- decodes and compares the echoed QNAME, QTYPE and QCLASS;
- discards unrelated datagrams while keeping one absolute `CLOCK_MONOTONIC` deadline;
- uses the actual `recvfrom()` byte count as the UDP parser boundary;
- validates into a local DNS header and only copies it out after the response is accepted;
- preserves the secure query ID introduced by #3030 and derives `request_id` from the final `dns.id`;
- reads both the TCP length prefix and announced DNS message body completely under one absolute deadline, rejects replies shorter than a DNS header, and bounds parsing by the received length;
- adds a deterministic regression harness under `test/` for the stale-response sequence.

The independent `return NULL;` → `return false;` cleanup identified during review was split into #3027 and has already landed separately. The three remaining cases in this `bool` resolver function were corrected here during the rebase as requested.

## How to test the change during review

The regression harness lets lookup A time out, then releases A's delayed response while lookup B starts on the same UDP socket. The server sends the stale A response before the correct B response.

On the pre-rebase baseline used to demonstrate the regression (`a17efdd3307a233172d2f3b0d1e2ead5f9c85302`):

```text
FIRST_LOOKUP_TIMEOUT=PASS
SECOND_LOOKUP_RESULT=late-a.example
SERVER_SEQUENCE=PASS
PTR_RESPONSE_REGRESSION=FAIL
```

With this change applied:

```text
FIRST_LOOKUP_TIMEOUT=PASS
SECOND_LOOKUP_RESULT=answer-b.example
SERVER_SEQUENCE=PASS
PTR_RESPONSE_REGRESSION=PASS
```

The harness is integrated into the normal test suite as `PTR stale-response regression harness`.

The current PR head (`3126faff259335facba39794013b76da180d9b9b`) passed the full GitHub CI matrix. An isolated local merge of this head into current `development` at `c4144a786bf1ceea0cae6d8aec8763b9f24a4927` was also built and tested in the current `ghcr.io/pi-hole/ftl-build:v2.25` environment:

```text
193 BATS tests, 0 failures
151 pytest API tests passed
12 dotdoh client tests, 0 failures
25 dotdoh server tests, 0 failures
9 final log-validation tests, 0 failures
TLS terminator test: PASS
```

The original UDP regression harness and a temporary TCP fault-injection harness also passed under ASan/UBSan. The TCP audit covered fragmented length-prefix and body reads, EOF after a partial prefix, replies shorter than a DNS header, oversized announced lengths, premature body EOF, and byte trickling constrained by the single 2000 ms deadline.

The earlier full-daemon reproduction documented on #2978 remains independent corroboration of the same stale-response mechanism.

## Additional information

**Related issue or feature (if applicable):** Refs #2978

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits.
6. My change does not modify `src/dnsmasq/`.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I signed off all commits (DCO).
- [x] I cryptographically signed all commits.
- [x] I have read the above and my PR is ready for review.
