### PR TITLE
catch a pihole.toml written before the watcher exists

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -627,6 +627,11 @@ void *GC_thread(void *val)
 	// Create inotify watcher for pihole.toml config file
 	watch_config(true);
 
+	// The watcher above reports only what follows it, so compare the file
+	// against the loaded configuration once to pick up anything written
+	// during startup
+	reread_config();
+
 	// Run as long as this thread is not canceled
 	while(!killed)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,8 @@
 #include "config/setupVars.h"
 #include "args.h"
 #include "config/config.h"
+// watch_config()
+#include "config/inotify.h"
 #include "main.h"
 // exit_code
 #include "signals.h"
@@ -141,7 +143,15 @@ int main (int argc, char *argv[])
 	// Skip it here if we jump back to this point from die()
 	const int jmpret = setjmp(exit_jmp);
 	if(jmpret == 0)
+	{
+		// main_dnsmasq() opens by closing every descriptor it
+		// inherited from us, a config watcher armed while the config
+		// was read included, and the numbers are reissued afterwards.
+		// Close it here, while it is still ours to close
+		watch_config(false);
+
 		main_dnsmasq(argc_dnsmasq, (char**)argv_dnsmasq);
+	}
 	else
 	{
 		// We are jumping back to this point from dnsmasq's die()


### PR DESCRIPTION
# What does this implement/fix?

nothing watches /etc/pihole for most of ftl's startup. the inotify instance is created by the gc thread, which starts long after readFTLconf() has loaded the file, with delay_startup() and all of dnsmasq's initialization in between. a pihole.toml written in that stretch is never announced, so ftl keeps serving what it loaded while the file on disk says something else, and it stays that way until the file is written a second time. for a setting put in place once while a box is provisioned that can be for good

creating the watcher earlier does not cover it either. writeFTLtoml() arms one whenever it rewrites the file, startup included, but create_inotify_watcher() overwrites inotify_fd without looking at what is already there, so the gc thread's instance replaces that one along with whatever it had collected

the window is closed from the other end instead. the watcher goes up first, which leaves every later change certain to be reported, and the file is then compared against the loaded configuration once. a normal start pays a single sha256 of pihole.toml for it, reread_config() gives up as soon as the checksum turns out to be the one it recorded

mid impact as i read it. the window is narrow and a hand edited config will almost never land in it, but a provisioning script that writes pihole.toml straight after starting ftl lands in it every time, and what follows is silent, indefinite and looks exactly like the setting having been ignored. the cost on every other start is one checksum

## How to test the change during review

widen the window with a sleepms(10000) in front of watch_config() in GC_thread(), start ftl and write into pihole.toml while it sleeps. FTL.log then gets "Reloading config due to pihole.toml change" and ftl rewrites the file with the "### CHANGED" marker on that setting, on development neither happens and the running config keeps what it loaded at startup. 194 bats and 151 pytest

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
