### PR TITLE
follow-up: bound IFLA_VF_INFO by its own header length

### DIFF
--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -1186,8 +1186,10 @@ static int nlparsemsg_link(struct ifinfomsg *ifi, void *buf, size_t len, cJSON *
 					break;
 
 				// The nested attribute carries its own length, so it
-				// must not claim more than the outer payload holds
-				if(RTA_PAYLOAD(rta) < vfinfo->rta_len)
+				// must cover its header and must not claim more than
+				// the outer payload holds
+				if(vfinfo->rta_len < sizeof(struct rtattr) ||
+				   RTA_PAYLOAD(rta) < vfinfo->rta_len)
 				{
 					log_debug(DEBUG_NETLINK, "IFLA_VF_INFO claims %u byte(s) of %zu, skipping",
 					          (unsigned int)vfinfo->rta_len, (size_t)RTA_PAYLOAD(rta));

--- a/src/tools/netlink.c
+++ b/src/tools/netlink.c
@@ -50,7 +50,7 @@ static size_t __attribute__ ((const)) family_addrlen(const int family)
 }
 
 // Convert an address attribute into its string representation. Returns false
-// if the family is none we can render or the payload is too short for it.
+// if the family is not one we can render or the payload is too short for it.
 static bool rta_address(const struct rtattr *rta, const int family, const char *name,
                         char *ip, const size_t iplen)
 {


### PR DESCRIPTION
# What does this implement/fix?

`RTA_PAYLOAD()` is unsigned, so a nested `IFLA_VF_INFO` attribute claiming fewer bytes than its own header wraps to a huge length. Nothing is parsed out of bounds today, as `parse_rtattr_flags()` takes an `int`, the truncated value is negative and `RTA_OK()` rejects it - but that is a conversion, not a check. `vfinfo` is the only nested attribute we take straight from `RTA_DATA()` without validating it first, so it gets an explicit lower bound here.

Also fixes the wording of a comment added in #2986.

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [ ] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
