### PR TITLE
Update embedded dnsmasq to v2.93+16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,6 @@ set(CMAKE_C_STANDARD 17)
 
 project(PIHOLE_FTL C)
 
-set(DNSMASQ_VERSION pi-hole-v2.93)
+set(DNSMASQ_VERSION pi-hole-v2.93+16)
 
 add_subdirectory(src)

--- a/src/dnsmasq/blockdata.c
+++ b/src/dnsmasq/blockdata.c
@@ -132,7 +132,7 @@ int blockdata_expand(struct blockdata *block, size_t oldlen, char *data, size_t 
   /* find size of current final block */
   for (b = block; oldlen > KEYBLOCK_LEN && b;  b = b->next, oldlen -= KEYBLOCK_LEN);
 
-  /* chain to short for length, something is broken */
+  /* chain too short for length, something is broken */
   if (oldlen > KEYBLOCK_LEN)
     {
       blockdata_free(block);

--- a/src/dnsmasq/cache.c
+++ b/src/dnsmasq/cache.c
@@ -2427,7 +2427,7 @@ const char *edestr(int ede)
     }
 }
 
-static int error_occured(unsigned int flags) {
+static int error_occurred(unsigned int flags) {
   if (flags & F_RCODE)
     return 1;
   else if (flags & F_NEG)
@@ -2451,10 +2451,10 @@ void _log_query(unsigned int flags, char *name, union all_addr *addr, char *arg,
   if (!option_bool(OPT_LOG))
     return;
 
-  if(option_bool(OPT_LOG_ONLY_FAILED) && !error_occured(flags))
+  if(option_bool(OPT_LOG_ONLY_FAILED) && !error_occurred(flags))
     return;
 
-  /* F_NOERR is reused here to indicate logs arrising from auth queries */ 
+  /* F_NOERR is reused here to indicate logs arising from auth queries */ 
   if (!(flags & F_NOERR) && option_bool(OPT_AUTH_LOG))
     return;
 

--- a/src/dnsmasq/dhcp-common.c
+++ b/src/dnsmasq/dhcp-common.c
@@ -734,7 +734,7 @@ static const struct opttab_t opttab6[] = {
   { "status", 13, OT_INTERNAL },
   { "rapid-commit", 14, OT_INTERNAL },
   { "user-class", 15, OT_INTERNAL | OT_CSTRING },
-  { "vendor-class", 16, OT_INTERNAL | OT_CSTRING },
+  { "vendor-class", 16, OT_DHCP6_VENDOR },
   { "vendor-opts", 17, OT_INTERNAL },
   { "sip-server-domain", 21,  OT_RFC1035_NAME },
   { "sip-server", 22, OT_ADDR_LIST },
@@ -907,6 +907,37 @@ char *option_string(int prot, unsigned int opt, unsigned char *val, int opt_len,
 		    i += len + 2;
 		    if (i < opt_len && j < buf_len)
 		      buf[j++] = ',';
+		  }
+	      }
+	    else if ((ot[o].size & OT_DHCP6_VENDOR))
+	      {
+		unsigned int enterprise;
+		unsigned char *p = &val[0];
+
+		if (opt_len >= 4)
+		  {
+		    GETLONG(enterprise, p);
+		    snprintf(buf, buf_len, "%u", enterprise);
+		    j = strlen(buf);
+		    i = 4;
+		    while (i + 2 <= opt_len)
+		      {
+			int k, len;
+			p = &val[i];
+			GETSHORT(len, p);
+			if (i + 2 + len > opt_len)
+			  break;
+			if (j < buf_len - 1)
+			  buf[j++] = ',';
+			for (k = 0; k < len && j < buf_len - 1; k++)
+			  {
+			    char c = *p++;
+			    if (isprint((unsigned char)c))
+			      buf[j++] = c;
+			  }
+			buf[j] = 0;
+			i += len + 2;
+		      }
 		  }
 	      }
 #endif

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -2216,6 +2216,8 @@ static void do_tcp_connection(struct listener *listener, time_t now, int slot)
 	 forever awaiting the result. To avoid this
 	 close the netlink socket in the child. */
       close(daemon->netlinkfd);
+#elif defined(HAVE_BSD_NETWORK)
+      close(daemon->routefd);
 #endif
 
       /* Close inherited listening sockets in the child process.
@@ -2366,6 +2368,8 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
 
     // Pi-hole modification
     daemon->netlinkfd = -1;
+#elif defined(HAVE_BSD_NETWORK)
+	  close(daemon->routefd);
 #endif
 	  
 	  /* Close inherited listening sockets in the child process.

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -1972,7 +1972,7 @@ static void check_dns_listeners(time_t now)
   /* Note that handling events here can create or destroy fds and
      render the result of the last poll() call invalid. Once
      we find an fd that needs service, do it, then return to go around the
-     poll() loop again. This avoid really, really, wierd bugs. */
+     poll() loop again. This avoid really, really, weird bugs. */
 
   if (!option_bool(OPT_DEBUG))
     for (i = 0; i < daemon->max_procs; i++)

--- a/src/dnsmasq/dnsmasq.c
+++ b/src/dnsmasq/dnsmasq.c
@@ -2052,7 +2052,8 @@ static void do_tcp_connection(struct listener *listener, time_t now, int slot)
   pid_t p;
   union mysockaddr tcp_addr;
   socklen_t tcp_len = sizeof(union mysockaddr);
-  struct server *s; 
+  struct server *s;
+  struct listener *l;
   int flags, auth_dns = 0;
   struct in_addr netmask;
   int pipefd[2];
@@ -2175,25 +2176,19 @@ static void do_tcp_connection(struct listener *listener, time_t now, int slot)
 	  /* fork() done: parent side */
 	  close(pipefd[1]); /* parent needs read pipe end. */
       
-#ifdef HAVE_LINUX_NETWORK
-	  /* The child process inherits the netlink socket, 
-	     which it never uses, but when the parent (us) 
-	     uses it in the future, the answer may go to the 
-	     child, resulting in the parent blocking
-	     forever awaiting the result. To avoid this
-	     the child closes the netlink socket, but there's
-	     a nasty race, since the parent may use netlink
-	     before the child has done the close.
+	  /* The child process inherits various sockets,
+	     whose existence can mess up the function of
+	     the parent. See below for details of which
+	     sockets, and why they cause problems. The
+	     child closes the sockets during startup,
+	     but there's a nasty race, since the parent
+	     may use them before the child has done the close.
 	     
-	     To avoid this, the parent blocks here until a 
+	     To avoid the race, the parent blocks here until a 
 	     single byte comes back up the pipe, which
-	     is sent by the child after it has closed the
-	     netlink socket. */
-
+	     is sent by the child has finshed the close. */
 	  read_write(pipefd[0], &a, 1, RW_READ);
-#endif
 	  
-
 	  daemon->tcp_pids[slot] = p;
 	  daemon->tcp_pipes[slot] = pipefd[0];
 	  daemon->metrics[METRIC_TCP_CONNECTIONS]++;
@@ -2213,18 +2208,41 @@ static void do_tcp_connection(struct listener *listener, time_t now, int slot)
 	  return;
 	}
       
+#ifdef HAVE_LINUX_NETWORK
+      /* The child process inherits the netlink socket, 
+	 which it never uses, but when the parent
+	 uses it in the future, the answer may go to the 
+	 child, resulting in the parent blocking
+	 forever awaiting the result. To avoid this
+	 close the netlink socket in the child. */
+      close(daemon->netlinkfd);
+#endif
+
+      /* Close inherited listening sockets in the child process.
+         These are not needed here and holding them prevents the
+         parent from re-binding if an interface is removed and
+         re-added (the child's copy causes EADDRINUSE). */
+      for (l = daemon->listeners; l; l = l->next)
+        {
+          if (l->fd != -1)
+	    close(l->fd);
+          if (l->tcpfd != -1)
+	    close(l->tcpfd);
+	  if (l->tftpfd != -1)
+	    close(l->tftpfd);
+        }
+
+      /* unblock parent now we're not holding sockets we shouldn't. */
+      read_write(pipefd[1], &a, 1, RW_WRITE);
+		  
       /* Arrange for SIGALRM after CHILD_LIFETIME seconds to
 	 terminate the process. */
-#ifdef HAVE_LINUX_NETWORK
-      /* See comment above re: netlink socket. */
-      close(daemon->netlinkfd);
-      read_write(pipefd[1], &a, 1, RW_WRITE);
-#endif		  
       alarm(CHILD_LIFETIME);
       close(pipefd[0]); /* close read end in child. */
       daemon->pipe_to_parent = pipefd[1];
-    }
 
+    }
+  
   /* The connected socket inherits non-blocking
      attribute from the listening socket. 
      Reset that here. */
