### PR TITLE
lua: add `pihole.download()`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -623,6 +623,35 @@ int main(void) { return 0; }
     else()
         message(STATUS "Building FTL with HTTP/3 support: NO (nghttp3 not found)")
     endif()
+
+    # libcurl backs pihole.download(). It sits inside this block because the
+    # bundled libcurl is built against OpenSSL, so it can only be linked where
+    # libssl/libcrypto are. Optional: without it pihole.download() reports that
+    # this build has no HTTP client.
+    find_library(LIBCURL NAMES libcurl${LIBRARY_SUFFIX} curl)
+    find_library(LIBZ NAMES libz${LIBRARY_SUFFIX} z)
+    if(LIBCURL)
+        message(STATUS "Building FTL with HTTP client support: YES")
+        target_compile_definitions(webserver PRIVATE HAVE_CURL)
+        # Everything libcurl draws on has to be repeated after it: the linker
+        # only searches archives that follow the object needing them. OpenSSL,
+        # nghttp2 and libidn2 appear earlier too, which is harmless - naming a
+        # static archive twice costs nothing.
+        target_link_libraries(pihole-FTL ${LIBCURL} ${LIBSSL} ${LIBCRYPTO})
+        if(LIBNGHTTP2)
+            target_link_libraries(pihole-FTL ${LIBNGHTTP2})
+        endif()
+        if(LIBIDN2 AND LIBUNISTRING)
+            target_link_libraries(pihole-FTL ${LIBIDN2} ${LIBUNISTRING})
+        endif()
+        # zlib is libcurl's alone - FTL itself deflates through the vendored
+        # miniz, which also provides the ZIP container the Teleporter needs.
+        if(LIBZ)
+            target_link_libraries(pihole-FTL ${LIBZ})
+        endif()
+    else()
+        message(STATUS "Building FTL with HTTP client support: NO (libcurl not found)")
+    endif()
 else()
     message(STATUS "Building FTL with TLS support: NO")
 endif()

--- a/src/lua/ftl_lua.c
+++ b/src/lua/ftl_lua.c
@@ -25,6 +25,8 @@
 #include "scripts/scripts.h"
 // get_prefix_webhome(), get_api_uri()
 #include "webserver/webserver.h"
+// http_get()
+#include "webserver/http-client.h"
 
 // prototype for luaopen_pihole()
 #include "lualib.h"
@@ -311,6 +313,63 @@ static int pihole_format_path(lua_State *L) {
 	return 1; // number of results
 }
 
