### PR TITLE
Release the SHM lock and roll back on early returns

### DIFF
--- a/src/api/history.c
+++ b/src/api/history.c
@@ -27,15 +27,25 @@ int api_history(struct ftl_conn *api)
 
 	cJSON *history = JSON_NEW_ARRAY();
 	const unsigned int max_slot = get_max_overtime_slot();
-	// Loop over all overTime slots and add them to the array
+	// Loop over all overTime slots and add them to the array. The JSON_*
+	// macros cannot be used while we hold the lock, as their early return
+	// would leave it taken for good
 	for(unsigned int slot = 0; slot <= max_slot; slot++)
 	{
 		cJSON *item = JSON_NEW_OBJECT();
-		JSON_ADD_NUMBER_TO_OBJECT(item, "timestamp", overTime[slot].timestamp);
-		JSON_ADD_NUMBER_TO_OBJECT(item, "total", overTime[slot].total);
-		JSON_ADD_NUMBER_TO_OBJECT(item, "cached", overTime[slot].cached);
-		JSON_ADD_NUMBER_TO_OBJECT(item, "blocked", overTime[slot].blocked);
-		JSON_ADD_NUMBER_TO_OBJECT(item, "forwarded", overTime[slot].forwarded);
+		if(cJSON_AddNumberToObject(item, "timestamp", overTime[slot].timestamp) == NULL ||
+		   cJSON_AddNumberToObject(item, "total", overTime[slot].total) == NULL ||
+		   cJSON_AddNumberToObject(item, "cached", overTime[slot].cached) == NULL ||
+		   cJSON_AddNumberToObject(item, "blocked", overTime[slot].blocked) == NULL ||
+		   cJSON_AddNumberToObject(item, "forwarded", overTime[slot].forwarded) == NULL)
+		{
+			log_err("api_history(): Failed to allocate JSON item");
+			cJSON_Delete(item);
+			cJSON_Delete(history);
+			unlock_shm();
+			send_http_internal_error(api);
+			return 500;
+		}
 		JSON_ADD_ITEM_TO_ARRAY(history, item);
 	}
 
@@ -150,12 +160,18 @@ int api_history_clients(struct ftl_conn *api)
 	// Main return loop
 	int others_total = 0;
 
+	// The JSON_* macros cannot be used below while we hold the lock, as
+	// their early return would leave it taken for good. Everything that
+	// still has to be released is tracked in these pointers, so the cleanup
+	// at the end of this function can run from any point
 	cJSON *history = JSON_NEW_ARRAY();
+	cJSON *clients = NULL, *item = NULL, *data = NULL;
 	const unsigned int max_slot = get_max_overtime_slot();
 	for(unsigned int slot = 0; slot <= max_slot; slot++)
 	{
-		cJSON *item = JSON_NEW_OBJECT();
-		JSON_ADD_NUMBER_TO_OBJECT(item, "timestamp", overTime[slot].timestamp);
+		item = JSON_NEW_OBJECT();
+		if(cJSON_AddNumberToObject(item, "timestamp", overTime[slot].timestamp) == NULL)
+			goto oom;
 
 		// If we are not in global-max mode, we need to build the temporary
 		// client array for each slot individually
@@ -173,7 +189,7 @@ int api_history_clients(struct ftl_conn *api)
 
 		// Loop over clients to generate output to be sent to the client
 		int others = 0;
-		cJSON *data = JSON_NEW_OBJECT();
+		data = JSON_NEW_OBJECT();
 		for(unsigned int arrayID = 0; arrayID < num_clients; arrayID++)
 		{
 
@@ -201,14 +217,17 @@ int api_history_clients(struct ftl_conn *api)
 		}
 		// Add others as last element in the array
 		others_total += others;
-		JSON_ADD_NUMBER_TO_OBJECT(data, "others", others);
+		if(cJSON_AddNumberToObject(data, "others", others) == NULL)
+			goto oom;
 
 		JSON_ADD_ITEM_TO_OBJECT(item, "data", data);
+		data = NULL;
 		JSON_ADD_ITEM_TO_ARRAY(history, item);
+		item = NULL;
 	}
 
 	// Loop over clients to generate output to be sent to the client
