### PR TITLE
hand base64_decode_update() the size of the buffer it writes into

### DIFF
--- a/src/config/password.c
+++ b/src/config/password.c
@@ -178,14 +178,28 @@ static uint8_t * __attribute__((malloc)) base64_decode(const char *data, size_t 
 	// Base64 decoding requires 3 bytes for every 4 bytes of input, plus
 	// additional bytes for padding. The output buffer must be large enough
 	// to hold the decoded data.
-	uint8_t *decoded = calloc(BASE64_DECODE_LENGTH(strlen(data)), sizeof(uint8_t));
+	const size_t buflen = BASE64_DECODE_LENGTH(strlen(data));
+	uint8_t *decoded = calloc(buflen, sizeof(uint8_t));
+	if(decoded == NULL)
+		return NULL;
 
-	// Decode the data
+	// Decode the data. Since nettle 4.0, the length is passed in as well
+	// as out: it carries the size of the destination buffer in and the
+	// number of bytes written back out, and decoding fails when the
+	// buffer is too small. Earlier versions only write to it, so handing
+	// the size in is right for both
+	size_t decodedlen = buflen;
 	struct base64_decode_ctx ctx;
 	base64_decode_init(&ctx);
-	base64_decode_update(&ctx, length, decoded, strlen(data), data);
-	base64_decode_final(&ctx);
+	if(!base64_decode_update(&ctx, &decodedlen, decoded, strlen(data), data) ||
+	   !base64_decode_final(&ctx))
+	{
+		log_err("Base64 decoding failed");
+		free(decoded);
+		return NULL;
+	}
 
+	*length = decodedlen;
 	return decoded;
 }
 
@@ -353,7 +367,7 @@ static bool parse_PHC_string(const char *phc, size_t *s_cost, size_t *t_cost, ui
 	if(*salt == NULL)
 	{
 		// Error
-		log_err("Error while decoding salt: %s", strerror(errno));
+		log_err("Error while decoding salt");
 		return false;
 	}
 	if(salt_len != SALT_LEN)
@@ -369,7 +383,7 @@ static bool parse_PHC_string(const char *phc, size_t *s_cost, size_t *t_cost, ui
 	if(*hash == NULL)
 	{
 		// Error
-		log_err("Error while decoding hash: %s", strerror(errno));
+		log_err("Error while decoding hash");
 		return false;
 	}
 	if(hash_len != SHA256_DIGEST_SIZE)


### PR DESCRIPTION
# What does this implement/fix?

this comes out of https://github.com/pi-hole/FTL/pull/3000#issuecomment-5506261348, where darkexplosiveqwx hit it while taking that pr to fedora 45

since nettle 4.0 the length argument of base64_decode_update() is read as well as written, it carries the size of the destination buffer in and the decode fails when that is not enough. base64_decode() in password.c passes the caller's variable straight through and both callers in parse_PHC_string() start it at zero, so on nettle 4.0 every decode fails and leaves the length at zero

nothing catches it there. the return value is discarded, so a zeroed buffer comes back as though it were the salt, the salt_len != SALT_LEN guard turns that into "Invalid decoded salt length: 0" and verify_password() answers PASSWORD_INCORRECT for a hash ftl wrote itself. on a distribution shipping nettle 4.0 that is every password login and every session check, with the hash on disk perfectly intact and unreadable

the size goes in and the decoded length comes back out. nettle 3.x only ever writes to that argument, so one form serves both

while in there, base64_decode_update() and base64_decode_final() are checked, so a decode failing for any other reason returns NULL instead of a buffer of zeros, and the allocation is checked too, both callers already handle NULL and nothing ever reached them. the strerror(errno) in those two messages goes with it, errno has nothing to say about a base64 decode

low to no impact on anything pi-hole ships: ci builds in the image .github/Dockerfile pins (ftl-build v2.25), which carries nettle 3.10 as a static libnettle.a, so released binaries are on 3.x and cannot hit this. where it does land it is total lockout from the web interface, with the message pointing at the stored hash rather than at the decoder, and the people who get there are those compiling ftl themselves against a system nettle on an edge distribution, fedora 45 being the first

## How to test the change during review

a standalone c file with the old and the new helper against the system nettle: on fedora 45 (nettle 4.0-5.fc45) the old one decodes a 16 byte salt to len=0 and the new one to 16, on the build container (nettle 3.10) both give 16 and the bytes match. full suite in the container is 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** reported in #3000

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
