### PR TITLE
netlink: prevent OOB read if LLADDR has size zero

### DIFF
--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -1147,13 +1147,26 @@ static int nlparsemsg_arp(struct ndmsg *ndm, struct rtattr *rta, int rta_len, cJ
 				inet_ntop(AF_INET6, RTA_DATA(rta), ip, sizeof(ip));
 		}
 		else if(rta->rta_type == NDA_LLADDR) {
-			const unsigned char *addr = RTA_DATA(rta);
-			log_debug(DEBUG_NETLINK, "NDA_LLADDR raw bytes: %02x:%02x:%02x:%02x:%02x:%02x "
-			          "(rtattr at %p, rta_len %u, payload %zu)",
-			          addr[0], addr[1], addr[2], addr[3], addr[4], addr[5],
-			          (void*)rta, rta->rta_len, RTA_PAYLOAD(rta));
-			snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
-				addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
+			// LLADDR must be exactly 6 bytes (EUI-48 MAC).
+			// There are interfaces with a different MAC length,
+			// but they are rejected for use in the network table.
+			// The kernel sends NDA_LLADDR with a 0-byte payload
+			// for some virtual interfaces (e.g. WireGuard peers).
+			// Reading from RTA_DATA() without checking the payload
+			// size reads garbage bytes from the rtattr padding.
+			if(RTA_PAYLOAD(rta) == 6) {
+				const unsigned char *addr = RTA_DATA(rta);
+				log_debug(DEBUG_NETLINK, "NDA_LLADDR raw bytes: %02x:%02x:%02x:%02x:%02x:%02x "
+				          "(rtattr at %p, rta_len %u, payload %zu)",
+				          addr[0], addr[1], addr[2], addr[3], addr[4], addr[5],
+				          (void*)rta, rta->rta_len, RTA_PAYLOAD(rta));
+				snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
+					addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
+			}
+			else {
+				log_debug(DEBUG_NETLINK, "NDA_LLADDR with unexpected payload %zu on ifindex %d, skipping",
+				          RTA_PAYLOAD(rta), ndm->ndm_ifindex);
+			}
 		}
 	}
 	if_indextoname(ndm->ndm_ifindex, ifname);

