### PR TITLE
Reduce the shipped binary size by 36%

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -238,6 +238,23 @@ set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -funroll-loops -Wp,-U_FORTIFY_SOURCE -Wp
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} -g3")
 set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3")
 
+# We ship with debug information so crash backtraces resolve to file:line, which
+# makes DWARF the largest part of the binary. Compressing it is lossless as gdb
+# and addr2line decompress transparently, and the link option is what also
+# covers the statically linked libraries we do not compile ourselves. zstd
+# compresses marginally better but needs binutils >= 2.40 to be read back.
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS "-g -gz=zlib")
+set(CMAKE_REQUIRED_LINK_OPTIONS "-Wl,--compress-debug-sections=zlib")
+check_c_source_compiles("int main(void) { return 0; }" HAVE_COMPRESSED_DEBUG_SECTIONS)
+unset(CMAKE_REQUIRED_FLAGS)
+unset(CMAKE_REQUIRED_LINK_OPTIONS)
+if(HAVE_COMPRESSED_DEBUG_SECTIONS)
+    string(APPEND CMAKE_C_FLAGS_DEBUG " -gz=zlib")
+    string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -gz=zlib")
+    add_link_options(-Wl,--compress-debug-sections=zlib)
+endif()
+
 set(sources
         args.c
         args.h

--- a/src/api/docs/CMakeLists.txt
+++ b/src/api/docs/CMakeLists.txt
@@ -48,7 +48,20 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hex/images)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hex/external)
 
 # Compile files from content/ into hex/
+# The assets are embedded GZIP-compressed and handed to the client as such (see
+# docs.c), which keeps roughly 1.2 MB of JavaScript and YAML out of the binary
+# and saves the same amount of transfer. -n omits the original name and
+# timestamp from the GZIP header, keeping the build reproducible.
 find_program(RESOURCE_COMPILER xxd)
+find_program(GZIP_COMPRESSOR gzip)
+# Fail at configure time: a missing tool leaves the pipeline below with the exit
+# status of sed, so the build would otherwise succeed with empty assets
+if(NOT RESOURCE_COMPILER)
+    message(FATAL_ERROR "xxd not found, cannot embed the API documentation assets")
+endif()
+if(NOT GZIP_COMPRESSOR)
+    message(FATAL_ERROR "gzip not found, cannot embed the API documentation assets")
+endif()
 file(GLOB_RECURSE COMPILED_RESOURCES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/content" "content/*")
 foreach(INPUT_FILE ${COMPILED_RESOURCES})
     set(IN ${CMAKE_CURRENT_SOURCE_DIR}/content/${INPUT_FILE})
@@ -57,8 +70,8 @@ foreach(INPUT_FILE ${COMPILED_RESOURCES})
     set(OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/hex/${INPUT_FILE_MODIFIED}.h)
     add_custom_command(
         OUTPUT hex/${INPUT_FILE_MODIFIED}.h
-        COMMAND ${RESOURCE_COMPILER} -iC -n ${VARIABLE_NAME} - < ${IN} | sed "s/unsigned /static const unsigned /" > ${OUTPUT_FILE}
-        COMMENT "Compiling ${INPUT_FILE}"
+        COMMAND ${GZIP_COMPRESSOR} -9 -n -c ${IN} | ${RESOURCE_COMPILER} -iC -n ${VARIABLE_NAME} - | sed "s/unsigned /static const unsigned /" > ${OUTPUT_FILE}
+        COMMENT "Compressing and compiling ${INPUT_FILE}"
         VERBATIM)
     list(APPEND COMPILED_RESOURCES ${OUTPUT_FILE})
 endforeach()

--- a/src/api/docs/docs.c
+++ b/src/api/docs/docs.c
@@ -9,6 +9,59 @@
 *  Please see LICENSE file for your rights under this license. */
 
 #include "docs.h"
+// inflate_buffer()
+#include "zip/gzip.h"
+
+// Serve one documentation asset. The assets are stored GZIP-compressed (see
+// CMakeLists.txt in this directory), so a client advertising gzip gets the
+// stored stream verbatim. Everything else - most notably curl, which sends no
+// Accept-Encoding at all - gets it inflated on the fly.
+static int send_doc_file(struct ftl_conn *api, const unsigned int i)
+{
+	const char *content = docs_files[i].content;
+	size_t content_size = docs_files[i].content_size;
+	unsigned char *inflated = NULL;
+
+	const char *accept = mg_get_header(api->conn, "Accept-Encoding");
+	const bool send_gzip = accept != NULL && strstr(accept, "gzip") != NULL;
+
+	if(!send_gzip)
+	{
+		// inflate_buffer() rewrites its input when the GZIP header carries an
+		// extra field, so it must not be pointed at the read-only asset itself
+		unsigned char *copy = malloc(content_size);
+		if(copy == NULL)
+			return send_http_internal_error(api);
+		memcpy(copy, content, content_size);
+
+		mz_ulong inflated_size = 0;
+		const bool ok = inflate_buffer(copy, (mz_ulong)content_size,
+		                               &inflated, &inflated_size);
+		free(copy);
+		if(!ok)
+		{
+			if(inflated != NULL)
+				free(inflated);
+			return send_http_internal_error(api);
+		}
+
+		content = (const char *)inflated;
+		content_size = inflated_size;
+	}
+
+	// Both encodings are served from the same URL, so caches have to key on
+	// the request header to not hand a gzip stream to a client asking for plain
+	snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),
+	         "%sVary: Accept-Encoding",
+	         send_gzip ? "Content-Encoding: gzip\r\n" : "");
+
+	mg_send_http_ok(api->conn, docs_files[i].mime_type, (long long)content_size);
+	const int ret = mg_write(api->conn, content, content_size);
+
+	if(inflated != NULL)
+		free(inflated);
+	return ret;
+}
 
 int api_docs(struct ftl_conn *api)
 {
@@ -32,11 +85,7 @@ int api_docs(struct ftl_conn *api)
 		// Check if this is the requested file
 		if(strcmp(docs_files[i].path, api->item) == 0 ||
 		   (serve_index && strcmp(docs_files[i].path, "index.html") == 0))
-		{
-			// Send the file
-			mg_send_http_ok(api->conn, docs_files[i].mime_type, (long long)docs_files[i].content_size);
-			return mg_write(api->conn, docs_files[i].content, docs_files[i].content_size);
-		}
+			return send_doc_file(api, i);
 	}
 
 	// Requested path was not found


