### PR TITLE
cache API doc asset over builds

### DIFF
--- a/src/api/docs/CMakeLists.txt
+++ b/src/api/docs/CMakeLists.txt
@@ -69,11 +69,11 @@ foreach(INPUT_FILE ${COMPILED_RESOURCES})
     string(REPLACE "/" "_" VARIABLE_NAME ${INPUT_FILE})
     set(OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/hex/${INPUT_FILE_MODIFIED}.h)
     add_custom_command(
-        OUTPUT hex/${INPUT_FILE_MODIFIED}.h
+        OUTPUT ${OUTPUT_FILE}
         COMMAND ${GZIP_COMPRESSOR} -9 -n -c ${IN} | ${RESOURCE_COMPILER} -iC -n ${VARIABLE_NAME} - | sed "s/unsigned /static const unsigned /" > ${OUTPUT_FILE}
+        DEPENDS ${IN}
         COMMENT "Compressing and compiling ${INPUT_FILE}"
         VERBATIM)
-    list(APPEND COMPILED_RESOURCES ${OUTPUT_FILE})
 endforeach()
 
 add_library(api_docs OBJECT ${sources})

--- a/src/lua/scripts/CMakeLists.txt
+++ b/src/lua/scripts/CMakeLists.txt
@@ -27,7 +27,7 @@ foreach(res_file ${resources})
     set(OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/${res_file}.hex)
     add_custom_command(
         OUTPUT ${OUTPUT_FILE}
-	SOURCES ${INPUT_FILE}
+	DEPENDS ${INPUT_FILE}
 	COMMAND ${RESOURCE_COMPILER} -i < ${INPUT_FILE} > ${OUTPUT_FILE}
         COMMENT "Compiling ${INPUT_FILE}"
         VERBATIM)


### PR DESCRIPTION
# What does this implement/fix?

two cmake rules that embed a generated file into the binary re-ran on every build

the api docs rule declares OUTPUT hex/<name>.h, which cmake resolves against the build tree, while the command writes into the source tree. cmake never sees that output appear, so it re-runs all 29 assets through gzip and xxd on every single build and recompiles docs.c behind them. it also has no DEPENDS, so a changed asset does not regenerate on its own. that goes unnoticed because the rule runs every time anyway

the lua scripts rule passes SOURCES where it means DEPENDS. add_custom_command has no SOURCES keyword, so the word and the path after it are absorbed as two further OUTPUT entries: a file named SOURCES that the command never writes, and inspect.lua itself, declared as an output of the rule that reads it. the first keeps the rule permanently out of date, the second makes every build run touch_nocreate on a tracked source file. inspect.lua.hex is rewritten each time and ftl_lua.c.o recompiles behind it

in both rules OUTPUT now names the file the command actually writes and DEPENDS tracks the input. in the docs rule the list(APPEND COMPILED_RESOURCES ...) below it appended to the list the foreach was iterating over, which cmake copies, so it never did anything and is gone

## How to test the change during review

build twice in a row without changing anything, the second build compresses and compiles nothing where it used to redo all 29 doc assets plus inspect.lua and two objects. touch src/api/docs/content/index.css or src/lua/scripts/inspect.lua and only that one asset is regenerated. the suite passes, 192 bats and 151 pytest

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