-	cJSON *clients = JSON_NEW_OBJECT();
+	clients = JSON_NEW_OBJECT();
 	for(unsigned int arrayID = 0; arrayID < num_clients; arrayID++)
 	{
 		// Get client pointer
@@ -232,14 +251,19 @@ int api_history_clients(struct ftl_conn *api)
 		const char *client_name = client->namepos != 0 ? getstr(client->namepos) : NULL;
 
 		// Create JSON object for this client
-		cJSON *item = JSON_NEW_OBJECT();
+		item = JSON_NEW_OBJECT();
 		// Must COPY, not reference: the SHM strings buffer can be
 		// relocated by mremap(MREMAP_MAYMOVE) in another thread after
 		// we release the lock below, which would leave a dangling
-		// pointer if we used JSON_REF_STR_IN_OBJECT here (see #2786)
-		JSON_COPY_STR_TO_OBJECT(item, "name", client_name);
-		JSON_ADD_NUMBER_TO_OBJECT(item, "total", client->count);
+		// pointer if we referenced the string here (see #2786)
+		cJSON *name = client_name != NULL ? cJSON_CreateString(client_name) : cJSON_CreateNull();
+		if(name == NULL)
+			goto oom;
+		cJSON_AddItemToObject(item, "name", name);
+		if(cJSON_AddNumberToObject(item, "total", client->count) == NULL)
+			goto oom;
 		JSON_ADD_ITEM_TO_OBJECT(clients, client_ip, item);
+		item = NULL;
 	}
 
 	// Unlock here to avoid keeping the lock during JSON generation.
@@ -253,10 +277,15 @@ int api_history_clients(struct ftl_conn *api)
 	// and if we are not returning all clients
 	if(num_clients > Nc)
 	{
-		cJSON *item = JSON_NEW_OBJECT();
-		JSON_REF_STR_IN_OBJECT(item, "name", "other clients");
-		JSON_ADD_NUMBER_TO_OBJECT(item, "total", others_total);
+		item = JSON_NEW_OBJECT();
+		cJSON *name = cJSON_CreateStringReference("other clients");
+		if(name == NULL)
+			goto oom_unlocked;
+		cJSON_AddItemToObject(item, "name", name);
+		if(cJSON_AddNumberToObject(item, "total", others_total) == NULL)
+			goto oom_unlocked;
 		JSON_ADD_ITEM_TO_OBJECT(clients, "others", item);
+		item = NULL;
 	}
 
 	// Free memory
@@ -266,4 +295,17 @@ int api_history_clients(struct ftl_conn *api)
 	JSON_ADD_ITEM_TO_OBJECT(json, "history", history);
 	JSON_ADD_ITEM_TO_OBJECT(json, "clients", clients);
 	JSON_SEND_OBJECT(json);
+
+	// Common cleanup for the allocation failures above
+oom:
+	unlock_shm();
+oom_unlocked:
+	log_err("api_history_clients(): Failed to allocate JSON object");
+	cJSON_Delete(data);
+	cJSON_Delete(item);
+	cJSON_Delete(history);
+	cJSON_Delete(clients);
+	free(temparray);
+	send_http_internal_error(api);
+	return 500;
 }

--- a/src/api/padd.c
+++ b/src/api/padd.c
@@ -62,7 +62,19 @@ int api_padd(struct ftl_conn *api)
 				if(domain == NULL)
 					continue;
 
-				JSON_COPY_STR_TO_OBJECT(json, "recent_blocked", domain);
+				// The JSON_* macros cannot be used while we hold
+				// the lock, as their early return would leave it
+				// taken for good
+				cJSON *item = cJSON_CreateString(domain);
+				if(item == NULL)
+				{
+					log_err("api_padd(): Failed to allocate JSON string");
+					cJSON_Delete(json);
+					unlock_shm();
+					send_http_internal_error(api);
+					return 500;
+				}
+				cJSON_AddItemToObject(json, "recent_blocked", item);
 				break;
 			}
 		}

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -866,7 +866,19 @@ int api_stats_recentblocked(struct ftl_conn *api)
 			// thread after we release the lock below, which would
 			// leave a dangling pointer if we used
 			// JSON_REF_STR_IN_ARRAY here (see #2786)