### PR DESCRIPTION
# What does this implement/fix?

We ship `pihole-FTL` as a `RelWithDebInfo` build so that crash backtraces resolve to `file:line` through `addr2line` and attached `gdb` sessions immediately show the relevant code. That is worth keeping, but it had become expensive: of the 37.2 MB we ship on x86-64, 21.3 MB (57%) was DWARF. On top of that, the `/api/docs` assets are compiled into the binary and were served verbatim, even though they are all highly compressible text - the RapiDoc bundle alone is 865 kB of minified JavaScript.

This PR takes 36.5% off the binary with two independent changes, neither of which gives anything up:

1. **Compress the DWARF debug information.** `-gz=zlib` on the compile line plus `-Wl,--compress-debug-sections=zlib` on the link line. Both are needed: the compile flag covers the DWARF we generate ourselves, the link flag is what also covers the DWARF arriving from the statically linked libraries we do not build in this project. `gdb` and `addr2line` decompress these sections transparently, so backtraces, source listings and variable inspection are unchanged. Everything sits behind a combined compile-and-link feature check, so a toolchain built without zlib support still produces a working - merely larger - binary.

2. **Store and serve the API documentation assets GZIP-compressed.** Each asset is piped through `gzip -9 -n` before `xxd`, and the stored stream is handed to the client with `Content-Encoding: gzip`. Clients that do not advertise gzip - most notably `curl`, which sends no `Accept-Encoding` at all - are not left behind: for those we inflate on the fly using our existing `inflate_buffer()`, so the response stays byte-identical to what we served before and scripted users see no change. `Vary: Accept-Encoding` is sent on both paths so intermediate caches key on the request header rather than handing a GZIP stream to a client that asked for plain text.

Measured on an x86-64 static build, comparing against the same binary with its debug sections decompressed again:

```
development:            37,217,184 bytes
DWARF compression:      24,913,329 bytes  (-12,303,855)
docs assets:            35,954,161 bytes  (-1,263,023)
both:                   23,648,401 bytes  (-13,568,783, -36.5%)
```

The two are essentially additive. `.text` (8.87 MB) is now the largest section in the binary, ahead of the entire remaining DWARF (8.9 MB), so anything beyond this would have to come out of code rather than debug information.

The transfer saving on `/api/docs` is proportionally larger than the binary saving: `specs/main.yaml` goes from 8,511 to 1,860 bytes on the wire, `rapidoc-min.js` from 865 kB to 218 kB.

A few things we deliberately did *not* do:

- **Splitting the DWARF into a separate file.** This would get us down to ~16 MB, but a user-submitted crash log would then lose its line numbers unless that user also installed the debug file. Those backtraces are worth more to us than the 6 MB.
- **Lowering `-g3` to `-g`.** Worth only 0.5 MB, and it costs macro expansion in `gdb`.
- **Dropping the RapiDoc source map.** It looks tempting at 423 kB uncompressed, but it is only 81 kB once compressed, and removing it would mean editing the vendored `rapidoc-min.js` to strip its `sourceMappingURL` line. Not worth a local modification of vendored code.
- **zstd instead of zlib.** Compresses marginally better (~70 kB) but needs binutils >= 2.40 to be read back, which is a steeper requirement on our users' debugging tools than the saving justifies.

`inflate_buffer()` rewrites its input buffer when the GZIP header carries an extra field, so the fallback path inflates from a copy rather than pointing it at the read-only asset in `.rodata`. Making that function const-correct would let us skip the copy, but it is also used by the teleporter, so we kept this change contained.

## How to test the change during review

Build as usual (`bash build.sh`) and compare against a `development` build.

**1. The binary is smaller, and the DWARF is genuinely compressed:**

```
ls -l pihole-FTL
readelf -S -W pihole-FTL | grep debug
```

Every `.debug_*` section should carry the `C` (compressed) flag. To see the exact saving without needing a second build, decompress them again and compare:

```
objcopy --decompress-debug-sections pihole-FTL /tmp/uncompressed
stat -c%s pihole-FTL /tmp/uncompressed
```

**2. Backtraces are unaffected:**

```
./pihole-FTL backtrace
```

Frames must still resolve to source locations, e.g. `parse_args   src/args.c:322`, not to bare addresses.

**3. `gdb` still reads the debug information:**

```
gdb -q -batch -ex 'list main' -ex 'info line signals.c:398' ./pihole-FTL
```

This must print actual source lines and resolve the address.

**4. `/api/docs` serves both encodings correctly.** With FTL running, a client advertising gzip gets the compressed stream:

```
curl -sD - -o /tmp/gz -H 'Accept-Encoding: gzip' http://127.0.0.1/api/docs/specs/main.yaml | grep -iE 'content-encoding|content-length|vary'
```

and a client that does not (plain `curl`) gets the inflated original, byte-identical to the source asset:

```
curl -s http://127.0.0.1/api/docs/specs/main.yaml | cmp - src/api/docs/content/specs/main.yaml
curl -s http://127.0.0.1/api/docs/external/rapidoc-min.js | cmp - src/api/docs/content/external/rapidoc-min.js
curl -s --compressed http://127.0.0.1/api/docs/external/rapidoc-min.js | cmp - src/api/docs/content/external/rapidoc-min.js
curl -s http://127.0.0.1/api/docs/images/favicon.ico | cmp - src/api/docs/content/images/favicon.ico
```

All four `cmp` calls must be silent. The last one covers a binary asset going through the inflate path.

**5. Open `http://pi.hole/api/docs/` in a browser.** The RapiDoc page must render as before; the network tab shows the assets arriving gzip-encoded.

**Automated coverage:** the existing CI matrix builds this on every supported architecture, which is what exercises the feature check on the different toolchains. `test/api/test_openapi.py` fetches every OpenAPI spec through the API and validates the responses, so it covers the docs endpoints end to end. `test/test_final.bats` is relevant here too - its "No WARNING messages in FTL.log" check caught a `free(NULL)` in an earlier revision of this branch that the endpoint tests alone did not.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
