### PR TITLE
Use false for resolver TCP error returns

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -378,7 +378,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		{
 			log_err("Cannot send TCP DNS query: %s", strsockerr(errno));
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return NULL;
+			return false;
 		}
 
 		// Receive the answer, first the length of the message ...
@@ -387,7 +387,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		{
 			log_err("Cannot receive TCP DNS reply (1): %s", strsockerr(errno));
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return NULL;
+			return false;
 		}
 		prefix = ntohs(prefix);
 
@@ -398,7 +398,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		{
 			log_err("Received TCP DNS reply is too long (%u bytes)", prefix);
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return NULL;
+			return false;
 		}
 		bzero(buf, prefix + 1);
 		// ... then the message itself
@@ -406,7 +406,7 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 		{
 			log_err("Cannot receive TCP DNS reply (2): %s", strsockerr(errno));
 			log_resolve_info(host, config.dns.port.v.u16, tcp);
-			return NULL;
+			return false;
 		}
 	}
 


### PR DESCRIPTION
# What does this implement/fix?

`ngethostbyname()` returns `bool`, but four existing TCP error paths return `NULL`. This replaces those four returns with `false`.

This cleanup is split out from #2979 following maintainer review so it can land independently. No behavior change is intended.

## How to test the change during review

The publication script runs the Linux/amd64 FTL build using `.github/Dockerfile`, then runs:

```text
test/arch_test.sh && test/run.sh && test/http2_test.sh
```

The resulting diff is limited to four `return NULL;` → `return false;` replacements in the TCP branch of `ngethostbyname()`.

## Additional information

**Related issue or feature (if applicable):** Follow-up to #2979 review: https://github.com/pi-hole/FTL/pull/2979#issuecomment-5308567306

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