-			JSON_COPY_STR_TO_ARRAY(blocked, domain);
+			// The JSON_* macros cannot be used while we hold the
+			// lock, as their early return would leave it taken for
+			// good
+			cJSON *item = cJSON_CreateString(domain);
+			if(item == NULL)
+			{
+				log_err("api_stats_recentblocked(): Failed to allocate JSON string");
+				cJSON_Delete(blocked);
+				unlock_shm();
+				send_http_internal_error(api);
+				return 500;
+			}
+			cJSON_AddItemToArray(blocked, item);
 
 			// Only count when added successfully
 			found++;

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -1914,8 +1914,14 @@ bool queries_to_database(void)
 	bool phase1_error = false;
 
 	// Wrap linking table INSERTs in a transaction for efficiency (these are
-	// mostly skipped due to in_database caching)
-	SQL_bool(memdb, "BEGIN TRANSACTION");
+	// mostly skipped due to in_database caching). SQL_bool() cannot be used
+	// while we hold the SHM lock, as its early return would leave the lock
+	// taken for good
+	if(dbquery(memdb, "BEGIN TRANSACTION") != SQLITE_OK)
+	{
+		log_err("queries_to_database(): Failed to start linking table transaction");
+		goto unlock_fail;
+	}
 
 	for(unsigned int queryID = last_query; queryID < counters->queries; queryID++)
 	{
@@ -2166,7 +2172,11 @@ bool queries_to_database(void)
 	}
 
 	// Commit linking table transaction
-	SQL_bool(memdb, "END");
+	if(dbquery(memdb, "END") != SQLITE_OK)
+	{
+		log_err("queries_to_database(): Failed to commit linking table transaction");
+		goto rollback_unlock_fail;
+	}
 
 	// Release SHM lock — all data needed for phase 2 is in the snapshot
 	unlock_shm();
@@ -2184,7 +2194,11 @@ bool queries_to_database(void)
 	// the DNS processing or API threads.
 	// ===================================================================
 
-	SQL_bool(memdb, "BEGIN TRANSACTION");
+	if(dbquery(memdb, "BEGIN TRANSACTION") != SQLITE_OK)
+	{
+		log_err("queries_to_database(): Failed to start query transaction");
+		goto fail;
+	}
 
 	unsigned int succeeded = 0;
 	for(unsigned int i = 0; i < snap_count; i++)
@@ -2236,7 +2250,11 @@ bool queries_to_database(void)
 		succeeded++;
 	}
 
-	SQL_bool(memdb, "END");
+	if(dbquery(memdb, "END") != SQLITE_OK)
+	{
+		log_err("queries_to_database(): Failed to commit query transaction");
+		goto rollback_fail;
+	}
 
 	// ===================================================================
 	// PHASE 3: Brief SHM lock — write back db indices and clear changed
@@ -2293,4 +2311,18 @@ bool queries_to_database(void)
 	}
 
 	return true;
+
+	// Common cleanup for the transaction failures above. `SQL_bool()` is not
+	// usable there: its early return would skip the unlock and leave the SHM
+	// lock taken for good
+rollback_unlock_fail:
+	dbquery(memdb, "ROLLBACK");
+unlock_fail:
+	unlock_shm();
+	goto fail;
+rollback_fail:
+	dbquery(memdb, "ROLLBACK");
+fail:
+	free(snaps);
+	return false;
 }

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -1787,6 +1787,23 @@ static void init_disk_db_idx(sqlite3 *memdb)
 	log_debug(DEBUG_DATABASE, "Last long-term idx is %"PRId64, memdb_queries_maxid);
 }
 