@@ -2279,6 +2297,7 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
 		ssize_t *plen, char *name, int class, struct server *server, int *keycount, int *validatecount)
 {
   struct server *s;
+  struct listener *l;
 
   if (!option_bool(OPT_DEBUG))
     {
@@ -2307,22 +2326,18 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
 	      return STAT_ABANDONED;
 	    }
 
-#ifdef HAVE_LINUX_NETWORK
-	  /* The child process inherits the netlink socket, 
-	     which it never uses, but when the parent (us) 
-	     uses it in the future, the answer may go to the 
-	     child, resulting in the parent blocking
-	     forever awaiting the result. To avoid this
-	     the child closes the netlink socket, but there's
-	     a nasty race, since the parent may use netlink
-	     before the child has done the close.
+	  /* The child process inherits various sockets,
+	     whose existence can mess up the function of
+	     the parent. See below for details of which
+	     sockets, and why they cause problems. The
+	     child closes the sockets during startup,
+	     but there's a nasty race, since the parent
+	     may use them before the child has done the close.
 	     
-	     To avoid this, the parent blocks here until a 
+	     To avoid the race, the parent blocks here until a 
 	     single byte comes back up the pipe, which
-	     is sent by the child after it has closed the
-	     netlink socket. */
+	     is sent by the child has finshed the close. */
 	  read_write(pipefd[0], &a, 1, RW_READ);
-#endif
 	  
 	  /* i holds index of free slot */
 	  daemon->tcp_pids[i] = p;
@@ -2341,13 +2356,35 @@ int swap_to_tcp(struct frec *forward, time_t now, int status, struct dns_header 
 	{
 	  /* child starts here. */
 #ifdef HAVE_LINUX_NETWORK
-	  /* See comment above re: netlink socket. */
+	  /* The child process inherits the netlink socket, 
+	     which it never uses, but when the parent
+	     uses it in the future, the answer may go to the 
+	     child, resulting in the parent blocking
+	     forever awaiting the result. To avoid this
+	     close the netlink socket in the child. */
 	  close(daemon->netlinkfd);
-	  read_write(pipefd[1], &a, 1, RW_WRITE);
 
     // Pi-hole modification
     daemon->netlinkfd = -1;
-#endif		  
+#endif
+	  
+	  /* Close inherited listening sockets in the child process.
+	     These are not needed here and holding them prevents the
+	     parent from re-binding if an interface is removed and
+	     re-added (the child's copy causes EADDRINUSE). */
+	  for (l = daemon->listeners; l; l = l->next)
+	    {
+	      if (l->fd != -1)
+		close(l->fd);
+	      if (l->tcpfd != -1)
+		close(l->tcpfd);
+	      if (l->tftpfd != -1)
+		close(l->tftpfd);
+	    }
+	  
+	  /* unblock parent now we're not holding sockets we shouldn't. */
+	  read_write(pipefd[1], &a, 1, RW_WRITE);
+	
 	  alarm(CHILD_LIFETIME);
 	  close(pipefd[0]); /* close read end in child. */
 	  daemon->pipe_to_parent = pipefd[1];

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -849,6 +849,7 @@ struct frec {
 #define OT_CSTRING      0x0800
 #define OT_DEC          0x0400 
 #define OT_TIME         0x0200
+#define OT_DHCP6_VENDOR 0x0100
 
 /* actions in the daemon->helper RPC */
 #define ACTION_DEL           1

--- a/src/dnsmasq/dnsmasq.h
+++ b/src/dnsmasq/dnsmasq.h
@@ -738,7 +738,7 @@ struct resolvc {
 #endif
 };
 
-/* adn-hosts parms from command-line (also dhcp-hostsfile and dhcp-optsfile and dhcp-hostsdir*/
+/* addn-hosts parms from command-line (also dhcp-hostsfile and dhcp-optsfile and dhcp-hostsdir*/
 #define AH_DIR      1
 #define AH_INACTIVE 2
 #define AH_WD_DONE  4
@@ -1186,7 +1186,7 @@ struct dhcp_relay {
 };
 
 extern struct daemon {
-  /* datastuctures representing the command-line and 
+  /* datastructures representing the command-line and 
      config file arguments. All set (including defaults)
      in option.c */
 

--- a/src/dnsmasq/dump.c
+++ b/src/dnsmasq/dump.c
@@ -129,6 +129,23 @@ void dump_packet_icmp(int mask, void *packet, size_t len,
     do_dump_packet(mask, packet, len, src, dst, -1, IPPROTO_ICMP);
 }
 
+static u32 calc_data_checksum(u32 sum, void *packet, size_t len)
+{
+  u32 i;
+  
+  for (i = 0; i < len/2; i++)
+    sum += ((u16 *)packet)[i];
+  if (len & 1) /* last byte, in case length is odd. */
+    sum += ((unsigned char *)packet)[len - 1];
+  while (sum >> 16)
+    sum = (sum & 0xffff) + (sum >> 16);
+
+  if (sum != 0xffff)
+    sum = ~sum;
+  
+  return sum;
+}
+  
 static void do_dump_packet(int mask, void *packet, size_t len,
 			   union mysockaddr *src, union mysockaddr *dst, int port, int proto)
 {
@@ -226,13 +243,9 @@ static void do_dump_packet(int mask, void *packet, size_t len,
 	  udp.uh_dport = dst->in.sin_port;
 	}
       
-      ip.ip_sum = 0;
-      for (sum = 0, i = 0; i < sizeof(struct ip) / 2; i++)
-	sum += ((u16 *)&ip)[i];
-      while (sum >> 16)
-	sum = (sum & 0xffff) + (sum >> 16);  
-      ip.ip_sum = (sum == 0xffff) ? sum : ~sum;
-      
+      ip.ip_sum = 0; /* for the calculation */
+      ip.ip_sum = calc_data_checksum(0, &ip, sizeof(struct ip));
+            
       /* start UDP/ICMP checksum */
       sum = ip.ip_src.s_addr & 0xffff;
       sum += (ip.ip_src.s_addr >> 16) & 0xffff;
@@ -240,9 +253,6 @@ static void do_dump_packet(int mask, void *packet, size_t len,
       sum += (ip.ip_dst.s_addr >> 16) & 0xffff;
     }
   
-  if (len & 1)
-    ((unsigned char *)packet)[len] = 0; /* for checksum, in case length is odd. */
-
   if (proto == IPPROTO_UDP)
     {
       /* Add Remaining part of the pseudoheader. Note that though the
@@ -252,17 +262,12 @@ static void do_dump_packet(int mask, void *packet, size_t len,
       sum += htons(IPPROTO_UDP);
       sum += htons(sizeof(struct udphdr) + len);
       
-      udp.uh_sum = 0;
+      udp.uh_sum = 0; /* for the calculation */
       udp.uh_ulen = htons(sizeof(struct udphdr) + len);
-      
       for (i = 0; i < sizeof(struct udphdr)/2; i++)
 	sum += ((u16 *)&udp)[i];
-      for (i = 0; i < (len + 1) / 2; i++)
-	sum += ((u16 *)packet)[i];
-      while (sum >> 16)
-	sum = (sum & 0xffff) + (sum >> 16);
-      udp.uh_sum = (sum == 0xffff) ? sum : ~sum;
-
+      udp.uh_sum = calc_data_checksum(sum, packet, len);
+      
       pcap_header.incl_len = pcap_header.orig_len = ipsz + sizeof(udp) + len;
     }
   else
@@ -274,12 +279,9 @@ static void do_dump_packet(int mask, void *packet, size_t len,
       sum += htons(proto);
       sum += htons(len);
       
-      icmp->icmp6_cksum = 0;
-      for (i = 0; i < (len + 1) / 2; i++)
-	sum += ((u16 *)packet)[i];
-      while (sum >> 16)
-	sum = (sum & 0xffff) + (sum >> 16);
-      icmp->icmp6_cksum = (sum == 0xffff) ? sum : ~sum;
+      icmp->icmp6_cksum = 0; /* for the calculation */
+      icmp->icmp6_cksum = calc_data_checksum(sum, packet, len);
+      
 
       pcap_header.incl_len = pcap_header.orig_len = ipsz + len;
     }

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -1343,7 +1343,7 @@ void reply_query(int fd, time_t now)
      had replies from all to avoid filling the forwarding table when
      everything is broken */
 
-  /* decrement count of replies recieved if we sent to more than one server. */
+  /* decrement count of replies received if we sent to more than one server. */
   if (forward->forwardall && (--forward->forwardall > 1) && RCODE(header) == REFUSED)
     return;
 
@@ -2246,7 +2246,7 @@ static ssize_t tcp_talk(int first, int last, int start, struct dns_header *heade
 #if defined(SO_SNDTIMEO) && defined(SO_RCVTIMEO)
 	  /* TCP connections by default take ages to time out.
 	     Set shorter timeouts more appropriate for a DNS server.
-	     We set the recieve timeout as twice the send timeout; we
+	     We set the receive timeout as twice the send timeout; we
 	     want to fail quickly on a non-responsive server, but give it time to get an
 	     answer. */
 	  tv.tv_sec = TCP_TIMEOUT;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -209,12 +209,6 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
       unsigned int *bitvector = NULL;
       unsigned short id = ntohs(header->id); /* Retrieve the id from the new query before we overwrite it. */
       
-      /* Get the case-scambled version of the query to resend. This is important because we
-	 may fall through below and forward the query in the packet buffer again and we
-	 want to use the same case scrambling as the first time. */
-      blockdata_retrieve(forward->stash, forward->stash_len, (void *)header); 
-      plen = forward->stash_len;
-
       for (src = &forward->frec_src; src; src = src->next)
 	if (src->orig_id == id && 
 	    sockaddr_isequal(&src->source, udpaddr))
@@ -225,6 +219,11 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 	  old_src = 1;
 	  /* If a query is retried, use the log_id for the retry when logging the answer. */
 	  src->log_id = daemon->log_id;
+	  /* Get the case-scambled version of the query to resend. This is important because we
+	     may fall through below and forward the query in the packet buffer again and we
+	     want to use the same case scrambling as the first time. */
+	  blockdata_retrieve(forward->stash, forward->stash_len, (void *)header); 
+	  plen = forward->stash_len;
 	}
       else
 	{
@@ -271,7 +270,10 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 
 	     The original query we sent is now in packet buffer and the query name in the
 	     new instance is on daemon->namebuff. */
-	    	  
+
+	  blockdata_retrieve(forward->stash, forward->stash_len, (void *)header); 
+	  plen = forward->stash_len;
+
 	  if (extract_name(header, forward->stash_len, NULL, daemon->workspacename, EXTR_NAME_EXTRACT, 0))
 	    {
 	      unsigned int i, gobig = 0;

--- a/src/dnsmasq/forward.c
+++ b/src/dnsmasq/forward.c
@@ -185,7 +185,10 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
   int forwarded = 0;
   int ede = EDE_UNSET;
   unsigned short rrtype, rrclass;
-
+  unsigned short id = ntohs(header->id); /* Retrieve the id from the new query before we overwrite it. */
+  unsigned int casediff = 0;
+  unsigned int *bitvector = NULL;
+  
   gotname = extract_request(header, plen, daemon->namebuff, &rrtype, &rrclass);
   
   /* Check for retry on existing query.
@@ -205,10 +208,7 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 					     FREC_HAS_PHEADER | FREC_DNSKEY_QUERY | FREC_DS_QUERY | FREC_NO_CACHE)))
     {
       struct frec_src *src;
-      unsigned int casediff = 0;
-      unsigned int *bitvector = NULL;
-      unsigned short id = ntohs(header->id); /* Retrieve the id from the new query before we overwrite it. */
-      
+          
       for (src = &forward->frec_src; src; src = src->next)
 	if (src->orig_id == id && 
 	    sockaddr_isequal(&src->source, udpaddr))
@@ -249,9 +249,11 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 		 and never resetting until the frec gets deleted by
 		 aging followed by the receipt of a different query. This
 		 is a bit of a DoS vuln. Avoid by explicitly deleting the
-		 frec once it expires. */
-	      if (difftime(now, forward->time) >= TIMEOUT)
-		free_frec(forward);
+		 frec once it expires. The deletion is done at the end of
+		 this function, unless we set forward to NULL here. */
+	      if (difftime(now, forward->time) < TIMEOUT)
+		forward = NULL;
+
 	      goto reply;
 	    }
 
@@ -322,7 +324,6 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
 	  src->fd = udpfd;
 	  src->encode_bitmap = casediff;
 	  src->encode_bigmap = bitvector;
-	  
 	  src->udp_pkt_size = (unsigned short)replylimit;
 
 	  /* closely spaced identical queries cannot be a try and a retry, so
@@ -401,18 +402,15 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
       forward->frec_src.orig_id = ntohs(header->id);
       forward->new_id = get_id();
       header->id = ntohs(forward->new_id);
-      forward->frec_src.encode_bitmap = (!option_bool(OPT_NO_0x20) && option_bool(OPT_DO_0x20)) ? rand32() : 0;
+      forward->frec_src.encode_bitmap = casediff = (!option_bool(OPT_NO_0x20) && option_bool(OPT_DO_0x20)) ? rand32() : 0;
       forward->frec_src.encode_bigmap = NULL;
-
-      if (!extract_name(header, plen, NULL, (char *)&forward->frec_src.encode_bitmap, EXTR_NAME_FLIP, 1))
+      
+      if (casediff != 0 && !extract_name(header, plen, NULL, (char *)&casediff, EXTR_NAME_FLIP, 1))
 	goto reply;
       
       /* Keep copy of query for retries and move to TCP */
       if (!(forward->stash = blockdata_alloc((char *)header, plen)))
-	{
-	  free_frec(forward);
-	  goto reply; /* no mem. return REFUSED */
-	}
+	goto reply; /* no mem. return REFUSED */
       
       forward->stash_len = plen;
       forward->frec_src.log_id = daemon->log_id;
@@ -609,13 +607,25 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
     }
   
   /* could not send on, prepare to return */ 
-  header->id = htons(forward->frec_src.orig_id);
-  free_frec(forward); /* cancel */
   ede = EDE_NETERR;
   
  reply:
   if (udpfd != -1)
     {
+      /* The query now in the buffer can have changed from what arrived during
+	 the preparation for forwarding in two respects.
+	 1) The header->id field may have changed.
+	 2) The case of letters in the query may have been changed.
+	 
+	 Restore both of these changes before using it to build an error return for the client.
+	 The original id is held in local variable id, and the difference in case
+	 is encoded in casediff and also bitvector if the difference spreads beyond the first
+	 32 characters.
+      */
+      header->id = htons(id);
+      if (casediff != 0)
+	extract_name(header, plen, NULL, (char *)(bitvector ? bitvector : &casediff), EXTR_NAME_FLIP, bitvector ? casediff : 1);
+	      
       if (!(plen = make_local_answer(flags, gotname, plen, header, daemon->namebuff, replylimit, first, last, ede)))
 	return;
       
@@ -646,6 +656,11 @@ static void forward_query(int udpfd, union mysockaddr *udpaddr,
     }
   
   daemon->metrics[METRIC_DNS_LOCAL_ANSWERED]++;
+
+  /* This has to be after last use of bitvector. */
+  if (forward)
+    free_frec(forward);
+  
   return;
 }
 
@@ -1350,7 +1365,8 @@ void reply_query(int fd, time_t now)
   server->query_latency = server->mma_latency/128;
   
   /* Flip the bits back in the query name. */
-    if (!extract_name(header, n, NULL, (char *)&forward->frec_src.encode_bitmap, EXTR_NAME_FLIP, 1))
+    if (forward->frec_src.encode_bitmap != 0 &&
+	!extract_name(header, n, NULL, (char *)&forward->frec_src.encode_bitmap, EXTR_NAME_FLIP, 1))
     return;
       
 #ifdef HAVE_DNSSEC

--- a/src/dnsmasq/lease.c
+++ b/src/dnsmasq/lease.c
@@ -527,7 +527,7 @@ void lease_update_slaac(time_t now)
 
 /* Find interfaces associated with leases at start-up. This gets updated as
    we do DHCP transactions, but information about directly-connected subnets
-   is useful from scrips and necessary for determining SLAAC addresses from
+   is useful from scripts and necessary for determining SLAAC addresses from
    start-time. */
 void lease_find_interfaces(time_t now)
 {

--- a/src/dnsmasq/log.c
+++ b/src/dnsmasq/log.c
@@ -102,27 +102,30 @@ int log_start(struct passwd *ent_pw, int errfd)
       entries_alloced = 1;
     }
 
-  /* If we're running as root and going to change uid later,
-     change the ownership here so that the file is always owned by
-     the dnsmasq user. Then logrotate can just copy the owner.
-     Failure of the chown call is OK, (for instance when started as non-root).
-     
-     If we've created a file with group-id root, we also make
-     the file group-writable. This gives processes in the root group
-     write access to the file and avoids the problem that on some systems,
-     once the file is owned by the dnsmasq user, it can't be written
-     whilst dnsmasq is running as root during startup.
- */
   if (log_to_file && !log_stderr && ent_pw && ent_pw->pw_uid != 0)
     {
       struct stat ls;
-      if (getgid() == 0 && fstat(log_fd, &ls) == 0 && ls.st_gid == 0 &&
-	  (ls.st_mode & S_IWGRP) == 0)
-	(void)fchmod(log_fd, ls.st_mode | S_IWGRP);
-      if (fchown(log_fd, ent_pw->pw_uid, -1) != 0)
-	ret = errno;
+      
+      /* Only mess with permissions for regular files, not (eg) /dev/null */
+      if (fstat(log_fd, &ls) == 0 && S_ISREG(ls.st_mode))
+	{
+	  /* If we're running as root and going to change uid later,
+	     change the ownership here so that the file is always owned by
+	     the dnsmasq user. Then logrotate can just copy the owner. */
+	  if (fchown(log_fd, ent_pw->pw_uid, -1) != 0)
+	    ret = errno;
+	  
+	  /* If we've created a file with group-id root, we also make
+	     the file group-writable. This gives processes in the root group
+	     write access to the file and avoids the problem that on some systems,
+	     once the file is owned by the dnsmasq user, it can't be written
+	     whilst dnsmasq is running as root during startup.
+	     Failure of the chown call is OK, (for instance when started as non-root). */
+	  if (getgid() == 0 && ls.st_gid == 0 && (ls.st_mode & S_IWGRP) == 0)
+	    (void)fchmod(log_fd, ls.st_mode | S_IWGRP);
+	}
     }
-
+  
   return ret;
 }
 

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -1274,19 +1274,14 @@ void warn_bound_listeners(void)
   int advice = 0;
 
   for (iface = daemon->interfaces; iface; iface = iface->next)
-    if (!iface->dns_auth)
+    if (!iface->dns_auth && !iface->warned &&
+	iface->addr.sa.sa_family == AF_INET && !private_net(iface->addr.in.sin_addr, 1))
       {
-	if (iface->addr.sa.sa_family == AF_INET)
-	  {
-	    if (!private_net(iface->addr.in.sin_addr, 1))
-	      {
-		inet_ntop(AF_INET, &iface->addr.in.sin_addr, daemon->addrbuff, ADDRSTRLEN);
-		iface->warned = advice = 1;
-		my_syslog(LOG_WARNING, 
-			  _("LOUD WARNING: listening on %s may accept requests via interfaces other than %s"),
-			  daemon->addrbuff, iface->name);
-	      }
-	  }
+	inet_ntop(AF_INET, &iface->addr.in.sin_addr, daemon->addrbuff, ADDRSTRLEN);
+	iface->warned = advice = 1;
+	my_syslog(LOG_WARNING, 
+		  _("LOUD WARNING: listening on %s may accept requests via interfaces other than %s"),
+		  daemon->addrbuff, iface->name);
       }
   
   if (advice)

--- a/src/dnsmasq/network.c
+++ b/src/dnsmasq/network.c
@@ -1477,7 +1477,7 @@ static struct serverfd *allocate_sfd(union mysockaddr *addr, char *intname, unsi
   
   /* when using random ports, servers which would otherwise use
      the INADDR_ANY/port0 socket have sfd set to NULL, this is 
-     anything without an explictly set source port. */
+     anything without an explicitly set source port. */
   if (!daemon->osport)
     {
       errno = 0;

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1474,58 +1474,45 @@ static int parse_dhcp_opt(char *errstr, char *arg, int flags)
   
   while (arg)
     {
+      char *start = arg;
       comma = split(arg);      
-
-      for (cp = arg; *cp; cp++)
+      
+      if (strstr(arg, "option:") == arg)
+	start = arg+7;
+#ifdef HAVE_DHCP6
+      else if (strstr(arg, "option6:") == arg)
+	{
+	  start = arg+8;
+	  is6 = 1;
+	}
+#endif
+      else if (strstr(arg, "option4:") == arg)
+	start = arg+8;
+      
+      for (cp = start; *cp; cp++)
 	if (*cp < '0' || *cp > '9')
 	  break;
       
       if (!*cp)
 	{
-	  new->opt = atoi(arg);
+	  new->opt = atoi(start);
 	  opt_len = 0;
 	  option_ok = 1;
 	  break;
 	}
-      
-      if (strstr(arg, "option:") == arg)
+
+      /* option*:<opt>|<optname> must follow tag and vendor string. */
+      if (start != arg)
 	{
-	  if ((new->opt = lookup_dhcp_opt(AF_INET, arg+7)) != -1)
+	  if ((new->opt = lookup_dhcp_opt(is6 ? AF_INET6: AF_INET, start)) != -1)
 	    {
-	      opt_len = lookup_dhcp_len(AF_INET, new->opt);
+	      opt_len = lookup_dhcp_len(is6 ? AF_INET6: AF_INET, new->opt);
 	      /* option:<optname> must follow tag and vendor string. */
 	      if (!(opt_len & OT_INTERNAL) || flags == DHOPT_MATCH)
 		option_ok = 1;
 	    }
 	  break;
 	}
-#ifdef HAVE_DHCP6
-      else if (strstr(arg, "option6:") == arg)
-	{
-	  for (cp = arg+8; *cp; cp++)
-	    if (*cp < '0' || *cp > '9')
-	      break;
-	 
-	  if (!*cp)
-	    {
-	      new->opt = atoi(arg+8);
-	      opt_len = 0;
-	      option_ok = 1;
-	    }
-	  else
-	    {
-	      if ((new->opt = lookup_dhcp_opt(AF_INET6, arg+8)) != -1)
-		{
-		  opt_len = lookup_dhcp_len(AF_INET6, new->opt);
-		  if (!(opt_len & OT_INTERNAL) || flags == DHOPT_MATCH)
-		    option_ok = 1;
-		}
-	    }
-	  /* option6:<opt>|<optname> must follow tag and vendor string. */
-	  is6 = 1;
-	  break;
-	}
-#endif
       else if (strstr(arg, "vendor:") == arg)
 	{
 	  new->u.vendor_class = (unsigned char *)opt_string_alloc(arg+7);
@@ -2013,7 +2000,7 @@ static int parse_dhcp_opt(char *errstr, char *arg, int flags)
 
   if (flags == DHOPT_PXE_OPT &&  (new->flags & DHOPT_VENDOR))
     goto_err(_("No vendor-encap options allowed in dhcp-option-pxe")); 
-      
+
   if (flags == DHOPT_MATCH)
     {
       if ((new->flags & (DHOPT_ENCAPSULATE | DHOPT_VENDOR)) ||

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -2848,7 +2848,7 @@ static int one_opt(int option, char *arg, char *errstr, char *gen_err, int comma
 	break;
       }
       
-    case LOPT_CPE_ID: /* --add-dns-client */
+    case LOPT_CPE_ID: /* --add-cpe-id */
       if (arg)
 	daemon->dns_client_id = opt_string_alloc(arg);
       break;

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1908,6 +1908,51 @@ static int parse_dhcp_opt(char *errstr, char *arg, int flags)
 	      new->val = newp;
 	      new->len = p - newp;
 	    }
+	  else if (comma && (opt_len & OT_DHCP6_VENDOR))
+	    {
+	      /* First arg is Enterprise ID (4 bytes)
+		 subsequent are length fields (2 bytes each) + string */
+	      int i, commas = 1;
+	      unsigned char *p, *newp;
+
+	      for (i = 0; comma[i]; i++)
+		if (comma[i] == ',')
+		  commas++;
+
+	      newp = opt_malloc(strlen(comma)+(2*commas)+4);
+	      p = newp;
+	      arg = comma;
+	      comma = split(arg);
+
+	      if (arg && *arg)
+	      {
+	      unsigned int enterprise = atoi(arg);
+	      PUTLONG(enterprise, p);
+	      }
+	      else
+	      goto_err(_("missing enterprise ID in dhcp-option"));
+
+	      arg = comma;
+	      comma = split(arg);
+
+	      if (!arg || !*arg)
+	      goto_err(_("missing vendor class in dhcp-option"));
+
+	      while (arg && *arg)
+		{
+		  u16 len = strlen(arg);
+		  unhide_metas(arg);
+		  PUTSHORT(len, p);
+		  memcpy(p, arg, len);
+		  p += len;
+
+		  arg = comma;
+		  comma = split(arg);
+		}
+
+	      new->val = newp;
+	      new->len = p - newp;
+	    }
 	  else if (comma && (opt_len & OT_RFC1035_NAME))
 	    {
 	      unsigned char *p = NULL, *q, *newp, *end;

--- a/src/dnsmasq/option.c
+++ b/src/dnsmasq/option.c
@@ -1386,7 +1386,7 @@ static void dhcp_netid_list_free(struct dhcp_netid_list *netid)
       netid = netid->next;
       /* Note: don't use dhcp_netid_free() here, since that 
 	 frees a list linked on netid->next. Where a netid_list
-	 is used that's because the the ->next pointers in the
+	 is used that's because the ->next pointers in the
 	 netids are being used to temporarily construct 
 	 a list of valid tags. */
       free(tmplist->list->net);

--- a/src/dnsmasq/radv.c
+++ b/src/dnsmasq/radv.c
@@ -58,7 +58,7 @@ static int add_prefixes(struct in6_addr *local,  int prefix,
 			unsigned int preferred, unsigned int valid, void *vparam);
 static int iface_search(struct in6_addr *local,  int prefix,
 			int scope, int if_index, int flags, 
-			unsigned int prefered, unsigned int valid, void *vparam);
+			unsigned int preferred, unsigned int valid, void *vparam);
 static int add_lla(int index, unsigned int type, char *mac, size_t maclen, void *parm);
 static void new_timeout(struct dhcp_context *context, char *iface_name, time_t now);
 static unsigned int calc_lifetime(struct ra_interface *ra);

--- a/src/dnsmasq/rfc1035.c
+++ b/src/dnsmasq/rfc1035.c
@@ -586,11 +586,8 @@ static int find_soa(struct dns_header *header, size_t qlen, char *name, int *sub
 		    {
 		      len = to_wire(daemon->workspacename);
 		      if (!blockdata_expand(addr.rrblock.rrdata, addr.rrblock.datalen, daemon->workspacename, len))
-			{
-			  blockdata_free(addr.rrblock.rrdata);
-			  return 0;
-			}
-
+			return 0;
+		      
 		      addr.rrblock.datalen += len;
 		    }
 		}
@@ -608,11 +605,8 @@ static int find_soa(struct dns_header *header, size_t qlen, char *name, int *sub
 		  int secflag = 0;
 
 		  if (!blockdata_expand(addr.rrblock.rrdata, addr.rrblock.datalen, (char *)p, 20))
-		    {
-		      blockdata_free(addr.rrblock.rrdata);
-		      return 0;
-		    }
-		  
+		    return 0;
+		    		  
 		  addr.rrblock.datalen += 20;
 		  
 #ifdef HAVE_DNSSEC
@@ -966,10 +960,8 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 			    {
 			      /* Copy the rest of the RR and end. */
 			      if (!blockdata_expand(addr.rrblock.rrdata, addr.rrblock.datalen, (char *)p1, endrr - p1))
-				{
-				  blockdata_free(addr.rrblock.rrdata);
-				  return 0;
-				}
+				return 0;
+				
 			      addr.rrblock.datalen += endrr - p1;
 			    }
 			  else if (desc == 0)
@@ -986,11 +978,8 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 			      
 			      len = to_wire(name);
 			      if (!blockdata_expand(addr.rrblock.rrdata, addr.rrblock.datalen, name, len))
-				{
-				  blockdata_free(addr.rrblock.rrdata);
-				  return 0;
-				}
-			      
+				return 0;
+							      
 			      addr.rrblock.datalen += len;
 			    }
 			  else
@@ -1000,11 +989,8 @@ int extract_addresses(struct dns_header *header, size_t qlen, char *name, time_t
 				desc = endrr - p1;
 
 			      if (!blockdata_expand(addr.rrblock.rrdata, addr.rrblock.datalen, (char *)p1, desc))
-				{
-				  blockdata_free(addr.rrblock.rrdata);
-				  return 0;
-				}
-
+				return 0;
+				
 			      addr.rrblock.datalen += desc;
 			      p1 += desc;
 			    }

--- a/src/dnsmasq/rfc3315.c
+++ b/src/dnsmasq/rfc3315.c
@@ -255,10 +255,10 @@ static int dhcp6_maybe_relay(struct state *state, unsigned char *inbuff, size_t 
 	      /* the packet data is unaligned, copy to aligned storage */
 	      memcpy(&align, inbuff + 2, IN6ADDRSZ); 
 
-	      /* RFC6221 para 4 says if link_address in encapulation
+	      /* RFC6221 para 4 says if link_address in encapsulation
 		 is zero, ignore it, and, by implication, use the link
 		 address of any enclosing encapsulation or, failing that
-		 of the arrival interface on the the server. */
+		 of the arrival interface on the server. */
 	      if (!dhcp6_maybe_relay(state, opt6_ptr(opt, 0), opt6_len(opt), client_addr,
 				     IN6_IS_ADDR_UNSPECIFIED(&align) ? link_address : &align, now))
 		return 0;

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -855,7 +855,7 @@ static char *next(char **p, char *end)
   return ret;
 }
 
-/* If we don't do anything, don't write the the input/ouptut
+/* If we don't do anything, don't write the input/output
    buffer. This allows us to pass in safe read-only strings constants. */
 static void sanitise(char *buf)
 {

--- a/src/dnsmasq/tftp.c
+++ b/src/dnsmasq/tftp.c
@@ -251,15 +251,14 @@ static void tftp_request(char *packet, ssize_t plen, struct listener *listen, ti
 
       for (tftp_cnt = 0, transfer = daemon->tftp_trans, up = &daemon->tftp_trans; transfer; up = &transfer->next, transfer = transfer->next)
 	{
-	  tftp_cnt++;
-
 	  if (sockaddr_isequal(&peer, &transfer->peer))
 	    {
 	      if (ntohs(*((unsigned short *)packet)) == OP_RRQ)
 		{
 		  /* Handle repeated RRQ or abandoned transfer from same host and port 
-		     by unlinking and reusing the struct transfer. */
+		     by abandoning old transfer. */
 		  *up = transfer->next;
+		  free_transfer(transfer);
 		  break;
 		}
 	      else
@@ -268,12 +267,14 @@ static void tftp_request(char *packet, ssize_t plen, struct listener *listen, ti
 		  return;
 		}
 	    }
+
+	  tftp_cnt++;
 	}
       
       /* Enforce simultaneous transfer limit. In non-single-port mode
 	 this is done by not listening on the server socket when
 	 too many transfers are in progress. */
-      if (!transfer && tftp_cnt >= daemon->tftp_max)
+      if (tftp_cnt >= daemon->tftp_max)
 	return;
     }
   
@@ -302,12 +303,9 @@ static void tftp_request(char *packet, ssize_t plen, struct listener *listen, ti
 #endif
     }
 
-  /* May reuse struct transfer from abandoned transfer in single port mode. */
-  if (!transfer && !(transfer = whine_malloc(sizeof(struct tftp_transfer))))
+  if (!(transfer = whine_malloc(sizeof(struct tftp_transfer))))
     return;
 
-  memset(transfer, 0, sizeof(struct tftp_transfer));
-	 
   if (option_bool(OPT_SINGLE_PORT))
     transfer->sockfd = listen->tftpfd;
   else if ((transfer->sockfd = socket(family, SOCK_DGRAM, 0)) == -1)

--- a/test/dnsmasq_warnings
+++ b/test/dnsmasq_warnings
@@ -132,9 +132,9 @@ src/dnsmasq/log.c
 src/dnsmasq/network.c
 	    my_syslog(LOG_WARNING, s, daemon->addrbuff, strerror(errno));
 src/dnsmasq/network.c
-		my_syslog(LOG_WARNING, 
-			  _("LOUD WARNING: listening on %s may accept requests via interfaces other than %s"),
-			  daemon->addrbuff, iface->name);
+	my_syslog(LOG_WARNING, 
+		  _("LOUD WARNING: listening on %s may accept requests via interfaces other than %s"),
+		  daemon->addrbuff, iface->name);
 src/dnsmasq/network.c
     my_syslog(LOG_WARNING, _("LOUD WARNING: use --bind-dynamic rather than --bind-interfaces to avoid DNS amplification attacks via these interface(s)")); 
 src/dnsmasq/network.c


### PR DESCRIPTION
# What does this implement/fix?

Update the embedded dnsmasq to the current state of upstream `master`, which is 16 commits past `v2.93`. 13 of those commits touch `src/` and are included here, the remaining three only change `man/` and the `CHANGELOG`, neither of which we vendor. As there is no upstream tag for this state, `DNSMASQ_VERSION` becomes `pi-hole-v2.93+16`, following the `+N` scheme we already used for `pi-hole-v2.92test10+2`.

# Highlights

## Security

- **Information disclosure in the DNS error path.** An oversight in `f9f8d19b` leaves a code path where a repeated query gets an error reply that discloses the ID we use towards upstream servers. An attacker who can trigger this path learns the ID, which makes Kaminsky cache-poisoning attacks considerably cheaper and more reliable. This affects the stable releases 2.91, 2.92, 2.92rel2 and 2.93. Thanks to Ronen Shustin from Project Atlas, Wiz for finding this. A follow-up commit extends the fix: other error paths (not reachable by an attack) returned an incorrect `header->id` as well, and most of them returned the wrong query case when `--do-0x20-encode` is in use.
- **Double-free in `blockdata_expand()`.** The function already frees the block chain when it fails, but every caller ran its own `blockdata_free()` cleanup on the zero return, resulting in a double free and a crash.
- **File-descriptor leak in the TFTP code.** A leaked descriptor per failed transfer eventually exhausts the process' descriptor limit.
- CVE-2026-12969 has been allocated to the buffer OOB read in `find_soa()`. There is nothing to do for us: that fix is `14094e88` and was already released with v2.93, so the corresponding upstream commit is a CHANGELOG-only record.

## Correctness

- **Forked TCP children now close the listening sockets they inherit.** The children never use them, but keeping them alive in the kernel prevents the parent from re-binding when an interface goes away and comes back, which fails with `EADDRINUSE`. The parent already blocked on the pipe until the child had closed the netlink socket, and that handshake now covers the listening sockets too. A follow-up commit extends the same treatment to the route socket on *BSD.
- **The log file is only `chown`ed if it is a regular file.** Pointing `log-facility` at a device or a symlink no longer changes ownership of the target.
- **Fixed the logic that suppresses repeated warnings for bound interfaces**, which suppressed too much and hid warnings for other interfaces.
- **Fixed the packet dump code**, which wrote malformed records under some conditions.

## New features

- **DHCPv6 vendor class support.** `OT_DHCP6_VENDOR` is now implemented properly, so option 16 can be configured by name, e.g., `--dhcp-option=option6:vendor-class,343,HTTPClient`. Before, configuring it by name failed outright, and working around that with `option6:16` produced a payload with an unintended string-length prefix instead of the fixed 4-byte enterprise ID RFC 3315 requires. This broke, among others, UEFI HTTP IPv6 boot.
- **DHCPv4 and DHCPv6 option configuration are consistent now.** `option4:` is accepted as the explicit counterpart to `option6:`, and a numeric option is accepted after any of the prefixes, so `option:6`, `option4:6` and `option6:23` all work the way one would expect. Existing `option:` and `option6:` configurations are unaffected.

## Cosmetic

- A batch of typo fixes throughout the tree and a comment referring to a flag by its old name. No user-visible strings changed except for one re-indentation, which `test/dnsmasq_warnings` had to follow.

## Notes for the merge

Two commits needed a manual resolution against our tree. Both touch the child branch of `swap_to_tcp()`, where we keep a Pi-hole modification that resets `daemon->netlinkfd` to `-1` after closing it. Upstream moves the `read_write()` handshake out of the `#ifdef HAVE_LINUX_NETWORK` block and past the new socket-closing loop, so our reset stays with the netlink close inside the `#ifdef`, and the `#elif defined(HAVE_BSD_NETWORK)` branch is inserted after it. The result is identical to upstream apart from those two lines.

Upstream carries a latent build issue that we are not affected by and that I did not paper over: `read_write(pipefd[0], &a, 1, RW_READ)` is unconditional now, while `unsigned char a` is still declared under `#ifdef HAVE_LINUX_NETWORK` in both `do_tcp_connection()` and `swap_to_tcp()`. We always build with `HAVE_LINUX_NETWORK`, so this only bites non-Linux builds. I will report it on `dnsmasq-discuss`.

## How to test the change during review

- Build and check that `src/dnsmasq/` produces no new compiler warnings.
- `bash test/dnsmasq_warnings.sh` has to pass. It diffs the `LOG_WARNING` call sites against `test/dnsmasq_warnings` and picks up the re-indentation mentioned above.
- The full BATS suite in CI covers the rest, in particular `test/test_final.bats`, which fails on unexpected `WARNING:` lines in `FTL.log`.
- For the DHCPv6 vendor class, configure `dhcp-option=option6:vendor-class,343,HTTPClient` and confirm the option is emitted with the 4-byte enterprise ID followed by a 2-byte length, e.g., in a `pihole-FTL --dnsmasq-debug` capture.
- For the option parsing rework, confirm that existing `option:`/`option6:` configurations still parse, and that `option4:` is accepted.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I signed off all commits.
- [x] I signed all my commits.
- [x] I have read the above and my PR is ready for review.
