### PR TITLE
build the dot/doh attribution mac on nettle 4.0 as well

### DIFF
--- a/src/edns0.c
+++ b/src/edns0.c
@@ -25,6 +25,10 @@
 #include <sys/random.h>
 // HMAC-SHA256 for the per-run client-attribution MAC (same crypto lib as the TOTP code)
 #include <nettle/hmac.h>
+// SHA256_DIGEST_SIZE
+#include <nettle/sha2.h>
+// NETTLE_VERSION_MAJOR
+#include <nettle/version.h>
 
 // EDNS(0) Client Subnet [Optional, RFC7871]
 #define EDNS0_ECS EDNS0_OPTION_CLIENT_SUBNET
@@ -75,6 +79,7 @@ ednsData *getEDNS(void)
 // source is loopback. It does not defend against a process that can read our
 // memory, which is already privileged and out of scope.
 #define DOTDOH_MAC_LEN 16
+static_assert(DOTDOH_MAC_LEN <= SHA256_DIGEST_SIZE, "The MAC is a truncated SHA256 digest");
 static unsigned char dotdoh_mac_key[DOTDOH_MAC_LEN];
 static pthread_once_t dotdoh_mac_key_once = PTHREAD_ONCE_INIT;
 static void dotdoh_mac_key_init(void)
@@ -118,13 +123,16 @@ static size_t __attribute__((pure)) dotdoh_question_len(const unsigned char *msg
 	return pos - 12;
 }
 