+// lua_Alloc-shaped callback releasing a buffer handed over with
+// lua_pushexternalstring(); Lua calls it with nsize == 0 when collecting it.
+static void *pihole_download_free(void *ud, void *ptr, size_t osize, size_t nsize)
+{
+	if(ptr != NULL)
+		free(ptr);
+	return NULL;
+}
+
+// pihole.download(<url:str> [, <path:str>])
+//   without path: returns the body as a string, or nil plus an error message
+//   with path:    writes the body to that file and returns true plus the number
+//                 of bytes, or nil plus an error message
+static int pihole_download(lua_State *L) {
+	size_t urllen = 0, pathlen = 0;
+	const char *url = luaL_checklstring(L, 1, &urllen);
+	const char *path = luaL_optlstring(L, 2, NULL, &pathlen);
+
+	// Lua strings may embed NUL bytes, which a C string API cannot see past
+	if(strlen(url) != urllen || (path != NULL && strlen(path) != pathlen))
+	{
+		lua_pushnil(L);
+		lua_pushliteral(L, "embedded NUL byte in argument");
+		return 2; // number of results
+	}
+
+	struct http_result res = { 0 };
+	if(!http_get(url, path, &res))
+	{
+		// Debug level only: a failed download is handed back to the caller to
+		// deal with, and warning about it would let a page that retries a bad
+		// URL inflate the log file
+		log_debug(DEBUG_WEBSERVER, "pihole.download() failed: %s", res.err);
+		lua_pushnil(L);
+		lua_pushstring(L, res.err);
+		http_result_free(&res);
+		return 2; // number of results
+	}
+
+	if(path != NULL)
+	{
+		const size_t len = res.len;
+		http_result_free(&res);
+		lua_pushboolean(L, true);
+		lua_pushinteger(L, (lua_Integer)len);
+		return 2; // number of results
+	}
+
+	// Hand the buffer over instead of copying it. luaS_newextlstr() takes
+	// ownership unconditionally and calls the free callback even if it then
+	// hits a memory error, so this cannot leak.
+	char *body = res.body;
+	res.body = NULL;
+	lua_pushexternalstring(L, body, res.len, pihole_download_free, NULL);
+	return 1; // number of results
+}
+
 static const luaL_Reg piholelib[] = {
 	{"ftl_version", pihole_ftl_version},
 	{"hostname", pihole_hostname},
@@ -322,6 +381,7 @@ static const luaL_Reg piholelib[] = {
 	{"needLogin", pihole_needLogin},
 	{"api_url", pihole_api_url},
 	{"format_path", pihole_format_path},
+	{"download", pihole_download},
 	{NULL, NULL}
 };
 

--- a/src/webserver/CMakeLists.txt
+++ b/src/webserver/CMakeLists.txt
@@ -11,6 +11,8 @@
 set(sources
         http-common.c
         http-common.h
+        http-client.c
+        http-client.h
         json_macros.h
         lua_web.c
         lua_web.h

--- a/src/webserver/http-client.c
+++ b/src/webserver/http-client.c
@@ -1,0 +1,402 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Outbound HTTP(S) downloader
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#include "FTL.h"
+#include "webserver/http-client.h"
+// get_FTL_version()
+#include "log.h"
+// chown_pihole()
+#include "files.h"
+
+#include <fcntl.h>
+#include <limits.h>
+#include <strings.h>
+#include <sys/stat.h>
+
+#ifdef HAVE_CURL
+#include <curl/curl.h>
+#endif
+
+void http_result_free(struct http_result *res)
+{
+	// FTL's free() warns when handed NULL, and this is called on paths where
+	// there is nothing left to release
+	if(res == NULL || res->body == NULL)
+		return;
+	free(res->body);
+}
+
+#ifdef HAVE_CURL
+
+// Schemes we accept, and which of them are TLS. A redirect may upgrade into
+// TLS but never drop back out of it.
+static const struct {
+	const char *prefix;
+	bool tls;
+} schemes[] = {
+	{ "http://",  false },
+	{ "https://", true  },
+	{ "ftp://",   false },
+	{ "ftps://",  true  },
+	{ "file://",  false },
+};
+#define HTTP_DL_SCHEME_LIST "http://, https://, ftp://, ftps:// and file://"
+
+// Where the response body goes. Exactly one of buf (in-memory) and fd (file)
+// is in use; fd is -1 in the in-memory case.
+struct sink {
+	size_t len;
+	char *buf;
+	size_t cap;
+	int fd;
+	bool oversize;
+	bool io_error;
+	int err;
+};
+
+static size_t sink_write(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	struct sink *s = userdata;
+	const size_t n = size * nmemb;
+
+	if(n == 0)
+		return 0;
+
+	// The cap is enforced here rather than left to CURLOPT_MAXFILESIZE_LARGE:
+	// that one only acts on a declared Content-Length, so a chunked, a
+	// close-delimited or simply a lying response would walk straight past it.
+	// Returning short aborts the transfer with CURLE_WRITE_ERROR.
+	if(n > HTTP_DL_MAX_BYTES - s->len)
+	{
+		s->oversize = true;
+		return 0;
+	}
+
+	if(s->fd < 0)
+	{
+		// Keep one spare byte so the buffer can always be NUL-terminated:
+		// lua_pushexternalstring() asserts s[len] == '\0'.
+		if(s->len + n + 1 > s->cap)
+		{
+			size_t cap = s->cap > 0 ? s->cap : 8192;
+			while(cap < s->len + n + 1)
+				cap *= 2;
+			if(cap > (size_t)HTTP_DL_MAX_BYTES + 1)
+				cap = (size_t)HTTP_DL_MAX_BYTES + 1;
+			char *tmp = realloc(s->buf, cap);
+			if(tmp == NULL)
+			{
+				s->io_error = true;
+				s->err = ENOMEM;
+				return 0;
+			}
+			s->buf = tmp;
+			s->cap = cap;
+		}
+		memcpy(s->buf + s->len, ptr, n);
+		s->len += n;
+		s->buf[s->len] = '\0';
+		return n;
+	}
+
+	for(size_t off = 0; off < n;)
+	{
+		const ssize_t w = write(s->fd, ptr + off, n - off);
+		if(w < 0)
+		{
+			if(errno == EINTR)
+				continue;
+			s->io_error = true;
+			s->err = errno;
+			return 0;
+		}
+		off += (size_t)w;
+	}
+	s->len += n;
+	return n;
+}
+
+// A page may compose the destination from request data, so refuse anything that
+// could walk out of the directory it was handed.
+static bool dest_ok(const char *dest, char *err, size_t errsz)
+{
+	const size_t len = strlen(dest);
+
+	if(dest[0] != '/')
+	{
+		snprintf(err, errsz, "destination path must be absolute");
+		return false;
+	}
+	if(dest[len - 1] == '/')
+	{
+		snprintf(err, errsz, "destination path must name a file");
+		return false;
+	}
+	if(len + sizeof(".XXXXXX") > PATH_MAX)
+	{
+		snprintf(err, errsz, "destination path is too long");
+		return false;
+	}
+	for(const char *p = dest; p != NULL; p = strchr(p + 1, '/'))
+	{
+		if(strncmp(p, "/..", 3) == 0 && (p[3] == '/' || p[3] == '\0'))
+		{
+			snprintf(err, errsz, "destination path must not contain \"..\"");
+			return false;
+		}
+	}
+	return true;
+}
+
+// fsync the directory holding path, so the rename() itself is durable
+static void fsync_parent(const char *path)
+{
+	char dir[PATH_MAX];
+	if(snprintf(dir, sizeof(dir), "%s", path) >= (int)sizeof(dir))
+		return;
+
+	char *slash = strrchr(dir, '/');
+	if(slash == NULL)
+		return;
+	*slash = '\0';
+
+	const int fd = open(dir[0] != '\0' ? dir : "/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if(fd < 0)
+		return;
+	fsync(fd);
+	close(fd);
+}
+
+// Move the completed temporary file into place. Consumes fd either way.
+static bool tmp_commit(int fd, const char *tmp, const char *dest, char *err, size_t errsz)
+{
+	if(fsync(fd) != 0)
+	{
+		snprintf(err, errsz, "could not flush %s to disk: %s", tmp, strerror(errno));
+		close(fd);
+		return false;
+	}
+	if(close(fd) != 0)
+	{
+		snprintf(err, errsz, "could not finalize %s: %s", tmp, strerror(errno));
+		return false;
+	}
+
+	// Hand the file to the pihole user before it becomes visible under its
+	// final name, so it is never briefly owned by root under that name.
+	chown_pihole(tmp, NULL);
+
+	if(rename(tmp, dest) != 0)
+	{
+		snprintf(err, errsz, "could not rename %s to %s: %s", tmp, dest, strerror(errno));
+		return false;
+	}
+
+	fsync_parent(dest);
+	return true;
+}
+
+static pthread_once_t curl_once = PTHREAD_ONCE_INIT;
+static bool curl_ready = false;
+
+static void curl_init_once(void)
+{
+	curl_ready = curl_global_init(CURL_GLOBAL_DEFAULT) == CURLE_OK;
+}
+
+#endif // HAVE_CURL
+
+bool http_get(const char *url, const char *dest, struct http_result *res)
+{
+	memset(res, 0, sizeof(*res));
+
+#ifndef HAVE_CURL
+	(void)url;
+	(void)dest;
+	snprintf(res->err, sizeof(res->err),
+	         "this pihole-FTL was built without HTTP client support");
+	return false;
+#else
+	pthread_once(&curl_once, curl_init_once);
+	if(!curl_ready)
+	{
+		snprintf(res->err, sizeof(res->err), "could not initialize libcurl");
+		return false;
+	}
+
+	// Matched here as well as through CURLOPT_PROTOCOLS_STR so the message names
+	// the offending scheme instead of curl's generic "unsupported protocol".
+	bool tls = false;
+	bool known = false;
+	for(size_t i = 0; !known && i < sizeof(schemes) / sizeof(*schemes); i++)
+		if(strncasecmp(url, schemes[i].prefix, strlen(schemes[i].prefix)) == 0)
+		{
+			tls = schemes[i].tls;
+			known = true;
+		}
+	if(!known)
+	{
+		snprintf(res->err, sizeof(res->err), "unsupported URL scheme (only %s are supported)",
+		         HTTP_DL_SCHEME_LIST);
+		return false;
+	}
+
+	struct sink sink = { .fd = -1 };
+	char tmp[PATH_MAX] = "";
+
+	if(dest != NULL)
+	{
+		if(!dest_ok(dest, res->err, sizeof(res->err)))
+			return false;
+
+		// mkostemp() rather than a fixed ".tmp" suffix: several CivetWeb workers
+		// may download to the same destination at once, and an unpredictable
+		// name leaves no window for a planted decoy either.
+		snprintf(tmp, sizeof(tmp), "%s.XXXXXX", dest);
+		sink.fd = mkostemp(tmp, O_CLOEXEC);
+		if(sink.fd < 0)
+		{
+			snprintf(res->err, sizeof(res->err), "could not create a temporary file next to %s: %s",
+			         dest, strerror(errno));
+			return false;
+		}
+		if(fchmod(sink.fd, S_IRUSR | S_IWUSR | S_IRGRP) != 0)
+			log_warn("Unable to set permissions on file \"%s\": %s", tmp, strerror(errno));
+	}
+
+	CURL *curl = curl_easy_init();
+	if(curl == NULL)
+	{
+		snprintf(res->err, sizeof(res->err), "could not initialize a libcurl handle");
+		if(sink.fd >= 0)
+		{
+			close(sink.fd);
+			unlink(tmp);
+		}
+		return false;
+	}
+
+	char ebuf[CURL_ERROR_SIZE] = "";
+	char agent[64] = "";
+	snprintf(agent, sizeof(agent), "pihole-FTL/%s", get_FTL_version());
+
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, ebuf);
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, agent);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, sink_write);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &sink);
+
+	// The image builds curl with only these protocols, but say so anyway: this
+	// is the gate that survives someone rebuilding it less restrictively.
+	curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https,ftp,ftps,file");
+	// file and ftp are deliberately absent here. A redirect must never be able
+	// to reach them, or a remote server could answer a fetch with
+	// "Location: file:///..." and have us read that back to the caller. For the
+	// same reason an https fetch may not be redirected down to http, while the
+	// upgrade is fine.
+	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, tls ? "https" : "http,https");
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_MAXREDIRS, HTTP_DL_MAX_REDIRECTS);
+
+	// A total timeout, not just a connect one: without it a peer trickling a
+	// byte per idle window pins a CivetWeb worker indefinitely.
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, HTTP_DL_CONNECT_MS);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, HTTP_DL_TOTAL_MS);
+	// Mandatory off the main thread: keeps curl away from alarm() and SIGPIPE.
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+
+	// Offer every encoding this libcurl can undo, and let it decompress before
+	// the body reaches us. The cap in the write callback therefore counts
+	// decompressed bytes, so a small response that inflates to gigabytes still
+	// trips it - CURLOPT_MAXFILESIZE_LARGE only ever sees the compressed length.
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+	// Only used when the URL carries credentials, and CURLOPT_UNRESTRICTED_AUTH
+	// stays off, so a redirect to another host never sees them.
+	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (long)(CURLAUTH_BASIC | CURLAUTH_DIGEST));
+	curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)HTTP_DL_MAX_BYTES);
+	// Ignore http_proxy and friends so a download does not quietly behave
+	// differently depending on the environment FTL was started in.
+	curl_easy_setopt(curl, CURLOPT_PROXY, "");
+
+	// Honour OpenSSL's own environment variables, which is also what lets the
+	// test suite point at its private CA without a config key.
+	const char *ca_file = getenv("SSL_CERT_FILE");
+	const char *ca_dir = getenv("SSL_CERT_DIR");
+	if(ca_file != NULL && ca_file[0] != '\0')
+		curl_easy_setopt(curl, CURLOPT_CAINFO, ca_file);
+	if(ca_dir != NULL && ca_dir[0] != '\0')
+		curl_easy_setopt(curl, CURLOPT_CAPATH, ca_dir);
+
+	log_debug(DEBUG_WEBSERVER, "Downloading %s to %s", url, dest != NULL ? dest : "memory");
+
+	const CURLcode rc = curl_easy_perform(curl);
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &res->status);
+	curl_easy_cleanup(curl);
+
+	bool ok = true;
+	if(rc != CURLE_OK)
+	{
+		ok = false;
+		if(sink.oversize || rc == CURLE_FILESIZE_EXCEEDED)
+			snprintf(res->err, sizeof(res->err), "response is larger than %u bytes",
+			         HTTP_DL_MAX_BYTES);
+		else if(sink.io_error)
+			snprintf(res->err, sizeof(res->err), "could not store the downloaded data: %s",
+			         strerror(sink.err));
+		else
+			snprintf(res->err, sizeof(res->err), "%s",
+			         ebuf[0] != '\0' ? ebuf : curl_easy_strerror(rc));
+	}
+	else if(res->status >= 400)
+	{
+		ok = false;
+		snprintf(res->err, sizeof(res->err), "server responded with HTTP %ld", res->status);
+	}
+
+	if(sink.fd >= 0)
+	{
+		if(ok)
+			ok = tmp_commit(sink.fd, tmp, dest, res->err, sizeof(res->err));
+		else
+			close(sink.fd);
+		// Nothing is left behind on failure, and dest keeps whatever it held
+		if(!ok)
+			unlink(tmp);
+	}
+
+	if(!ok)
+	{
+		if(sink.buf != NULL)
+			free(sink.buf);
+		return false;
+	}
+
+	res->len = sink.len;
+	if(dest == NULL)
+	{
+		// An empty body is still a body: hand Lua a valid pointer, not NULL
+		if(sink.buf == NULL)
+		{
+			sink.buf = calloc(1, 1);
+			if(sink.buf == NULL)
+			{
+				snprintf(res->err, sizeof(res->err), "out of memory");
+				return false;
+			}
+		}
+		res->body = sink.buf;
+	}
+
+	return true;
+#endif
+}

