### PR TITLE
Clear the cached interface when none could be resolved

### DIFF
--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1366,6 +1366,12 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 		                            "    --> NO MATCH <--");
 	}
 
+	// Interface resolved by the last call, used to skip the address
+	// collection below when the same one is seen again. The pointer is
+	// stable within dnsmasq's daemon->interfaces list and is invalidated on
+	// SIGHUP/restart.
+	static struct irec *cached_recviface = NULL;
+
 	// Return early when there is no interface available at this point
 	// This means we didn't get one passed + we didn't find one above
 	if(!recviface)
@@ -1377,14 +1383,14 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 		next_iface.haveIPv4 = next_iface.haveIPv6 = false;
 		next_iface.name[0] = '-';
 		next_iface.name[1] = '\0';
+		// Drop the cache too, so the next query on that interface
+		// collects its addresses again
+		cached_recviface = NULL;
 		return;
 	}
 
-	// Cache: if the resolved interface is the same as last time, skip the
-	// expensive second loop (which iterates all interfaces to collect IPv4
-	// and IPv6 addresses).  The pointer is stable within dnsmasq's
-	// daemon->interfaces list and is invalidated on SIGHUP/restart.
-	static struct irec *cached_recviface = NULL;
+	// Skip the expensive second loop (which iterates all interfaces to
+	// collect IPv4 and IPv6 addresses) when the interface is unchanged
 	if(recviface == cached_recviface)
 	{
 		log_debug(DEBUG_NETWORKING, "Interface unchanged, using cached result");


### PR DESCRIPTION
# What does this implement/fix?

`_FTL_iface()` caches the interface it last resolved so a repeat query on it can skip the address collection loop. Clear that cache on the early return taken when no interface is available, so the next query on it collects the addresses again rather than reusing the invalidated ones.

`is_pihole_domain()` answers `pi.hole` and the local host name from the receiving interface, so a stale entry makes both A and AAAA reply NODATA until the next restart (#3050).

## How to test the change during review

Point a client at a Pi-hole whose own host name resolves, and query that name. It has to answer with the interface address rather than NODATA, both on the first query and on every repeat.

To exercise the path directly, query the name over `lo` on the Pi-hole itself and then from a LAN client: both have to answer, in either order, since each forces a different interface to be resolved.

The existing bats and pytest suites cover the surrounding behavior; there is no dedicated test for the cache.

## Additional information

**Related issue or feature (if applicable):** #3050

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
