### PR TITLE
synthesize a HTTPS record for pi.hole

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -576,8 +576,6 @@ if(LIBSSL AND LIBCRYPTO AND USE_TLS)
         target_compile_definitions(webserver PRIVATE HAVE_HTTP2)
         # The dotdoh client auto-negotiates HTTP/2 (DoH2) on https:// upstreams.
         target_compile_definitions(dotdoh PRIVATE HAVE_HTTP2)
-        # h2 is dynamically enabled in the HTTPS RR
-        target_compile_definitions(core PRIVATE HAVE_HTTP2)
         target_link_libraries(pihole-FTL ${LIBNGHTTP2})
     else()
         message(STATUS "Building FTL with HTTP/2 support: NO (nghttp2 not found)")
@@ -602,8 +600,6 @@ int main(void) { return 0; }
         target_compile_definitions(webserver PRIVATE HAVE_HTTP3)
         # The dotdoh client speaks DoH3 (HTTP/3 over QUIC) on h3:// upstreams.
         target_compile_definitions(dotdoh PRIVATE HAVE_HTTP3)
-        # h3 is dynamically enabled in the HTTPS RR
-        target_compile_definitions(core PRIVATE HAVE_HTTP3)
         target_link_libraries(pihole-FTL ${LIBNGHTTP3})
     elseif(LIBNGHTTP3)
         message(STATUS "Building FTL with HTTP/3 support: NO (OpenSSL < 4.0 lacks the QUIC peer-address API)")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -576,6 +576,8 @@ if(LIBSSL AND LIBCRYPTO AND USE_TLS)
         target_compile_definitions(webserver PRIVATE HAVE_HTTP2)
         # The dotdoh client auto-negotiates HTTP/2 (DoH2) on https:// upstreams.
         target_compile_definitions(dotdoh PRIVATE HAVE_HTTP2)
+        # h2 is dynamically enabled in the HTTPS RR
+        target_compile_definitions(core PRIVATE HAVE_HTTP2)
         target_link_libraries(pihole-FTL ${LIBNGHTTP2})
     else()
         message(STATUS "Building FTL with HTTP/2 support: NO (nghttp2 not found)")
@@ -600,6 +602,8 @@ int main(void) { return 0; }
         target_compile_definitions(webserver PRIVATE HAVE_HTTP3)
         # The dotdoh client speaks DoH3 (HTTP/3 over QUIC) on h3:// upstreams.
         target_compile_definitions(dotdoh PRIVATE HAVE_HTTP3)
+        # h3 is dynamically enabled in the HTTPS RR
+        target_compile_definitions(core PRIVATE HAVE_HTTP3)
         target_link_libraries(pihole-FTL ${LIBNGHTTP3})
     elseif(LIBNGHTTP3)
         message(STATUS "Building FTL with HTTP/3 support: NO (OpenSSL < 4.0 lacks the QUIC peer-address API)")

--- a/src/dnsmasq/dns-protocol.h
+++ b/src/dnsmasq/dns-protocol.h
@@ -97,14 +97,15 @@
 #define T_NSEC          47
 #define T_DNSKEY        48
 #define T_NSEC3         50
+/*************** Pi-hole modification ****************/
+#define T_HTTPS         65
+/*****************************************************/
 #define	T_TKEY		249		
 #define	T_TSIG		250
 #define T_AXFR          252
 #define T_MAILB		253	
 #define T_ANY		255
 #define T_CAA           257
-
-#define T_HTTPS         65
 
 #define EDNS0_OPTION_MAC            65001 /* dyndns.org temporary assignment */
 #define EDNS0_OPTION_CLIENT_SUBNET  8     /* IANA */

--- a/src/dnsmasq/dns-protocol.h
+++ b/src/dnsmasq/dns-protocol.h
@@ -104,6 +104,8 @@
 #define T_ANY		255
 #define T_CAA           257
 
+#define T_HTTPS         65
+
 #define EDNS0_OPTION_MAC            65001 /* dyndns.org temporary assignment */
 #define EDNS0_OPTION_CLIENT_SUBNET  8     /* IANA */
 #define EDNS0_OPTION_EDE            15    /* IANA - RFC 8914 */

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -699,7 +699,9 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			unsigned char svcparams[64];
 			unsigned char *sp = svcparams;
 
