### PR TITLE
Use `ccache` to stop recompiling unchanged units in CI

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -16,11 +16,25 @@ ENV BUILD_OPTS=${BUILD_OPTS}
 # Setting TERM is needed for pretty output in BATS tests
 ENV TERM=xterm
 
+# CI starts from a fresh checkout every time, so cmake has no build tree to
+# compare against and recompiles all 207 translation units on every run - on
+# riscv64, sqlite3.c alone is over half of that under QEMU. ccache is keyed on
+# content rather than on mtimes in a build tree, so it survives the fresh clone
+# and only units that actually changed are compiled. Installed here rather than
+# in ftl-build while we measure the payoff; move it into the image once proven.
+RUN apk add --no-cache ccache
+ENV CCACHE_DIR=/app/.ccache
+ENV CCACHE_MAXSIZE=500M
+
 # Build FTL
 # Remove possible old build files
 RUN rm -rf cmake && \
+# Start from clean counters so the statistics below describe this build alone
+    ccache --zero-stats && \
 # Build and test FTL
-    bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON" ${BUILD_OPTS} && \
+    bash build.sh "-DSTATIC=${STATIC} -DBUILD_TAR_REGRESSION=ON -DBUILD_GZIP_REGRESSION=ON -DBUILD_DOTDOH_REGRESSION=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache" ${BUILD_OPTS} && \
+# Report what the cache saved, so the CI log shows whether it is worth keeping
+    ccache --show-stats && \
 # Copy FTL binary to root directory
     cd / &&\
     cp /app/pihole-FTL . && \

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pi-hole/ftl-build:v2.23
+FROM ghcr.io/pi-hole/ftl-build:v2.25
 
 WORKDIR /app
 
@@ -20,9 +20,7 @@ ENV TERM=xterm
 # compare against and recompiles all 207 translation units on every run - on
 # riscv64, sqlite3.c alone is over half of that under QEMU. ccache is keyed on
 # content rather than on mtimes in a build tree, so it survives the fresh clone
-# and only units that actually changed are compiled. Installed here rather than
-# in ftl-build while we measure the payoff; move it into the image once proven.
-RUN apk add --no-cache ccache
+# and only units that actually changed are compiled.
 ENV CCACHE_DIR=/app/.ccache
 ENV CCACHE_MAXSIZE=500M
 # Identify the compiler by hashing the binary rather than by its mtime and size,

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -25,6 +25,11 @@ ENV TERM=xterm
 RUN apk add --no-cache ccache
 ENV CCACHE_DIR=/app/.ccache
 ENV CCACHE_MAXSIZE=500M
+# Identify the compiler by hashing the binary rather than by its mtime and size,
+# which is what ccache would do by default. The compiler arrives in an image
+# here, so a rebuilt ftl-build must never be able to reuse entries made by the
+# gcc it replaced.
+ENV CCACHE_COMPILERCHECK=content
 
 # Build FTL
 # Remove possible old build files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,19 @@ jobs:
         shell: bash
         run: ls -l
       -
+        name: Restore ccache
+        # Restored into the build context, where .github/Dockerfile picks it up
+        # through its COPY. Keyed per matrix entry: the platforms compile for
+        # different architectures and the clang entry uses a different compiler,
+        # so none of them can share entries. The restore-keys prefix falls back
+        # to whatever the most recent run of this entry saved.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: .ccache
+          key: ccache-${{ matrix.bin_name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ matrix.bin_name }}-
+      -
         name: Build FTL in ftl-build container (QEMU)
         # Creates an image to build FTL and load it into the local Docker daemon
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
@@ -140,6 +153,28 @@ jobs:
               --build-arg "BUILD_OPTS=${{ matrix.build_opts }}" \
               --tag ftl-builder:local \
               --file .github/Dockerfile .
+      -
+        name: Export ccache from ftl-build container (QEMU)
+        # Exported here rather than alongside the other files further down, so a
+        # failing test run does not discard a cache the build just filled. The
+        # restored copy is removed first, as docker cp would otherwise nest the
+        # directory inside it.
+        run: |
+            docker create --platform ${{ matrix.platform }} --name ccache-container ftl-builder:local
+            rm -rf .ccache
+            docker cp ccache-container:/app/.ccache ./.ccache
+            docker rm ccache-container
+      -
+        name: Save ccache
+        # Cache entries are immutable, so the key carries the commit SHA and
+        # every run writes a new entry for GitHub to age out. Pull requests only
+        # run here when they come from a fork, and a fork's token cannot write
+        # caches, so there is nothing to save for them.
+        if: github.event_name == 'push'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: .ccache
+          key: ccache-${{ matrix.bin_name }}-${{ github.sha }}
       -
         name: Test FTL in ftl-build container (QEMU)
         # Uses the ftl-builder image to run tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ version~
 /cmake-build-debug/
 /cmake-build-release/
 
