### PR TITLE
Do not drop a database connection that refused to close

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -68,6 +68,16 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 	if(FTLDBerror())
 		return;
 
+	// The shared in-memory connection is owned by close_memory_database() and
+	// its prepared statements live as long as FTL does. Closing it here would
+	// finalize them behind the back of whoever cached them
+	if(db != NULL && is_memdb(*db))
+	{
+		log_err("dbclose() called on the in-memory database in %s() (%s:%i)",
+		        func, short_path(file), line);
+		return;
+	}
+
 	if(config.debug.database.v.b)
 		log_debug(DEBUG_DATABASE, "Closing FTL database in %s() (%s:%i)", func, short_path(file), line);
 
@@ -1208,7 +1218,8 @@ int64_t get_row_count(const char *table_name, const bool memory)
 		log_err("Failed to prepare statement to get size of in-memory table %s: %s",
 		        table_name, sqlite3_errmsg(db));
 		sqlite3_free(query);
-		dbclose(&db);
+		if(!memory)
+			dbclose(&db);
 		return -3;
 	}
 	sqlite3_free(query);

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -72,12 +72,30 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 		log_debug(DEBUG_DATABASE, "Closing FTL database in %s() (%s:%i)", func, short_path(file), line);
 
 	// Only try to close an existing database connection
-	int rc = SQLITE_OK;
-	if(db != NULL && *db != NULL && (rc = sqlite3_close(*db)) != SQLITE_OK)
+	if(db != NULL && *db != NULL)
 	{
-		log_err("Error while trying to close database: %s",
-		        sqlite3_errstr(rc));
-		checkFTLDBrc(rc);
+		// A statement that outlives its connection keeps the database
+		// file locked and any transaction it is part of open, and
+		// sqlite3_close() refuses with SQLITE_BUSY while one exists -
+		// which would leave the connection open behind the pointer we
+		// drop below, with no way left to release the file. Finalize
+		// what the caller forgot and name it, it is a bug either way
+		sqlite3_stmt *stmt = NULL;
+		while((stmt = sqlite3_next_stmt(*db, NULL)) != NULL)
+		{
+			log_err("Statement not finalized when closing database in %s() (%s:%i): %s",
+			        func, short_path(file), line, sqlite3_sql(stmt));
+			sqlite3_finalize(stmt);
+		}
+
+		// _v2 also takes over blob handles and backups still in flight
+		const int rc = sqlite3_close_v2(*db);
+		if(rc != SQLITE_OK)
+		{
+			log_err("Error while trying to close database: %s",
+			        sqlite3_errstr(rc));
+			checkFTLDBrc(rc);
+		}
 	}
 
 	// Always set database pointer to NULL, even when closing failed

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -61,13 +61,9 @@ bool checkFTLDBrc(const int rc)
 	return atomic_load_explicit(&DBerror, memory_order_relaxed);
 }
 
