### PR TITLE
fix(dnsmasq): restore INSECURE result for empty DS replies without NSEC records

### DIFF
--- a/src/dnsmasq/dnssec.c
+++ b/src/dnsmasq/dnssec.c
@@ -2304,7 +2304,20 @@ int dnssec_validate_reply(time_t now, struct dns_header *header, size_t plen, ch
 	  {
 	    if (rc_nsec & DNSSEC_FAIL_WORK)
 	      return STAT_ABANDONED;
-	    
+
+	    /* Empty DS reply with no NSEC/NSEC3 proof. This is what many
+	       public resolvers return for the reverse zones of RFC-1918
+	       private address space, which they serve as empty zones (RFC 6303),
+	       ie a bare NXDOMAIN/NODATA with no records to prove non-existence.
+	       Treat the answer to the DS query itself (j == 0) as insecure so
+	       the caller's bogus-priv/domain-specific-server heuristics can act
+	       on it. Without this, zone_status() below returns STAT_NEED_DS for
+	       the very name we're validating the DS for, and the resulting
+	       self-dependent DS query is detected as a loop and abandoned.
+	       CNAME targets (j > 0) are handled via prim_ok above. */
+	    if (qtype == T_DS && j == 0)
+	      return STAT_INSECURE;
+
 	    if ((rc_nsec & (DNSSEC_FAIL_NONSEC | DNSSEC_FAIL_NSEC3_ITERS)) &&
 		!STAT_ISEQUAL((rc = zone_status(name, qclass, keyname, now)), STAT_SECURE))
 	      {


### PR DESCRIPTION
## Summary

Fixes #2942 — a regression in FTL v6.7's embedded dnsmasq (v2.93) that broke DNSSEC-validated PTR lookups for RFC-1918 private address ranges forwarded via `rev-server`/`dns.revServers` to a local authoritative resolver.

This PR is a straight cherry-pick of @DL6ER's own fix commit (`4c6704ee`), already pushed to the `fix/dnssec-empty-ds-rfc1918-2942` branch in this repo and confirmed working by the reporter in the issue thread. It is opened here as an upstreamable PR since that branch had no PR associated with it yet — original authorship (and `Signed-off-by`) is preserved via the cherry-pick.

### Why it's broken

Upstream dnsmasq commit `707bc2d25` ("Fix DNSSEC fail with CNAME replies to DS queries") removed this shortcut from `dnssec_validate_reply()`:

```c
/* Empty DS without NSECS */
if (qtype == T_DS)
  return STAT_INSECURE;
```

Many public resolvers serve the reverse zones of private address space (e.g. `168.192.in-addr.arpa`) as empty zones per RFC 6303, answering a `DS` query with a bare `NXDOMAIN`/`NODATA` that carries no `SOA`, `NSEC`, or `RRSIG`. Without the shortcut, `prove_non_existence()` returns `DNSSEC_FAIL_NONSEC`, and `zone_status()` is then asked about the very name whose `DS` is currently being resolved — returning `STAT_NEED_DS` for that same name. `dnssec_validate_ds()` propagates `STAT_NEED_DS`, the identical `DS` query is re-issued, the self-dependency is detected as a loop, and validation is abandoned (`STAT_ABANDONED` -> `SERVFAIL`). The `bogus-priv` RFC-1918 escape hatch in `dnssec_validate_ds()` never gets a chance to fire because it's gated on `rc == STAT_INSECURE`.

### The fix

Restores the shortcut in `src/dnsmasq/dnssec.c`, scoped to the primary query (`j == 0`) so it doesn't regress the CNAME-to-DS handling that `707bc2d25` was itself fixing (which operates on CNAME targets, `j > 0`, via `prim_ok`):

```c
if (qtype == T_DS && j == 0)
  return STAT_INSECURE;
```

An empty `DS` reply with no non-existence proof for the queried name itself is again reported as `STAT_INSECURE`, letting the `bogus-priv`/domain-specific-server heuristics decide instead of looping into `STAT_ABANDONED`.

## Test plan

- [x] Cherry-picked cleanly onto current `master`, no conflicts.
- [x] `src/dnsmasq/dnssec.c` and the `dnsmasq` build target compile with zero new warnings.
- [x] Reporter (`jelliuk`) already confirmed on the issue thread that checking out the original `fix/dnssec-empty-ds-rfc1918-2942` branch (same commit) resolves the SERVFAIL regression in their environment.

Fixes #2942.