### PR TITLE
Remove `dns.blockESNI` and the deprecated `flush/arp` API route

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -104,7 +104,6 @@ static struct {
 	{ "/api/action/gravity",                    "",                           api_action_gravity,                    { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/restartdns",                 "",                           api_action_restartDNS,                 { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/flush/logs",                 "",                           api_action_flush_logs,                 { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
-	{ "/api/action/flush/arp",                  "",                           api_action_flush_network,              { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/action/flush/network",              "",                           api_action_flush_network,              { API_PARSE_JSON, 0                         }, true,  HTTP_POST },
 	{ "/api/padd",                              "",                           api_padd,                              { API_PARSE_JSON, 0                         }, true,  HTTP_GET },
 	{ "/api/docs",                              "",                           api_docs,                              { API_PARSE_JSON, 0                         }, false, HTTP_GET },

--- a/src/api/docs/content/specs/action.yaml
+++ b/src/api/docs/content/specs/action.yaml
@@ -117,40 +117,6 @@ components:
                   allOf:
                     - $ref: 'common.yaml#/components/errors/unauthorized'
                     - $ref: 'common.yaml#/components/schemas/took'
-    flush_arp:
-      post:
-        summary: Flush the network table
-        tags:
-          - Actions
-        operationId: "action_flusharp"
-        deprecated: true
-        description: |
-          Deprecated! Use '/action/flush/network' instead.
-          Flushes the network table. This includes removing both all known devices and their associated addresses.
-        responses:
-          '200':
-            description: OK
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: 'common.yaml#/components/schemas/success'
-                    - $ref: 'common.yaml#/components/schemas/took'
-          '401':
-            description: Unauthorized
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: 'common.yaml#/components/errors/unauthorized'
-                    - $ref: 'common.yaml#/components/schemas/took'
-          '403':
-            description: Forbidden
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: 'action.yaml#/components/errors/forbidden'
     flush_network:
       post:
         summary: Flush the network table

--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -229,8 +229,6 @@ components:
                     type: string
                 CNAMEdeepInspect:
                   type: boolean
-                blockESNI:
-                  type: boolean
                 EDNS0ECS:
                   type: boolean
                 ignoreLocalhost:
@@ -776,7 +774,6 @@ components:
             doh: true
             dot: true
             CNAMEdeepInspect: true
-            blockESNI: true
             EDNS0ECS: true
             ignoreLocalhost: false
             showDNSSEC: true

--- a/src/api/docs/content/specs/main.yaml
+++ b/src/api/docs/content/specs/main.yaml
@@ -270,9 +270,6 @@ paths:
   /action/flush/logs:
     $ref: 'action.yaml#/components/paths/flush_logs'
 
-  /action/flush/arp:
-    $ref: 'action.yaml#/components/paths/flush_arp'
-
   /action/flush/network:
     $ref: 'action.yaml#/components/paths/flush_network'
 

--- a/src/args.c
+++ b/src/args.c
@@ -443,7 +443,7 @@ void parse_args(int argc, char *argv[])
 		else
 		{
 			printf("Usage: %s --config [<config item key>] [<value>]\n", argv[0]);
-			printf("Example: %s --config dns.blockESNI true\n", argv[0]);
+			printf("Example: %s --config dns.CNAMEdeepInspect true\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -426,12 +426,6 @@ void initConfig(struct config *conf)
 	conf->dns.CNAMEdeepInspect.d.b = true;
 	conf->dns.CNAMEdeepInspect.c = validate_stub; // Only type-based checking
 
-	conf->dns.blockESNI.k = "dns.blockESNI";
-	conf->dns.blockESNI.h = "Should _esni. subdomains of blocked domains also be blocked by default? Encrypted Server Name Indication (ESNI) is certainly a good step into the right direction to enhance privacy on the web. It prevents on-path observers, including ISPs, coffee shop owners and firewalls, from intercepting the TLS Server Name Indication (SNI) extension by encrypting it. This prevents the SNI from being used to determine which websites users are visiting.\n\n ESNI will obviously cause issues for pixelserv-tls which will be unable to generate matching certificates on-the-fly when it cannot read the SNI. According to the IETF draft (link above), we can easily restore pixelserv-tls's operation by replying NXDOMAIN to _esni. subdomains of blocked domains as this mimics a \"not configured for this domain\" behavior.\n\n ESNI is mostly obsolete. It was previously rolled out by Cloudflare and Firefox, but they, as well as almost every client and server, are now using Encrypted Client Hello (ECH) instead of ESNI. ECH is served via the HTTPS record on the same RRname, so it will automatically be blocked.";
-	conf->dns.blockESNI.t = CONF_BOOL;
-	conf->dns.blockESNI.d.b = true;
-	conf->dns.blockESNI.c = validate_stub; // Only type-based checking
-
 	conf->dns.EDNS0ECS.k = "dns.EDNS0ECS";
 	conf->dns.EDNS0ECS.h = "Should we overwrite the query source when client information is provided through EDNS0 client subnet (ECS) information? This allows Pi-hole to obtain client IPs even if they are hidden behind the NAT of a router. This feature has been requested and discussed on Discourse where further information how to use it can be found: https://discourse.pi-hole.net/t/support-for-add-subnet-option-from-dnsmasq-ecs-edns0-client-subnet/35940";
 	conf->dns.EDNS0ECS.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -134,7 +134,6 @@ struct config {
 	struct {
 		struct conf_item upstreams;
 		struct conf_item CNAMEdeepInspect;
-		struct conf_item blockESNI;
 		struct conf_item EDNS0ECS;
 		struct conf_item ignoreLocalhost;
 		struct conf_item showDNSSEC;

--- a/src/config/legacy_reader.c
+++ b/src/config/legacy_reader.c
@@ -265,11 +265,6 @@ const char *readFTLlegacy(struct config *conf)
 	if(buffer != NULL && sscanf(buffer, "%u", &unum) == 1 && unum > 0 && unum <= 300)
 		conf->misc.delay_startup.v.ui = unum;
 
-	// BLOCK_ESNI
-	// defaults to: true
-	buffer = parseFTLconf(fp, "BLOCK_ESNI");
-	parseBool(buffer, &conf->dns.blockESNI.v.b);
-
 	// WEBROOT
 	conf->webserver.paths.webroot.v.s = getPath(fp, "WEBROOT", conf->webserver.paths.webroot.v.s);
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2076,37 +2076,6 @@ static bool FTL_check_blocking(const char *domainstr, queriesData *query, client
 	TIMED_DB_OP_RESULT(blockDomain, check_domain_blocked(domainstr, client, query, dns_cache, &new_status, &db_okay));
 	PERF_END(_pcb_deny, PERF_STAT_CB_DENYLIST);
 
-	// Check blacklist (exact + regex) and gravity for _esni.domain if enabled
-	// (defaulting to true). Timed into the same slot as the primary call above
-	// so the rollup reflects total denylist/gravity work per query, regardless
-	// of whether the _esni fallback ran.
-	if(config.dns.blockESNI.v.b &&
-	   !query->flags.allowed && !blockDomain &&
-	   domainstr[0] == '_' &&
-	   strncmp(domainstr, "_esni.", 6u) == 0 && domainstr[6] != '\0')
-	{
-		PERF_START(_pcb_deny_esni);
-		TIMED_DB_OP_RESULT(blockDomain, check_domain_blocked(domainstr + 6u, client, query, dns_cache, &new_status, &db_okay));
-		PERF_END(_pcb_deny_esni, PERF_STAT_CB_DENYLIST);
-
-		// Update DNS cache status
-		cacheStatus = dns_cache->blocking_status;
-
-		if(blockDomain)
-		{
-			// Truncate "_esni." from queried domain if the parenting domain was
-			// the reason for blocking this query
-			blockedDomain = domainstr + 6u;
-			// Force next DNS reply to be NXDOMAIN for _esni.* queries
-			force_next_DNS_reply = REPLY_NXDOMAIN;
-
-			// Store this in the DNS cache only if the database is available at
-			// this point
-			if(db_okay)
-				dns_cache->force_reply = REPLY_NXDOMAIN;
-		}
-	}
-
 	// Common actions regardless what the possible blocking reason is
 	if(blockDomain)
 	{

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -105,13 +105,13 @@ class TestHTTPErrors:
 
 class TestConfigValidationAPIType:
 
-    def test_blockESNI_rejects_float(self, api_session):
+    def test_CNAMEdeepInspect_rejects_float(self, api_session):
         data = _j(api_session.patch(f"{FTL_URL}/api/config",
-                                    json={"config": {"dns": {"blockESNI": 15.5}}}, timeout=20))
+                                    json={"config": {"dns": {"CNAMEdeepInspect": 15.5}}}, timeout=20))
         assert data["error"] == {
             "key": "bad_request",
             "message": "Config item is invalid",
-            "hint": "dns.blockESNI: not of type bool",
+            "hint": "dns.CNAMEdeepInspect: not of type bool",
         }, json.dumps(data, indent=2)
 
     def test_piholePTR_rejects_invalid_option(self, api_session):
@@ -1050,7 +1050,7 @@ class TestConfigGet:
         assert "debug" in config
         assert "database" in config
         assert config["dns"]["CNAMEdeepInspect"] is True
-        assert config["dns"]["blockESNI"] is True
+        assert config["dns"]["EDNS0ECS"] is True
 
     def test_config_element(self, api_session):
         data = _j(api_session.get(f"{FTL_URL}/api/config/dns/upstreams", timeout=5))

--- a/test/api/test_m_mutations.py
+++ b/test/api/test_m_mutations.py
@@ -659,30 +659,30 @@ class TestConfigPatchRoundTrip:
 
     def test_patch_bool_config_round_trip(self, api_session):
         """PATCH a boolean config value, verify, then restore."""
-        url = f"{FTL_URL}/api/config/dns/blockESNI"
+        url = f"{FTL_URL}/api/config/dns/CNAMEdeepInspect"
 
         # Read original
         original = _j(api_session.get(url, timeout=5))
-        orig_val = original["config"]["dns"]["blockESNI"]
+        orig_val = original["config"]["dns"]["CNAMEdeepInspect"]
 
         # Change to opposite
         new_val = not orig_val
         r = api_session.patch(url,
-                              json={"config": {"dns": {"blockESNI": new_val}}},
+                              json={"config": {"dns": {"CNAMEdeepInspect": new_val}}},
                               timeout=20)
         assert r.status_code == 200, f"PATCH failed: {r.status_code} {r.text}"
-        assert _j(r)["config"]["dns"]["blockESNI"] == new_val
+        assert _j(r)["config"]["dns"]["CNAMEdeepInspect"] == new_val
 
         # Verify via GET
         data = _j(api_session.get(url, timeout=5))
-        assert data["config"]["dns"]["blockESNI"] == new_val
+        assert data["config"]["dns"]["CNAMEdeepInspect"] == new_val
 
         # Restore
         r = api_session.patch(url,
-                              json={"config": {"dns": {"blockESNI": orig_val}}},
+                              json={"config": {"dns": {"CNAMEdeepInspect": orig_val}}},
                               timeout=20)
         assert r.status_code == 200
-        assert _j(r)["config"]["dns"]["blockESNI"] == orig_val
+        assert _j(r)["config"]["dns"]["CNAMEdeepInspect"] == orig_val
 
     def test_patch_integer_config_round_trip(self, api_session):
         """PATCH an integer config value, verify, then restore."""

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -22,28 +22,6 @@
   #     true or false
   CNAMEdeepInspect = true
 
-  # Should _esni. subdomains of blocked domains also be blocked by default? Encrypted
-  # Server Name Indication (ESNI) is certainly a good step into the right direction to
-  # enhance privacy on the web. It prevents on-path observers, including ISPs, coffee
-  # shop owners and firewalls, from intercepting the TLS Server Name Indication (SNI)
-  # extension by encrypting it. This prevents the SNI from being used to determine which
-  # websites users are visiting.
-  #
-  # ESNI will obviously cause issues for pixelserv-tls which will be unable to generate
-  # matching certificates on-the-fly when it cannot read the SNI. According to the IETF
-  # draft (link above), we can easily restore pixelserv-tls's operation by replying
-  # NXDOMAIN to _esni. subdomains of blocked domains as this mimics a "not configured
-  # for this domain" behavior.
-  #
-  # ESNI is mostly obsolete. It was previously rolled out by Cloudflare and Firefox, but
-  # they, as well as almost every client and server, are now using Encrypted Client
-  # Hello (ECH) instead of ESNI. ECH is served via the HTTPS record on the same RRname,
-  # so it will automatically be blocked.
-  #
-  # Allowed values are:
-  #     true or false
-  blockESNI = true
-
   # Should we overwrite the query source when client information is provided through
   # EDNS0 client subnet (ECS) information? This allows Pi-hole to obtain client IPs even
   # if they are hidden behind the NAT of a router. This feature has been requested and
@@ -1783,7 +1761,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 171 total entries out of which 115 entries are default
+# 170 total entries out of which 114 entries are default
 # --> 56 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice


### PR DESCRIPTION
# What does this implement/fix?

## This is a BREAKING CHANGE

Two removals that are only possible in a major release.

`dns.blockESNI` guarded a `_esni.` fallback lookup. ESNI never saw real deployment - clients moved to Encrypted Client Hello, which rides in the HTTPS record and is already blocked along with the domain. Our own help text for the key has said so for a while.

`/api/action/flush/arp` was an alias of `/api/action/flush/network` on the same handler, marked `deprecated` in the spec.

An existing `pihole.toml` keeps working: the reader only iterates keys it knows, so a stale `blockESNI` line is ignored and drops out on the next write.

## How to test the change during review

1. `pihole-FTL --config dns.blockESNI` is rejected as an unknown key, and `blockESNI` no longer appears in a freshly written `pihole.toml`.
2. Start FTL against a `pihole.toml` that still contains `blockESNI = true`. It must start without complaint, and the line must be gone after the next config write.
3. `POST /api/action/flush/arp` returns 404. `POST /api/action/flush/network` still flushes the network table.
4. Covered by the existing pytest suite (`test_api.py`, `test_m_mutations.py`, both repointed at `dns.CNAMEdeepInspect`) and by `test_suite.bats` "No missing config items in pihole.toml".

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A - `docs/ftldns/configfile.md` is generated from `pihole.toml` by the release workflow, and the endpoint is only documented in our own OpenAPI spec, which this PR updates.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