-// Close a connection owned by the caller. A statement that outlives its
-// connection keeps the database file locked and any transaction it is part of
-// open, and sqlite3_close() refuses with SQLITE_BUSY while one exists - it then
-// does nothing at all, so a caller dropping its pointer afterwards can never
-// release the file again. Finalize what was left behind, naming it as it is a
-// bug either way, and hand the connection over with the _v2 variant, which also
-// takes over blob handles and backups still in flight
+// Close a connection owned by the caller. sqlite3_close() refuses while a
+// statement of that connection is still alive, so finalize what was left behind
+// - naming it, as it is a bug - before handing the connection over
 int _dbclose_handle(sqlite3 *db, const char *func, const int line, const char *file)
 {
 	if(db == NULL)
@@ -98,7 +94,9 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 
 	// The shared in-memory connection is owned by close_memory_database() and
 	// its prepared statements live as long as FTL does. Closing it here would
-	// finalize them behind the back of whoever cached them
+	// finalize them behind the back of whoever cached them, so return before
+	// both the NULL assignment and the counter below: the handle stays valid
+	// for its owner, and it never went through dbopen() to be counted
 	if(db != NULL && is_memdb(*db))
 	{
 		log_err("dbclose() called on the in-memory database in %s() (%s:%i)",
@@ -1204,9 +1202,10 @@ const char *get_sqlite3_version(void)
 /**
  * get_row_count - Get the row count of an in-memory SQLite table.
  *
- * Opens a transient SQLite connection (dbopen(false, false)), prepares and
- * executes a "SELECT COUNT(*) FROM <table>;" query for the given table name,
- * and returns the number of rows in that table.
+ * Uses the shared in-memory connection or opens a transient read-only one
+ * (dbopen(true, false)), prepares and executes a "SELECT COUNT(*) FROM
+ * <table>;" query for the given table name, and returns the number of rows in
+ * that table. Only a connection opened here is closed again.
  * 
  * @param table_name The name of the table to get the size of.
  * @param memory If true, use the in-memory database; if false, use the on-disk database.

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -61,6 +61,34 @@ bool checkFTLDBrc(const int rc)
 	return atomic_load_explicit(&DBerror, memory_order_relaxed);
 }
 
+// Close a connection owned by the caller. A statement that outlives its
+// connection keeps the database file locked and any transaction it is part of
+// open, and sqlite3_close() refuses with SQLITE_BUSY while one exists - it then
+// does nothing at all, so a caller dropping its pointer afterwards can never
+// release the file again. Finalize what was left behind, naming it as it is a
+// bug either way, and hand the connection over with the _v2 variant, which also
+// takes over blob handles and backups still in flight
+int _dbclose_handle(sqlite3 *db, const char *func, const int line, const char *file)
+{
+	if(db == NULL)
+		return SQLITE_OK;
+
+	sqlite3_stmt *stmt = NULL;
+	while((stmt = sqlite3_next_stmt(db, NULL)) != NULL)
+	{
+		log_err("Statement not finalized when closing database in %s() (%s:%i): %s",
+		        func, short_path(file), line, sqlite3_sql(stmt));
+		sqlite3_finalize(stmt);
+	}
+
+	const int rc = sqlite3_close_v2(db);
+	if(rc != SQLITE_OK)
+		log_err("Error while trying to close database in %s() (%s:%i): %s",
+		        func, short_path(file), line, sqlite3_errstr(rc));
+
+	return rc;
+}
+
 void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 {
 	// Silently return if the database is known to be broken. It may not be
@@ -84,28 +112,9 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 	// Only try to close an existing database connection
 	if(db != NULL && *db != NULL)
 	{
-		// A statement that outlives its connection keeps the database
-		// file locked and any transaction it is part of open, and
-		// sqlite3_close() refuses with SQLITE_BUSY while one exists -
-		// which would leave the connection open behind the pointer we
-		// drop below, with no way left to release the file. Finalize
-		// what the caller forgot and name it, it is a bug either way
-		sqlite3_stmt *stmt = NULL;
-		while((stmt = sqlite3_next_stmt(*db, NULL)) != NULL)
-		{
-			log_err("Statement not finalized when closing database in %s() (%s:%i): %s",
-			        func, short_path(file), line, sqlite3_sql(stmt));
-			sqlite3_finalize(stmt);
-		}
-
-		// _v2 also takes over blob handles and backups still in flight
-		const int rc = sqlite3_close_v2(*db);
+		const int rc = _dbclose_handle(*db, func, line, file);
 		if(rc != SQLITE_OK)
-		{
-			log_err("Error while trying to close database: %s",
-			        sqlite3_errstr(rc));
 			checkFTLDBrc(rc);
-		}
 	}
 
 	// Always set database pointer to NULL, even when closing failed

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -42,6 +42,8 @@ int sqliteBusyCallback(void *ptr, int count);
 sqlite3 *_dbopen(const bool readonly, const bool create, const char *func, const int line, const char *file) __attribute__((warn_unused_result));
 #define dbclose(db) _dbclose(db, __FUNCTION__, __LINE__, __FILE__)
 void _dbclose(sqlite3 **db, const char *func, const int line, const char *file);
+#define dbclose_handle(db) _dbclose_handle(db, __FUNCTION__, __LINE__, __FILE__)
+int _dbclose_handle(sqlite3 *db, const char *func, const int line, const char *file);
 
 void piholeFTLDB_reopen(void);
 int db_query_int(sqlite3 *db, const char *querystr);

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1184,7 +1184,9 @@ void gravityDB_close(void)
 
 	// Close table
 	log_debug(DEBUG_ANY, "Closing gravity database");
-	sqlite3_close(gravity_db);
+	const int rc = sqlite3_close(gravity_db);
+	if(rc != SQLITE_OK)
+		log_err("gravityDB_close() - Cannot close gravity database: %s", sqlite3_errstr(rc));
 	gravity_db = NULL;
 	gravityDB_opened = false;
 }

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -360,7 +360,10 @@ static bool gravityDB_open(void)
 	if( rc != SQLITE_OK )
 	{
 		log_err("gravityDB_open() - SQL error: %s", sqlite3_errstr(rc));
-		gravityDB_close();
+		// gravityDB_close() returns early while gravityDB_opened is false,
+		// so release the handle sqlite3_open_v2() allocated ourselves
+		sqlite3_close_v2(gravity_db);
+		gravity_db = NULL;
 		return false;
 	}
 
@@ -1184,7 +1187,12 @@ void gravityDB_close(void)
 
 	// Close table
 	log_debug(DEBUG_ANY, "Closing gravity database");
-	const int rc = sqlite3_close(gravity_db);
+	// Only the shared statements are finalized above, a table cursor handed to
+	// an API thread by gravityDB_readTable() may still be open. dbclose_handle()
+	// would finalize it under that thread's feet, and sqlite3_close() would
+	// refuse and leave us with a connection - and its mmap - nobody can release.
+	// _v2 hands the connection over: it goes away once that cursor is finalized
+	const int rc = sqlite3_close_v2(gravity_db);
 	if(rc != SQLITE_OK)
 		log_err("gravityDB_close() - Cannot close gravity database: %s", sqlite3_errstr(rc));
 	gravity_db = NULL;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2125,7 +2125,7 @@ bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
 		return false;
 
 	const bool ret = addToTable(db, listtype, row, message, method);
-	sqlite3_close(db);
+	dbclose_handle(db);
 	return ret;
 }
 
@@ -2400,7 +2400,7 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 		return false;
 
 	const bool ret = delFromTable(db, listtype, array, deleted, message);
-	sqlite3_close(db);
+	dbclose_handle(db);
 	return ret;
 }
 
@@ -3007,7 +3007,7 @@ bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 		return false;
 
 	const bool ret = edit_groups(db, listtype, groups, row, message);
-	sqlite3_close(db);
+	dbclose_handle(db);
 	return ret;
 }
 

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1829,7 +1829,7 @@ static bool getMACVendor(const char *hwaddr, char vendor[MAXVENDORLEN])
 	if(rc != SQLITE_OK)
 	{
 		log_err("getMACVendor(\"%s\") - SQL error: %s", hwaddr, sqlite3_errstr(rc));
-		sqlite3_close(macvendor_db);
+		dbclose_handle(macvendor_db);
 		return false;
 	}
 
@@ -1887,7 +1887,7 @@ getMACVendor_end:
 	// Finalize statement and close database
 	if(stmt != NULL)
 		sqlite3_finalize(stmt);
-	sqlite3_close(macvendor_db);
+	dbclose_handle(macvendor_db);
 
 	log_debug(DEBUG_ARP, "MAC Vendor lookup for %s returned \"%s\"", hwaddr, vendor);
 

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1881,8 +1881,8 @@ static bool getMACVendor(const char *hwaddr, char vendor[MAXVENDORLEN])
 
 getMACVendor_end:
 
-	if(!success)
-		checkFTLDBrc(rc);
+	// No checkFTLDBrc() here: this is macvendor.db, a broken one says
+	// nothing about the FTL database and must not take it out of service
 
 	// Finalize statement and close database
 	if(stmt != NULL)

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -503,6 +503,13 @@ void close_memory_database(void)
 	_memdb = NULL;
 }
 
+// Is this the shared in-memory connection? Used to keep dbclose() away from a
+// handle it does not own
+bool __attribute__((pure)) is_memdb(const sqlite3 *db)
+{
+	return db != NULL && db == _memdb;
+}
+
 sqlite3 *__attribute__((pure)) _get_memdb(const int line, const char *func, const char *file)
 {
 	log_debug(DEBUG_DATABASE, "Accessing in-memory database in %s() (%s:%i)", func, file, line);

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -120,6 +120,7 @@ bool delete_old_queries_from_db(const bool use_memdb, const double mintime);
 bool add_additional_info_column(sqlite3 *db);
 void DB_read_queries(void);
 bool queries_to_database(void);
+bool is_memdb(const sqlite3 *db) __attribute__((pure));
 bool get_memdb_size(size_t *memsize, int *queries);
 
 bool optimize_queries_table(sqlite3 *db);


### PR DESCRIPTION
# What does this implement/fix?

sqlite3_close() answers SQLITE_BUSY while a statement of that connection is still alive, and then does nothing at all. the connection stays open, with its transaction and its file locks. _dbclose() logs the error and sets the pointer to NULL anyway, so from that moment nothing can close the database or release the lock any more, and the next dbopen() just adds another connection

it finalizes what the caller left behind now, and says which statement that was and where the close came from, as that is a bug in the caller either way. the connection is then handed over with sqlite3_close_v2(), which also takes over blob handles and backups that are still in flight

get_row_count() did reach that, its prepare-failure path closed unconditionally while the success path already guarded with if(!memory), so with memory set it handed _memdb to dbclose(). that was inert while sqlite3_close() refused, but finalizing the statements query-table.c caches on that connection would have left them dangling, so the call site is guarded now and dbclose() refuses the shared in-memory handle outright, the call-site discipline has failed once already

the finalize-and-hand-over part sits in dbclose_handle() and the other places that own a connection use it too: the gravity write connection, which can hold an exclusive lock and is the worst place to lose one, and macvendor_db. gravityDB_close() reports a refused close instead of dropping it. checkFTLDBrc() stays in dbclose(), a refused close on gravity.db or macvendor.db says nothing about the FTL database

## How to test the change during review

nothing changes in normal operation, the suite passes and neither the "Statement not finalized" nor the in-memory guard line appears. there is no test for the failures themselves, provoking them means leaking a statement or closing someone else's connection on purpose

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.