--- a/src/webserver/http-client.h
+++ b/src/webserver/http-client.h
@@ -1,0 +1,48 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  FTL Engine
+*  Outbound HTTP(S) downloader
+*
+*  Public interface of the libcurl-backed downloader behind pihole.download().
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+#ifndef HTTP_CLIENT_H
+#define HTTP_CLIENT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+// Compile-time limits rather than configuration keys: `pihole-FTL lua` never
+// reads the config, so a config-backed limit would be zero in exactly the mode
+// the tests use.
+#define HTTP_DL_MAX_BYTES     (16u * 1024u * 1024u)
+#define HTTP_DL_CONNECT_MS    5000L
+#define HTTP_DL_TOTAL_MS      60000L
+#define HTTP_DL_MAX_REDIRECTS 5L
+
+struct http_result {
+	char *body;  // in-memory mode only, NUL-terminated, owned by the caller
+	size_t len;  // body bytes received, in both modes
+	long status; // final HTTP status, 0 if we never got one
+	char err[256];
+};
+
+// Fetch url, which may be http://, https://, ftp://, ftps:// or file://. A NULL
+// dest streams the body into res->body, otherwise it is written to dest via a
+// temporary file that is renamed into place only after the transfer completed.
+// A redirect is never allowed to reach file:// or ftp://, nor to leave TLS.
+//
+// The URL must never be derived from request data: a Lua page can be served
+// without authentication, and this issues an arbitrary outbound request.
+//
+// Returns true on success, false with res->err filled otherwise. Never aborts.
+bool http_get(const char *url, const char *dest, struct http_result *res);
+
+// Release whatever *res still owns. Idempotent.
+void http_result_free(struct http_result *res);
+
+#endif // HTTP_CLIENT_H

