### PR TITLE
read shared state while it is still protected

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -49,6 +49,17 @@ void _set_event(const enum events event, int line, const char *function, const c
 	}
 }
 
+// Raise an event from a signal handler
+// SIGRT_handler() already states that nothing async-signal-unsafe may run in
+// it, but set_event() reaches log_debug() and from there _FTL_log(), which
+// formats with printf and can take the SHM lock. Neither is allowed to happen
+// with a signal interrupting arbitrary code, so the signal path gets the
+// exchange on its own: the event is logged where it is processed anyway
+void set_event_from_signal(const enum events event)
+{
+	atomic_exchange(&eventqueue[event], true);
+}
+
 // Get and clear event
 // Read and clear in one exchange, so there is no window in which a producer
 // sees a value the consumer has already taken. Compiles to XCHG on x86_64 and

--- a/src/events.c
+++ b/src/events.c
@@ -12,7 +12,7 @@
 #include "FTL.h"
 // public prototypes
 #include "events.h"
-// atomic_flag_test_and_set()
+// atomic_exchange()
 #include <stdatomic.h>
 // struct config
 #include "config/config.h"
@@ -23,7 +23,12 @@
 static const char *eventtext(const enum events event);
 
 // Queue containing all possible events
-static volatile atomic_flag eventqueue[EVENTS_MAX] = { ATOMIC_FLAG_INIT };
+// An atomic_bool rather than an atomic_flag: a flag cannot be read without
+// setting it, which is what used to lose events (see below). RELOAD_GRAVITY is
+// raised from the SIGRTMIN handler, so the type has to be lock-free for the
+// exchange to be async-signal-safe
+static _Atomic bool eventqueue[EVENTS_MAX];
+static_assert(ATOMIC_BOOL_LOCK_FREE == 2, "Event queue must be lock-free, it is used from a signal handler");
 
 // Set/Request event
 // We set the events atomically to ensure no race collisions can happen. If an
@@ -31,10 +36,8 @@ static volatile atomic_flag eventqueue[EVENTS_MAX] = { ATOMIC_FLAG_INIT };
 // added multiple times
 void _set_event(const enum events event, int line, const char *function, const char *file)
 {
-	bool is_set = false;
-	// Set eventqueue bit
-	if(atomic_flag_test_and_set(&eventqueue[event]))
-		is_set = true;
+	// Set eventqueue bit, learning what it was in the same operation
+	const bool is_set = atomic_exchange(&eventqueue[event], true);
 
 	// Possible debug logging
 	if(config.debug.events.v.b)
@@ -47,25 +50,13 @@ void _set_event(const enum events event, int line, const char *function, const c
 }
 
 // Get and clear event
-// Unfortunately, we cannot read the value of an atomic_flag without setting it
-// either to true or false. This is by design. Hence, we implement testing by
-// first trying to set the the flag to true. If this "fails", we know the flag
-// has already been set.
-// On x86_64 and i686 CPUs, these atomic instrictions are implemented using the
-// XCHG asm instruction, which simply exchanges the content of two registers or,
-// in this case, a register and a memory location (the respective eventqueue
-// pointer). This is guaranteed to happen atomically by automatically
-// implementing the processor's locking protocol during the operation.
-// On other architecture, similar instructions are used to reassemble the same
-// effect (but typically with a few more instructions). ARM64, for instance,
-// uses LDAXRB (Load-aquire exclusive register byte) and STAXRB (Store-release
-// exclusive register byte) to implement the same thing with a few more
-// instructions.
+// Read and clear in one exchange, so there is no window in which a producer
+// sees a value the consumer has already taken. Compiles to XCHG on x86_64 and
+// i686, and to the LDAXRB/STLXRB pair on ARM64
 bool _get_and_clear_event(const enum events event, int line, const char *function, const char *file)
 {
-	bool is_set = false;
-	if(atomic_flag_test_and_set(&eventqueue[event]))
-		is_set = true;
+	// Read the bit and clear it in the same operation
+	const bool is_set = atomic_exchange(&eventqueue[event], false);
 
 	// Possible debug logging only for SET status, to avoid log file flooding with NOT SET messages
 	if(is_set && config.debug.events.v.b)
@@ -74,10 +65,6 @@ bool _get_and_clear_event(const enum events event, int line, const char *functio
 		          eventtext(event), function, file, line);
 	}
 
-	// Clear eventqueue bit (we set it above) ...
-	atomic_flag_clear(&eventqueue[event]);
-
-	// ... and return status
 	return is_set;
 }
 

--- a/src/events.h
+++ b/src/events.h
@@ -16,6 +16,9 @@
 
 #define set_event(event) _set_event(event, __LINE__, __FUNCTION__, __FILE__)
 void _set_event(const enum events event, int line, const char *function, const char *file);
+// Raise an event from a signal handler, where the debug logging in _set_event()
+// must not run
+void set_event_from_signal(const enum events event);
 #define get_and_clear_event(event) _get_and_clear_event(event, __LINE__, __FUNCTION__, __FILE__)
 bool _get_and_clear_event(const enum events event, int line, const char *function, const char *file);
 

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -751,6 +751,17 @@ void _unlock_shm(const char *func, const int line, const char * file)
 		        (long int)shmLock->owner.pid, (long int)shmLock->owner.tid);
 	}
 
