### PR TITLE
Search gravity on a connection of its own

### DIFF
--- a/src/api/list.c
+++ b/src/api/list.c
@@ -31,7 +31,7 @@ static int api_list_read(struct ftl_conn *api,
 {
 	const char *sql_msg = NULL;
 	sqlite3_stmt *stmt = NULL;
-	if(!gravityDB_readTable(listtype, item, &sql_msg, true, NULL, &stmt))
+	if(!gravityDB_readTable(NULL, listtype, item, &sql_msg, true, NULL, &stmt))
 	{
 		return send_json_error(api, 400, // 400 Bad Request
 		                       "database_error",

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -231,10 +231,11 @@ int api_search(struct ftl_conn *api)
 	for(unsigned int i = 0u; i < strlen(punycode); i++)
 		punycode[i] = tolower((unsigned char)punycode[i]);
 
-	// Search through all exact domains. This runs on a connection of its own:
-	// a partial search is a LIKE '%term%' over the whole gravity table, far too
-	// long to hold the SHM lock for, and the shared connection can be closed by
-	// a gravity reload while we walk our cursor
+	// Search through all exact domains. The six searches below run on a
+	// connection of their own: a partial search is a LIKE '%term%' over the
+	// whole gravity table, far too long to hold the SHM lock for, and on the
+	// shared connection a reload between two of them shows up as a spurious
+	// 400 or as an answer assembled from two different gravities
 	sqlite3 *db = gravityDB_open_RO();
 	if(db == NULL)
 	{

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -21,7 +21,7 @@
 
 #define MAX_SEARCH_RESULTS 10000u
 
-static int search_table(struct ftl_conn *api, const char *item,
+static int search_table(struct ftl_conn *api, sqlite3 *db, const char *item,
                         const enum gravity_list_type listtype,
                         char *ids, const unsigned int limit,
                         unsigned int *N, const bool partial, cJSON* json)
@@ -39,7 +39,7 @@ static int search_table(struct ftl_conn *api, const char *item,
 	// Check domain against lists table
 	const char *sql_msg = NULL;
 	sqlite3_stmt *stmt = NULL;
-	if(!gravityDB_readTable(listtype, item, &sql_msg, !partial, ids, &stmt))
+	if(!gravityDB_readTable(db, listtype, item, &sql_msg, !partial, ids, &stmt))
 	{
 		return send_json_error(api, 400, // 400 Bad Request
 		                       "database_error",
@@ -101,7 +101,7 @@ static int search_table(struct ftl_conn *api, const char *item,
 	return 200;
 }
 
-static int search_gravity(struct ftl_conn *api, const char *punycode, cJSON *array,
+static int search_gravity(struct ftl_conn *api, sqlite3 *db, const char *punycode, cJSON *array,
                           cJSON **abp_patterns, const unsigned int limit, unsigned int *N,
                           const bool partial, const bool antigravity)
 {
@@ -109,14 +109,14 @@ static int search_gravity(struct ftl_conn *api, const char *punycode, cJSON *arr
 	if(partial)
 	{
 		// Search for partial matches in (anti/)gravity
-		const int ret = search_table(api, punycode, table, NULL, limit, N, partial, array);
+		const int ret = search_table(api, db, punycode, table, NULL, limit, N, partial, array);
 		if(ret != 200)
 			return ret;
 	}
 	else
 	{
 		// Search for exact matches in (anti/)gravity
-		int ret = search_table(api, punycode, table, NULL, limit, N, false, array);
+		int ret = search_table(api, db, punycode, table, NULL, limit, N, false, array);
 		if(ret != 200)
 			return ret;
 
@@ -131,7 +131,7 @@ static int search_gravity(struct ftl_conn *api, const char *punycode, cJSON *arr
 
 			// Skip leading "@@" for gravity matches
 			const char *this_pattern = antigravity ? pattern : pattern + 2;
-			ret = search_table(api, this_pattern, table, NULL, limit, N, partial, array);
+			ret = search_table(api, db, this_pattern, table, NULL, limit, N, partial, array);
 			if(ret != 200)
 				return ret;
 		}
@@ -231,12 +231,24 @@ int api_search(struct ftl_conn *api)
 	for(unsigned int i = 0u; i < strlen(punycode); i++)
 		punycode[i] = tolower((unsigned char)punycode[i]);
 
-	// Search through all exact domains
+	// Search through all exact domains. This runs on a connection of its own:
+	// a partial search is a LIKE '%term%' over the whole gravity table, far too
+	// long to hold the SHM lock for, and the shared connection can be closed by
+	// a gravity reload while we walk our cursor
+	sqlite3 *db = gravityDB_open_RO();
+	if(db == NULL)
+	{
+		free(punycode);
+		return send_json_error(api, 500, "database_error",
+		                       "Could not open gravity database", NULL);
+	}
+
 	cJSON *domains = JSON_NEW_ARRAY();
 	unsigned int Nexact = 0u;
-	ret = search_table(api, punycode, GRAVITY_DOMAINLIST_ALL_EXACT, NULL, limit, &Nexact, partial, domains);
+	ret = search_table(api, db, punycode, GRAVITY_DOMAINLIST_ALL_EXACT, NULL, limit, &Nexact, partial, domains);
 	if(ret != 200)
 	{
+		gravityDB_close_RO(db);
 		free(punycode);
 		return ret;
 	}
@@ -246,9 +258,10 @@ int api_search(struct ftl_conn *api)
 	unsigned int Nregex = 0u;
 	if(partial)
 	{
-		ret = search_table(api, punycode, GRAVITY_DOMAINLIST_ALL_REGEX, NULL, limit, &Nregex, partial, domains);
+		ret = search_table(api, db, punycode, GRAVITY_DOMAINLIST_ALL_REGEX, NULL, limit, &Nregex, partial, domains);
 		if(ret != 200)
 		{
+			gravityDB_close_RO(db);
 			free(punycode);
 			return ret;
 		}
@@ -258,9 +271,10 @@ int api_search(struct ftl_conn *api)
 	cJSON *gravity = JSON_NEW_ARRAY();
 	cJSON *gravity_patterns = NULL;
 	unsigned int Ngravity = 0u;
-	ret = search_gravity(api, punycode, gravity, &gravity_patterns, limit, &Ngravity, partial, false);
+	ret = search_gravity(api, db, punycode, gravity, &gravity_patterns, limit, &Ngravity, partial, false);
 	if(ret != 200)
 	{
+		gravityDB_close_RO(db);
 		free(punycode);
 		return ret;
 	}
@@ -268,9 +282,10 @@ int api_search(struct ftl_conn *api)
 	// Search through antigravity
 	cJSON *antigravity_patterns = NULL;
 	unsigned int Nantigravity = 0u;
-	ret = search_gravity(api, punycode, gravity, &antigravity_patterns, limit, &Nantigravity, partial, true);
+	ret = search_gravity(api, db, punycode, gravity, &antigravity_patterns, limit, &Nantigravity, partial, true);
 	if(ret != 200)
 	{
+		gravityDB_close_RO(db);
 		free(punycode);
 		return ret;
 	}
@@ -285,10 +300,11 @@ int api_search(struct ftl_conn *api)
 	if(cJSON_GetArraySize(allow_ids) > 0)
 	{
 		char *allow_list = cJSON_PrintUnformatted(allow_ids);
-		ret = search_table(api, NULL, GRAVITY_DOMAINLIST_ALLOW_REGEX, allow_list, limit, &Nregex, false, domains);
+		ret = search_table(api, db, NULL, GRAVITY_DOMAINLIST_ALLOW_REGEX, allow_list, limit, &Nregex, false, domains);
 		free(allow_list);
 		if(ret != 200)
 		{
+			gravityDB_close_RO(db);
 			free(punycode);
 			return ret;
 		}
@@ -297,14 +313,17 @@ int api_search(struct ftl_conn *api)
 	if(cJSON_GetArraySize(deny_ids) > 0)
 	{
 		char *deny_list = cJSON_PrintUnformatted(deny_ids);
-		ret = search_table(api, NULL, GRAVITY_DOMAINLIST_DENY_REGEX, deny_list, limit, &Nregex, false, domains);
+		ret = search_table(api, db, NULL, GRAVITY_DOMAINLIST_DENY_REGEX, deny_list, limit, &Nregex, false, domains);
 		free(deny_list);
 		if(ret != 200)
 		{
+			gravityDB_close_RO(db);
 			free(punycode);
 			return ret;
 		}
 	}
+
+	gravityDB_close_RO(db);
 
 	cJSON *search = JSON_NEW_OBJECT();
 	// .domains.{}

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -339,6 +339,48 @@ static void gravity_check_list_presence(void)
 }
 
 // Open gravity database
+// Connection settings every gravity connection gets. They live in one place
+// because a pragma added to one opener and forgotten in the other does not fail
+// anywhere, it just makes that connection slower - which is how the search
+// connection ended up without them
+static const struct gravity_pragma {
+	const char *sql;
+	bool required;
+} gravity_pragmas[] = {
+	// Temporary tables, indices and views are read from memory rather than disk
+	{ "PRAGMA temp_store = MEMORY", true },
+	// Read B-tree pages straight from the kernel page cache by virtual address
+	// instead of pread() plus a copy. gravity.db is effectively read-only at
+	// runtime (journal_mode = OFF, "pihole -g" swaps in a new file), 256 MiB
+	// covers every real-world gravity, and SQLite falls back to regular I/O
+	// where mmap is unavailable. The in-process page cache is raised globally
+	// via -DSQLITE_DEFAULT_CACHE_SIZE, so no cache_size pragma here
+	{ "PRAGMA mmap_size = 268435456", false },
+};
+
+// Returns false only when a required pragma failed
+static bool gravity_apply_pragmas(sqlite3 *db, const char *func)
+{
+	for(unsigned int i = 0; i < ArraySize(gravity_pragmas); i++)
+	{
+		const struct gravity_pragma *p = &gravity_pragmas[i];
+		char *zErrMsg = NULL;
+		if(sqlite3_exec(db, p->sql, NULL, NULL, &zErrMsg) == SQLITE_OK)
+			continue;
+
+		if(p->required)
+			log_err("%s(%s) - SQL error: %s", func, p->sql, zErrMsg);
+		else
+			log_warn("%s(%s) - SQL error: %s", func, p->sql, zErrMsg);
+		sqlite3_free(zErrMsg);
+
+		if(p->required)
+			return false;
+	}
+
+	return true;
+}
+
 static bool gravityDB_open(void)
 {
 	struct stat st;
@@ -370,44 +412,11 @@ static bool gravityDB_open(void)
 	// Database connection is now open
 	gravityDB_opened = true;
 
-	// Tell SQLite3 to store temporary tables in memory. This speeds up read operations on
-	// temporary tables, indices, and views.
-	log_debug(DEBUG_DATABASE, "gravityDB_open(): Setting location for temporary object to MEMORY");
-	char *zErrMsg = NULL;
-	rc = sqlite3_exec(gravity_db, "PRAGMA temp_store = MEMORY", NULL, NULL, &zErrMsg);
-	if( rc != SQLITE_OK )
+	log_debug(DEBUG_DATABASE, "gravityDB_open(): Applying connection pragmas");
+	if(!gravity_apply_pragmas(gravity_db, "gravityDB_open"))
 	{
-		log_err("gravityDB_open(PRAGMA temp_store) - SQL error (%i): %s", rc, zErrMsg);
-		sqlite3_free(zErrMsg);
 		gravityDB_close();
 		return false;
-	}
-
-	// Enable memory-mapped I/O for the gravity database.
-	// gravity.db is effectively read-only at runtime (journal_mode = OFF;
-	// writes only happen during "pihole -g" which then swaps in a new
-	// file). With mmap enabled, SQLite reads B-tree pages directly from the
-	// kernel's page cache via virtual-address loads rather than going
-	// through pread() + a kernel-to-user copy. This eliminates syscall
-	// overhead for every domain lookup. 256 MiB covers all real-world
-	// gravity databases; SQLite falls back silently to regular I/O on
-	// systems where mmap is unavailable.
-	// Memory implications: Without mmap, SQLite reads pages via pread()
-	// which the kernel caches AND SQLite caches separately in its own page
-	// cache. Two copies. With mmap, SQLite reads directly from the kernel
-	// page cache via a virtual address mapping — one copy, shared. Process
-	// RSS (virtual) increases, but physical RAM usage stays the same or
-	// decreases.
-	// Note: the in-process page cache size is already raised globally via
-	// -DSQLITE_DEFAULT_CACHE_SIZE=16384 in src/CMakeLists.txt, so we do
-	// NOT issue a separate PRAGMA cache_size here.
-	log_debug(DEBUG_DATABASE, "gravityDB_open(): Enabling memory-mapped I/O (mmap_size = 256 MiB)");
-	rc = sqlite3_exec(gravity_db, "PRAGMA mmap_size = 268435456", NULL, NULL, &zErrMsg);
-	if( rc != SQLITE_OK )
-	{
-		log_warn("gravityDB_open(PRAGMA mmap_size) - SQL error (%i): %s", rc, zErrMsg);
-		sqlite3_free(zErrMsg);
-		// Non-fatal: gravity lookups continue with regular I/O
 	}
 
 	// Pre-warm: advise kernel to read gravity.db into page cache
@@ -2431,6 +2440,12 @@ sqlite3 *gravityDB_open_RO(void)
 	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
 		log_err("gravityDB_open_RO() - Cannot set busy handler: %s", sqlite3_errmsg(db));
 
+	if(!gravity_apply_pragmas(db, "gravityDB_open_RO"))
+	{
+		sqlite3_close_v2(db);
+		return NULL;
+	}
+
 	return db;
 }
 
@@ -2449,9 +2464,12 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
                          const bool exact, const char *ids,
                          sqlite3_stmt **read_stmt_p)
 {
-	// NULL means the shared connection. A long-running read - the search scans
-	// the whole gravity table - passes its own instead, so a gravity reload
-	// closing the shared one cannot pull the cursor away mid-walk
+	// NULL means the shared connection. Passing one in pins it for the whole
+	// read: we take the global here and only prepare on it further below, and a
+	// reload landing in that window frees the handle right there - an open
+	// cursor keeps it alive (see gravityDB_close()), but between two calls
+	// there is none. A caller making several calls also wants them to see one
+	// gravity, not one per reload
 	if(db == NULL)
 		db = gravity_db;
 

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -338,7 +338,6 @@ static void gravity_check_list_presence(void)
 	log_debug(DEBUG_DATABASE, "Exact denylist has entries: %s", gravity_has_exact_denylist ? "yes" : "no");
 }
 
-// Open gravity database
 // Connection settings every gravity connection gets. They live in one place
 // because a pragma added to one opener and forgotten in the other does not fail
 // anywhere, it just makes that connection slower - which is how the search
@@ -381,6 +380,7 @@ static bool gravity_apply_pragmas(sqlite3 *db, const char *func)
 	return true;
 }
 
+// Open gravity database (read-write mode)
 static bool gravityDB_open(void)
 {
 	struct stat st;
@@ -397,7 +397,7 @@ static bool gravityDB_open(void)
 		return true;
 	}
 
-	log_debug(DEBUG_DATABASE, "gravityDB_open(): Trying to open %s in read-only mode", config.files.gravity.v.s);
+	log_debug(DEBUG_DATABASE, "gravityDB_open(): Trying to open %s in read-write mode", config.files.gravity.v.s);
 	int rc = sqlite3_open_v2(config.files.gravity.v.s, &gravity_db, SQLITE_OPEN_READWRITE, NULL);
 	if( rc != SQLITE_OK )
 	{

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2412,12 +2412,50 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 	return ret;
 }
 
-bool gravityDB_readTable(const enum gravity_list_type listtype,
+// A read-only connection of its own, for reads too long to run on the shared
+// one. Holding the SHM lock across such a read would stall DNS for its whole
+// duration, and without the lock a reload could close the shared connection
+// underneath it
+sqlite3 *gravityDB_open_RO(void)
+{
+	sqlite3 *db = NULL;
+	const int rc = sqlite3_open_v2(config.files.gravity.v.s, &db,
+	                               SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL);
+	if(rc != SQLITE_OK || db == NULL)
+	{
+		log_err("gravityDB_open_RO() - SQL error open: %s", sqlite3_errstr(rc));
+		sqlite3_close_v2(db);
+		return NULL;
+	}
+
+	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
+		log_err("gravityDB_open_RO() - Cannot set busy handler: %s", sqlite3_errmsg(db));
+
+	return db;
+}
+
+void gravityDB_close_RO(sqlite3 *db)
+{
+	if(db == NULL)
+		return;
+
+	const int rc = sqlite3_close_v2(db);
+	if(rc != SQLITE_OK)
+		log_err("gravityDB_close_RO() - Cannot close gravity database: %s", sqlite3_errstr(rc));
+}
+
+bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
                          const char *item, const char **message,
                          const bool exact, const char *ids,
                          sqlite3_stmt **read_stmt_p)
 {
-	if(gravity_db == NULL)
+	// NULL means the shared connection. A long-running read - the search scans
+	// the whole gravity table - passes its own instead, so a gravity reload
+	// closing the shared one cannot pull the cursor away mid-walk
+	if(db == NULL)
+		db = gravity_db;
+
+	if(db == NULL)
 	{
 		*message = "Database not available";
 		return false;
@@ -2578,9 +2616,9 @@ bool gravityDB_readTable(const enum gravity_list_type listtype,
 
 	// Prepare SQLite statement
 	*read_stmt_p = NULL;
-	int rc = sqlite3_prepare_v2(gravity_db, querystr, -1, read_stmt_p, NULL);
+	int rc = sqlite3_prepare_v2(db, querystr, -1, read_stmt_p, NULL);
 	if( rc != SQLITE_OK ){
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_readTable(%d => (%s)) - SQL error prepare (%i): %s => %s",
 		        listtype, type, rc, querystr, *message);
 		if(!exact)
@@ -2593,7 +2631,7 @@ bool gravityDB_readTable(const enum gravity_list_type listtype,
 	int idx = sqlite3_bind_parameter_index(*read_stmt_p, ":item");
 	if(idx > 0 && (rc = sqlite3_bind_text(*read_stmt_p, idx, like_name, -1, SQLITE_TRANSIENT)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_readTable(%d => (%s), %s): Failed to bind item (error %d) - %s",
 		        listtype, type, like_name, rc, *message);
 		sqlite3_finalize(*read_stmt_p);
@@ -2608,7 +2646,7 @@ bool gravityDB_readTable(const enum gravity_list_type listtype,
 	idx = sqlite3_bind_parameter_index(*read_stmt_p, ":ids");
 	if(idx > 0 && (rc = sqlite3_bind_text(*read_stmt_p, idx, ids, -1, SQLITE_STATIC)) != SQLITE_OK)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_readTable(%d => (%s), %s): Failed to bind ids (error %d) - %s",
 		        listtype, type, like_name, rc, *message);
 		sqlite3_finalize(*read_stmt_p);
@@ -2778,7 +2816,7 @@ bool gravityDB_readTableGetRow(const enum gravity_list_type listtype, tablerow *
 	// SQLITE_DONE (we are finished reading the table)
 	if(rc != SQLITE_DONE)
 	{
-		*message = sqlite3_errmsg(gravity_db);
+		*message = sqlite3_errmsg(sqlite3_db_handle(read_stmt));
 		log_err("gravityDB_readTableGetRow() - SQL error step (%i): %s",
 		        rc, *message);
 		return false;

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -76,7 +76,9 @@ enum db_result in_allowlist(const char *domain, DNSCacheData *dns_cache, clients
 bool gravityDB_get_regex_client_groups(clientsData *client, const unsigned int numregex, const regexData *regex,
                                        const unsigned char type, const char* table);
 
-bool gravityDB_readTable(const enum gravity_list_type listtype, const char *filter,
+sqlite3 *gravityDB_open_RO(void);
+void gravityDB_close_RO(sqlite3 *db);
+bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype, const char *filter,
                          const char **message, const bool exact, const char *ids,
                          sqlite3_stmt **stmt);
 bool gravityDB_readTableGetRow(const enum gravity_list_type listtype, tablerow *row, const char **message,


### PR DESCRIPTION
# What does this implement/fix?

api_search() walks a table cursor on the shared gravity connection and takes no lock, while FTL_reload_all_domainlists() holds the SHM lock and reopens that connection under it. a GET /api/search that runs into a list edit setting RELOAD_GRAVITY therefore has its cursor pulled away mid-walk, which is the case gravityDB_close() had to be made survivable for in #3036

taking the SHM lock like api_list_read() does would be wrong here. a partial search is a LIKE '%term%' over the whole gravity table joined against adlist, so it cannot use an index and scans everything, and DNS would block for as long as that takes. api_list_read() gets away with the lock because it is a single indexed lookup on domainlist

the search opens its own read-only connection instead, the way gravity_updated() and the write paths already do, and closes it when it is done. gravityDB_readTable() takes the connection to use and NULL keeps the shared one, so api_list_read() is unchanged. gravityDB_readTableGetRow() reports errors on the connection its cursor belongs to rather than on the global

## How to test the change during review

searching in the web interface returns what it did before, on all of domains, gravity and the regex lists. the suite passes. overall the defect is hard to provoke but it happens. on retry it usually immediately works so users are likely not reporting it. the code change is small and review by code should make clear that this is a hardening mechanism more than a specific bugfix

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.