--- a/test/http_shim.py
+++ b/test/http_shim.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2026 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# FTL Engine
+# HTTP(S) test shim for pihole.download()
+#
+# Serves the response shapes FTL's own web server cannot produce on demand:
+# chunked bodies, redirects and a body that never ends. Listens on 8099 (plain)
+# and 8098 (TLS, using the repo test certificate). See test/test_suite.bats.
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+import gzip
+import http.server
+import ssl
+import threading
+import time
+
+PLAIN_PORT = 8099
+TLS_PORT = 8098
+# Comfortably above the 16 MiB cap in src/webserver/http-client.h
+HUGE_BLOCKS = 400
+BLOCK = b"x" * 65536
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):
+        pass
+
+    def _redirect(self, location):
+        self.send_response(302)
+        self.send_header("Location", location)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _chunks(self, parts):
+        self.send_response(200)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        try:
+            for part in parts:
+                self.wfile.write(b"%x\r\n" % len(part) + part + b"\r\n")
+            self.wfile.write(b"0\r\n\r\n")
+        except (BrokenPipeError, ConnectionResetError):
+            # Expected once FTL aborts an oversized transfer
+            pass
+
+    def do_GET(self):
+        if self.path == "/chunked":
+            self._chunks([b"AAA", b"BBB", b"CCC"])
+        elif self.path == "/chunked-huge":
+            # No Content-Length, so CURLOPT_MAXFILESIZE_LARGE cannot see this
+            # coming - only the write callback can stop it
+            self._chunks(BLOCK for _ in range(HUGE_BLOCKS))
+        elif self.path == "/redirect":
+            self._redirect("/final")
+        elif self.path == "/redirect-relative":
+            self._redirect("a/../final")
+        elif self.path == "/redirect-loop":
+            self._redirect("/redirect-loop")
+        elif self.path == "/downgrade":
+            self._redirect("http://127.0.0.1:%d/final" % PLAIN_PORT)
+        elif self.path == "/to-file":
+            # A server must not be able to talk us into reading a local file
+            self._redirect("file:///etc/passwd")
+        elif self.path == "/gzip":
+            body = gzip.compress(b"GZIPPED" * 1000)
+            self.send_response(200)
+            self.send_header("Content-Encoding", "gzip")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/gzip-bomb":
+            # ~64 MiB of zeroes in a handful of KB: only a cap counting
+            # decompressed bytes stops this
+            body = gzip.compress(b"\0" * (64 * 1024 * 1024))
+            self.send_response(200)
+            self.send_header("Content-Encoding", "gzip")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/slow":
+            self.send_response(200)
+            self.send_header("Content-Length", "1000")
+            self.end_headers()
+            try:
+                for _ in range(1000):
+                    self.wfile.write(b"z")
+                    self.wfile.flush()
+                    time.sleep(1)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+        elif self.path == "/final":
+            body = b"FINAL"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+
+def main():
+    plain = http.server.ThreadingHTTPServer(("127.0.0.1", PLAIN_PORT), Handler)
+    tls = http.server.ThreadingHTTPServer(("127.0.0.1", TLS_PORT), Handler)
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain("test/test.pem")
+    tls.socket = context.wrap_socket(tls.socket, server_side=True)
+
+    threading.Thread(target=plain.serve_forever, daemon=True).start()
+    tls.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/run.sh
+++ b/test/run.sh
@@ -67,6 +67,17 @@ cp test/versions /etc/pihole/versions
 cp test/broken_lua.lp /var/www/html/broken_lua.lp
 cp test/broken_lua_2.lp /var/www/html/broken_lua_2.lp
 
