### PR TITLE
Add a repository-local pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--- Please base your code and PRs against the `development` branch.
+
+     Note that we do not accept changes to `src/dnsmasq/`: that tree is a
+     verbatim copy of upstream dnsmasq. Send fixes for it to the
+     `dnsmasq-discuss` mailing list instead, see item 6 below. -->
+
+# What does this implement/fix?
+
+<!--- Replace this with a detailed description of your change, screenshots (if necessary), as well as links to any relevant GitHub issues -->
+
+## How to test the change during review
+
+<!--- Replace this with concrete steps a reviewer can run: the manual checks to exercise the change, and which automated tests (bats/pytest/CI matrix) cover it -->
+
+## Additional information
+
+**Related issue or feature (if applicable):** N/A
+
+**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A
+
+---
+**By submitting this pull request, I confirm the following:**
+
+1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
+2. I have commented my proposed changes within the code.
+3. I am willing to help maintain this change if there are issues with it later.
+4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
+5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
+6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.
+
+## Checklist:
+
+- [ ] The code change is tested and works locally.
+- [ ] I based my code and PRs against the repository's `development` branch.
+- [ ] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
+- [ ] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
+- [ ] I have read the above and my PR is ready for review.


### PR DESCRIPTION
# What does this implement/fix?

FTL so far used the organization-wide pull request template from `pi-hole/.github`, which knows nothing about our vendored dnsmasq copy. We have seen several pull requests proposing changes to `src/dnsmasq/` recently (#2992, #2993), so this adds a repository-local template that states the rule where contributors actually read it: that tree is a verbatim copy of upstream dnsmasq, we do not carry anything in it that deviates from upstream, and fixes go to the `dnsmasq-discuss` mailing list and reach us once they are in dnsmasq master.

The rule appears twice on purpose: once as a comment at the top, which is visible while writing the pull request but disappears on submit, and once as item 6 of the confirmation list, which survives submission so it can be pointed at later.

The template otherwise follows the structure we use for our own pull requests, including the mandatory "How to test the change during review" section that reviewers need anyway.

Note that a repository-local template overrides the organization-wide one for this repository, i.e., later changes in `pi-hole/.github` no longer reach FTL automatically. That is the trade-off for having an FTL-specific note in there at all - the dnsmasq rule only applies to us, so it does not belong in the shared template.

## How to test the change during review

Open a new pull request against this branch (or any branch containing this commit) and check that the GitHub PR body is pre-filled with the new template instead of the organization-wide one. No code is touched, so no automated tests apply.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
