### PR TITLE
leave the database in a usable state when a write fails

### DIFF
--- a/src/database/common.c
+++ b/src/database/common.c
@@ -87,11 +87,6 @@ int _dbclose_handle(sqlite3 *db, const char *func, const int line, const char *f
 
 void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 {
-	// Silently return if the database is known to be broken. It may not be
-	// possible to close the connection properly.
-	if(FTLDBerror())
-		return;
-
 	// The shared in-memory connection is owned by close_memory_database() and
 	// its prepared statements live as long as FTL does. Closing it here would
 	// finalize them behind the back of whoever cached them, so return before
@@ -327,12 +322,11 @@ static bool create_counter_table(sqlite3* db)
 	return true;
 }
 
-static bool db_create(void)
+// Split from db_create() so that every failure below returns through it and
+// the connection is closed exactly once. SQL_bool() returns on failure, so the
+// close cannot live in here
+static bool db_create_tables(sqlite3 *db)
 {
-	sqlite3 *db = dbopen(false, true);
-	if(db == NULL)
-		return false;
-
 	// Create Queries table in the database
 	SQL_bool(db, CREATE_QUERIES_TABLE_V1);
 
@@ -350,10 +344,23 @@ static bool db_create(void)
 	if(!db_set_FTL_property(db, DB_LASTTIMESTAMP, 0))
 		return false;
 
-	// Close database handle
+	return true;
+}
+
+static bool db_create(void)
+{
+	sqlite3 *db = dbopen(false, true);
+	if(db == NULL)
+		return false;
+
+	const bool okay = db_create_tables(db);
+
+	// Close database handle whether or not the tables were created: a
+	// half-created database that stays open holds the file for the life of
+	// the process while db_init() carries on without it
 	dbclose(&db);
 
-	return true;
+	return okay;
 }
 
 void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg)

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -1009,8 +1009,16 @@ bool export_queries_to_disk(const bool final)
 		log_debug(DEBUG_DATABASE, "Exported %i rows to disk.%s", sqlite3_changes(memdb), subtable_names[i]);
 	}
 
-	// End transaction
-	SQL_bool(memdb, "END");
+	// End transaction. A bare SQL_bool() would return with the transaction
+	// still open on the shared in-memory connection, which every later
+	// caller inherits
+	if((rc = dbquery(memdb, "END")) != SQLITE_OK)
+	{
+		log_err("export_queries_to_disk(): Cannot end transaction: %s",
+		        sqlite3_errstr(rc));
+		sqlite3_exec(memdb, "ROLLBACK", NULL, NULL, NULL);
+		return false;
+	}
 
 	log_debug(DEBUG_DATABASE, "Exported %u rows for disk.query_storage (took %.1f ms)",
 		  insertions, timer_elapsed_msec(DATABASE_WRITE_TIMER));
@@ -1811,6 +1819,41 @@ static bool memdb_exec(sqlite3 *memdb, const char *sql, const char *what)
 	return false;
 }
 
