### PR TITLE
count a database connection from the moment it exists

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -210,9 +210,18 @@ sqlite3* _dbopen(const bool readonly, const bool create, const char *func, const
 	if( rc != SQLITE_OK )
 	{
 		log_err("Error while trying to open database: %s", sqlite3_errstr(rc));
+
+		// sqlite3_open_v2() associates resources with the handle even
+		// when it fails. dbclose_handle() releases it without the
+		// decrement dbclose() carries, as it is not counted yet
+		dbclose_handle(db);
 		checkFTLDBrc(rc);
 		return NULL;
 	}
+
+	// Count the connection as soon as it exists. The failure paths below
+	// release it through dbclose(), which is the matching decrement
+	atomic_fetch_add_explicit(&dbopen_cnt, 1, memory_order_relaxed);
 
 	// If the database is opened in read-write mode, actually check if it is
 	// writable. If it is not, close the database and return an error
@@ -233,9 +242,6 @@ sqlite3* _dbopen(const bool readonly, const bool create, const char *func, const
 		checkFTLDBrc(rc);
 		return NULL;
 	}
-
-	// Increment the number of open database connections
-	atomic_fetch_add_explicit(&dbopen_cnt, 1, memory_order_relaxed);
 
 	return db;
 }


### PR DESCRIPTION
# What does this implement/fix?

_dbopen() raises dbopen_cnt at the very end, once everything has succeeded, but the two failure paths after the open give the connection back through dbclose(), which lowers it unconditionally. a connection refused for being read-only, or one whose busy handler could not be set, takes the counter down without ever having raised it, so dbopen_cnt walks towards negative numbers for as long as ftl runs

the increment moves up to just after sqlite3_open_v2() returns success. that is the moment there is something to count, and the point from which dbclose() is the way back out

sqlite3_open_v2() also hands back a handle when it fails, and the sqlite documentation is explicit that resources are associated with it whether or not an error occurs. that path returned NULL and dropped it, so every failed open leaked an sqlite3 object. it closes the handle now, with a plain sqlite3_close() rather than dbclose(), because the connection was never counted and dbclose() would take a decrement with it

low impact. the counter feeds one line, the DEBUG_DATABASE "Database busy - waiting %d ms (dbopen: %d)" message, and a failed open is not the common case. but that line exists to say how many connections are open while the database is contended, which is exactly when someone reads it

## How to test the change during review

nothing user visible changes, it is by inspection: the counter is raised and lowered on the same paths now, and the failed-open path releases what sqlite handed it. full suite in the container is 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
