### PR TITLE
let a write wait for the gravity database instead of failing

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1827,26 +1827,34 @@ bool gravityDB_get_regex_client_groups(clientsData *client, const unsigned int n
 	return true;
 }
 
-// The gravity connection deliberately runs without a busy handler so that a DNS
-// lookup never waits for the database (see gravityDB_open()). Writes need the
-// opposite: gravity_updated() opens its own read connection once per second, and
-// a COMMIT landing in that window fails outright without one. Arm it for the
-// duration of a write and take it off again afterwards
-static void gravity_write_wait(const bool wait)
+// Writes get their own connection. sqlite3_busy_handler() is a property of the
+// connection, and the shared one is deliberately left without one so a DNS
+// lookup never waits for the database (see gravityDB_open()). A write does want
+// to wait: the database thread reads gravity.db once per second in
+// gravity_updated(), and a COMMIT meeting that reader fails outright otherwise
+static sqlite3 *gravity_write_open(const char **message)
 {
-	if(gravity_db == NULL)
-		return;
+	sqlite3 *db = NULL;
+	const int rc = sqlite3_open_v2(config.files.gravity.v.s, &db, SQLITE_OPEN_READWRITE, NULL);
+	if(rc != SQLITE_OK || db == NULL)
+	{
+		log_err("gravity_write_open() - SQL error open: %s", sqlite3_errstr(rc));
+		if(message != NULL)
+			*message = "Cannot open gravity database for writing";
+		sqlite3_close(db);
+		return NULL;
+	}
 
-	const int rc = sqlite3_busy_handler(gravity_db, wait ? sqliteBusyCallback : NULL, NULL);
-	if(rc != SQLITE_OK)
-		log_err("gravity_write_wait(%s) - Cannot set busy handler: %s",
-		        wait ? "true" : "false", sqlite3_errstr(rc));
+	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
+		log_err("gravity_write_open() - Cannot set busy handler: %s", sqlite3_errmsg(db));
+
+	return db;
 }
 
-static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
+static bool addToTable(sqlite3 *db, const enum gravity_list_type listtype, tablerow *row,
                        const char **message, const enum http_method method)
 {
-	if(gravity_db == NULL)
+	if(db == NULL)
 	{
 		*message = "Database not available";
 		return false;
@@ -1943,10 +1951,10 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 			           "ON CONFLICT(domain,type) DO UPDATE SET type = :type, enabled = :enabled, comment = :comment;";
 	}
 
-	int rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &stmt, NULL);
+	int rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_addToTable(%d, %s) - SQL error prepare (%i): %s",
 		        row->type_int, row->item, rc, *message);
 		return false;
