### PR TITLE
Fix non-reentrant libc calls reachable from FTL's threads

### DIFF
--- a/src/config/env.c
+++ b/src/config/env.c
@@ -593,7 +593,8 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 			// Parse envvar array and generate a JSON array (env var
 			// arrays are ; or \n-delimited)
 			const char delim[] =";\n";
-			const char *elem = strtok(envvar_copy, delim);
+			char *saveptr = NULL;
+			const char *elem = strtok_r(envvar_copy, delim, &saveptr);
 			while(elem != NULL)
 			{
 				// Only import non-empty entries
@@ -605,7 +606,7 @@ bool __attribute__((nonnull(1,2,3))) readEnvValue(struct conf_item *conf_item, s
 				}
 
 				// Search for the next element
-				elem = strtok(NULL, delim);
+				elem = strtok_r(NULL, delim, &saveptr);
 			}
 			free(envvar_copy);
 			item->valid = true;

--- a/src/config/password.c
+++ b/src/config/password.c
@@ -99,6 +99,8 @@ static char * __attribute__((malloc)) double_sha256_password(const char *passwor
 	return strdup(response);
 }
 
+// Thread-safe: getrandom() is a syscall and the /dev/urandom fallback opens
+// its own stream per call, so this keeps no state shared between callers
 bool get_secure_randomness(uint8_t *buffer, const size_t length)
 {
 	ssize_t result = -1;
@@ -112,8 +114,6 @@ bool get_secure_randomness(uint8_t *buffer, const size_t length)
 	if (result < 0 && errno == EAGAIN)
 	{
 		log_warn("Not enough entropy available right now for generating secure randomness, retrying in blocking mode");
-		// Sleep for 1 second to give the kernel some time to gather entropy
-		sleepms(1000);
 	}
 	else
 	{

--- a/src/config/setupVars.c
+++ b/src/config/setupVars.c
@@ -754,7 +754,8 @@ char *read_setupVarsconf(const char *key)
 // setupVarsArray[3] = NULL
 void getSetupVarsArray(const char * input)
 {
-	char * p = strtok((char*)input, ",");
+	char *saveptr = NULL;
+	char * p = strtok_r((char*)input, ",", &saveptr);
 
 	/* split string and append tokens to 'res' */
 
@@ -768,7 +769,7 @@ void getSetupVarsArray(const char * input)
 		}
 		setupVarsArray = tmp;
 		setupVarsArray[setupVarsElements-1] = p;
-		p = strtok(NULL, ",");
+		p = strtok_r(NULL, ",", &saveptr);
 	}
 
 	/* realloc one extra element for the last NULL */

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -35,6 +35,8 @@
 #include <assert.h>
 // TCP_MAX_QUERIES
 #include "dnsmasq/config.h"
+// get_secure_randomness()
+#include "config/password.h"
 
 // Function Prototypes
 static size_t nameToDNS(unsigned char *dns, const size_t dnslen, const char *host, const size_t hostlen) __attribute__((nonnull(1,3)));
@@ -291,7 +293,16 @@ static bool ngethostbyname(const int sock, const bool tcp, struct sockaddr_in *d
 {	
 	// Initialize request DNS header
 	struct DNS_HEADER dns = { 0 };
-	dns.id = (unsigned short) htons(random()); // random query ID
+
+	// Random query ID. This has to be unpredictable, as an off-path
+	// attacker who can guess it may forge a reply
+	uint16_t query_id = 0;
+	if(!get_secure_randomness((uint8_t *)&query_id, sizeof(query_id)))
+	{
+		log_err("Unable to generate a random DNS query ID");
+		return false;
+	}
+	dns.id = htons(query_id);
 	dns.qr = 0; // This is a query
 	dns.opcode = 0; // This is a standard query
 	dns.aa = 0; // Not Authoritative

--- a/src/tools/arp-scan.c
+++ b/src/tools/arp-scan.c
@@ -89,6 +89,15 @@ enum status {
 	STATUS_COMPLETE
 } __attribute__ ((packed));
 
+// IP4STR() formats into a single static buffer shared by all callers, so
+// concurrent interface threads would overwrite each other's address. Format
+// into a caller-provided buffer instead.
+static const char *ip4str(const struct in_addr addr, char *buf)
+{
+	return inet_ntop(AF_INET, &addr, buf, INET_ADDRSTRLEN) != NULL ? buf : "?";
+}
+#define IP4STR(a) ip4str((a), (char[INET_ADDRSTRLEN]){ 0 })
+
 struct thread_data {
 	bool scan_all :1;
 	bool extreme :1;
@@ -168,7 +177,7 @@ static int send_arps(const int fd, const int ifindex, struct thread_data *thread
 		memcpy(arp_req->target_ip, &dst_ip.s_addr, sizeof(dst_ip.s_addr));
 
 #ifdef DEBUG
-		printf("Sending ARP request for %s@%s\n", inet_ntoa(*dst_ip), iface);
+		printf("Sending ARP request for %s@%s\n", IP4STR(*dst_ip), iface);
 #endif
 
 		// Send ARP request
@@ -245,7 +254,7 @@ static void add_result(struct in_addr *rcv_ip, unsigned char *sender_mac,
 	if(i >= thread_data->result_size)
 	{
 		printf("Received IP address %s out of range for interface %s (%u >= %zu)\n",
-		       inet_ntoa(*rcv_ip), thread_data->iface, i, thread_data->result_size);
+		       IP4STR(*rcv_ip), thread_data->iface, i, thread_data->result_size);
 		return;
 	}
 
@@ -335,7 +344,7 @@ static ssize_t read_arp(const int fd, struct thread_data *thread_data)
 
 #ifdef DEBUG
 		printf("%-16s %-20s\t%02x:%02x:%02x:%02x:%02x:%02x",
-		     thread_data->iface, inet_ntoa(sender_a),
+		     thread_data->iface, IP4STR(sender_a),
 		     arp_resp->sender_mac[0],
 		     arp_resp->sender_mac[1],
 		     arp_resp->sender_mac[2],

--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -37,6 +37,8 @@
 
 // strncpy()
 #include <string.h>
+// get_secure_randomness()
+#include "config/password.h"
 
 // IP4STR() formats into a single static buffer shared by all callers, so
 // concurrent interface threads would overwrite each other's address. Format
@@ -713,9 +715,13 @@ static void *dhcp_discover_iface_v4(void *args)
 	unsigned char mac[MAX_DHCP_CHADDR_LENGTH] = { 0 };
 	get_hardware_address(dhcp_socket, tdata->iface, mac);
 
-	// Generate pseudo-random transaction ID
-	srand((unsigned int)time(NULL) + getpid());
-	const uint32_t xid = (uint32_t)random();
+	// Random transaction ID identifying this exchange
+	uint32_t xid = 0;
+	if(!get_secure_randomness((uint8_t *)&xid, sizeof(xid)))
+	{
+		log_err("Unable to generate a random DHCP transaction ID");
+		goto end_dhcp_discover_iface_v4;
+	}
 
 	// Probe servers on this interface
 	if(!send_dhcp_discover(dhcp_socket, xid, tdata->iface, mac))

--- a/src/tools/dhcp-discover.c
+++ b/src/tools/dhcp-discover.c
@@ -38,6 +38,15 @@
 // strncpy()
 #include <string.h>
 
+// IP4STR() formats into a single static buffer shared by all callers, so
+// concurrent interface threads would overwrite each other's address. Format
+// into a caller-provided buffer instead.
+static const char *ip4str(const struct in_addr addr, char *buf)
+{
+	return inet_ntop(AF_INET, &addr, buf, INET_ADDRSTRLEN) != NULL ? buf : "?";
+}
+#define IP4STR(a) ip4str((a), (char[INET_ADDRSTRLEN]){ 0 })
+
 //*** DHCP definitions **
 #define MAX_DHCP_CHADDR_LENGTH           16
 #define MAX_DHCP_SNAME_LENGTH            64
@@ -233,12 +242,12 @@ static bool send_dhcp_discover(const int sock, const uint32_t xid, const char *i
 
 #ifdef DEBUG
 	start_lock();
-	printf("Sending DHCPDISCOVER on interface %s@%s ... \n", inet_ntoa(target.sin_addr), iface);
+	printf("Sending DHCPDISCOVER on interface %s@%s ... \n", IP4STR(target.sin_addr), iface);
 	printf("DHCPDISCOVER XID: %lu (0x%X)\n", (unsigned long) ntohl(discover_packet.xid), ntohl(discover_packet.xid));
-	printf("DHCDISCOVER ciaddr:  %s\n", inet_ntoa(discover_packet.ciaddr));
-	printf("DHCDISCOVER yiaddr:  %s\n", inet_ntoa(discover_packet.yiaddr));
-	printf("DHCDISCOVER siaddr:  %s\n", inet_ntoa(discover_packet.siaddr));
-	printf("DHCDISCOVER giaddr:  %s\n", inet_ntoa(discover_packet.giaddr));
+	printf("DHCDISCOVER ciaddr:  %s\n", IP4STR(discover_packet.ciaddr));
+	printf("DHCDISCOVER yiaddr:  %s\n", IP4STR(discover_packet.yiaddr));
+	printf("DHCDISCOVER siaddr:  %s\n", IP4STR(discover_packet.siaddr));
+	printf("DHCDISCOVER giaddr:  %s\n", IP4STR(discover_packet.giaddr));
 	end_lock();
 #endif
 	// send the DHCPDISCOVER packet
@@ -252,7 +261,7 @@ static bool send_dhcp_discover(const int sock, const uint32_t xid, const char *i
 		const char *error = errno == ENOKEY ? "No route to host (no such peer available)" : strerror(errno);
 		start_lock();
 		printf("Error: Could not send DHCPDISCOVER to %s@%s: %s\n",
-		              inet_ntoa(target.sin_addr), iface, error);
+		              IP4STR(target.sin_addr), iface, error);
 		end_lock();
 		return false;
 	}
@@ -336,7 +345,7 @@ static void print_dhcp_offer(struct in_addr source, struct dhcp_packet_data *off
 					if(n > 0)
 						printf("   ");
 
-					printf("%s: %s\n", opttab[i].name, inet_ntoa(addr_list));
+					printf("%s: %s\n", opttab[i].name, IP4STR(addr_list));
 				}
 
 				// Special case: optlen == 0
@@ -456,7 +465,7 @@ static void print_dhcp_offer(struct in_addr source, struct dhcp_packet_data *off
 					if(n > 0)
 						printf("   ");
 
-					printf("Port Control Protocol (PCP) server: %s\n", inet_ntoa(addr_list));
+					printf("Port Control Protocol (PCP) server: %s\n", IP4STR(addr_list));
 				}
 			}
 			else if((opttype == 121 || opttype == 249) && optlen > 4)
@@ -553,7 +562,7 @@ static bool receive_dhcp_packet(void *buffer, int buffer_size, const char *iface
 	recv_result = recvfrom(sock, (char *)buffer, buffer_size, 0, (struct sockaddr *)address, &address_size);
 
 	start_lock();
-	printf("* Received %d bytes from %s @ %s\n", recv_result, inet_ntoa(address->sin_addr), iface);
+	printf("* Received %d bytes from %s @ %s\n", recv_result, IP4STR(address->sin_addr), iface);
 #ifdef DEBUG
 	printf("  after waiting for %f seconds\n", difftime(time(NULL), start_time));
 #endif
@@ -623,19 +632,19 @@ static unsigned int get_dhcp_offer(const int sock, const uint32_t xid, const cha
 
 		printf("  Offered IP address: ");
 		if(offer_packet.yiaddr.s_addr != 0)
-			printf("%s\n", inet_ntoa(offer_packet.yiaddr));
+			printf("%s\n", IP4STR(offer_packet.yiaddr));
 		else
 			printf("N/A\n");
 
 		printf("  Server IP address: ");
 		if(offer_packet.siaddr.s_addr != 0)
-			printf("%s\n", inet_ntoa(offer_packet.siaddr));
+			printf("%s\n", IP4STR(offer_packet.siaddr));
 		else
 			printf("N/A\n");
 
 		printf("  Relay-agent IP address: ");
 		if(offer_packet.giaddr.s_addr != 0)
-			printf("%s\n", inet_ntoa(offer_packet.giaddr));
+			printf("%s\n", IP4STR(offer_packet.giaddr));
 		else
 			printf("N/A\n");
 

--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -370,7 +370,8 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 			continue;
 
 		// Split by whitespace and tabs and look over the tokens
-		char *token = strtok(line, " \t");
+		char *saveptr = NULL;
+		char *token = strtok_r(line, " \t", &saveptr);
 		while(token != NULL)
 		{
 			// Skip empty tokens
@@ -542,7 +543,7 @@ int gravity_parseList(const char *infile, const char *outfile, const char *adlis
 				}
 			}
 next_domain:
-			token = strtok(NULL, " \t");
+			token = strtok_r(NULL, " \t", &saveptr);
 		}
 
 		// Print progress if the file is large enough every 100 lines


### PR DESCRIPTION
# What does this implement/fix?

A sweep for non-reentrant libc calls reachable from more than one thread, prompted by #3029.

`arp-scan` and `dhcp-discover` run one thread per interface and print through `inet_ntoa()`, which hands every one of them the same static buffer. Both now format into a caller-provided buffer.

`strtok()` keeps its parser state in a static pointer. The setupVars, environment and gravity parsers use `strtok_r()` instead - hygiene rather than a fix, as all three are single-threaded today.

The internal resolver's DNS query ID now comes from `get_secure_randomness()`. `random()` is not seeded anywhere in FTL and is the wrong generator for an identifier that should be hard to guess. `dhcp-discover`'s transaction ID gets the same treatment.

`/api/info/database` is deliberately not in here, #3020 already converts it along with `chown_pihole()`.

## How to test the change during review

Full test suite on this branch: 191, 12, 25 and 9 BATS tests plus 151 pytest cases, no failures.
