### PR TITLE
Serialize config changes so concurrent API writes cannot drop each other

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -271,9 +271,11 @@ int api_handler(struct mg_connection *conn, void *ignored)
 		                      api.request->local_uri_raw);
 	}
 
-	// Restart FTL if requested
+	// Restart FTL if requested. Config changes go through the delay so that a
+	// burst of them results in a single restart, /api/action/restartdns is an
+	// explicit request and restarts right away.
 	if(api.ftl.restart)
-		restart_ftl(api.ftl.restart_reason);
+		request_restart(api.ftl.restart_reason);
 
 	return ret;
 }

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -741,7 +741,7 @@ static int api_config_get(struct ftl_conn *api)
 	JSON_SEND_OBJECT(json);
 }
 
-static int api_config_patch(struct ftl_conn *api)
+static int config_patch(struct ftl_conn *api)
 {
 	// Is there a payload with valid JSON data?
 	const int ret = check_json_payload(api);
@@ -950,13 +950,21 @@ static int api_config_patch(struct ftl_conn *api)
 	return api_config_get(api);
 }
 
+static int api_config_patch(struct ftl_conn *api)
+{
+	lock_config();
+	const int ret = config_patch(api);
+	unlock_config();
+	return ret;
+}
+
 // Inspired by https://stackoverflow.com/a/32496721
 //static void replace_char(char* str, char find, char replace)
 //{
 //	for (char *current_pos = strchr(str, find); (current_pos = strchr(str+1, find)) != NULL; *current_pos = replace);
 //}
 
-static int api_config_put_delete(struct ftl_conn *api)
+static int config_put_delete(struct ftl_conn *api)
 {
 	if(api->item == NULL || strlen(api->item) == 0)
 		return 0;
@@ -1175,6 +1183,14 @@ static int api_config_put_delete(struct ftl_conn *api)
 		send_http_code(api, NULL, 204, "");
 		return 204;
 	}
+}
+
+static int api_config_put_delete(struct ftl_conn *api)
+{
+	lock_config();
+	const int ret = config_put_delete(api);
+	unlock_config();
+	return ret;
 }
 
 // Endpoint /api/config router

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -586,6 +586,8 @@ components:
                   type: integer
                 delay_startup:
                   type: integer
+                restart_delay:
+                  type: integer
                 addr2line:
                   type: boolean
                 etc_dnsmasq_d:
@@ -935,6 +937,7 @@ components:
           misc:
             nice: -10
             delay_startup: 10
+            restart_delay: 0
             addr2line: true
             privacylevel: 0
             etc_dnsmasq_d: false

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -116,9 +116,14 @@ int api_info_database(struct ftl_conn *api)
 	JSON_ADD_NUMBER_TO_OBJECT(json, "ctime", st.st_ctime); // Time of last status change (owner or mode change, etc.)
 
 	// Get owner details
+	// The reentrant lookups are required as this runs on a webserver worker
+	// thread: getpwuid()/getgrgid() share one buffer between all threads
+	char pwbuf[PWBUF_SIZE];
+	struct passwd pwstore, *pw = NULL;
+	getpwuid_r(st.st_uid, &pwstore, pwbuf, sizeof(pwbuf), &pw);
+
 	cJSON *user = JSON_NEW_OBJECT();
 	JSON_ADD_NUMBER_TO_OBJECT(user, "uid", st.st_uid); // UID
-	const struct passwd *pw = getpwuid(st.st_uid);
 	if(pw != NULL)
 	{
 		JSON_COPY_STR_TO_OBJECT(user, "name", pw->pw_name); // User name
@@ -130,9 +135,12 @@ int api_info_database(struct ftl_conn *api)
 		JSON_ADD_NULL_TO_OBJECT(user, "info");
 	}
 
+	char grbuf[PWBUF_SIZE];
+	struct group grstore, *gr = NULL;
+	getgrgid_r(st.st_gid, &grstore, grbuf, sizeof(grbuf), &gr);
+
 	cJSON *group = JSON_NEW_OBJECT();
 	JSON_ADD_NUMBER_TO_OBJECT(group, "gid", st.st_gid); // GID