@@ -1956,7 +1964,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 	const int item_idx = sqlite3_bind_parameter_index(stmt, ":item");
 	if(item_idx > 0 && (rc = sqlite3_bind_text(stmt, item_idx, row->item, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_addToTable(%d, %s): Failed to bind item (error %d) - %s",
 		        row->type_int, row->item, rc, *message);
 		sqlite3_finalize(stmt);
@@ -1967,7 +1975,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 	const int name_idx = sqlite3_bind_parameter_index(stmt, ":name");
 	if(name_idx > 0 && (rc = sqlite3_bind_text(stmt, name_idx, row->name, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_addToTable(%d, %s): Failed to bind name (error %d) - %s",
 		        row->type_int, row->item, rc, *message);
 		sqlite3_finalize(stmt);
@@ -1978,7 +1986,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 	const int type_idx = sqlite3_bind_parameter_index(stmt, ":type");
 	if(type_idx > 0 && (rc = sqlite3_bind_int(stmt, type_idx, row->type_int)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_addToTable(%d, %s): Failed to bind type (error %d) - %s",
 		        row->type_int, row->item, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2040,7 +2048,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 		// Bind oldtype to database statement
 		if((rc = sqlite3_bind_int(stmt, oldtype_idx, oldtype)) != SQLITE_OK)
 		{
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			log_err("gravityDB_addToTable(%d, %s): Failed to bind oldtype (error %d) - %s",
 			        row->type_int, row->item, rc, *message);
 			sqlite3_finalize(stmt);
@@ -2052,7 +2060,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 	const int enabled_idx = sqlite3_bind_parameter_index(stmt, ":enabled");
 	if(enabled_idx > 0 && (rc = sqlite3_bind_int(stmt, enabled_idx, row->enabled ? 1 : 0)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_addToTable(%d, %s): Failed to bind enabled (error %d) - %s",
 		        row->type_int, row->item, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2063,7 +2071,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 	const int comment_idx = sqlite3_bind_parameter_index(stmt, ":comment");
 	if(comment_idx > 0 && (rc = sqlite3_bind_text(stmt, comment_idx, row->comment, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_addToTable(%d, %s): Failed to bind comment (error %d) - %s",
 		        row->type_int, row->item, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2082,7 +2090,7 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 		if(rc == SQLITE_CONSTRAINT)
 			*message = "The item is already present";
 		else
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 	}
 
 	// Finalize statement and close database handle
@@ -2110,16 +2118,19 @@ static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
 bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
                           const char **message, const enum http_method method)
 {
-	gravity_write_wait(true);
-	const bool ret = addToTable(listtype, row, message, method);
-	gravity_write_wait(false);
+	sqlite3 *db = gravity_write_open(message);
+	if(db == NULL)
+		return false;
+
+	const bool ret = addToTable(db, listtype, row, message, method);
+	sqlite3_close(db);
 	return ret;
 }
 
-static bool delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
+static bool delFromTable(sqlite3 *db, const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
 {
 	// Return early if database is not available
-	if(gravity_db == NULL)
+	if(db == NULL)
 	{
 		*message = "Database not available";
 		return false;
@@ -2145,10 +2156,10 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 
 	// Begin transaction
 	const char *querystr = "BEGIN TRANSACTION;";
-	int rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+	int rc = sqlite3_exec(db, querystr, NULL, NULL, NULL);
 	if(rc != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
 		        listtype, querystr, *message);
 		return false;
@@ -2162,16 +2173,16 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 		querystr = "CREATE TEMPORARY TABLE deltable (item TEXT);";
 
 	sqlite3_stmt* stmt = NULL;
-	rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &stmt, NULL);
+	rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_delFromTable(%d) - SQL error prepare(\"%s\"): %s",
 		        listtype, querystr, *message);
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+		sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 		return false;
 	}
@@ -2179,14 +2190,14 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 	// Execute statement
 	if((rc = sqlite3_step(stmt)) != SQLITE_DONE)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_delFromTable(%d) - SQL error step(\"%s\"): %s",
 		        listtype, querystr, *message);
 		sqlite3_finalize(stmt);
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+		sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 		return false;
 	}
@@ -2200,16 +2211,16 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 	else
 		querystr = "INSERT INTO deltable (item) VALUES (:item);";
 
-	rc = sqlite3_prepare_v2(gravity_db, querystr, -1, &stmt, NULL);
+	rc = sqlite3_prepare_v2(db, querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_delFromTable(%d) - SQL error prepare(\"%s\"): %s",
 		        listtype, querystr, *message);
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+		sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 		return false;
 	}
@@ -2235,14 +2246,14 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 		const int type_idx = sqlite3_bind_parameter_index(stmt, ":type");
 		if(type_idx > 0 && (rc = sqlite3_bind_int(stmt, type_idx, type_int)) != SQLITE_OK)
 		{
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			log_err("gravityDB_delFromTable(%d): Failed to bind type (error %d) - %s",
 			        type_int, rc, *message);
 			sqlite3_finalize(stmt);
 
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+			sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 			return false;
 		}
@@ -2252,14 +2263,14 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 		const int item_idx = sqlite3_bind_parameter_index(stmt, ":item");
 		if(item_idx > 0 && (!cJSON_IsString(item) || (rc = sqlite3_bind_text(stmt, item_idx, item->valuestring, -1, SQLITE_STATIC)) != SQLITE_OK))
 		{
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			log_err("gravityDB_delFromTable(%d): Failed to bind item (error %d) - %s",
 			        listtype, rc, *message);
 			sqlite3_finalize(stmt);
 
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+			sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 			return false;
 		}
@@ -2267,14 +2278,14 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 		// Execute statement
 		if((rc = sqlite3_step(stmt)) != SQLITE_DONE)
 		{
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			log_err("gravityDB_delFromTable(%d) - SQL error step(\"%s\"): %s",
 			        listtype, querystr, *message);
 			sqlite3_finalize(stmt);
 
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+			sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 			return false;
 		}
@@ -2327,52 +2338,52 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 			break;
 
 		// Execute statement
-		rc = sqlite3_exec(gravity_db, querystrs[i], NULL, NULL, NULL);
+		rc = sqlite3_exec(db, querystrs[i], NULL, NULL, NULL);
 		if(rc != SQLITE_OK)
 		{
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
 			        listtype, querystrs[i], *message);
 
 			// Rollback transaction
 			querystr = "ROLLBACK TRANSACTION;";
-			sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+			sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 			return false;
 		}
 
 		// Add number of deleted rows
-		*deleted += sqlite3_changes(gravity_db);
+		*deleted += sqlite3_changes(db);
 	}
 
 	// Drop temporary table
 	querystr = "DROP TABLE deltable;";
-	rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+	rc = sqlite3_exec(db, querystr, NULL, NULL, NULL);
 	if(rc != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
 		        listtype, querystr, *message);
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+		sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 		return false;
 	}
 
 	// Commit transaction
 	querystr = "COMMIT TRANSACTION;";
-	rc = sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+	rc = sqlite3_exec(db, querystr, NULL, NULL, NULL);
 	if(rc != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_delFromTable(%d): SQL error exec(\"%s\"): %s",
 		        listtype, querystr, *message);
 
 		// Rollback transaction
 		querystr = "ROLLBACK TRANSACTION;";
-		sqlite3_exec(gravity_db, querystr, NULL, NULL, NULL);
+		sqlite3_exec(db, querystr, NULL, NULL, NULL);
 
 		return false;
 	}
@@ -2382,9 +2393,12 @@ static bool delFromTable(const enum gravity_list_type listtype, const cJSON* arr
 
 bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
 {
-	gravity_write_wait(true);
-	const bool ret = delFromTable(listtype, array, deleted, message);
-	gravity_write_wait(false);
+	sqlite3 *db = gravity_write_open(message);
+	if(db == NULL)
+		return false;
+
+	const bool ret = delFromTable(db, listtype, array, deleted, message);
+	sqlite3_close(db);
 	return ret;
 }
 
@@ -2771,10 +2785,10 @@ void gravityDB_readTableFinalize(sqlite3_stmt *read_stmt)
 	sqlite3_finalize(read_stmt);
 }
 
-static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
+static bool edit_groups(sqlite3 *db, const enum gravity_list_type listtype, cJSON *groups,
                         const tablerow *row, const char **message)
 {
-	if(gravity_db == NULL)
+	if(db == NULL)
 	{
 		*message = "Database not available";
 		return false;
@@ -2810,10 +2824,10 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 
 	// First step: Get ID of the item to modify
 	sqlite3_stmt* stmt = NULL;
-	int rc = sqlite3_prepare_v2(gravity_db, get_querystr, -1, &stmt, NULL);
+	int rc = sqlite3_prepare_v2(db, get_querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d) - SQL error prepare SELECT (%i): %s",
 		        listtype, rc, *message);
 		return false;
@@ -2823,7 +2837,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	int idx = sqlite3_bind_parameter_index(stmt, ":item");
 	if(idx > 0 && (rc = sqlite3_bind_text(stmt, idx, row->item, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d): Failed to bind item SELECT (error %d) - %s",
 		        listtype, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2834,7 +2848,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	idx = sqlite3_bind_parameter_index(stmt, ":type");
 	if(idx > 0 && (rc = sqlite3_bind_int(stmt, idx, row->type_int)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d): Failed to bind type SELECT (error %d) - %s",
 		        listtype, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2852,7 +2866,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	}
 	else
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 	}
 
 	// Debug output
@@ -2871,10 +2885,10 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 		return false;
 
 	// Second step: Delete all existing group associations for this item
-	rc = sqlite3_prepare_v2(gravity_db, del_querystr, -1, &stmt, NULL);
+	rc = sqlite3_prepare_v2(db, del_querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d) - SQL error prepare DELETE (%i): %s",
 		        listtype, rc, *message);
 		return false;
@@ -2884,7 +2898,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	idx = sqlite3_bind_parameter_index(stmt, ":id");
 	if(idx > 0 && (rc = sqlite3_bind_int(stmt, idx, id)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d): Failed to bind id DELETE (error %d) - %s",
 		        listtype, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2899,7 +2913,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	else
 	{
 		okay = false;
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 	}
 
 	// Debug output
@@ -2917,10 +2931,10 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 		return false;
 
 	// Third step: Create new group associations for this item
-	rc = sqlite3_prepare_v2(gravity_db, add_querystr, -1, &stmt, NULL);
+	rc = sqlite3_prepare_v2(db, add_querystr, -1, &stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d) - SQL error prepare INSERT (%i): %s",
 		        listtype, rc, *message);
 		return false;
@@ -2930,7 +2944,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	idx = sqlite3_bind_parameter_index(stmt, ":id");
 	if(idx > 0 && (rc = sqlite3_bind_int(stmt, idx, id)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_edit_groups(%d): Failed to bind id INSERT (error %d) - %s",
 		        listtype, rc, *message);
 		sqlite3_finalize(stmt);
@@ -2949,7 +2963,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 		idx = sqlite3_bind_parameter_index(stmt, ":gid");
 		if(idx > 0 && (rc = sqlite3_bind_int(stmt, idx, group->valueint)) != SQLITE_OK)
 		{
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			log_err("gravityDB_edit_groups(%d): Failed to bind gid INSERT (error %d) - %s",
 			listtype, rc, *message);
 			sqlite3_finalize(stmt);
@@ -2960,7 +2974,7 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 		if((rc = sqlite3_step(stmt)) != SQLITE_DONE)
 		{
 			okay = false;
-			*message = sqlite3_errmsg(gravity_db);
+			*message = sqlite3_errmsg(db);
 			break;
 		}
 
@@ -2986,9 +3000,12 @@ static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
                            const tablerow *row, const char **message)
 {
-	gravity_write_wait(true);
-	const bool ret = edit_groups(listtype, groups, row, message);
-	gravity_write_wait(false);
+	sqlite3 *db = gravity_write_open(message);
+	if(db == NULL)
+		return false;
+
+	const bool ret = edit_groups(db, listtype, groups, row, message);
+	sqlite3_close(db);
 	return ret;
 }
 

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1827,8 +1827,24 @@ bool gravityDB_get_regex_client_groups(clientsData *client, const unsigned int n
 	return true;
 }
 
-bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
-                          const char **message, const enum http_method method)
+// The gravity connection deliberately runs without a busy handler so that a DNS
+// lookup never waits for the database (see gravityDB_open()). Writes need the
+// opposite: gravity_updated() opens its own read connection once per second, and
+// a COMMIT landing in that window fails outright without one. Arm it for the
+// duration of a write and take it off again afterwards
+static void gravity_write_wait(const bool wait)
+{
+	if(gravity_db == NULL)
+		return;
+
+	const int rc = sqlite3_busy_handler(gravity_db, wait ? sqliteBusyCallback : NULL, NULL);
+	if(rc != SQLITE_OK)
+		log_err("gravity_write_wait(%s) - Cannot set busy handler: %s",
+		        wait ? "true" : "false", sqlite3_errstr(rc));
+}
+
+static bool addToTable(const enum gravity_list_type listtype, tablerow *row,
+                       const char **message, const enum http_method method)
 {
 	if(gravity_db == NULL)
 	{
@@ -2091,7 +2107,16 @@ bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
 	return okay;
 }
 
-bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
+bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
+                          const char **message, const enum http_method method)
+{
+	gravity_write_wait(true);
+	const bool ret = addToTable(listtype, row, message, method);
+	gravity_write_wait(false);
+	return ret;
+}
+
+static bool delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
 {
 	// Return early if database is not available
 	if(gravity_db == NULL)
@@ -2353,6 +2378,14 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 	}
 
 	return true;
+}
+
+bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
+{
+	gravity_write_wait(true);
+	const bool ret = delFromTable(listtype, array, deleted, message);
+	gravity_write_wait(false);
+	return ret;
 }
 
 bool gravityDB_readTable(const enum gravity_list_type listtype,
@@ -2738,8 +2771,8 @@ void gravityDB_readTableFinalize(sqlite3_stmt *read_stmt)
 	sqlite3_finalize(read_stmt);
 }
 
-bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
-                           const tablerow *row, const char **message)
+static bool edit_groups(const enum gravity_list_type listtype, cJSON *groups,
+                        const tablerow *row, const char **message)
 {
 	if(gravity_db == NULL)
 	{
@@ -2948,6 +2981,15 @@ bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 	sqlite3_finalize(stmt);
 
 	return okay;
+}
+
+bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
+                           const tablerow *row, const char **message)
+{
+	gravity_write_wait(true);
+	const bool ret = edit_groups(listtype, groups, row, message);
+	gravity_write_wait(false);
+	return ret;
 }
 
 void check_inaccessible_adlists(void)

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1872,22 +1872,31 @@ setup() {
   assert_success
 }
 
-@test "Gravity: API write is not refused while another connection reads" {
-  # gravity_updated() opens its own read-only connection to gravity.db once per
-  # second. The gravity connection carries no busy handler so DNS lookups never
-  # wait, and a write committing inside that window used to fail outright with
-  # "database is locked", losing the edit. Hold a read transaction here and
-  # write through the API while it is held.
-  printf 'BEGIN;\nSELECT count(*) FROM domainlist;\n.shell sleep 0.4\nCOMMIT;\n' | \
+@test "Gravity: API write waits for a concurrent reader instead of failing" {
+  # gravity_updated() reads gravity.db from its own connection once per second.
+  # A write meeting that reader used to fail with "database is locked" instead
+  # of waiting for it. Hold a read transaction here, wait until it is really
+  # held, and write through the API while it is
+  rm -f /tmp/gravity_reader_ready
+  printf 'BEGIN;\nSELECT count(*) FROM domainlist;\n.shell touch /tmp/gravity_reader_ready\n.shell sleep 0.4\nCOMMIT;\n' | \
     ./pihole-FTL sqlite3 -interactive /etc/pihole/gravity.db > /dev/null 2>&1 &
   reader=$!
-  sleep 0.1
 
-  run bash -c 'curl -s -o /dev/null -w "%{http_code}" -X PUT http://127.0.0.1/api/domains/deny/exact/lockrace.ftl -d "{\"comment\":\"busy handler regression\",\"groups\":[0],\"enabled\":true}"'
+  # Do not guess how long the reader needs to take its lock
+  for _ in $(seq 1 100); do
+    [ -f /tmp/gravity_reader_ready ] && break
+    sleep 0.05
+  done
+  run bash -c '[ -f /tmp/gravity_reader_ready ]'
   assert_success
-  assert_output --regexp '^20[01]$'
+
+  # The write has to succeed AND to have waited: if it returns immediately the
+  # reader was already gone and this test proved nothing
+  run bash -c 'out="$(curl -s -o /dev/null -w "%{http_code} %{time_total}" -X PUT http://127.0.0.1/api/domains/deny/exact/lockrace.ftl -d "{\"comment\":\"busy handler regression\",\"groups\":[0],\"enabled\":true}")"; echo "${out}"; code="${out%% *}"; secs="${out##* }"; case "${code}" in 200|201) ;; *) exit 1;; esac; awk -v t="${secs}" "BEGIN{exit !(t>0.1)}"'
+  assert_success
 
   wait "${reader}"
+  rm -f /tmp/gravity_reader_ready
 
   # Remove it again so the following tests see the list they expect
   run bash -c 'curl -s -o /dev/null -w "%{http_code}" -X DELETE http://127.0.0.1/api/domains/deny/exact/lockrace.ftl'

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1872,4 +1872,26 @@ setup() {
   assert_success
 }
 
+@test "Gravity: API write is not refused while another connection reads" {
+  # gravity_updated() opens its own read-only connection to gravity.db once per
+  # second. The gravity connection carries no busy handler so DNS lookups never
+  # wait, and a write committing inside that window used to fail outright with
+  # "database is locked", losing the edit. Hold a read transaction here and
+  # write through the API while it is held.
+  printf 'BEGIN;\nSELECT count(*) FROM domainlist;\n.shell sleep 0.4\nCOMMIT;\n' | \
+    ./pihole-FTL sqlite3 -interactive /etc/pihole/gravity.db > /dev/null 2>&1 &
+  reader=$!
+  sleep 0.1
+
+  run bash -c 'curl -s -o /dev/null -w "%{http_code}" -X PUT http://127.0.0.1/api/domains/deny/exact/lockrace.ftl -d "{\"comment\":\"busy handler regression\",\"groups\":[0],\"enabled\":true}"'
+  assert_success
+  assert_output --regexp '^20[01]$'
+
+  wait "${reader}"
+
+  # Remove it again so the following tests see the list they expect
+  run bash -c 'curl -s -o /dev/null -w "%{http_code}" -X DELETE http://127.0.0.1/api/domains/deny/exact/lockrace.ftl'
+  assert_output "204"
+}
+
 # NOTE: FTL termination test moved to run.sh (runs after both BATS and pytest)


### PR DESCRIPTION
# What does this implement/fix?

the gravity connection has no busy handler so that a DNS lookup never waits for the database. API writes use that same connection, and once per second gravity_updated() opens a second, read-only connection to gravity.db from the database thread. gravity.db uses the normal rollback journal, so that reader blocks the writer and a COMMIT landing in the window fails right away:

```
ERROR: gravityDB_delFromTable(0): SQL error exec("COMMIT TRANSACTION;"): database is locked
```

the rollback works, so nothing is corrupted, but the edit is also lost. It depends on timing, the test suite here hit it once in six runs. the relevant now set the busy handler while the write runs and remove it again afterwards, so a write waits and retries instead of failing.

## How to test the change during review

adding, editing and deleting list items works as before. a new test holds a read transaction on gravity.db and writes over the API while it is held, revert gravity-db.c and keep it and the suite says 192 tests, 1 failure. please infor me if you have different test needs. regarding comment and test style I tried to stay close to existing code

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.