### PR TITLE
Fix network table host names that never expire and return after a flush

### DIFF
--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -1244,6 +1244,8 @@ static bool clean_network_table(sqlite3 *db)
  *
  * This function opens the database, deletes all entries from the
  * `network_addresses` and `network` tables, and then closes the database.
+ * The host names FTL holds in shared memory are dropped as well so the
+ * next ARP cycle cannot write them straight back.
  *
  * @return true if the operation was successful, false otherwise.
  */
@@ -1269,6 +1271,31 @@ bool flush_network_table(void)
 
 	// Close database
 	dbclose(&db);
+
+	// Drop the host names we hold in shared memory. They survive the
+	// two DELETEs above and would be mirrored back into the emptied
+	// table on the next ARP cycle, making the flush cosmetic.
+	lock_shm();
+	for(unsigned int clientID = 0; clientID < counters->clients; clientID++)
+	{
+		clientsData *client = getClient(clientID, true);
+		if(client == NULL)
+			continue;
+
+		client->namepos = 0;
+		client->flags.nameFromDB = false;
+
+		// The (ip, name) pair changed, so the client needs a new
+		// client_by_id record, and the name is one of the identities
+		// group assignment matches on
+		client->flags.in_database = false;
+		client->db_id = 0;
+		client->flags.found_group = false;
+
+		// Have the resolver look at this client again
+		client->flags.new = true;
+	}
+	unlock_shm();
 
 	return true;
 }

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -820,11 +820,18 @@ static bool add_FTL_clients_to_network_table(sqlite3 *db, const enum arp_status 
 		}
 
 		// Get hostname and IP address of this client
-		char hostname[MAXHOSTNAMELEN], ipaddr[INET6_ADDRSTRLEN], interface[MAXIFACESTRLEN];
+		// A name we only inherited from network_addresses is left out:
+		// writing it back would refresh the very timestamp
+		// clean_network_table() uses to expire it, so it could never age
+		// out. A DHCP lease name found below still fills this in.
+		char hostname[MAXHOSTNAMELEN] = { 0 }, ipaddr[INET6_ADDRSTRLEN], interface[MAXIFACESTRLEN];
 		strncpy(ipaddr, getstr(client->ippos), sizeof(ipaddr) - 1);
 		ipaddr[sizeof(ipaddr) - 1] = '\0';
-		strncpy(hostname, getstr(client->namepos), sizeof(hostname) - 1);
-		hostname[sizeof(hostname) - 1] = '\0';
+		if(!client->flags.nameFromDB)
+		{
+			strncpy(hostname, getstr(client->namepos), sizeof(hostname) - 1);
+			hostname[sizeof(hostname) - 1] = '\0';
+		}
 		strncpy(interface, getstr(client->ifacepos), sizeof(interface) - 1);
 		interface[sizeof(interface) - 1] = '\0';
 
@@ -1441,8 +1448,12 @@ void parse_neighbor_cache(sqlite3 *db)
 				// Client is known to Pi-hole, update properties
 				// with their real values
 				client_valid = true;
