### PR TITLE
Fix typo in command line options for version flag

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -1532,7 +1532,7 @@ void suggest_complete(const int argc, char *argv[])
 		    "luac", "ntp", "no-daemon", "--perf", "ptr", "--read-x509",
 		    "--read-x509-key", "regex-test", "sha256sum", "sqlite3",
 		    "sqlite3_rsync", "tag", "--teleporter", "test", "--totp",
-		    "--tls-ciphers", "-v", "-vv", "--v", "version", "verify",
+		    "--tls-ciphers", "-v", "-vv", "--version", "version", "verify",
 		};
 
 		// Provide matching suggestions


### PR DESCRIPTION
### What and how does this PR aim to accomplish?

Removes unused option from autocomplete suggestions and add the correct one.

There was never a `--v` option, but there is `--version`. 
Apparently it was a typo, introduced by commit 36c1c23, but we never noticed.


### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