+// Snapshot struct for lock-free SQLite writes in phase 2
+struct query_snap {
+	unsigned int queryID;       // SHM index for writeback
+	int64_t idx;                // pre-assigned db index
+	double timestamp;
+	int type_val;               // pre-computed type for param 3
+	int status;                 // param 4
+	int domain_db_id;           // param 5
+	int client_db_id;           // param 6
+	int upstream_db_id;         // param 7
+	int addinfo_id;             // param 8
+	int reply;                  // param 9
+	double response;            // param 10
+	int dnssec;                 // param 11
+	int list_id;                // param 12
+	int ede;                    // param 13
+	bool has_upstream;
+	bool response_calculated;
+	bool is_new;
+	bool blocked;
+};
+
+// Give the snapshotted queries their changed flag back so a later run picks
+// them up. The caller holds the SHM lock
+static void requeue_snapshots(const struct query_snap *snaps, const unsigned int from,
+                              const unsigned int to)
+{
+	for(unsigned int i = from; i < to; i++)
+	{
+		queriesData *query = getQuery(snaps[i].queryID, true);
+		if(query != NULL)
+			query->flags.database.changed = true;
+	}
+}
+
 bool queries_to_database(void)
 {
 	int rc;
@@ -1901,27 +1944,6 @@ bool queries_to_database(void)
 	// (thanks to the in_database flag).
 	// ===================================================================
 
-	// Snapshot struct for lock-free SQLite writes in phase 2
-	struct query_snap {
-		unsigned int queryID;       // SHM index for writeback
-		int64_t idx;                // pre-assigned db index
-		double timestamp;
-		int type_val;               // pre-computed type for param 3
-		int status;                 // param 4
-		int domain_db_id;           // param 5
-		int client_db_id;           // param 6
-		int upstream_db_id;         // param 7
-		int addinfo_id;             // param 8
-		int reply;                  // param 9
-		double response;            // param 10
-		int dnssec;                 // param 11
-		int list_id;                // param 12
-		int ede;                    // param 13
-		bool has_upstream;
-		bool response_calculated;
-		bool is_new;
-		bool blocked;
-	};
 
 	const unsigned int window = counters->queries - last_query;
 	struct query_snap *snaps = malloc(window * sizeof(*snaps));
@@ -2199,12 +2221,11 @@ bool queries_to_database(void)
 	// Release SHM lock — all data needed for phase 2 is in the snapshot
 	unlock_shm();
 
-	// If phase 1 encountered an error, skip phase 2 but still clean up
+	// If phase 1 encountered an error, skip phase 2. Everything it
+	// snapshotted had its changed flag cleared, so this goes out through
+	// the same restore as the transaction failures below
 	if(phase1_error)
-	{
-		free(snaps);
-		return false;
-	}
+		goto fail;
 
 	// ===================================================================
 	// PHASE 2: Without SHM lock — bind and step query_stmt for each
@@ -2274,6 +2295,16 @@ bool queries_to_database(void)
 	// ===================================================================
 	lock_shm();
 
+	// A step error in phase 2 left the rest of the snapshot uncommitted, so
+	// those queries get their changed flag back and are written next time
+	if(succeeded < snap_count)
+	{
+		requeue_snapshots(snaps, succeeded, snap_count);
+
+		log_err("Could not store %u queries, they are queued for the next run",
+		        snap_count - succeeded);
+	}
+
 	// Loop through snapshots of successfully committed queries and write
 	// back db indices
 	for(unsigned int i = 0; i < succeeded; i++)
@@ -2330,11 +2361,19 @@ bool queries_to_database(void)
 rollback_unlock_fail:
 	dbquery(memdb, "ROLLBACK");
 unlock_fail:
+	// Nothing was committed, so give the snapshotted queries their changed
+	// flag back and let the next run pick them up. The lock is still ours
+	requeue_snapshots(snaps, 0, snap_count);
 	unlock_shm();
-	goto fail;
+	goto fail_free;
 rollback_fail:
 	dbquery(memdb, "ROLLBACK");
 fail:
+	// Same restore, but phase 2 runs without the lock
+	lock_shm();
+	requeue_snapshots(snaps, 0, snap_count);
+	unlock_shm();
+fail_free:
 	free(snaps);
 	return false;
 }


### PR DESCRIPTION
# What does this implement/fix?

three failure paths in the database layer that hand back something worse than they found, grouped because they are the same mistake in three shapes

queries_to_database() clears flags.database.changed in phase 1 under the shm lock, on purpose, so a dns thread updating the query during phase 2 marks it again. every route out after that left the flag clear: the phase1_error return, the BEGIN, a step error that breaks out with succeeded < snap_count, and the END, which rolls everything back, and nothing else will, because dnsmasq_interface.c only sets it when the query itself changes and a query in its final state does not change again. those queries are skipped by every later run and reach neither database, silently. phase 3 walks the uncommitted tail now and says so once through log_err, the failure labels do the same for the whole snapshot, taking the lock where phase 2 gave it up, and phase1_error leaves through them instead of returning on its own

_dbclose() returned before doing anything once FTLDBerror() was latched. that latch is one way, so from the first corruption on, every close leaked its handle, left the caller holding a pointer it believes was closed, and skipped the open counter. sqlite3_close_v2() copes with a corrupt file, so the check goes

db_create() opened a connection and returned on five failure paths without closing it, keeping a half-created pihole-FTL.db open and locked for the life of the process while db_init() reported the failure and carried on. the table statements move into db_create_tables() so every return comes back through db_create(), which closes once

export_queries_to_disk() ended its transaction with a bare SQL_bool(), which returns without rolling back, on the shared in-memory connection that lives as long as ftl. a failing END left every later caller inside a transaction nobody opened

low to medium impact. each needs a failing write or a corrupt database to reach, but what they produce is silent data loss, a file locked until restart, and a connection stuck in a transaction

## How to test the change during review

not reachable without forcing the failures: make a step or an END fail and watch the next run pick the queries up rather than skip them, with "Could not store N queries" in FTL.log. full suite in the container is 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
