### PR TITLE
Check DHCP addresses against the configured netmask

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -832,7 +832,7 @@ void initConfig(struct config *conf)
 	conf->dhcp.netmask.t = CONF_STRUCT_IN_ADDR;
 	conf->dhcp.netmask.f = FLAG_RESTART_FTL;
 	memset(&conf->dhcp.netmask.d.in_addr, 0, sizeof(struct in_addr));
-	conf->dhcp.netmask.c = validate_stub; // Only type-based checking
+	conf->dhcp.netmask.c = validate_netmask;
 
 	conf->dhcp.leaseTime.k = "dhcp.leaseTime";
 	conf->dhcp.leaseTime.h = "If the lease time is given, then leases will be given for that length of time. If not given, the default lease time is one hour for IPv4 and one day for IPv6.";

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -263,6 +263,37 @@ static void write_config_header(FILE *fp, const char *description)
 	CONFIG_CENTER(fp, HEADER_WIDTH, "%s", "################################################################################");
 }
 
+// The netmask of the subnet the DHCP server is going to serve. If it is not
+// configured, we have to guess: dnsmasq takes it from the interface it serves
+// on, which we cannot know here, so we fall back to the classful network the
+// address belongs to (what dnsmasq itself does for relayed networks)
+static uint32_t dhcp_netmask(struct config *conf)
+{
+	const uint32_t netmask = ntohl(conf->dhcp.netmask.v.in_addr.s_addr);
+	if(netmask != 0)
+		return netmask;
+
+	const uint32_t addr = ntohl(conf->dhcp.start.v.in_addr.s_addr);
+	if((addr & 0x80000000u) == 0)
+		return 0xFF000000u; // class A
+	if((addr & 0xC0000000u) == 0x80000000u)
+		return 0xFFFF0000u; // class B
+	return 0xFFFFFF00u; // class C
+}
+
+// Neither the network nor the broadcast address of the subnet can be used by a
+// client. Which addresses these are depends on the netmask, e.g., x.x.x.255 is
+// an ordinary host address in any subnet wider than a /24
+static const char *invalid_host_address(const struct in_addr addr, const uint32_t netmask)
+{
+	const uint32_t host = ntohl(addr.s_addr) & ~netmask;
+	if(host == 0)
+		return "the network address of the subnet";
+	if(host == (~netmask & 0xFFFFFFFFu))
+		return "the broadcast address of the subnet";
+	return NULL;
+}
+
 bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE])
 {
 	// Early config checks
@@ -291,25 +322,37 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 			log_err("Unable to update dnsmasq configuration: %s", errbuf);
 			return false;
 		}
-		// The addresses should neither end in .0 or .255 in the last octet
-		if((ntohl(conf->dhcp.start.v.in_addr.s_addr) & 0xFF) == 0 ||
-		   (ntohl(conf->dhcp.start.v.in_addr.s_addr) & 0xFF) == 0xFF)
+		// A netmask has to be a contiguous block of leading one-bits,
+		// anything else has neither a network nor a broadcast address
+		const uint32_t netmask = dhcp_netmask(conf);
+		const uint32_t hostmask = ~netmask;
+		if((hostmask & (hostmask + 1)) != 0)
 		{
-			strncpy(errbuf, "DHCP start address is not valid", ERRBUF_SIZE);
+			strncpy(errbuf, "DHCP netmask is not valid", ERRBUF_SIZE);
 			log_err("Unable to update dnsmasq configuration: %s", errbuf);
 			return false;
 		}
-		if((ntohl(conf->dhcp.end.v.in_addr.s_addr) & 0xFF) == 0 ||
-		   (ntohl(conf->dhcp.end.v.in_addr.s_addr) & 0xFF) == 0xFF)
+
+		// The addresses may be neither the network nor the broadcast
+		// address of the subnet they are used in
+		const char *reason = invalid_host_address(conf->dhcp.start.v.in_addr, netmask);
+		if(reason != NULL)
 		{
-			strncpy(errbuf, "DHCP end address is not valid", ERRBUF_SIZE);
+			snprintf(errbuf, ERRBUF_SIZE, "DHCP start address is %s", reason);
 			log_err("Unable to update dnsmasq configuration: %s", errbuf);
 			return false;
 		}