+# Fixtures for pihole.download(). They live under webhome because
+# webserver.serve_all is false, and their names carry a dot so the request
+# falls through to CivetWeb instead of being redirected to the login page.
+# libcurl resolves through the system resolver rather than through FTL, so
+# pi.hole has to be pinned for the https test the way http2_test.sh does with
+# curl --resolve.
+mkdir -p /var/www/html/admin
+truncate -s 17M /var/www/html/admin/big.bin
+truncate -s 1M /var/www/html/admin/small.bin
+grep -q "pi.hole" /etc/hosts || echo "127.0.0.1 pi.hole" >> /etc/hosts
+
 # Prepare local powerDNS resolver
 bash test/pdns/setup.sh
 
@@ -91,9 +102,20 @@ export SHIM_LOG="/tmp/dotdoh_shim.log"
 rm -f "${SHIM_LOG}"
 python3 test/dotdoh_shim.py >"${SHIM_LOG}" 2>&1 &
 DOTDOH_SHIM_PID=$!
-# Stop the shim even if the script exits early (e.g. FTL fails to start below),
-# so a leftover process cannot hold ports 8853/8443 and make the next run flaky.
-trap 'kill "${DOTDOH_SHIM_PID}" 2>/dev/null; pkill -f "${SHIM_PATTERN}" 2>/dev/null' EXIT
+
+# Start the pihole.download() test shim, which serves the response shapes FTL's
+# own web server cannot produce on demand (chunked, redirects, a body that never
+# ends). Same pkill-by-exact-invocation reasoning as above.
+HTTP_SHIM_PATTERN="python3 test/http_shim.py"
+pkill -f "${HTTP_SHIM_PATTERN}" 2>/dev/null || true
+export HTTP_SHIM_LOG="/tmp/http_shim.log"
+rm -f "${HTTP_SHIM_LOG}"
+python3 test/http_shim.py >"${HTTP_SHIM_LOG}" 2>&1 &
+HTTP_SHIM_PID=$!
+
+# Stop the shims even if the script exits early (e.g. FTL fails to start below),
+# so a leftover process cannot hold their ports and make the next run flaky.
+trap 'kill "${DOTDOH_SHIM_PID}" "${HTTP_SHIM_PID}" 2>/dev/null; pkill -f "${SHIM_PATTERN}" 2>/dev/null; pkill -f "${HTTP_SHIM_PATTERN}" 2>/dev/null' EXIT
 
 # Set restrictive umask
 OLDUMASK=$(umask)