+# Compiler cache the CI workflow restores into the build context
+/.ccache/
+
 # IDE files
 .idea/
 *.sw*


### PR DESCRIPTION
# What does this implement/fix?

Our CI recompiles all 207 translation units on every run, on each of the seven matrix entries, and it does that even when a commit only touches a single file. The reason is not that anything actually changed: every job starts from a fresh checkout on a fresh runner, so cmake has no build tree left to compare timestamps against and has no choice but to build everything from scratch. Locally we never notice this, as our build tree persists and a rebuild only touches what we edited.

`ccache` gives us that same property in CI. It is keyed on *content* - a hash of the source, the headers it pulls in, the compiler, and the flags - rather than on mtimes inside a build tree, so it survives the fresh clone. The workflow restores the cache into the build context before the build, where `.github/Dockerfile` picks it up through its existing `COPY . /app`, and exports it again afterwards for the next run.

The win is concentrated where we need it most. `linux/riscv64` runs under QEMU and is by far our slowest job, and a single translation unit - `src/database/sqlite3.c` - dominates its compile. Measured on this branch, cold run against warm run, all seven jobs green in both:

| platform | cold | warm |
| --- | --- | --- |
| `linux/riscv64` | 24 min | 10 min |
| `linux/386` | 5 min | 3 min |
| `linux/amd64` | 5 min | 3 min |
| `linux/amd64` (clang) | 4 min | 3 min |
| `linux/arm64/v8` | 4 min | 3 min |
| `linux/arm/v6` | 4 min | 3 min |
| `linux/arm/v7` | 4 min | 3 min |

The riscv64 compile step itself goes from *895 seconds to 17 seconds*. What is left in that job is the static link and the test suite, neither of which `ccache` touches.

One qualifier on those numbers, so nobody reads them as better than they are: the warm run was a `workflow_dispatch` on an *unchanged* commit, so every unit hit, including the generated `version.c`. A real commit will do worse than that. Measured locally on `linux/amd64` by building `.github/Dockerfile` twice:

```
unchanged tree        207 / 207 hits    55.2s -> 6.2s
one .c file edited    206 / 207 hits
src/FTL.h edited      104 / 207 hits
```

That last row is the one worth looking at, because it is what makes this safe rather than merely fast. Editing our central header correctly recompiles every unit that includes it, while the 104 vendored units that do not - sqlite3, dnsmasq, lua, tre-regex, civetweb - stay cached. `ccache` records which headers each unit pulled in, so it cannot serve a stale object for a changed input; it can only skip work that would have produced a byte-identical one. This is more robust than a timestamp-based incremental build, as it does not care whether a file was rewritten with identical contents or merely touched.

For the same reason we set `CCACHE_COMPILERCHECK=content`. By default `ccache` identifies the compiler by its mtime and size, which is a weak assumption when the compiler arrives inside a container image rather than from a package manager, i.e., a rebuilt ftl-build could in principle ship a different `gcc` that still looks identical. Hashing the binary closes that off, at the cost of invalidating the cache once whenever the image changes - which is exactly what we want it to do.

`ccache` was originally installed with a plain `apk add` here, so we could measure the payoff without cutting a base image release first. Now that the numbers are in, it has moved to where it belongs: it ships in the toolchain as of ftl-build v2.25 (pi-hole/docker-base-images#184), and this branch has been switched over to that tag with the `apk add` dropped again. What is left in `.github/Dockerfile` is only the configuration of the cache, not its installation.

Two things reviewers may want to weigh:

- The cache costs about 30 MB per matrix entry per run. We currently use 1.45 GB of the 10 GB repository budget, so there is room, and GitHub ages old entries out. If that ever becomes tight, the obvious move is to keep `ccache` only for `linux/riscv64`, which is where nearly all of the benefit sits - the other six are now dominated by fixed overhead (checkout, QEMU setup, image pull, tests) and have little left to give.
- Saving is restricted to `push` events. Pull requests only run here when they come from a fork, and a fork's token cannot write caches anyway.

## How to test the change during review

The CI matrix on this branch covers it, and the effect is visible in the build log of every job - `ccache --show-stats` prints the hit rate right after `build.sh`.

To reproduce it locally:

```
docker buildx build --load --build-arg CI_ARCH=linux/amd64 --tag ftl-builder:local --file .github/Dockerfile .   # cold, 207 misses
docker create --name c ftl-builder:local && rm -rf .ccache && docker cp c:/app/.ccache ./.ccache && docker rm c
docker buildx build --load --build-arg CI_ARCH=linux/amd64 --tag ftl-builder:local --file .github/Dockerfile .   # warm, 207 hits
```

To confirm that changed inputs really are recompiled, add a declaration inside the include guard of `src/FTL.h` and build again: the hit count drops to 104 of 207, i.e., every unit that includes it is rebuilt. Editing a single `.c` file instead drops it to 206 of 207.

Note that the first build after merging will be a full recompile on every platform, as there is no cache to restore yet.

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.

