### PR TITLE
answer database failures with a server error, and free the half-built row

### DIFF
--- a/src/api/list.c
+++ b/src/api/list.c
@@ -33,7 +33,7 @@ static int api_list_read(struct ftl_conn *api,
 	sqlite3_stmt *stmt = NULL;
 	if(!gravityDB_readTable(NULL, listtype, item, &sql_msg, true, NULL, &stmt))
 	{
-		return send_json_error(api, 400, // 400 Bad Request
+		return send_json_error(api, 500, // 500 Internal Server Error
 		                       "database_error",
 		                       "Could not read domains from database table",
 		                       sql_msg);
@@ -98,6 +98,9 @@ static int api_list_read(struct ftl_conn *api,
 				const int ret = parse_groupIDs(api, &table, row);
 				if(ret != 0)
 				{
+					// row is not in rows yet, it is only
+					// appended at the end of the loop body
+					JSON_DELETE(row);
 					JSON_DELETE(rows);
 					gravityDB_readTableFinalize(stmt);
 					return ret;

--- a/src/api/network.c
+++ b/src/api/network.c
@@ -177,8 +177,11 @@ static int api_network_devices_GET(struct ftl_conn *api)
 	sqlite3 *db = dbopen(true, false);
 	if(db == NULL)
 	{
-		log_warn("Failed to open database in networkTable_readDevices()");
-		return false;
+		log_warn("Failed to open database in api_network_devices_GET()");
+		return send_json_error(api, 500,
+		                       "database_error",
+		                       "Could not open the long-term database",
+		                       NULL);
 	}
 
 	const char *sql_msg = NULL;
@@ -293,8 +296,11 @@ static int api_network_devices_DELETE(struct ftl_conn *api)
 	sqlite3 *db = dbopen(false, false);
 	if(db == NULL)
 	{
-		log_warn("Failed to open database in networkTable_readDevices()");
-		return false;
+		log_warn("Failed to open database in api_network_devices_DELETE()");
+		return send_json_error(api, 500,
+		                       "database_error",
+		                       "Could not open the long-term database",
+		                       NULL);
 	}
 
 	// Delete row from network table by ID

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -41,7 +41,7 @@ static int search_table(struct ftl_conn *api, sqlite3 *db, const char *item,
 	sqlite3_stmt *stmt = NULL;
 	if(!gravityDB_readTable(db, listtype, item, &sql_msg, !partial, ids, &stmt))
 	{
-		return send_json_error(api, 400, // 400 Bad Request
+		return send_json_error(api, 500, // 500 Internal Server Error
 		                       "database_error",
 		                       "Could not read domains from database table",
 		                       sql_msg);
@@ -84,6 +84,9 @@ static int search_table(struct ftl_conn *api, sqlite3 *db, const char *item,
 			const int ret = parse_groupIDs(api, &table, row);
 			if(ret != 0)
 			{
+				// row is only added to the array at the end of
+				// the loop body, so it is ours to free here
+				JSON_DELETE(row);
 				gravityDB_readTableFinalize(stmt);
 				return ret;
 			}


### PR DESCRIPTION
# What does this implement/fix?

three api paths report a failure as something the client did wrong, or as nothing at all

networkTable_readDevices() and api_network_devices_DELETE() are static int handlers whose return value is the http status, and both said return false when dbopen() failed. zero is what the router reads as "no handler answered", so a database that could not be opened came back as 404 not found for an endpoint that plainly exists. both send 500 now, and the delete path no longer logs the other function's name

the two gravity readers in api/search.c and api/list.c reported a failed gravityDB_readTable() as 400 bad request. nothing about the request is wrong when the gravity database cannot be read, so both are 500

while in those two files: the row object built inside the read loop is only appended to the array at the end of the loop body, so the parse_groupIDs() failure path in the middle returned with it owned by nobody

low impact, but the 404 is the kind of answer that sends someone hunting for a typo in a path that is perfectly correct

## How to test the change during review

make the database unreadable (chmod 000 on pihole-FTL.db as a non-root ftl) and call /api/network/devices: 500 with a database_error key instead of 404 not found. same for the gravity readers with gravity.db. full suite is 194 bats, 151 pytest, 12, 25, 9

not in this pr, deliberately: a wrong method still answers 404 rather than 405 with an Allow header. the router has the endpoint list to build that from, but send_json_error() cannot add a header, my_send_http_error_headers() emits the whole block, so it needs a header-capable error path first and that is a change of its own

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
