### PR TITLE
measure the label after the final dot as well

### DIFF
--- a/src/tools/gravity-parseList.c
+++ b/src/tools/gravity-parseList.c
@@ -98,6 +98,13 @@ inline bool __attribute__((pure)) valid_domain(const char *domain, const size_t 
 
 	// TLD checks
 
+	// The loop only measured a label once it reached the dot ending it,
+	// so the last label has not been looked at yet. It runs from
+	// last_dot + 1 to the end of the string, which is the entire string
+	// for a name without any dot (last_dot == -1)
+	if(len - (size_t)(last_dot + 1) > 63)
+		return false;
+
 	// There must be at least two labels (i.e. one dot)
 	// e.g., "example.com" but not "localhost" for exact domain
 	// We do not enforce this for ABP domains and domainlist input

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1618,6 +1618,17 @@ setup() {
   assert_line --index 0 'Invalid value: dns.hosts[2]: entry does not have at least one hostname ("1.2.3.4")'
   assert_failure 3
 
+  # No dot follows the last label, but its length is capped just the same
+  long_label="$(printf 'a%.0s' {1..64})"
+  run bash -c "./pihole-FTL --config dns.hosts '[\"1.2.3.4 test.${long_label}\"]'"
+  assert_line --index 0 "Invalid value: dns.hosts[0]: invalid hostname (\"test.${long_label}\")"
+  assert_failure 3
+
+  # A name that is one label and nothing else is measured just the same
+  run bash -c "./pihole-FTL --config dns.hosts '[\"1.2.3.4 ${long_label}\"]'"
+  assert_line --index 0 "Invalid value: dns.hosts[0]: invalid hostname (\"${long_label}\")"
+  assert_failure 3
+
   run bash -c './pihole-FTL --config dns.revServers "[\"abc,def,ghi\"]"'
   assert_line --index 0 'Invalid value: dns.revServers[0]: <enabled> not a boolean ("abc")'
   assert_failure 3


### PR DESCRIPTION
# What does this implement/fix?

the length check on a label in valid_domain() fires on the dot that ends it, and nothing follows the last label, so the part after the final dot is never looked at. a hostname carrying 64 characters there passes dns.hosts validation, as does a 64 character name with no dot in it at all, where RFC 1035 allows 63 octets per label

the resolver does not agree. legal_hostname() turns the name down and cache.c skips the line with one "bad name at /etc/pihole/custom.list line N" as the file is read, naming neither the offending hostname nor the setting it came from, so a record the api took and the dashboard lists never answers a query

measuring the last label needs nothing that is not already at hand, last_dot points at the dot in front of it and is -1 for a name without one, so the length of the whole string falls out of the same expression. the check sits with the other tests on that label. valid_domain() is shared, so gravity parsing and /api/lists take the limit on as well

low impact as i read it. the limit only bites at 64 characters in one label, which is not a thing anyone types by accident, and nothing is broken for names that stay under it. what it buys is that the rejection happens where someone can see it, instead of the record being taken, listed in the dashboard and then dropped by the resolver with a log line that names neither the name nor the setting

## How to test the change during review

pihole-FTL --config dns.hosts with 64 characters after the last dot exits 3 and prints "invalid hostname", 63 characters still goes through and so does a plain name. new bats case, 194 bats and 151 pytest

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