+// Run one of the transaction statements of queries_to_database(). SQL_bool()
+// cannot be used there, as its early return would skip the cleanup, but its
+// logging is worth keeping: a busy database is transient and only warned about
+static bool memdb_exec(sqlite3 *memdb, const char *sql, const char *what)
+{
+	const int rc = dbquery(memdb, "%s", sql);
+	if(rc == SQLITE_OK)
+		return true;
+
+	if(rc == SQLITE_BUSY)
+		log_warn("queries_to_database(): Database busy when trying to %s", what);
+	else
+		log_err("queries_to_database(): Failed to %s", what);
+
+	return false;
+}
+
 bool queries_to_database(void)
 {
 	int rc;
@@ -1917,11 +1934,8 @@ bool queries_to_database(void)
 	// mostly skipped due to in_database caching). SQL_bool() cannot be used
 	// while we hold the SHM lock, as its early return would leave the lock
 	// taken for good
-	if(dbquery(memdb, "BEGIN TRANSACTION") != SQLITE_OK)
-	{
-		log_err("queries_to_database(): Failed to start linking table transaction");
+	if(!memdb_exec(memdb, "BEGIN TRANSACTION", "start the linking table transaction"))
 		goto unlock_fail;
-	}
 
 	for(unsigned int queryID = last_query; queryID < counters->queries; queryID++)
 	{
@@ -2172,11 +2186,8 @@ bool queries_to_database(void)
 	}
 
 	// Commit linking table transaction
-	if(dbquery(memdb, "END") != SQLITE_OK)
-	{
-		log_err("queries_to_database(): Failed to commit linking table transaction");
+	if(!memdb_exec(memdb, "END", "commit the linking table transaction"))
 		goto rollback_unlock_fail;
-	}
 
 	// Release SHM lock — all data needed for phase 2 is in the snapshot
 	unlock_shm();
@@ -2194,11 +2205,8 @@ bool queries_to_database(void)
 	// the DNS processing or API threads.
 	// ===================================================================
 
-	if(dbquery(memdb, "BEGIN TRANSACTION") != SQLITE_OK)
-	{
-		log_err("queries_to_database(): Failed to start query transaction");
+	if(!memdb_exec(memdb, "BEGIN TRANSACTION", "start the query transaction"))
 		goto fail;
-	}
 
 	unsigned int succeeded = 0;
 	for(unsigned int i = 0; i < snap_count; i++)
@@ -2250,11 +2258,8 @@ bool queries_to_database(void)
 		succeeded++;
 	}
 
-	if(dbquery(memdb, "END") != SQLITE_OK)
-	{
-		log_err("queries_to_database(): Failed to commit query transaction");
+	if(!memdb_exec(memdb, "END", "commit the query transaction"))
 		goto rollback_fail;
-	}
 
 	// ===================================================================
 	// PHASE 3: Brief SHM lock — write back db indices and clear changed

--- a/src/webserver/json_macros.h
+++ b/src/webserver/json_macros.h
@@ -204,24 +204,6 @@
 	return 200; \
 })
 
-#define JSON_SEND_OBJECT_UNLOCK(object)({ \
-	cJSON_AddNumberToObject(object, "took", double_time() - api->now);\
-	char *json_string = json_formatter(object); \
-	if(json_string == NULL) \
-	{ \
-		cJSON_Delete(object); \
-		send_http_internal_error(api); \
-		log_err("JSON_SEND_OBJECT FAILED!"); \
-		unlock_shm(); \
-		return 500; \
-	} \
-	send_http(api, "application/json; charset=utf-8", json_string); \
-	cJSON_free(json_string); \
-	cJSON_Delete(object); \
-	unlock_shm(); \
-	return 200; \
-})
-
 #define JSON_SEND_OBJECT_CODE(object, code)({ \
 	if((code) < 200 || (code) == 204 || (code) == 304) \
 	{ \


### PR DESCRIPTION
# What does this implement/fix?

Two macro families return from the calling function on error: `SQL_bool()`/`SQL_void()` when a query fails, and the `JSON_*` macros when a cJSON allocation fails. Where that return happens between `lock_shm()` and `unlock_shm()`, the SHM lock stays taken with nothing left to release it, and every thread that touches shared memory blocks from then on.
`queries_to_database()` uses `SQL_bool()` for four transaction statements. Two of them sit inside the locked region, and all four run after the snapshot array is allocated, so they leak it as well. A failed `END` also left the transaction open on `_memdb`, which lives for the whole process, so every later `BEGIN` on that handle failed too. They now go through `dbquery()` and share one cleanup path that rolls back, unlocks and frees as required.
The same applies to eleven `JSON_*` uses in `api_history()`, `api_history_clients()`, `api_padd()` and `api_stats_recentblocked()`. Those sites now test the allocation themselves and release everything they own on the way out: the lock, the partially built JSON tree and, in `api_history_clients()`, the temporary client array. The guard cannot live in the macros instead, as they return from whichever function uses them, which is not always the one holding the lock - `api_list_read()` runs with the lock held by `api_list()`, so unlocking there would unlock twice. `JSON_SEND_OBJECT_UNLOCK()` is removed, it had no users.

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