-	const struct group *gr = getgrgid(st.st_gid);
 	if(gr != NULL)
 	{
 		JSON_COPY_STR_TO_OBJECT(group, "name", gr->gr_name); // Group name

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1455,6 +1455,13 @@ void initConfig(struct config *conf)
 	conf->misc.delay_startup.d.ui = 0;
 	conf->misc.delay_startup.c = validate_stub; // Only type-based checking
 
+	conf->misc.restart_delay.k = "misc.restart_delay";
+	conf->misc.restart_delay.h = "Some configuration changes can only be applied by restarting the DNS resolver. When a client changes many settings one after another, restarting on each of them takes the resolver down repeatedly. With this setting, FTL waits the given number of seconds and applies everything arriving in the meantime in a single restart.\n\n This setting takes any integer value between 0 and 60 seconds, where 0 restarts immediately. Each further change extends the wait, but a restart is postponed by no more than five times this value (hard-coded).";
+	conf->misc.restart_delay.a = cJSON_CreateStringReference("A positive integer value between 0 and 60");
+	conf->misc.restart_delay.t = CONF_UINT;
+	conf->misc.restart_delay.d.ui = 0;
+	conf->misc.restart_delay.c = validate_restart_delay;
+
 	conf->misc.nice.k = "misc.nice";
 	conf->misc.nice.h = "Set niceness of pihole-FTL. Defaults to -10 and can be disabled altogether by setting a value of -999. The nice value is an attribute that can be used to influence the CPU scheduler to favor or disfavor a process in scheduling decisions.\n\n The range of the nice value varies across UNIX systems. On modern Linux, the range is -20 (high priority = not very nice to other processes) to +19 (low priority).";
 	conf->misc.nice.a = cJSON_CreateStringReference("A signed integer value between -20 and 19, or -999 to disable niceness");

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -43,9 +43,44 @@ struct config config = { 0 };
 static bool config_initialized = false;
 uint8_t last_checksum[SHA256_DIGEST_SIZE] = { 0 };
 
+// Serializes config modifications against each other. duplicate_config() and
+// replace_config() each take the SHM lock only for themselves, so two writers
+// can both snapshot the config, both change their own copy and both install it
+// - whichever installs last silently drops the other's change. The same lock
+// also keeps the write-back (pihole.toml rotation, dnsmasq test file, HOSTS
+// file) of two writers from interleaving.
+// It is recursive because a config change can nest: setting webserver.api.password
+// runs the legacy password upgrade, which writes the config out on its own.
+static pthread_mutex_t config_write_lock;
+
 // Private prototypes
 static bool port_in_use(const in_port_t port);
 static void reset_config_default(struct conf_item *conf_item);
+
+void init_config_lock(void)
+{
+	pthread_mutexattr_t lock_attr;
+	pthread_mutexattr_init(&lock_attr);
+	pthread_mutexattr_settype(&lock_attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&config_write_lock, &lock_attr);
+	pthread_mutexattr_destroy(&lock_attr);
+}
+
+void lock_config(void)
+{
+	const int ret = pthread_mutex_lock(&config_write_lock);
+	if(ret != 0)
+		log_err("Error when obtaining config lock: %s", strerror(ret));
+	log_debug(DEBUG_LOCKS, "Obtained config write lock");
+}
+
+void unlock_config(void)
+{
+	const int ret = pthread_mutex_unlock(&config_write_lock);
+	if(ret != 0)
+		log_err("Error when releasing config lock: %s", strerror(ret));
+	log_debug(DEBUG_LOCKS, "Released config write lock");
+}
 
 // Set debug flags from config struct to global debug_flags array
 // This is called whenever the config is reloaded and debug flags may have
@@ -2102,12 +2137,17 @@ void replace_config(struct config *newconf)
 
 void reread_config(void)
 {
+	// Serialize against API config changes: the file we are about to read
+	// is only authoritative as long as no other thread is in the middle of
+	// changing the config in memory and writing it back
+	lock_config();
 
 	// Create checksum of config file
 	uint8_t checksum[SHA256_DIGEST_SIZE];
 	if(!sha256sum(GLOBALTOMLPATH, checksum, false))
 	{
 		log_err("Unable to create checksum of %s, not re-reading config file", GLOBALTOMLPATH);
+		unlock_config();
 		return;
 	}
 
@@ -2115,6 +2155,7 @@ void reread_config(void)
 	if(memcmp(checksum, last_checksum, SHA256_DIGEST_SIZE) == 0)
 	{
 		log_debug(DEBUG_CONFIG, "Checksum of %s has not changed, not re-reading config file", GLOBALTOMLPATH);
+		unlock_config();
 		return;
 	}
 
@@ -2167,6 +2208,8 @@ void reread_config(void)
 	// However, we do need to write the custom.list file as this file can change
 	// at any time and is automatically reloaded by dnsmasq
 	write_custom_list();
+
+	unlock_config();
 
 	// If we need to restart FTL, we do so now
 	if(restart)

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -399,6 +399,9 @@ bool check_paths_equal(char **paths1, char **paths2, unsigned int max_level) __a
 const char *get_conf_type_str(const enum conf_type type) __attribute__ ((const));
 void replace_config(struct config *newconf);
 void reread_config(void);
+void init_config_lock(void);
+void lock_config(void);
+void unlock_config(void);
 bool create_migration_target_v6(void);
 bool create_default_config(const char *filename);
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -318,6 +318,7 @@ struct config {
 	struct {
 		struct conf_item privacylevel;
 		struct conf_item delay_startup;
+		struct conf_item restart_delay;
 		struct conf_item nice;
 		struct conf_item addr2line;
 		struct conf_item etc_dnsmasq_d;

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -499,11 +499,13 @@ enum password_result verify_password(const char *password, const char *pwhash, c
 			if(new_hash != NULL)
 			{
 				log_info("Upgrading password from SHA256^2 to BALLOON-SHA256");
+				lock_config();
 				if(config.webserver.api.pwhash.t == CONF_STRING_ALLOCATED)
 					free(config.webserver.api.pwhash.v.s);
 				config.webserver.api.pwhash.v.s = new_hash;
 				config.webserver.api.pwhash.t = CONF_STRING_ALLOCATED;
 				writeFTLtoml(true, NULL);
+				unlock_config();
 			}
 
 			// Successful logins do not count against rate-limiting

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -641,6 +641,17 @@ bool validate_ui_min_7_or_0(union conf_value *val, const char *key, char err[VAL
 	return true;
 }
 
+bool validate_restart_delay(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	if(val->ui > 60)
+	{
+		snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: cannot be larger than 60", key);
+		return false;
+	}
+
+	return true;
+}
+
 // Sanitize the dns.hosts array
 // This function normalizes whitespace formatting in the dns.hosts entries
 // to ensure consistent formatting when saving to pihole.toml

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -28,6 +28,7 @@ bool validate_webserver_logfile(union conf_value *val, const char *key, char err
 bool validate_regex_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_revServers(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_ui_min_7_or_0(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+bool validate_restart_delay(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 void sanitize_dns_hosts(union conf_value *val);
 bool validate_dns_domain_or_ip(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_str_no_newline(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);

--- a/src/files.c
+++ b/src/files.c
@@ -433,19 +433,28 @@ static int copy_file(const char *source, const char *destination)
 // Change ownership of file to pihole user
 bool chown_pihole(const char *path, struct passwd *pwd)
 {
+	// getpwnam() and getgrgid() hand out pointers into a buffer shared by all
+	// threads and grow it as needed, so two threads in here at the same time
+	// corrupt that buffer. Use the reentrant variants with local storage.
+	char pwbuf[PWBUF_SIZE];
+	struct passwd pwstore;
+
 	// Get pihole user's UID and GID if not provided
 	if(pwd == NULL)
 	{
-		pwd = getpwnam("pihole");
+		const int ret = getpwnam_r("pihole", &pwstore, pwbuf, sizeof(pwbuf), &pwd);
 		if(pwd == NULL)
 		{
-			log_warn("chown_pihole(): Failed to get pihole user's UID/GID: %s", strerror(errno));
+			log_warn("chown_pihole(): Failed to get pihole user's UID/GID: %s",
+			         ret == 0 ? "user not found" : strerror(ret));
 			return false;
 		}
 	}
 
 	// Get group name
-	struct group *grp = getgrgid(pwd->pw_gid);
+	char grbuf[PWBUF_SIZE];
+	struct group grstore, *grp = NULL;
+	getgrgid_r(pwd->pw_gid, &grstore, grbuf, sizeof(grbuf), &grp);
 	const char *grp_name = grp != NULL ? grp->gr_name : "<unknown>";
 
 	// Change ownership of file to pihole user

--- a/src/files.h
+++ b/src/files.h
@@ -22,6 +22,9 @@
 #define MAX_ROTATIONS 15
 #define BACKUP_DIR "/etc/pihole/config_backups"
 
+// Scratch space handed to getpwnam_r()/getgrgid_r() and friends
+#define PWBUF_SIZE 2048
+
 bool chmod_file(const char *filename, const mode_t mode);
 bool file_exists(const char *filename);
 bool file_readable(const char *filename);

--- a/src/gc.c
+++ b/src/gc.c
@@ -727,6 +727,10 @@ void *GC_thread(void *val)
 		if(killed)
 			break;
 
+		// Check if a configuration change asked for a restart and enough
+		// time has passed for further changes to have arrived
+		check_pending_restart();
+
 		// Check if we need to terminate/restart FTL but this has been
 		// postponed because of an ongoing gravity run
 		check_if_want_terminate();

--- a/src/main.c
+++ b/src/main.c
@@ -69,6 +69,7 @@ int main (int argc, char *argv[])
 	init_FTL_log();
 	// Try to open FTL log
 	init_config_mutex();
+	init_config_lock();
 	timer_start(EXIT_TIMER);
 	log_info("########## FTL started on %s! ##########", hostname());
 	log_FTL_version(false);

--- a/src/signals.c
+++ b/src/signals.c
@@ -1524,6 +1524,64 @@ void restart_ftl(const char *reason)
 	kill(main_pid(), SIGTERM);
 }
 
+// Restart requested by a configuration change, not yet carried out. Written by
+// the webserver worker threads, read by the housekeeping thread, hence the lock.
+static pthread_mutex_t restart_lock = PTHREAD_MUTEX_INITIALIZER;
+static time_t restart_first_request = 0, restart_last_request = 0;
+static const char *restart_reason = NULL;
+
+// Ask for a restart once the configuration has settled. Clients writing many
+// settings one after another do not know which of their requests is the last
+// one, so we collect everything arriving within misc.restart_delay seconds and
+// tear the resolver down once instead of per request.
+void request_restart(const char *reason)
+{
+	if(config.misc.restart_delay.v.ui == 0)
+	{
+		restart_ftl(reason);
+		return;
+	}
+
+	pthread_mutex_lock(&restart_lock);
+	restart_last_request = time(NULL);
+	if(restart_first_request == 0)
+	{
+		restart_first_request = restart_last_request;
+		restart_reason = reason;
+	}
+	pthread_mutex_unlock(&restart_lock);
+
+	log_debug(DEBUG_CONFIG, "Restart requested (%s), waiting %u seconds for further changes",
+	          reason, config.misc.restart_delay.v.ui);
+}
+
+// Carry out a delayed restart once the requests have stopped coming in, or
+// after five times the delay so that a client writing continuously cannot
+// postpone the restart forever. Called once a second from the housekeeping
+// thread.
+void check_pending_restart(void)
+{
+	const time_t delay = config.misc.restart_delay.v.ui;
+	const char *reason = NULL;
+
+	pthread_mutex_lock(&restart_lock);
+	if(restart_first_request > 0)
+	{
+		const time_t now = time(NULL);
+		if(now - restart_last_request >= delay ||
+		   now - restart_first_request >= 5 * delay)
+		{
+			reason = restart_reason;
+			restart_first_request = restart_last_request = 0;
+			restart_reason = NULL;
+		}
+	}
+	pthread_mutex_unlock(&restart_lock);
+
+	if(reason != NULL)
+		restart_ftl(reason);
+}
+
 /**
  * @brief Checks if the current process is being debugged.
  *

--- a/src/signals.h
+++ b/src/signals.h
@@ -29,6 +29,8 @@ void generate_backtrace(void);
 int sigtest(void);
 int sigrtmin(void);
 void restart_ftl(const char *reason);
+void request_restart(const char *reason);
+void check_pending_restart(void);
 const char *get_term_source(void);
 pid_t debugger(void);
 

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -323,11 +323,15 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 
 	// Check if the file contains a valid configuration for Pi-hole by parsing it into
 	// a temporary config struct (teleporter_config)
+	// Everything from here on modifies the global config and writes it back,
+	// so it has to be serialized against other config writers
 	struct config teleporter_config = { 0 };
+	lock_config();
 	duplicate_config(&teleporter_config, &config);
 	if(!readFTLtoml(NULL, &teleporter_config, toml.toptab, true, NULL, 0, true))
 	{
 		free_config(&teleporter_config, false);
+		unlock_config();
 		toml_free(toml);
 		return "File etc/pihole/pihole.toml in ZIP archive contains invalid TOML configuration";
 	}
@@ -337,6 +341,7 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 	if(!write_dnsmasq_config(&teleporter_config, true, hint))
 	{
 		free_config(&teleporter_config, false);
+		unlock_config();
 		toml_free(toml);
 		return "File etc/pihole/pihole.toml in ZIP archive contains invalid dnsmasq configuration";
 	}
@@ -353,6 +358,7 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 	rotate_files(GLOBALTOMLPATH, NULL);
 	writeFTLtoml(true, NULL);
 	write_custom_list();
+	unlock_config();
 
 	toml_free(toml);
 	return NULL;

--- a/test/api/test_m_mutations.py
+++ b/test/api/test_m_mutations.py
@@ -14,9 +14,11 @@ Usage:
 """
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import quote
 
 import pytest
+import requests
 
 FTL_URL = "http://127.0.0.1"
 
@@ -30,6 +32,79 @@ def _j(response):
     data = response.json()
     data.pop("took", None)
     return data
+
+
+# ===========================================================================
+# Concurrent config mutations
+# ===========================================================================
+
+class TestConcurrentConfigMutations:
+    """Regression test for the lost-delete race (pi-hole/FTL#3015).
+
+    Config changes are a read-copy-modify-install sequence.  Without a lock
+    spanning the whole sequence, two API workers can each copy the config,
+    change their own copy and install it - whoever installs last silently
+    drops the other's change, so an entry deleted with a 204 reappears.
+
+    ``webserver.api.excludeDomains`` is used instead of ``dns.hosts`` because
+    it is empty in the test config and needs neither a dnsmasq test, a
+    ``custom.list`` rewrite nor a restart, which keeps the test out of the
+    other write counters ``test/test_final.bats`` asserts on.
+    """
+
+    # 2 * WORKERS * ROUNDS pihole.toml writes -- keep the count in
+    # test/test_final.bats ("Expected number of config file rotations") in sync
+    WORKERS = 4
+    ROUNDS = 6
+    BASE = f"{FTL_URL}/api/config/webserver/api/excludeDomains"
+
+    @staticmethod
+    def _entries(session):
+        r = session.get(TestConcurrentConfigMutations.BASE, timeout=10)
+        assert r.status_code == 200, f"GET failed: {r.status_code} {r.text}"
+        return _j(r)["config"]["webserver"]["api"]["excludeDomains"]
+
+    @classmethod
+    def _worker(cls, headers, idx):
+        """PUT and DELETE this worker's own entries, one at a time."""
+        problems = []
+        session = requests.Session()
+        session.headers.update(headers)
+        for i in range(cls.ROUNDS):
+            item = quote(f"pytest-3015-{idx}-{i}.test", safe="")
+            url = f"{cls.BASE}/{item}"
+            try:
+                r = session.put(url, timeout=20)
+                if r.status_code != 201:
+                    problems.append(f"PUT {item}: {r.status_code} {r.text}")
+                    continue
+                r = session.delete(url, timeout=20)
+                if r.status_code != 204:
+                    problems.append(f"DELETE {item}: {r.status_code} {r.text}")
+            except requests.RequestException as err:
+                # FTL died or dropped the connection mid-request
+                problems.append(f"{item}: {err}")
+                break
+        session.close()
+        return problems
+
+    def test_parallel_put_delete_leaves_no_entry_behind(self, api_session):
+        before = self._entries(api_session)
+        headers = dict(api_session.headers)
+
+        with ThreadPoolExecutor(max_workers=self.WORKERS) as pool:
+            results = pool.map(lambda i: self._worker(headers, i),
+                               range(self.WORKERS))
+            problems = [p for result in results for p in result]
+
+        assert not problems, "Requests failed:\n" + "\n".join(problems[:10])
+
+        after = self._entries(api_session)
+        resurrected = sorted(set(after) - set(before))
+        assert not resurrected, \
+            f"Entries returned after their DELETE was acked: {resurrected}"
+        assert sorted(after) == sorted(before), \
+            f"Config changed: {sorted(before)} -> {sorted(after)}"
 
 
 # ---------------------------------------------------------------------------

--- a/test/dotdoh.bats
+++ b/test/dotdoh.bats
@@ -50,6 +50,22 @@ api_patch_dns() {  # $1 = JSON object for "dns", $2 = readiness log marker
   ./pihole-FTL wait-for "$2" /var/log/pihole/FTL.log 30 "$before"
 }
 
+# PATCH a dns config object without waiting for the restart it may trigger, for
+# callers that issue several changes and wait for the collected restart once.
+api_patch_dns_async() {  # $1 = JSON object for "dns"
+  curl -s -o /dev/null --max-time 10 -X PATCH "${FTL_URL}/api/config" \
+       -H "Content-Type: application/json" \
+       -d "{\"config\":{\"dns\":$1}}" || true
+}
+
+# PATCH a misc config object. Nothing under misc used here is RESTART_FTL, so
+# this takes effect live and needs no wait.
+api_patch_misc() {  # $1 = JSON object for "misc"
+  curl -s -o /dev/null --max-time 10 -X PATCH "${FTL_URL}/api/config" \
+       -H "Content-Type: application/json" \
+       -d "{\"config\":{\"misc\":$1}}" || true
+}
+
 ensure_shim() {
   if ! pgrep -f dotdoh_shim.py >/dev/null 2>&1; then
     python3 test/dotdoh_shim.py >"$SHIM_LOG" 2>&1 &
@@ -152,8 +168,25 @@ setup_file() {
 teardown_file() {
   # Restore the plaintext upstream. It arms no proxy, so wait instead for the
   # regex recompile that every (re)start logs to know FTL is back up.
-  api_patch_dns "{\"upstreamCA\":\"\",\"upstreams\":[\"127.0.0.1#5555\"]}" \
-                "deny regex for"
+  #
+  # Both keys are RESTART_FTL settings and we write them in two separate
+  # requests on purpose: with misc.restart_delay armed, FTL has to collect them
+  # into a single restart rather than racing two against each other, which is
+  # what setup_file avoids by batching them into one request.
+  api_patch_misc "{\"restart_delay\":2}"
+
+  local before restarts
+  before=$(stat -c%s /var/log/pihole/FTL.log)
+  api_patch_dns_async "{\"upstreamCA\":\"\"}"
+  api_patch_dns_async "{\"upstreams\":[\"127.0.0.1#5555\"]}"
+  ./pihole-FTL wait-for "deny regex for" /var/log/pihole/FTL.log 30 "$before"
+
+  restarts=$(tail -c "+$((before + 1))" /var/log/pihole/FTL.log | grep -c "Restarting FTL" || true)
+  [ "$restarts" -eq 1 ] || \
+    echo "expected 1 restart for the two changes, got $restarts" >&2
+  [ "$restarts" -eq 1 ]
+
+  api_patch_misc "{\"restart_delay\":0}"
 }
 
 @test "dotdoh-client: a malformed tls:// upstream is rejected by the validator" {

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -1380,6 +1380,19 @@
   #     A positive integer value between 0 and 300
   delay_startup = 0
 
+  # Some configuration changes can only be applied by restarting the DNS resolver. When a
+  # client changes many settings one after another, restarting on each of them takes the
+  # resolver down repeatedly. With this setting, FTL waits the given number of seconds
+  # and applies everything arriving in the meantime in a single restart.
+  #
+  # This setting takes any integer value between 0 and 60 seconds, where 0 restarts
+  # immediately. Each further change extends the wait, but a restart is postponed by no
+  # more than five times this value (hard-coded).
+  #
+  # Allowed values are:
+  #     A positive integer value between 0 and 60
+  restart_delay = 0
+
   # Set niceness of pihole-FTL. Defaults to -10 and can be disabled altogether by setting
   # a value of -999. The nice value is an attribute that can be used to influence the
   # CPU scheduler to favor or disfavor a process in scheduling decisions.
@@ -1761,7 +1774,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 170 total entries out of which 114 entries are default
+# 171 total entries out of which 115 entries are default
 # --> 56 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -41,7 +41,8 @@ load 'bats_helper.bash'
   # pytest: 2x pihole.toml writes (auth security test TOTP secret set + remove)
   # pytest: 2x pihole.toml writes (top_domains exclude filter set + reset)
   # pytest: 48x pihole.toml writes (concurrent config mutations, 4 workers x 6 PUT+DELETE pairs)
-  # dotdoh.bats: 2x pihole.toml writes (encrypted setup + plaintext teardown)
+  # dotdoh.bats: 5x pihole.toml writes (encrypted setup, then misc.restart_delay
+  #              arm + reset around the two-request plaintext teardown)
   # dotdoh.bats: 2x pihole.toml writes (debug.dotdoh enable + disable)
   # dotdoh_server.bats: 1x pihole.toml write (reset dns.reply.host force to default)
   run bash -c 'grep -c "INFO: Config file written to /etc/pihole/pihole.toml" /var/log/pihole/FTL.log'
@@ -50,7 +51,7 @@ load 'bats_helper.bash'
   if [[ "${CI_ARCH}" == "linux/riscv64" ]]; then
       assert_line --index 0 "6"
   else
-    [[ ${lines[0]} == "77" ]]
+    [[ ${lines[0]} == "80" ]]
   fi
   # CLI password set/remove trigger inotify reload but result in
   # "pihole.toml unchanged" as the in-memory config already matches
@@ -60,6 +61,8 @@ load 'bats_helper.bash'
   assert_success
   # One more than the deterministic baseline: the randomised DoT/DoH loopback
   # tuples change the encrypted-upstream config on every (re)start.
+  # Unchanged by the split dotdoh teardown: clearing dns.upstreamCA leaves the
+  # generated dnsmasq.conf identical, only the dns.upstreams change rewrites it.
   run bash -c 'grep -c "DEBUG_CONFIG: Config file written to /etc/pihole/dnsmasq.conf" /var/log/pihole/FTL.log'
   printf "dnsmasq.conf write count: %s\n" "${lines[0]}"
   assert_line --index 0 "4"

--- a/test/test_final.bats
+++ b/test/test_final.bats
@@ -40,6 +40,7 @@ load 'bats_helper.bash'
   # pytest: 2x pihole.toml writes (auth security test password set + remove)
   # pytest: 2x pihole.toml writes (auth security test TOTP secret set + remove)
   # pytest: 2x pihole.toml writes (top_domains exclude filter set + reset)
+  # pytest: 48x pihole.toml writes (concurrent config mutations, 4 workers x 6 PUT+DELETE pairs)
   # dotdoh.bats: 2x pihole.toml writes (encrypted setup + plaintext teardown)
   # dotdoh.bats: 2x pihole.toml writes (debug.dotdoh enable + disable)
   # dotdoh_server.bats: 1x pihole.toml write (reset dns.reply.host force to default)
@@ -49,7 +50,7 @@ load 'bats_helper.bash'
   if [[ "${CI_ARCH}" == "linux/riscv64" ]]; then
       assert_line --index 0 "6"
   else
-    [[ ${lines[0]} == "29" ]]
+    [[ ${lines[0]} == "77" ]]
   fi
   # CLI password set/remove trigger inotify reload but result in
   # "pihole.toml unchanged" as the in-memory config already matches


### PR DESCRIPTION
# What does this implement/fix?

Changing the config is a read-copy-modify-install sequence: `duplicate_config()` takes a private copy, the copy is changed, `replace_config()` installs it. Both helpers lock the SHM for themselves, but nothing held a lock across the whole sequence. Two writers can therefore each copy the config, change their own copy and install it one after the other - the one installing last silently drops the other's change.

That is reachable from ordinary API use: we run 50 webserver worker threads, and `reread_config()` (housekeeping thread, on a `pihole.toml` change) as well as a Teleporter import are writers, too. When the dropped change is a `DELETE`, the record is back after we answered 204, and the next `PUT` of the same record fails with `Item already present` - the report in #3015. The same overlap also let several threads rotate `pihole.toml`, write the single `pihole.toml.tmp` and run `dnsmasq --test` on the shared temporary file at the same time.

Two commits:

1. Serialize the whole mutate-and-write-back sequence on a new config lock, taken by every in-process writer. It is recursive because a config change can nest: setting `webserver.api.password` runs the legacy password upgrade, which writes the config out on its own. Initialized at runtime, as musl has no `PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP`.
2. `getpwnam()`, `getpwuid()` and `getgrgid()` return pointers into a buffer libc shares between all threads. `chown_pihole()` and `/api/info/database` run on worker threads, so this was an actual heap corruption, not a theoretical one - `gdb` caught two workers aborting inside `realloc()` from `getgrgid()` while rotating `pihole.toml`. Those call sites now use the `_r` variants; the startup, CLI and crash-handler users are single-threaded and stay as they are.

The `waitpid()`/`ECHILD` half of #3015 is already fixed on `development` (we check the saved `err`, not the global `errno`), it is only missing from the v6.7 tag. The endless `Waiting for dnsmasq test returned: No child process` the reporter saw is a consequence of several threads testing the same dnsmasq config file at once, so it should go away with this as well.

## How to test the change during review

New pytest case `test/api/test_m_mutations.py::TestConcurrentConfigMutations` - four connections doing strictly serialized `PUT`/`DELETE` pairs on a config array in parallel, asserting nothing is left behind. On `development` this fails within a few hundred requests, usually by taking FTL down; with this branch it passes.

```
pytest test/api/test_m_mutations.py::TestConcurrentConfigMutations -v
```

Manually, against the endpoint from the issue:

```
for i in $(seq 1 40); do
  curl -sX PUT    "http://pi.hole/api/config/dns/hosts/10.0.0.$i%20stress-$i.local"
  curl -sX DELETE "http://pi.hole/api/config/dns/hosts/10.0.0.$i%20stress-$i.local"
done &   # start four of these in parallel
curl -s "http://pi.hole/api/config/dns/hosts"   # must be empty again
```

I ran this at 4, 8 and 12 concurrent writers with 50 rounds each: no lost deletes, no resurrected records, no crash. `test_m_mutations.py` and `test_z_auth*.py` are otherwise unchanged (the one remaining failure in the former is the pre-existing IDN validation issue with the umlaut record seeded in `test/pihole.toml`).

## Additional information

**Related issue or feature (if applicable):** #3015

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