-				strncpy(hostname, getstr(client->namepos), sizeof(hostname) - 1);
-				hostname[sizeof(hostname) - 1] = '\0';
+				// See above: an inherited name is not written back
+				if(!client->flags.nameFromDB)
+				{
+					strncpy(hostname, getstr(client->namepos), sizeof(hostname) - 1);
+					hostname[sizeof(hostname) - 1] = '\0';
+				}
 				firstSeen = client->firstSeen;
 				lastQuery = client->lastQuery;
 				numQueries = client->numQueriesARP;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -102,6 +102,10 @@ typedef struct {
 		bool aliasclient:1;
 		bool rate_limited:1;
 		bool in_database:1;
+		// Name was inherited from network_addresses, not resolved via
+		// PTR. Such a name must not be written back to the table, it
+		// would keep refreshing its own expiry timestamp.
+		bool nameFromDB:1;
 	} flags;
 	int count;
 	int blockedcount;

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -1059,8 +1059,11 @@ enum resolve_result
 
 // Resolve upstream destination host names
 static enum resolve_result resolveAndAddHostname(size_t ippos, size_t oldnamepos,
-                                                 size_t *newnamepos)
+                                                 size_t *newnamepos, bool *from_database)
 {
+	if(from_database != NULL)
+		*from_database = false;
+
 	// Get IP and host name strings. They are cloned in case shared memory is
 	// resized before the next lock
 	lock_shm();
@@ -1129,7 +1132,12 @@ static enum resolve_result resolveAndAddHostname(size_t ippos, size_t oldnamepos
 	if(!resolved && config.resolver.networkNames.v.b)
 	{
 		if(getNameFromIP(NULL, newname, ipaddr))
+		{
 			log_debug(DEBUG_RESOLVER, " ---> \"%s\" (provided by database)", newname);
+
+			if(from_database != NULL)
+				*from_database = true;
+		}
 	}
 
 	// Nothing resolved: the caller keeps the old name and retries later
@@ -1279,7 +1287,9 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 
 		// Obtain/update hostname of this client
 		size_t newnamepos = 0;
-		const enum resolve_result res = resolveAndAddHostname(ippos, oldnamepos, &newnamepos);
+		bool from_database = false;
+		const enum resolve_result res = resolveAndAddHostname(ippos, oldnamepos,
+		                                                      &newnamepos, &from_database);
 		if(res == RESOLVE_NO_SOCKET)
 		{
 			log_err("Unable to create DNS resolver socket, client host name resolution failed");
@@ -1330,6 +1340,10 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 			// get_client_groupids()).
 			client->flags.found_group = false;
 		}
+		// Record where the name came from, also when the name itself did
+		// not change: a name we only read back from network_addresses
+		// must not be mirrored into that table again
+		client->flags.nameFromDB = from_database;
 		// Mark entry as not new
 		client->flags.new = false;
 
@@ -1409,7 +1423,7 @@ static void resolveUpstreams(const bool onlynew)
 
 		// Obtain/update hostname of this client
 		size_t newnamepos = 0;
-		const enum resolve_result res = resolveAndAddHostname(ippos, oldnamepos, &newnamepos);
+		const enum resolve_result res = resolveAndAddHostname(ippos, oldnamepos, &newnamepos, NULL);
 		if(res == RESOLVE_NO_SOCKET)
 		{
 			log_err("Unable to create DNS resolver socket, upstream host name resolution failed");


### PR DESCRIPTION
# What does this implement/fix?

A host name FTL cannot resolve over PTR is read back from `network_addresses` into shared memory, where nothing marks it as inherited. The ARP cycle mirrors it back with `nameUpdated = now`, so the row keeps refreshing the timestamp it is expired by and never ages out (#3046). `pihole networkflush` leaves those same in-memory names behind, so the next ARP cycle restores them (#3047).

A new `nameFromDB` client bit marks inherited names and keeps them out of the write-back, and the flush now clears shared memory as well. Both are needed: the bit cannot reach a name FTL believes it resolved itself, which is how the wrong name arrived in #3047, and only clearing shared memory stops the dashboard from showing it. The bit fits an existing bitfield, so `clientsData` keeps its size.

## How to test the change during review

No automated test: FTL does not start the resolver thread in CI (`test/pihole.toml` sets `resolveIPv4 = false`), so a bats test of this path cannot fail. I can add a late-stage bats file that restarts FTL with its own config if you want one. The existing suite is unaffected.

Manually, with `resolveIPv4`, `networkNames` and `refreshNames = "ALL"` enabled: seed `network_addresses` with a name and a `nameUpdated` an hour old, query from that IP, then send `SIGRTMIN+4` and `SIGRTMIN+5`. `nameUpdated` jumps to now before this change and stays put after. Then flush via `POST /api/action/flush/network` and repeat `SIGRTMIN+5`: two named rows come back before, none after.

## Additional information

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/FTL/issues/3046 and https://github.com/pi-hole/FTL/issues/3047

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
