### PR TITLE
Close the raw socket when dropping privileges fails

### DIFF
--- a/src/tools/dhcpv6-discover.c
+++ b/src/tools/dhcpv6-discover.c
@@ -837,7 +837,11 @@ int dhcpv6_discover_iface(const char *ifname, const unsigned int timeout)
 	// Drop root privileges after creating the raw socket for security
 	// measures. This is a no-op if the process is not running as sudo.
 	if (setuid(getuid()))
+	{
+		if(fd >= 0)
+			close(fd);
 		return 1;
+	}
 
 	errno = errval; /* restore socket() error value */
 	return do_discoverv6(fd, ifname, timeout);


### PR DESCRIPTION
# What does this implement/fix?

dhcpv6_discover_iface() creates a raw socket, drops privileges and only then hands the socket to do_discoverv6(). when the setuid() fails it returns without closing it. the process exits right after, so nothing is really lost, it is just untidy. this is not a fix but a cleanup to not leave anything behind future ai workflows may find and report about

found with gcc -fanalyzer over the tree

## How to test the change during review

pihole-FTL dhcpv6-discover behaves as before, the path only differs when dropping privileges fails

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.