### PR TITLE
fix(dnsmasq): answer NODATA instead of forwarding for locally-known names

### DIFF
--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -817,21 +817,31 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
       return resize_packet(header, n, pheader, plen);
     }
   
+  /* If we forwarded a query for a locally known name (because it was for
+     an unknown type) and the answer is NXDOMAIN, convert that to NODATA,
+     since we know that the domain exists, even if upstream doesn't. Local
+     host records (/etc/hosts, DHCP leases, Pi-hole's dns.hosts/custom.list)
+     are authoritative for the *existence* of the domain regardless of what
+     upstream DNSSEC validation says about it, so this must happen before
+     the bogusanswer gate below: otherwise a signed upstream NXDOMAIN proof
+     that fails validation (because it contradicts our local knowledge)
+     bypasses this safety net entirely and the client is handed the bogus
+     NXDOMAIN instead of the correct NODATA. */
+  if (!(header->hb3 & HB3_TC) &&
+      rcode == NXDOMAIN && extract_name(header, n, NULL, daemon->namebuff, EXTR_NAME_EXTRACT, 0) &&
+      (check_for_local_domain(daemon->namebuff, now) || lookup_domain(daemon->namebuff, F_CONFIG, NULL, NULL)))
+    {
+      header->hb3 |= HB3_AA;
+      SET_RCODE(header, NOERROR);
+      cache_secure = 0;
+      bogusanswer = 0;
+      rcode = NOERROR;
+    }
+
   if (header->hb3 & HB3_TC)
     log_query(F_UPSTREAM, NULL, NULL, "truncated", 0);
   else if (!bogusanswer || (header->hb4 & HB4_CD))
     {
-      if (rcode == NXDOMAIN && extract_name(header, n, NULL, daemon->namebuff, EXTR_NAME_EXTRACT, 0) &&
-	  (check_for_local_domain(daemon->namebuff, now) || lookup_domain(daemon->namebuff, F_CONFIG, NULL, NULL)))
-	{
-	  /* if we forwarded a query for a locally known name (because it was for 
-	     an unknown type) and the answer is NXDOMAIN, convert that to NODATA,
-	     since we know that the domain exists, even if upstream doesn't */
-	  header->hb3 |= HB3_AA;
-	  SET_RCODE(header, NOERROR);
-	  cache_secure = 0;
-	}
-      
       if (daemon->doctors && do_doctor(header, n, daemon->namebuff))
 	cache_secure = 0;
       

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -2357,11 +2357,26 @@ size_t answer_request(struct dns_header *header, char *limit, size_t qlen,
 	    }
 	}
     }
-  
-  if (!ans)
-    return 0; /* failed to answer a question */
 
-  /* We found a negative record. See if we have an SOA record to 
+  if (!ans)
+    {
+      /* We have no answer for this specific query type, but the name is
+	 locally configured (F_HOSTS/F_DHCP/F_CONFIG), e.g. only an A record
+	 exists and the client asked for AAAA/HTTPS/SVCB. The domain does
+	 exist, just not for this type, so answer NODATA ourselves rather
+	 than forwarding: forwarding would let an upstream authoritative
+	 server return NXDOMAIN for a name that's actually a local override,
+	 which incorrectly makes the whole domain look non-existent. */
+      if (qclass == C_IN && cache_find_by_name(NULL, name, now, F_HOSTS | F_DHCP | F_CONFIG))
+	{
+	  ans = 1;
+	  sec_data = 0;
+	}
+      else
+	return 0; /* failed to answer a question */
+    }
+
+  /* We found a negative record. See if we have an SOA record to
      return in the AUTH section. 
      
      For FORWARD NEG records, the addr.rrdata.datalen field of the othewise


### PR DESCRIPTION
## Summary

Fixes #2841 — local host overrides (`/etc/hosts`, DHCP leases, Pi-hole's `dns.hosts` / `custom.list`) placed under a publicly-signed parent domain were intermittently shadowed by an upstream `NXDOMAIN`, so the same query returned a different answer depending on which client asked. Root cause was diagnosed by @DL6ER in the issue thread as two related gaps in dnsmasq's local-name handling; this PR implements both fixes described there.

### 1. `answer_request()` in `src/dnsmasq/rfc1035.c`

Previously, if a client queried a locally-configured name for a record type with no local answer (e.g. `AAAA`/`HTTPS`/`SVCB` when only an `A` record is configured), the function gave up (`return 0`) and let the query fall through to upstream forwarding. Since the name only exists locally, upstream then correctly-but-misleadingly returns `NXDOMAIN` for the *type*, which callers/resolvers interpret as "domain doesn't exist" rather than "domain exists, wrong type". This explains the client-dependent behavior: `systemd-resolved` and other modern Linux resolvers routinely send `AAAA`/`HTTPS` alongside `A`, so they hit this path far more than clients that don't.

Fix: before giving up, check whether the queried name has *any* local record (`F_HOSTS`/`F_DHCP`/`F_CONFIG`). If so, answer `NODATA` (`NOERROR`, no records) ourselves instead of forwarding — this correctly tells the resolver "this name exists, just not for this type."

### 2. `process_reply()` in `src/dnsmasq/forward.c`

dnsmasq already had a safety net for this: if an upstream reply for a locally-known name comes back `NXDOMAIN`, it gets converted to `NODATA`. But that conversion was gated behind `!bogusanswer`, i.e. it was skipped whenever DNSSEC validation flagged the reply as bogus. For a local override under a publicly-signed domain, the upstream's signed `NXDOMAIN` proof will often fail validation *precisely because* it contradicts the locally-known answer — so the one case this safety net exists for is the one case it was disabled for.

Fix: moved the `NXDOMAIN`→`NODATA` conversion so it runs unconditionally, before the `bogusanswer` gate, and clears `bogusanswer` once it applies (so the later DNSSEC bogus-check doesn't turn the corrected `NODATA` back into `SERVFAIL`/`NXDOMAIN`). Local host records are authoritative for a domain's *existence* regardless of upstream DNSSEC status.

## Why this fixes the reported behavior

Both gaps independently caused the same symptom (client-dependent `NXDOMAIN` for a locally-overridden name):
- Gap 1 fires per-query-type, explaining why it depended on which record types a given client's stack queries for.
- Gap 2 fires once DNSSEC validation is involved, explaining why disabling DNSSEC "fixed" some but not all cases in the original report.

With both fixed, a local host override is always authoritative for its name's existence: unsupported record types get `NODATA` directly from FTL, and any upstream `NXDOMAIN` that does get forwarded (e.g. via the type-gap before this fix, in transitional states, or via other code paths) is corrected to `NODATA` regardless of DNSSEC bogus status.

## Test plan

- [x] Clean CMake build (`-DCMAKE_BUILD_TYPE=Debug`) compiles `src/dnsmasq/forward.c` and `src/dnsmasq/rfc1035.c` with no new warnings, and links `pihole-FTL` successfully.
- [ ] Manual reproduction per the issue's steps (local `A`-only override under a public domain, query for `AAAA`/`HTTPS` from a Linux client, confirm `NODATA` instead of `NXDOMAIN`).
- [ ] Manual reproduction with DNSSEC enabled, confirm `NODATA` survives instead of being overwritten by the bogus-answer check.

Fixes #2841.