@@ -236,9 +258,11 @@ rm /home/pihole/pihole-FTL
 killall pdns_server
 killall pdns_recursor
 
-# Stop the DoT/DoH test shim (same narrow pattern as at startup)
+# Stop the test shims (same narrow patterns as at startup)
 [ -n "${DOTDOH_SHIM_PID}" ] && kill "${DOTDOH_SHIM_PID}" 2>/dev/null
 pkill -f "${SHIM_PATTERN}" 2>/dev/null || true
+[ -n "${HTTP_SHIM_PID}" ] && kill "${HTTP_SHIM_PID}" 2>/dev/null
+pkill -f "${HTTP_SHIM_PATTERN}" 2>/dev/null || true
 
 # Exit with return code of bats tests
 exit $RET

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1165,6 +1165,118 @@ setup() {
   assert_line --partial '_VERSION = "inspect.lua 3.1.0"'
 }
 
+@test "LUA: pihole.download() fetches http:// into a string" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1/api/auth\"); print(b or (\"ERR: \"..e))"'
+  assert_success
+  assert_line --partial '"valid"'
+}
+
+@test "LUA: pihole.download() fetches https:// and verifies the certificate" {
+  run bash -c 'SSL_CERT_FILE=test/test_ca.crt ./pihole-FTL lua -e "local b,e = pihole.download(\"https://pi.hole/api/auth\"); print(b or (\"ERR: \"..e))"'
+  assert_success
+  assert_line --partial '"valid"'
+}
+
+@test "LUA: pihole.download() fails closed when the certificate cannot be verified" {
+  run bash -c 'SSL_CERT_FILE=test/test_ca.crt ./pihole-FTL lua -e "local b,e = pihole.download(\"https://127.0.0.1/api/auth\"); print(b == nil, e)"'
+  assert_success
+  assert_line --index 0 --partial "true"
+}
+
+@test "LUA: pihole.download() writes the file atomically and leaves no temporary behind" {
+  rm -f /tmp/dl_test.json /tmp/dl_test.json.*
+  run bash -c './pihole-FTL lua -e "print(pihole.download(\"http://127.0.0.1/api/auth\", \"/tmp/dl_test.json\"))"'
+  assert_success
+  assert_line --partial "true"
+  run bash -c 'cat /tmp/dl_test.json'
+  assert_line --partial '"valid"'
+  run bash -c 'ls /tmp/dl_test.json.* 2>/dev/null | wc -l'
+  assert_line --index 0 "0"
+  run bash -c 'stat -c "%a" /tmp/dl_test.json'
+  assert_line --index 0 "640"
+}
+
+@test "LUA: pihole.download() streams a 1 MiB body byte-exactly" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1/admin/small.bin\"); print(b and #b or (\"ERR: \"..e))"'
+  assert_line --index 0 "1048576"
+}
+
+@test "LUA: pihole.download() refuses a response above the size cap" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1/admin/big.bin\"); print(b == nil, e)"'
+  assert_success
+  assert_line --partial "larger than"
+}
+
+# No Content-Length here, so CURLOPT_MAXFILESIZE_LARGE cannot catch it and the
+# write callback has to
+@test "LUA: pihole.download() caps a chunked response with no Content-Length" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1:8099/chunked-huge\"); print(b == nil, e)"'
+  assert_success
+  assert_line --partial "larger than"
+}
+
+@test "LUA: pihole.download() decodes a chunked body" {
+  run bash -c './pihole-FTL lua -e "print(pihole.download(\"http://127.0.0.1:8099/chunked\"))"'
+  assert_line --index 0 "AAABBBCCC"
+}
+
+@test "LUA: pihole.download() follows redirects" {
+  run bash -c './pihole-FTL lua -e "print(pihole.download(\"http://127.0.0.1:8099/redirect\"))"'
+  assert_line --index 0 "FINAL"
+  run bash -c './pihole-FTL lua -e "print(pihole.download(\"http://127.0.0.1:8099/redirect-relative\"))"'
+  assert_line --index 0 "FINAL"
+}
+
+@test "LUA: pihole.download() gives up on a redirect loop" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1:8099/redirect-loop\"); print(b == nil, e)"'
+  assert_success
+  assert_line --partial "edirect"
+}
+
+@test "LUA: pihole.download() refuses an https -> http redirect" {
+  run bash -c 'SSL_CERT_FILE=test/test_ca.crt ./pihole-FTL lua -e "local b,e = pihole.download(\"https://pi.hole:8098/downgrade\"); print(b == nil, e)"'
+  assert_success
+  assert_line --index 0 --partial "true"
+}
+
+@test "LUA: pihole.download() reads a local file:// path" {
+  echo "hello-from-disk" > /tmp/dl_local.txt
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"file:///tmp/dl_local.txt\"); print(b or (\"ERR: \"..e))"'
+  assert_line --index 0 "hello-from-disk"
+}
+
+# A server must not be able to talk the downloader into reading a local file
+@test "LUA: pihole.download() refuses a redirect to file://" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1:8099/to-file\"); print(b == nil, e)"'
+  assert_success
+  assert_line --index 0 --partial "true"
+}
+
+@test "LUA: pihole.download() transparently decompresses gzip" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1:8099/gzip\"); print(b and #b or (\"ERR: \"..e))"'
+  assert_line --index 0 "7000"
+}
+
+# The cap counts decompressed bytes, so a small body that inflates past it fails
+@test "LUA: pihole.download() survives a gzip bomb" {
+  run bash -c './pihole-FTL lua -e "local b,e = pihole.download(\"http://127.0.0.1:8099/gzip-bomb\"); print(b == nil, e)"'
+  assert_success
+  assert_line --partial "larger than"
+}
+
+@test "LUA: pihole.download() rejects unsupported schemes and bad destinations" {
+  for url in 'gopher://example.com/' 'smb://example.com/x' 'not a url'; do
+    run bash -c "./pihole-FTL lua -e 'local b,e = pihole.download(\"${url}\"); print(b == nil, e)'"
+    assert_success
+    assert_line --index 0 --partial "true"
+  done
+  for path in 'relative.bin' '/tmp/../etc/evil'; do
+    run bash -c "./pihole-FTL lua -e 'local b,e = pihole.download(\"http://127.0.0.1/api/auth\", \"${path}\"); print(b == nil, e)'"
+    assert_success
+    assert_line --index 0 --partial "true"
+  done
+}
+
 @test "EDNS(0) analysis working as expected" {
   # Get number of lines in the log before the test
   before="$(grep -c ^ /var/log/pihole/FTL.log)"


### PR DESCRIPTION
> [!IMPORTANT]
> Blocked on pi-hole/docker-base-images#186 being merged and tagged first. Until `.github/Dockerfile` is bumped off `ftl-build:v2.25`, this builds with `HTTP client support: NO` and the new tests fail.

# What does this implement/fix?

`pihole.download(url [, path])` for the Lua `pihole` module: streams a body into a string, or writes it to a file, returning `nil, "message"` on failure. We had no HTTP client - CivetWeb is built with `NO_SSL`, so its `mg_download()` silently fetches `https://` in plaintext.

`http`, `https`, `ftp`, `ftps` and `file` are accepted, gzip is decompressed on the way in. The 16 MiB cap sits in the write callback and so counts decompressed bytes; redirects may never reach `file`/`ftp` or leave TLS; files land via `mkostemp()` + `rename()`, as libcurl would otherwise truncate the destination up front.

libcurl is optional: without it the function says the build has no HTTP client.

## How to test the change during review

`test/run.sh` covers it with 16 bats tests (http, https, cert verification, fail-closed, atomic write, size cap, chunked, redirects, gzip bomb, `file://`, redirect-to-`file://` refusal, bad schemes and paths). Locally: 207 bats, 151 pytest, 46 dotdoh, 0 failures on a static build.

```
./pihole-FTL lua -e 'print(pihole.download("https://ftl.pi-hole.net/libraries/"))'
```

Also worth compiling without libcurl to check the fallback path.

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