-			// "alpn" SvcParamKey (key=1, RFC 9460 §7.1): include "h2"/"h3" based on compile-time support
+			// "alpn" SvcParamKey (key=1, RFC 9460 §7.1): include "h2"/"h3" based on compile-time support.
+			// RFC 9460 §9 defines the default ALPN set as ["http/1.1"], so we do not emit
+			// "no-default-alpn" (key=2): http/1.1 is always available via the CivetWeb server.
 			unsigned char alpn[6];
 			unsigned char *ap = alpn;
 #ifdef HAVE_HTTP2
@@ -722,7 +724,10 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			PUTSHORT(2, sp); // value length: 2 octets, network byte order (RFC 9460 §7.2)
 			PUTSHORT(https_port, sp);
 
-			// "ipv4hint" SvcParamKey (key=4, RFC 9460 §7.3) — if available
+			// "ipv4hint" SvcParamKey (key=4, RFC 9460 §7.3) — if available.
+			// Note: RFC 9460 §7.3 says server operators SHOULD NOT include these
+			// hints when TargetName is "." (owner name), but we include them here
+			// as they may save clients an additional A/AAAA lookup.
 			const bool have_v4 = next_iface.haveIPv4 || config.dns.reply.host.force4.v.b;
 			if(have_v4)
 			{
@@ -755,21 +760,21 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			const size_t svcparam_len = sp - svcparams;
 
 			// Debug logging
-			if(config.debug.queries.v.b)
-				log_debug(DEBUG_QUERIES, "  Adding RR: \"%s HTTPS 1 . port=%d\"",
-				          name, https_port);
+			log_debug(DEBUG_QUERIES, "  Adding RR: \"%s HTTPS 1 . port=%d\"",
+				      name, https_port);
 
 			// Add HTTPS RR (ServiceMode, RFC 9460 §2.4.3): SvcPriority=1, TargetName="." (self, RFC 9460 §2.5.2)
-			header->ancount = htons(ntohs(header->ancount) + 1);
 			if(add_resource_record(header, limit, &trunc, sizeof(struct dns_header),
 			                       &p, daemon->local_ttl, NULL,
 			                       T_HTTPS, C_IN, (char*)"sbt",
 			                       1,                            // SvcPriority = 1 (ServiceMode)
 			                       0,                            // TargetName "." (zero-length label, RFC 9460 §2.5.2)
 			                       (int)svcparam_len, svcparams))
+			{
+				header->ancount = htons(ntohs(header->ancount) + 1);
 				log_query(flags, name, NULL, (char*)blockingreason, 0);
-
-			https_rr_added = true;
+				https_rr_added = true;
+			}
 		}
 	}
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -688,18 +688,18 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			log_query(flags & ~F_IPV4, name, &addr, (char*)blockingreason, 0);
 	}
 