--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -596,13 +596,25 @@ static int nlparsemsg_link(struct ifinfomsg *ifi, void *buf, size_t len, cJSON *
 			case IFLA_BROADCAST:
 			case IFLA_PERM_ADDRESS:
 			{
-				char mac[18];
-				const unsigned char *addr = RTA_DATA(rta);
-				snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
-				         addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
+				// MAC addresses must be exactly 6 bytes (EUI-48).
+				// Some virtual interfaces may send a zero-length payload.
+				// Reading from RTA_DATA() without checking the payload
+				// size reads garbage bytes from the rtattr padding.
+				if(RTA_PAYLOAD(rta) == 6)
+				{
+					char mac[18];
+					const unsigned char *addr = RTA_DATA(rta);
+					snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
+					         addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 
-				// Addresses may be empty, so only add them if they are not
-				cJSON_AddStringToObject(link, iflaTypeToString(rta->rta_type), mac);
+					// Addresses may be empty, so only add them if they are not
+					cJSON_AddStringToObject(link, iflaTypeToString(rta->rta_type), mac);
+				}
+				else
+				{
+					log_debug(DEBUG_NETLINK, "%s with unexpected payload %zu on ifindex %d, skipping",
+					          iflaTypeToString(rta->rta_type), RTA_PAYLOAD(rta), ifi->ifi_index);
+				}
 				break;
 			}
 

--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -1148,6 +1148,10 @@ static int nlparsemsg_arp(struct ndmsg *ndm, struct rtattr *rta, int rta_len, cJ
 		}
 		else if(rta->rta_type == NDA_LLADDR) {
 			const unsigned char *addr = RTA_DATA(rta);
+			log_debug(DEBUG_NETLINK, "NDA_LLADDR raw bytes: %02x:%02x:%02x:%02x:%02x:%02x "
+			          "(rtattr at %p, rta_len %u, payload %zu)",
+			          addr[0], addr[1], addr[2], addr[3], addr[4], addr[5],
+			          (void*)rta, rta->rta_len, RTA_PAYLOAD(rta));
 			snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
 				addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 		}

--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -1156,10 +1156,6 @@ static int nlparsemsg_arp(struct ndmsg *ndm, struct rtattr *rta, int rta_len, cJ
 			// size reads garbage bytes from the rtattr padding.
 			if(RTA_PAYLOAD(rta) == 6) {
 				const unsigned char *addr = RTA_DATA(rta);
-				log_debug(DEBUG_NETLINK, "NDA_LLADDR raw bytes: %02x:%02x:%02x:%02x:%02x:%02x "
-				          "(rtattr at %p, rta_len %u, payload %zu)",
-				          addr[0], addr[1], addr[2], addr[3], addr[4], addr[5],
-				          (void*)rta, rta->rta_len, RTA_PAYLOAD(rta));
 				snprintf(mac, sizeof(mac), "%02x:%02x:%02x:%02x:%02x:%02x",
 					addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 			}


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

My network table showed a single device entry with: interface `wg41`, MAC `08:00:04:00:00:00` and may IPs belonging to CDNs (Akami, Meta, Google) (my WireGuard interface is IPv6-only).
This is suspicious because: those IPs are not real source IPs of clients, wireguard has no MAC and the MAC has most bits set to zero.
For debugging I disabled EDNS Client Subnet and flushed it. The same MAC reappeared.
Those IPs did however exist in the wireguard interface’s neighbor table.


I enabled `DEBUG_ARP` and `DEBUG_NETLINK`:
```log

Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: NDA_LLADDR raw bytes: 08:00:04:00:00:00 (rtattr at 0x7fff7c1832b0, rta_len 4, payload 0)
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: ARP entry: redacted::159 -> 08:00:04:00:00:00 on wg41
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: NDA_LLADDR raw bytes: 08:00:04:00:00:00 (rtattr at 0x7fff7c1833a4, rta_len 4, payload 0)
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: ARP entry: redacted::2:9 -> 08:00:04:00:00:00 on wg41
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: NDA_LLADDR raw bytes: 08:00:04:00:00:00 (rtattr at 0x7fff7c1834fc, rta_len 4, payload 0)
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: ARP entry: redacted::2a1 -> 08:00:04:00:00:00 on wg41
[...]
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: Network table: Parsing ARP cache line: {
                                                      "ip":        "redacted::159",
                                                      "mac":        "08:00:04:00:00:00",
                                                      "iface":        "wg41",
                                                      "state":        64,
                                                      "type":        1,
                                                      "flags":        0
                                              }
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: find_device_by_hwaddr(08:00:04:00:00:00)
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: Network table: Parsing ARP cache line: {
                                                      "ip":        "redacted::2:9",
                                                      "mac":        "08:00:04:00:00:00",
                                                      "iface":        "wg41",
                                                      "state":        64,
                                                      "type":        1,
                                                      "flags":        0
                                              }
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: find_device_by_hwaddr(08:00:04:00:00:00)
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: Network table: Parsing ARP cache line: {
                                                      "ip":        "redacted::2a1",
                                                      "mac":        "08:00:04:00:00:00",
                                                      "iface":        "wg41",
                                                      "state":        64,
                                                      "type":        1,
                                                      "flags":        0
                                              }
Jul 27 22:43:00 blueberrypi pihole-FTL[5685]: find_device_by_hwaddr(08:00:04:00:00:00)
```

`rta_len 4, payload 0` is the important part. We assumed that just because `NDA_LLADDR` is present that there is a MAC to read, without checking the attribute’s length. The kernel may send `LLADDR ` attributes of any size, like zero for wireguard, six bytes for Ethernet or more for Infiniband or firewire. This caused it to read six adjacent bytes. I limited the read to exactly six bytes, since the network table only supports Ethernet-type devices and rejects non-six lengths later anyway. If you prefer I can adjust it to allow reading firewire/Infiniband/arbitrary lengths, based on what the kernel reports.


**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