+	// Read the timestamps while the lock is still ours. Both live in shared
+	// memory, so once the mutexes below are released another thread can take
+	// the lock and overwrite time.begin before we get to read it
+	struct timespec begin = { 0 }, end = { 0 };
+	const bool timing = config.debug.timing.v.b;
+	if(timing)
+	{
+		clock_gettime(CLOCK_MONOTONIC, &end);
+		begin = shmLock->time.begin;
+	}
+
 	// Unlock mutex
 	int result = pthread_mutex_unlock(&shmLock->lock.inner);
 	shmLock->owner.pid = 0;
@@ -763,11 +774,11 @@ void _unlock_shm(const char *func, const int line, const char * file)
 	if(result != 0)
 		log_err("Failed to unlock outer SHM lock: %s", strerror(result));
 
-	if(config.debug.timing.v.b)
+	if(timing)
 	{
-		clock_gettime(CLOCK_MONOTONIC, &shmLock->time.end);
-		const double lock_time = (shmLock->time.end.tv_sec - shmLock->time.begin.tv_sec) / 1000.0 +
-		                         (shmLock->time.end.tv_nsec - shmLock->time.begin.tv_nsec) / 1e6;
+		// Seconds scale up to milliseconds, nanoseconds scale down
+		const double lock_time = (end.tv_sec - begin.tv_sec) * 1000.0 +
+		                         (end.tv_nsec - begin.tv_nsec) / 1e6;
 		log_debug(DEBUG_TIMING, "SHM lock held for %.3f ms in %s() (%s:%i)",
 		          lock_time, func, file, line);
 	}

--- a/src/signals.c
+++ b/src/signals.c
@@ -1190,7 +1190,7 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *context)
 		// - allowed domains and regex
 		// - denied domains and regex
 		// WITHOUT wiping the DNS cache itself
-		set_event(RELOAD_GRAVITY);
+		set_event_from_signal(RELOAD_GRAVITY);
 	}
 	else if(rtsig == 2)
 	{
@@ -1200,19 +1200,19 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *context)
 	else if(rtsig == 3)
 	{
 		// Reimport alias-clients from database
-		set_event(REIMPORT_ALIASCLIENTS);
+		set_event_from_signal(REIMPORT_ALIASCLIENTS);
 	}
 	else if(rtsig == 4)
 	{
 		// Re-resolve all clients and forward destinations
 		// Force refreshing hostnames according to
 		// REFRESH_HOSTNAMES config option
-		set_event(RERESOLVE_HOSTNAMES_FORCE);
+		set_event_from_signal(RERESOLVE_HOSTNAMES_FORCE);
 	}
 	else if(rtsig == 5)
 	{
 		// Parse neighbor cache
-		set_event(PARSE_NEIGHBOR_CACHE);
+		set_event_from_signal(PARSE_NEIGHBOR_CACHE);
 	}
 	// else if(rtsig == 6)
 	// {
@@ -1221,7 +1221,7 @@ static void SIGRT_handler(int signum, siginfo_t *si, void *context)
 	else if(rtsig == 7)
 	{
 		// Search for hash collisions in the lookup tables
-		set_event(SEARCH_LOOKUP_HASH_COLLISIONS);
+		set_event_from_signal(SEARCH_LOOKUP_HASH_COLLISIONS);
 	}
 
 	// SIGRT32: Used internally by valgrind, do not use


### PR DESCRIPTION
# What does this implement/fix?

two places where shared state is read outside the protection that is supposed to cover it

_get_and_clear_event() learned an event's state by setting it, because an atomic_flag cannot be read any other way, and cleared it a few lines further down with the debug logging in between. a producer running in that window found the flag already set, took its own event for a duplicate and dropped it. the queue has one consumer and many producers, RELOAD_GRAVITY alone comes from the SIGRTMIN handler, from two places in the api, from the teleporter, from dnsmasq_interface.c and from the database thread. a lost one means a list edit or pihole reloaddns reports success and never takes effect. an _Atomic bool can be read and written in one atomic_exchange(), so the window closes, and a static_assert pins the lock-free property the signal handler depends on

_unlock_shm() released both mutexes and only then took the end timestamp and read time.begin. both live in the shared memory region, so by then another thread can hold the lock and have overwritten time.begin: the number reported is the time since somebody else's acquisition, and the read races their write. the timestamps are taken into locals before the unlocks now. while there, the scaling: seconds were divided by 1000 where they should be multiplied, so a lock held for two seconds was reported as 0.002 ms plus the nanosecond remainder

third commit, out of review here: SIGRT_handler() states in its own comment that nothing async-signal-unsafe may run in it and that its events are logged where they are processed, but set_event() reaches log_debug() and from there _FTL_log(), which formats with printf and can take the shm lock. a signal arriving while the interrupted code holds that lock, or sits inside malloc, deadlocks the process. set_event_from_signal() is the exchange and nothing else, and the five calls in the handler use it. the wider async-signal-safe logging api darkexplosiveqwx is working towards is a separate matter, this only removes the call that contradicts the comment already in the file

medium impact for the first, it is rare and unreproducible but produces a silent no-op on exactly the operation someone just asked for. the second only affects a debug line, which is nevertheless the line someone reads when they are trying to understand lock contention

## How to test the change during review

by inspection: a set followed by a clear is one exchange now, and the timestamps are read while the lock is held. reproducing the lost event means widening the window on purpose, a sleep between the old set and clear plus set_event from a second thread. full suite is 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
