### PR TITLE
Demote server-side TLS handshake alerts to the webserver debug log

### DIFF
--- a/patch/civetweb.sh
+++ b/patch/civetweb.sh
@@ -23,4 +23,7 @@ patch -p1 < patch/civetweb/0001-Expose-bound-to-addresses-from-CivetWeb-to-the-f
 echo "Applying patch 0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch"
 patch -p1 < patch/civetweb/0001-Increase-niceness-of-all-civetweb-threads-as-DNS-ope.patch
 
+echo "Applying patch 0001-Demote-server-side-TLS-handshake-alerts-to-debug.patch"
+patch -p1 < patch/civetweb/0001-Demote-server-side-TLS-handshake-alerts-to-debug.patch
+
 echo "ALL PATCHES APPLIED OKAY"

--- a/patch/civetweb/0001-Demote-server-side-TLS-handshake-alerts-to-debug.patch
+++ b/patch/civetweb/0001-Demote-server-side-TLS-handshake-alerts-to-debug.patch
@@ -1,0 +1,24 @@
+diff --git a/src/webserver/civetweb/civetweb.c b/src/webserver/civetweb/civetweb.c
+index 357d259ed..cec9a1aeb 100644
+--- a/src/webserver/civetweb/civetweb.c
++++ b/src/webserver/civetweb/civetweb.c
+@@ -17097,7 +17097,18 @@ sslize(struct mg_connection *conn,
+ 
+ 			} else {
+ 				/* This is an SSL specific error, e.g. SSL_ERROR_SSL */
+-				mg_cry_internal(conn, "sslize error: %s", ssl_error());
++#if !defined(USE_MBEDTLS) && !defined(USE_GNUTLS)
++				/* Pi-hole modification: a failed server-side handshake is
++				 * usually the peer rejecting our self-signed certificate via a
++				 * TLS alert - recoverable, so log it only in webserver debug. */
++				if ((conn->phys_ctx->context_type == CONTEXT_SERVER)
++				    && (ERR_GET_REASON(ERR_peek_error()) >= SSL_AD_REASON_OFFSET)) {
++					DEBUG_TRACE("sslize handshake alert: %s", ssl_error());
++				} else
++#endif
++				{
++					mg_cry_internal(conn, "sslize error: %s", ssl_error());
++				}
+ 				break;
+ 			}
+ 

--- a/src/webserver/civetweb/civetweb.c
+++ b/src/webserver/civetweb/civetweb.c
@@ -17097,7 +17097,18 @@ sslize(struct mg_connection *conn,
 
 			} else {
 				/* This is an SSL specific error, e.g. SSL_ERROR_SSL */
-				mg_cry_internal(conn, "sslize error: %s", ssl_error());
+#if !defined(USE_MBEDTLS) && !defined(USE_GNUTLS)
+				/* Pi-hole modification: a failed server-side handshake is
+				 * usually the peer rejecting our self-signed certificate via a
+				 * TLS alert - recoverable, so log it only in webserver debug. */
+				if ((conn->phys_ctx->context_type == CONTEXT_SERVER)
+				    && (ERR_GET_REASON(ERR_peek_error()) >= SSL_AD_REASON_OFFSET)) {
+					DEBUG_TRACE("sslize handshake alert: %s", ssl_error());
+				} else
+#endif
+				{
+					mg_cry_internal(conn, "sslize error: %s", ssl_error());
+				}
 				break;
 			}
 


### PR DESCRIPTION
What does this PR aim to accomplish?
=============================================

After the mbedTLS -> OpenSSL migration (#2941), `webserver.log` fills with lines like

```
sslize error: error:0A000416:SSL routines::tls alert certificate unknown
sslize error: error:0A000418:SSL routines::tlsv1 alert unknown ca
```

on every fresh browser connection to the web interface over HTTPS. This was reported on #2941 by @yubiuser and @rdwebdesign. The messages look alarming but are harmless: they are the TLS alert (`certificate_unknown` / `unknown_ca`, the exact code depends on the browser) a client sends when it rejects our self-signed certificate during the handshake. The user then clicks through the browser warning and the connection proceeds as normal.

mbedTLS silently swallowed these received alerts. OpenSSL instead puts them on its error queue, which CivetWeb dumps verbatim through `mg_cry_internal`, hence the new noise.

How does this PR accomplish the above?
=============================================

In `sslize`, when the failing call runs in a server context (`SSL_accept`) and the error reason is a received TLS alert (`reason >= SSL_AD_REASON_OFFSET`), the message is logged via `DEBUG_TRACE` instead of `mg_cry_internal`, i.e., it only shows when `debug.webserver` is enabled. A rejected-but-recoverable handshake is not really an error on our side to begin with.

Genuine SSL errors (non-alert reasons) and the client-side path (`SSL_connect`) keep logging as before, so no real failure is hidden.

The in-tree `civetweb.c` edit is mirrored in `patch/civetweb/0001-Demote-server-side-TLS-handshake-alerts-to-debug.patch` and wired into `patch/civetweb.sh` so it survives the next CivetWeb update. The change is guarded to the OpenSSL backend.

What documentation changes (if any) are needed to support this PR?
=============================================

None.