-		if((ntohl(conf->dhcp.router.v.in_addr.s_addr) & 0xFF) == 0 ||
-		   (ntohl(conf->dhcp.router.v.in_addr.s_addr) & 0xFF) == 0xFF)
+		reason = invalid_host_address(conf->dhcp.end.v.in_addr, netmask);
+		if(reason != NULL)
 		{
-			strncpy(errbuf, "DHCP router address is not valid", ERRBUF_SIZE);
+			snprintf(errbuf, ERRBUF_SIZE, "DHCP end address is %s", reason);
+			log_err("Unable to update dnsmasq configuration: %s", errbuf);
+			return false;
+		}
+		reason = invalid_host_address(conf->dhcp.router.v.in_addr, netmask);
+		if(reason != NULL)
+		{
+			snprintf(errbuf, ERRBUF_SIZE, "DHCP router address is %s", reason);
 			log_err("Unable to update dnsmasq configuration: %s", errbuf);
 			return false;
 		}

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -284,6 +284,24 @@ bool validate_cidr(union conf_value *val, const char *key, char err[VALIDATOR_ER
 	return true;
 }
 
+// Validate a netmask
+// The one-bits have to be contiguous and leading, anything else describes no
+// subnet and has neither a network nor a broadcast address. 0.0.0.0 is allowed
+// and means the netmask is determined from the interface
+bool validate_netmask(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	const uint32_t hostmask = ~ntohl(val->in_addr.s_addr);
+	if((hostmask & (hostmask + 1)) != 0)
+	{
+		char addr[INET_ADDRSTRLEN] = { 0 };
+		inet_ntop(AF_INET, &val->in_addr, addr, sizeof(addr));
+		snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: not a valid netmask (\"%s\"), the one-bits are not contiguous", key, addr);
+		return false;
+	}
+
+	return true;
+}
+
 // Validate domain
 bool validate_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
 {

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -19,6 +19,7 @@ bool validate_dns_hosts(union conf_value *val, const char *key, char err[VALIDAT
 bool validate_dns_cnames(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_cidr(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+bool validate_netmask(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_domain(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_filepath_two_slash(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1628,6 +1628,21 @@ setup() {
   run bash -c './pihole-FTL --config webserver.api.excludeClients "[\".*\",\"$$$\",\"[[[\"]"'
   assert_line --index 0 'Invalid value: webserver.api.excludeClients[2]: not a valid regex ("[[["): Missing '\'']'\'''
   assert_failure 3
+
+  run bash -c './pihole-FTL --config dhcp.netmask 255.254.255.0'
+  assert_line --index 0 'Invalid value: dhcp.netmask: not a valid netmask ("255.254.255.0"), the one-bits are not contiguous'
+  assert_failure 3
+
+  run bash -c './pihole-FTL --config dhcp.netmask 255.255.254.0'
+  assert_success
+
+  run bash -c './pihole-FTL --config dhcp.netmask'
+  assert_line --index 0 '255.255.254.0'
+  assert_success
+
+  # An empty netmask is valid, it is then taken from the interface
+  run bash -c './pihole-FTL --config dhcp.netmask ""'
+  assert_success
 }
 
 @test "DNS hosts sanitization: Whitespace is normalized when saving" {


### PR DESCRIPTION
# What does this implement/fix?

The DHCP validation rejected any address ending in `.0` or `.255`, which is only correct for a /24. With `dhcp.netmask = "255.255.0.0"`, network and broadcast are, e.g., 10.20.0.0 and 10.20.255.255, so a pool ending at 10.20.5.255 is a perfectly ordinary range and was refused nevertheless.

Both addresses are now derived from the netmask and only those two are rejected, for start, end and router alike. Without a configured netmask there is no way to know the one dnsmasq takes from the interface, so the fallback is the classful network, as dnsmasq does for relayed networks, and the usual /24 stays as protected as it was.

As `dhcp.netmask` was only checked to be a valid dotted quad, a mask that is not a contiguous block of one-bits is now rejected before it is used: such a mask has neither a network nor a broadcast address and would only lead to confusing rejections further down.

The second commit moves that question to the moment the value is set. Whether the one-bits are contiguous needs no other config item, so `validate_netmask()` answers it for the CLI, the API and `FTLCONF_` variables alike, instead of only when DHCP is switched on. The check in `write_dnsmasq_config()` stays as the backstop, because reading `pihole.toml` does not run validators at all.

## How to test the change during review

```
pihole-FTL --config dhcp.netmask 255.255.0.0
pihole-FTL --config dhcp.start 10.20.5.1
pihole-FTL --config dhcp.end 10.20.5.255
pihole-FTL --config dhcp.router 10.20.3.1
pihole-FTL --config dhcp.active true
```

This is accepted now and failed with "DHCP end address is not valid" before. An end of 10.20.255.255 or a start of 10.20.0.0 are still rejected, now naming the broadcast resp. network address, and 192.168.1.255 stays rejected both with `dhcp.netmask` set to 255.255.255.0 and with it left empty.

```
pihole-FTL --config dhcp.netmask 255.254.255.0
```

is refused straight away, with or without DHCP enabled. `test/test_suite.bats` covers the netmask validator; the address checks still have no dedicated automated test.

## Additional information

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/3043

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