-// HMAC-SHA256(key = dotdoh_mac_key, code || addr || question), truncated into out.
-// Binds the value to the exact query (so the MAC is not a reusable bearer secret)
-// AND to the option code (so a dest option cannot be replayed as a client one).
+// HMAC-SHA256(key = dotdoh_mac_key, code || addr || question), of which the
+// first DOTDOH_MAC_LEN bytes are the MAC. Binds the value to the exact query (so
+// the MAC is not a reusable bearer secret) AND to the option code (so a dest
+// option cannot be replayed as a client one).
+// The whole digest is written, so out has to hold SHA256_DIGEST_SIZE bytes even
+// though only the first DOTDOH_MAC_LEN of them are ever looked at.
 static void dotdoh_addr_mac(const unsigned short code,
                             const unsigned char *addr, const size_t addrlen,
                             const unsigned char *question, const size_t qlen,
-                            unsigned char out[DOTDOH_MAC_LEN])
+                            unsigned char out[SHA256_DIGEST_SIZE])
 {
 	const unsigned char codebytes[2] = { (unsigned char)(code >> 8), (unsigned char)(code & 0xff) };
 	struct hmac_sha256_ctx ctx;
@@ -133,7 +141,12 @@ static void dotdoh_addr_mac(const unsigned short code,
 	hmac_sha256_update(&ctx, addrlen, addr);
 	if(qlen > 0)
 		hmac_sha256_update(&ctx, qlen, question);
-	hmac_sha256_digest(&ctx, DOTDOH_MAC_LEN, out);
+#if NETTLE_VERSION_MAJOR >= 4
+	// nettle 4.0 dropped the length argument, the digest is always written in full
+	hmac_sha256_digest(&ctx, out);
+#else
+	hmac_sha256_digest(&ctx, SHA256_DIGEST_SIZE, out);
+#endif
 }
 
 // Encode ip as [family(1B): 4 or 6][address] into out (<= 17 bytes), returning the
@@ -209,10 +222,18 @@ static bool dotdoh_opt_rrfilter_safe(unsigned char *buf, size_t plen)
 static size_t dotdoh_inject_addr(unsigned char *buf, size_t plen, size_t cap,
                                  const unsigned short code, const char *ip)
 {
-	unsigned char payload[1 + 16 + DOTDOH_MAC_LEN];
+	unsigned char payload[1 + 16 + SHA256_DIGEST_SIZE];
 	size_t optlen = dotdoh_encode_addr(ip, payload);
 	if(optlen == 0)
 		return plen;
+
+	// The digest lands directly behind the encoded address and is written
+	// in full, so payload carries room for all of it. Only the first
+	// DOTDOH_MAC_LEN bytes travel, the rest is scratch. The bound is
+	// checked rather than trusted: optlen comes out of dotdoh_encode_addr()
+	if(optlen + SHA256_DIGEST_SIZE > sizeof(payload))
+		return plen;
+
 	dotdoh_addr_mac(code, payload + 1, optlen - 1, buf + 12,
 	                dotdoh_question_len(buf, plen), payload + optlen);
 	optlen += DOTDOH_MAC_LEN;
@@ -493,7 +514,7 @@ void FTL_parse_pseudoheaders(const unsigned char *msg, const size_t msglen,
 				const size_t qbound = ((const unsigned char *)pheader >= msg &&
 				    (size_t)((const unsigned char *)pheader - msg) <= msglen)
 				    ? (size_t)((const unsigned char *)pheader - msg) : msglen;
-				unsigned char want[DOTDOH_MAC_LEN];
+				unsigned char want[SHA256_DIGEST_SIZE];
 				dotdoh_addr_mac(code, p + 1, addrlen, msg + 12,
 				                dotdoh_question_len(msg, qbound), want);
 				for(size_t i = 0; i < DOTDOH_MAC_LEN; i++)


### PR DESCRIPTION
# What does this implement/fix?

the other half of https://github.com/pi-hole/FTL/pull/3000#issuecomment-5506261348, the build failure darkexplosiveqwx hit on fedora 45. it is not #3000's, the call came in with the inbound dot/doh server in 49fee227 (#2989) and is on development, so development is what does not build against nettle 4.0

nettle 4.0 dropped the length argument of hmac_sha256_digest() and always writes the full digest, and edns0.c:136 still passes DOTDOH_MAC_LEN as the second argument, which the compiler reads as a pointer:

```
error: passing argument 2 of 'nettle_hmac_sha256_digest' makes pointer from integer without a cast
```

2fa.c, files.c and password.c already have the NETTLE_VERSION_MAJOR guard for this, edns0.c is the one that was missed

dropping the argument alone would swap the build failure for a stack overflow, because both callers size their buffer for the truncated mac and not for the digest. the verify path passes want[16], and dotdoh_inject_addr() has the digest written at payload + optlen with payload 33 bytes and optlen 5 or 17, so 4 or 16 bytes of a 32 byte write go past the end

rather than truncate through a scratch buffer at each call site, both buffers are simply SHA256_DIGEST_SIZE now and the digest is written whole on either nettle. nothing about the wire format moves, the mac is still the first DOTDOH_MAC_LEN bytes and only those travel, the rest is stack the frame had room for anyway. dotdoh_inject_addr() checks the offset against the buffer before handing it over instead of trusting dotdoh_encode_addr() to keep returning 5 or 17 forever, and a static_assert keeps DOTDOH_MAC_LEN from outgrowing the digest it is a prefix of

low to no impact on anything pi-hole ships, same as #3058: ci builds in the image .github/Dockerfile pins, which carries nettle 3.10, so this is only reachable by someone compiling ftl against a system nettle 4.0. there it is a build failure rather than anything at runtime

## How to test the change during review

edns0.c's mac function in a standalone file against the system nettle: on fedora 45 (nettle 4.0-5.fc45) the call as it stands on development gives exactly the error above and the new one builds, on the build container (nettle 3.10) both build, and the mac over the same key and input is fe5fb7b4a4cfe30cff5a5b362407d21a on both. full suite in the container is 194 bats, 151 pytest, 12, 25, 9, the 25 being the dot/doh server tests that exercise this mac end to end

## Additional information

**Related issue or feature (if applicable):** reported in #3000, sibling of #3058

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