-	// Add HTTPS RR for pi.hole / <hostname> if HTTPS is active
+	// Add HTTPS RR (RFC 9460 §9) for pi.hole / <hostname> if HTTPS is active
 	bool https_rr_added = false;
 	if(hostn && qtype == T_HTTPS)
 	{
 		const in_port_t https_port = get_https_port();
 		if(https_port > 0)
 		{
-			// Build SvcParams
+			// Build SvcParams (RFC 9460 §2.2)
 			unsigned char svcparams[64];
 			unsigned char *sp = svcparams;
 
-			// ALPN (key=1): include "h2"/"h3" based on compile-time support
+			// "alpn" SvcParamKey (key=1, RFC 9460 §7.1): include "h2"/"h3" based on compile-time support
 			unsigned char alpn[6];
 			unsigned char *ap = alpn;
 #ifdef HAVE_HTTP2
@@ -711,18 +711,18 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			const size_t alpn_len = ap - alpn;
 			if(alpn_len > 0)
 			{
-				PUTSHORT(1, sp); // alpn key
+				PUTSHORT(1, sp); // SvcParamKey 1 = "alpn"
 				PUTSHORT(alpn_len, sp);
 				memcpy(sp, alpn, alpn_len);
 				sp += alpn_len;
 			}
 
-			// port (key=3)
-			PUTSHORT(3, sp); // port key
-			PUTSHORT(2, sp); // length: 2 bytes (in_port_t)
+			// "port" SvcParamKey (key=3, RFC 9460 §7.2)
+			PUTSHORT(3, sp); // SvcParamKey 3 = "port"
+			PUTSHORT(2, sp); // value length: 2 octets, network byte order (RFC 9460 §7.2)
 			PUTSHORT(https_port, sp);
 
-			// ipv4hint (key=4) — if available
+			// "ipv4hint" SvcParamKey (key=4, RFC 9460 §7.3) — if available
 			const bool have_v4 = next_iface.haveIPv4 || config.dns.reply.host.force4.v.b;
 			if(have_v4)
 			{
@@ -731,13 +731,13 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 					memcpy(&v4addr, &config.dns.reply.host.v4.v.in_addr, sizeof(v4addr));
 				else
 					memcpy(&v4addr, &next_iface.addr4.addr4, sizeof(v4addr));
-				PUTSHORT(4, sp); // ipv4hint key
+				PUTSHORT(4, sp); // SvcParamKey 4 = "ipv4hint"
 				PUTSHORT(4, sp); // length: 4 bytes
 				memcpy(sp, &v4addr, 4);
 				sp += 4;
 			}
 
-			// ipv6hint (key=6) — if available
+			// "ipv6hint" SvcParamKey (key=6, RFC 9460 §7.3) — if available
 			const bool have_v6 = next_iface.haveIPv6 || config.dns.reply.host.force6.v.b;
 			if(have_v6)
 			{
@@ -746,7 +746,7 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 					memcpy(&v6addr, &config.dns.reply.host.v6.v.in6_addr, sizeof(v6addr));
 				else
 					memcpy(&v6addr, &next_iface.addr6.addr6, sizeof(v6addr));
-				PUTSHORT(6, sp); // ipv6hint key
+				PUTSHORT(6, sp); // SvcParamKey 6 = "ipv6hint"
 				PUTSHORT(16, sp); // length: 16 bytes
 				memcpy(sp, &v6addr, 16);
 				sp += 16;
@@ -759,13 +759,13 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 				log_debug(DEBUG_QUERIES, "  Adding RR: \"%s HTTPS 1 . port=%d\"",
 				          name, https_port);
 
-			// Add HTTPS resource record: priority=1 (ServiceMode), target="." (self)
+			// Add HTTPS RR (ServiceMode, RFC 9460 §2.4.3): SvcPriority=1, TargetName="." (self, RFC 9460 §2.5.2)
 			header->ancount = htons(ntohs(header->ancount) + 1);
 			if(add_resource_record(header, limit, &trunc, sizeof(struct dns_header),
 			                       &p, daemon->local_ttl, NULL,
 			                       T_HTTPS, C_IN, (char*)"sbt",
-			                       1,                            // priority
-			                       0,                            // target "." (root label)
+			                       1,                            // SvcPriority = 1 (ServiceMode)
+			                       0,                            // TargetName "." (zero-length label, RFC 9460 §2.5.2)
 			                       (int)svcparam_len, svcparams))
 				log_query(flags, name, NULL, (char*)blockingreason, 0);
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -45,7 +45,7 @@
 #include <stddef.h>
 // logg_rate_limit_message()
 #include "database/message-table.h"
-// http_init(), webserver_thread()
+// http_init(), webserver_thread(), get_https_port(), webserver_have_http2(), webserver_have_http3()
 #include "webserver/webserver.h"
 // init_memory_database()
 #include "database/query-table.h"
@@ -704,12 +704,14 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			// "no-default-alpn" (key=2): http/1.1 is always available via the CivetWeb server.
 			unsigned char alpn[6];
 			unsigned char *ap = alpn;
-#ifdef HAVE_HTTP2
-			*ap++ = 2; *ap++ = 'h'; *ap++ = '2';
-#endif
-#ifdef HAVE_HTTP3
-			*ap++ = 2; *ap++ = 'h'; *ap++ = '3';
-#endif
+			if(webserver_have_http2())
+			{
+				*ap++ = 2; *ap++ = 'h'; *ap++ = '2';
+			}
+			if(webserver_have_http3())
+			{
+				*ap++ = 2; *ap++ = 'h'; *ap++ = '3';
+			}
 			const size_t alpn_len = ap - alpn;
 			if(alpn_len > 0)
 			{
@@ -763,12 +765,10 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			if(config.debug.queries.v.b)
 			{
 				char alpn_buf[32] = "";
-#ifdef HAVE_HTTP2
-				strcat(alpn_buf, "h2,");
-#endif
-#ifdef HAVE_HTTP3
-				strcat(alpn_buf, "h3,");
-#endif
+				if(webserver_have_http2())
+					strcat(alpn_buf, "h2,");
+				if(webserver_have_http3())
+					strcat(alpn_buf, "h3,");
 				const size_t alpn_s = strlen(alpn_buf);
 				if(alpn_s > 0)
 					alpn_buf[alpn_s - 1] = '\0';

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -729,9 +729,9 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			// hints when TargetName is "." (owner name), but we include them here
 			// as they may save clients an additional A/AAAA lookup.
 			const bool have_v4 = next_iface.haveIPv4 || config.dns.reply.host.force4.v.b;
+			struct in_addr v4addr = {};
 			if(have_v4)
 			{
-				struct in_addr v4addr = {};
 				if(config.dns.reply.host.force4.v.b)
 					memcpy(&v4addr, &config.dns.reply.host.v4.v.in_addr, sizeof(v4addr));
 				else
@@ -744,9 +744,9 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 
 			// "ipv6hint" SvcParamKey (key=6, RFC 9460 §7.3) — if available
 			const bool have_v6 = next_iface.haveIPv6 || config.dns.reply.host.force6.v.b;
+			struct in6_addr v6addr = {};
 			if(have_v6)
 			{
-				struct in6_addr v6addr = {};
 				if(config.dns.reply.host.force6.v.b)
 					memcpy(&v6addr, &config.dns.reply.host.v6.v.in6_addr, sizeof(v6addr));
 				else
@@ -759,9 +759,39 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 
 			const size_t svcparam_len = sp - svcparams;
 
-			// Debug logging
-			log_debug(DEBUG_QUERIES, "  Adding RR: \"%s HTTPS 1 . port=%d\"",
-				      name, https_port);
+			// Debug logging — show all SvcParams in presentation format
+			if(config.debug.queries.v.b)
+			{
+				char alpn_buf[32] = "";
+#ifdef HAVE_HTTP2
+				strcat(alpn_buf, "h2,");
+#endif
+#ifdef HAVE_HTTP3
+				strcat(alpn_buf, "h3,");
+#endif
+				const size_t alpn_s = strlen(alpn_buf);
+				if(alpn_s > 0)
+					alpn_buf[alpn_s - 1] = '\0';
+
+				char v4_buf[INET6_ADDRSTRLEN + 16] = "";
+				if(have_v4)
+				{
+					char ip[INET6_ADDRSTRLEN];
+					inet_ntop(AF_INET, &v4addr, ip, sizeof(ip));
+					snprintf(v4_buf, sizeof(v4_buf), " ipv4hint=%s", ip);
+				}
+
+				char v6_buf[INET6_ADDRSTRLEN + 16] = "";
+				if(have_v6)
+				{
+					char ip[INET6_ADDRSTRLEN];
+					inet_ntop(AF_INET6, &v6addr, ip, sizeof(ip));
+					snprintf(v6_buf, sizeof(v6_buf), " ipv6hint=%s", ip);
+				}
+
+				log_debug(DEBUG_QUERIES, "  Adding RR: \"%s HTTPS 1 . alpn=%s port=%d%s%s\"",
+				          name, alpn_s > 0 ? alpn_buf : "-", https_port, v4_buf, v6_buf);
+			}
 
 			// Add HTTPS RR (ServiceMode, RFC 9460 §2.4.3): SvcPriority=1, TargetName="." (self, RFC 9460 §2.5.2)
 			if(add_resource_record(header, limit, &trunc, sizeof(struct dns_header),

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -802,6 +802,10 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			                       (int)svcparam_len, svcparams))
 			{
 				header->ancount = htons(ntohs(header->ancount) + 1);
+				// Set the Authoritative Answer flag to be consistent with the
+				// A/AAAA replies for pi.hole / <hostname> (setup_reply() above
+				// cleared it, see rfc1035.c)
+				header->hb3 |= HB3_AA;
 				log_query(flags, name, NULL, (char*)blockingreason, 0);
 				https_rr_added = true;
 			}

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -688,8 +688,93 @@ size_t _FTL_make_answer(struct dns_header *header, char *limit, const size_t len
 			log_query(flags & ~F_IPV4, name, &addr, (char*)blockingreason, 0);
 	}
 
-	// Log empty replies
-	if(!(flags & (F_IPV4 | F_IPV6)))
+	// Add HTTPS RR for pi.hole / <hostname> if HTTPS is active
+	bool https_rr_added = false;
+	if(hostn && qtype == T_HTTPS)
+	{
+		const in_port_t https_port = get_https_port();
+		if(https_port > 0)
+		{
+			// Build SvcParams
+			unsigned char svcparams[64];
+			unsigned char *sp = svcparams;
+
+			// ALPN (key=1): include "h2"/"h3" based on compile-time support
+			unsigned char alpn[6];
+			unsigned char *ap = alpn;
+#ifdef HAVE_HTTP2
+			*ap++ = 2; *ap++ = 'h'; *ap++ = '2';
+#endif
+#ifdef HAVE_HTTP3
+			*ap++ = 2; *ap++ = 'h'; *ap++ = '3';
+#endif
+			const size_t alpn_len = ap - alpn;
+			if(alpn_len > 0)
+			{
+				PUTSHORT(1, sp); // alpn key
+				PUTSHORT(alpn_len, sp);
+				memcpy(sp, alpn, alpn_len);
+				sp += alpn_len;
+			}
+
+			// port (key=3)
+			PUTSHORT(3, sp); // port key
+			PUTSHORT(2, sp); // length: 2 bytes (in_port_t)
+			PUTSHORT(https_port, sp);
+
+			// ipv4hint (key=4) — if available
+			const bool have_v4 = next_iface.haveIPv4 || config.dns.reply.host.force4.v.b;
+			if(have_v4)
+			{
+				struct in_addr v4addr = {};
+				if(config.dns.reply.host.force4.v.b)
+					memcpy(&v4addr, &config.dns.reply.host.v4.v.in_addr, sizeof(v4addr));
+				else
+					memcpy(&v4addr, &next_iface.addr4.addr4, sizeof(v4addr));
+				PUTSHORT(4, sp); // ipv4hint key
+				PUTSHORT(4, sp); // length: 4 bytes
+				memcpy(sp, &v4addr, 4);
+				sp += 4;
+			}
+
+			// ipv6hint (key=6) — if available
+			const bool have_v6 = next_iface.haveIPv6 || config.dns.reply.host.force6.v.b;
+			if(have_v6)
+			{
+				struct in6_addr v6addr = {};
+				if(config.dns.reply.host.force6.v.b)
+					memcpy(&v6addr, &config.dns.reply.host.v6.v.in6_addr, sizeof(v6addr));
+				else
+					memcpy(&v6addr, &next_iface.addr6.addr6, sizeof(v6addr));
+				PUTSHORT(6, sp); // ipv6hint key
+				PUTSHORT(16, sp); // length: 16 bytes
+				memcpy(sp, &v6addr, 16);
+				sp += 16;
+			}
+
+			const size_t svcparam_len = sp - svcparams;
+
+			// Debug logging
+			if(config.debug.queries.v.b)
+				log_debug(DEBUG_QUERIES, "  Adding RR: \"%s HTTPS 1 . port=%d\"",
+				          name, https_port);
+
+			// Add HTTPS resource record: priority=1 (ServiceMode), target="." (self)
+			header->ancount = htons(ntohs(header->ancount) + 1);
+			if(add_resource_record(header, limit, &trunc, sizeof(struct dns_header),
+			                       &p, daemon->local_ttl, NULL,
+			                       T_HTTPS, C_IN, (char*)"sbt",
+			                       1,                            // priority
+			                       0,                            // target "." (root label)
+			                       (int)svcparam_len, svcparams))
+				log_query(flags, name, NULL, (char*)blockingreason, 0);
+
+			https_rr_added = true;
+		}
+	}
+
+	// Log empty replies (skip if we added an HTTPS RR above)
+	if(!(flags & (F_IPV4 | F_IPV6)) && !https_rr_added)
 	{
 		if(flags == 0)
 		{
@@ -826,6 +911,15 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 			            "interface-local IP address" :
 			            "NODATA due to missing iface address");
 
+			cacheStatus = QUERY_CACHE;
+			return true;
+		}
+		else if(querytype == TYPE_HTTPS)
+		{
+			// Reply with NODATA by default; _FTL_make_answer() will
+			// craft an HTTPS RR if HTTPS is actually active
+			force_next_DNS_reply = REPLY_NODATA;
+			blockingreason = HOSTNAME;
 			cacheStatus = QUERY_CACHE;
 			return true;
 		}
@@ -1675,7 +1769,7 @@ static bool special_domain(const queriesData *query, const char *domain)
 	// _dns.resolver.arpa.     86400   IN      SVCB    2 dns.google. alpn="h2,h3" key7="/dns-query{?dns}"
 	//
 	// RFC 9462, Section 4 says:
-	// 
+	//
 	// If the recursive resolver that receives this query has no Designated
 	// Resolvers, it SHOULD return NODATA for queries to the "resolver.arpa"
 	// zone, to provide a consistent and accurate signal to clients that it
@@ -1925,7 +2019,7 @@ static bool FTL_check_blocking(const char *domainstr, queriesData *query, client
 	}
 
 	// when we reach this point: the query is not in FTL's cache (for this client)
-	
+
 	// Check exact whitelist for match
 	const char *blockedDomain = domainstr;
 	PERF_START(_pcb_allow);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1337,10 +1337,7 @@ setup() {
 
 @test "Pi-hole returns HTTPS RR for pi.hole" {
   run bash -c "dig HTTPS pi.hole @127.0.0.1 +short"
-  assert_line --partial "alpn=\"h2,h3\""
-  assert_line --partial "port=443"
-  assert_line --partial "ipv4hint="
-  assert_line --partial "ipv6hint="
+  assert_line --index 0 "1 . alpn=\"h2,h3\" port=443 ipv4hint=127.0.0.1 ipv6hint=::1"
 
   run bash -c "dig HTTPS pi.hole @127.0.0.1 +noall +comments | grep -o \" aa\""
   assert_line --index 0 " aa"
@@ -1354,6 +1351,10 @@ setup() {
   run bash -c "dig AAAA pihole.mydomain.net +short @127.0.0.1"
   assert_line --index 0 "pi.hole."
   assert_line --index 1 "::1"
+
+  run bash -c "dig HTTPS pihole.mydomain.net @127.0.0.1 +short"
+  assert_line --index 0 "pi.hole."
+  assert_line --index 1 "1 . alpn=\"h2,h3\" port=443 ipv4hint=127.0.0.1 ipv6hint=::1"
 }
 
 @test "Pi-hole uses dns.reply.host.IPv4/6 for pi.hole" {

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -50,7 +50,7 @@ setup() {
   run bash -c "dig denied.ftl @127.0.0.1 +short"
   assert_line --index 0 "0.0.0.0"
   assert_line --index 1 ""
-  
+
   run bash -c "dig denied.ftl @127.0.0.1 | grep 'EDE: '"
   assert_line --partial --index 0 "EDE: 15 (Blocked): (denylist)"
   assert_line --index 1 ""
@@ -70,7 +70,7 @@ setup() {
   run bash -c "dig gravity.ftl @127.0.0.1 +tcp +short"
   assert_line --index 0 "0.0.0.0"
   assert_line --index 1 ""
-  
+
   run bash -c "dig gravity.ftl @127.0.0.1 +tcp | grep 'EDE: '"
   assert_line --partial --index 0 "EDE: 15 (Blocked): (gravity)"
   assert_line --index 1 ""
@@ -95,7 +95,7 @@ setup() {
   run bash -c "dig regex5.ftl @127.0.0.1 +short"
   assert_line --index 0 "0.0.0.0"
   assert_line --index 1 ""
-  
+
   run bash -c "dig regex5.ftl @127.0.0.1 | grep 'EDE: '"
   assert_line --partial --index 0 "EDE: 15 (Blocked): (regex)"
   assert_line --index 1 ""
@@ -1324,7 +1324,7 @@ setup() {
 @test "Check dnsmasq warnings in source code" {
   run bash -c "bash test/dnsmasq_warnings.sh"
   refute_output
-  
+
 }
 
 @test "Pi-hole use interface-dependent replies for pi.hole" {
@@ -1333,6 +1333,14 @@ setup() {
 
   run bash -c "dig AAAA pi.hole +short @127.0.0.1"
   assert_line --index 0 "::1"
+}
+
+@test "Pi-hole returns HTTPS RR for pi.hole" {
+  run bash -c "dig HTTPS pi.hole @127.0.0.1 +short"
+  assert_line --partial "alpn=\"h2,h3\""
+  assert_line --partial "port=443"
+  assert_line --partial "ipv4hint="
+  assert_line --partial "ipv6hint="
 }
 
 @test "Pi-hole uses interface-dependent replies inside CNAME chains" {
@@ -1398,7 +1406,7 @@ setup() {
   logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
 
   run bash -c './pihole-FTL --config dns.blocking.mode IP'
- 
+
   # Wait for change to become effective
   run bash -c "./pihole-FTL wait-for 'DEBUG_CONFIG: pihole.toml unchanged' /var/log/pihole/FTL.log 5 $logsize_before"
   assert_success
@@ -1645,7 +1653,7 @@ setup() {
   assert_line --index 0 '[ 192.168.1.1 host1.local, 10.0.0.1 host2.local host3.local, 127.0.0.1 host4.local host5.local ]'
 }
 
-@test "DNS hosts sanitization: Comments are handled correctly" { 
+@test "DNS hosts sanitization: Comments are handled correctly" {
   # Set dns.hosts with entries containing comments
   logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
   run bash -c './pihole-FTL --config dns.hosts "[\"192.168.1.1   host1.local   # this is a comment with  double spaces\", \"   10.0.0.1\\thost2.local\\t\\t\\t\"]"'

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1341,6 +1341,9 @@ setup() {
   assert_line --partial "port=443"
   assert_line --partial "ipv4hint="
   assert_line --partial "ipv6hint="
+
+  run bash -c "dig HTTPS pi.hole @127.0.0.1 +noall +comments | grep -o \" aa\""
+  assert_line --index 0 " aa"
 }
 
 @test "Pi-hole uses interface-dependent replies inside CNAME chains" {


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

FTL now includes native HTTP/2 and HTTP/3 support, it makes sense to advertise those capabilities via DNS, more specifically the HTTPS RR. Modern browsers are already querying for it in addition to A/AAAA. This allows them to connect directly using QUIC instead of upgrading later. 


**How does this PR accomplish the above?:**

This PR adds an automatically synthesized RFC 9460 HTTPS RR for `pi.hole.` if any native TLS listener is active. 
example:
```
1 . alpn="h2,h3" port=8086 ipv4hint=127.0.0.1 ipv6hint=::1
```

`alpn` is decided based on compile-time support.
The IP hints are localized and match the A/AAAA data.


Limitation I am working on:

This currently doesn't work with CNAMEs targeting `pi.hole`. It is not as simple as https://github.com/pi-hole/FTL/pull/2585, since dnsmasq's cache differs for host (A/AAAA) and generic Resource Records. 

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
