### PR TITLE
say something when the configuration does not do what was asked

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -15,6 +15,8 @@
 #include "FTL.h"
 #include "capabilities.h"
 #include "config/config.h"
+// DOT_PORT
+#include "dotdoh/server.h"
 #include "log.h"
 
 static const unsigned int capabilityIDs[]   = { CAP_CHOWN ,  CAP_DAC_OVERRIDE ,  CAP_DAC_READ_SEARCH ,  CAP_FOWNER ,  CAP_FSETID ,  CAP_KILL ,  CAP_SETGID ,  CAP_SETUID ,  CAP_SETPCAP ,  CAP_LINUX_IMMUTABLE ,  CAP_NET_BIND_SERVICE ,  CAP_NET_BROADCAST ,  CAP_NET_ADMIN ,  CAP_NET_RAW ,  CAP_IPC_LOCK ,  CAP_IPC_OWNER ,  CAP_SYS_MODULE ,  CAP_SYS_RAWIO ,  CAP_SYS_CHROOT ,  CAP_SYS_PTRACE ,  CAP_SYS_PACCT ,  CAP_SYS_ADMIN ,  CAP_SYS_BOOT ,  CAP_SYS_NICE ,  CAP_SYS_RESOURCE ,  CAP_SYS_TIME ,  CAP_SYS_TTY_CONFIG ,  CAP_MKNOD ,  CAP_LEASE ,  CAP_AUDIT_WRITE ,  CAP_AUDIT_CONTROL ,  CAP_SETFCAP };
@@ -110,6 +112,66 @@ bool check_capability(const unsigned int cap)
  *
  * @return true if all required capabilities are available, false otherwise.
  */
+// Does anything in this configuration want a port below 1024? 1024 itself is
+// the first unprivileged one (net.ipv4.ip_unprivileged_port_start). dns.port,
+// the DoT listener on DOT_PORT and every entry of webserver.port count, the
+// last being a list like "80o,443os,[::]:80o", so the port is what follows the
+// final colon, if any. DoH needs nothing extra, it rides on a webserver port
+static bool binds_privileged_port(void)
+{
+	if(config.dns.port.v.u16 != 0 && config.dns.port.v.u16 < 1024)
+		return true;
+
+	if(config.dns.dot.v.b && DOT_PORT < 1024)
+		return true;
+
+	const char *list = config.webserver.port.v.s;
+	if(list == NULL)
+		return false;
+
+	char *copy = strdup(list);
+	if(copy == NULL)
+		return false;
+
+	bool privileged = false;
+	char *save = NULL;
+	for(char *tok = strtok_r(copy, ",", &save); tok != NULL && !privileged; tok = strtok_r(NULL, ",", &save))
+	{
+		// Skipped through a separate pointer so the loop variable itself
+		// is not modified in the body
+		const char *ent = tok;
+		while(*ent == ' ')
+			ent++;
+
+		// An entry may carry an address, so the port follows the last colon
+		const char *port = strrchr(ent, ':');
+		port = port != NULL ? port + 1 : ent;
+
+		const long p = strtol(port, NULL, 10);
+		if(p > 0 && p < 1024)
+			privileged = true;
+	}
+
+	free(copy);
+	return privileged;
+}
+
+// Warn when a capability this configuration needs is missing. Returns false
+// only in that case: a capability the running configuration does not use is
+// not reported at all
+static bool warn_missing_cap(const cap_user_data_t data, const unsigned int capid,
+                             const char *name, const bool needed, const char *what)
+{
+	if(!needed)
+		return true;
+
+	if((data->permitted & (1u << capid)) && (data->effective & (1u << capid)))
+		return true;
+
+	log_warn("Linux capability %s is not available, needed for %s", name, what);
+	return false;
+}
+
 bool check_capabilities(void)
 {
 	cap_user_data_t data = NULL;
@@ -129,49 +191,26 @@ bool check_capabilities(void)
 	}
 	log_debug(DEBUG_CAPS, "***************************************");
 
+	// Warn only about what this configuration actually uses. A container
+	// started without a capability it does not need is a deliberate choice,
+	// not a fault to report on every start
 	bool capabilities_okay = true;
-	if (!(data->permitted & (1 << CAP_NET_ADMIN)) ||
-	    !(data->effective & (1 << CAP_NET_ADMIN)))
-	{
-		// Needed for ARP-injection (used when we're the DHCP server)
-		log_warn("Required Linux capability CAP_NET_ADMIN not available");
-		capabilities_okay = false;
-	}
-	if (!(data->permitted & (1 << CAP_NET_RAW)) ||
-	    !(data->effective & (1 << CAP_NET_RAW)))
-	{
-		// Needed for raw socket access (necessary for ICMP)
-		log_warn("Required Linux capability CAP_NET_RAW not available");
-		capabilities_okay = false;
-	}
-	if (!(data->permitted & (1 << CAP_NET_BIND_SERVICE)) ||
-	    !(data->effective & (1 << CAP_NET_BIND_SERVICE)))
-	{
-		// Necessary for dynamic port binding
-		log_warn("Required Linux capability CAP_NET_BIND_SERVICE not available");
-		capabilities_okay = false;
-	}
-	if (!(data->permitted & (1 << CAP_SYS_NICE)) ||
-	    !(data->effective & (1 << CAP_SYS_NICE)))
-	{
-		// Necessary for setting higher process priority through nice
-		log_warn("Required Linux capability CAP_SYS_NICE not available");
-		capabilities_okay = false;
-	}
-	if (!(data->permitted & (1 << CAP_CHOWN)) ||
-	    !(data->effective & (1 << CAP_CHOWN)))
-	{
-		// Necessary to chown required files that are owned by another user
-		log_warn("Required Linux capability CAP_CHOWN not available");
-		capabilities_okay = false;
-	}
-	if (!(data->permitted & (1 << CAP_SYS_TIME)) ||
-	    !(data->effective & (1 << CAP_SYS_TIME)))
-	{
-		// Necessary for setting the system time in the NTP client
-		log_warn("Required Linux capability CAP_SYS_TIME not available");
-		capabilities_okay = false;
-	}
+	capabilities_okay &= warn_missing_cap(data, CAP_NET_ADMIN, "CAP_NET_ADMIN",
+	                                      config.dhcp.active.v.b,
+	                                      "ARP injection while acting as the DHCP server");
+	capabilities_okay &= warn_missing_cap(data, CAP_NET_BIND_SERVICE, "CAP_NET_BIND_SERVICE",
+	                                      binds_privileged_port(),
+	                                      "binding a privileged port");
+	capabilities_okay &= warn_missing_cap(data, CAP_SYS_NICE, "CAP_SYS_NICE",
+	                                      config.misc.nice.v.i < 0,
+	                                      "raising the process priority set in misc.nice");
+	capabilities_okay &= warn_missing_cap(data, CAP_SYS_TIME, "CAP_SYS_TIME",
+	                                      config.ntp.sync.active.v.b,
+	                                      "setting the system time from the NTP client");
+
+	// Always needed: FTL chowns the files it creates to the pihole user
+	capabilities_okay &= warn_missing_cap(data, CAP_CHOWN, "CAP_CHOWN", true,
+	                                      "taking ownership of the files FTL creates");
 
 	// Free allocated memory
 	free(data);

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -78,8 +78,10 @@ FILE * __attribute((malloc)) __attribute((nonnull(1))) openFTLtoml(const char *m
 }
 
 // Open the TOML file for reading or writing
-void closeFTLtoml(FILE *fp, const bool locked)
+bool closeFTLtoml(FILE *fp, const bool locked)
 {
+	bool okay = true;
+
 	// Release file lock
 	if(locked)
 		unlock_file(fp, NULL);
@@ -90,9 +92,31 @@ void closeFTLtoml(FILE *fp, const bool locked)
 	if (mode == -1)
 		log_err("Cannot get access mode for FTL's config file: %s", strerror(errno));
 
+	// A write error shows up here and nowhere else: fprintf() sets the
+	// error indicator and carries on, and the bytes are lost at the flush.
+	// The caller renames this file over the live config, so it has to know.
+	// When fcntl() failed we do not know the mode, which is the least
+	// reason to skip the check
+	if(mode == -1 || (mode & O_ACCMODE) != O_RDONLY)
+	{
+		if(fflush(fp) != 0 || ferror(fp))
+		{
+			log_err("Cannot write FTL's config file: %s", strerror(errno));
+			okay = false;
+		}
+		else if(fsync(fn) != 0)
+		{
+			log_err("Cannot flush FTL's config file to disk: %s", strerror(errno));
+			okay = false;
+		}
+	}
+
 	// Close file
 	if(fclose(fp) != 0)
+	{
 		log_err("Cannot close FTL's config file: %s", strerror(errno));
+		okay = false;
+	}
 
 	// Chown file if we are root
 	if(geteuid() == 0 && mode != -1)
@@ -105,7 +129,7 @@ void closeFTLtoml(FILE *fp, const bool locked)
 		chown_pihole(read_only ? GLOBALTOMLPATH : GLOBALTOMLPATH".tmp", NULL);
 	}
 
-	return;
+	return okay;
 }
 
 // Print a string to a TOML file, escaping special characters as necessary
@@ -445,6 +469,24 @@ void writeTOMLvalue(FILE * fp, const int indent, const enum conf_type t, union c
 	}
 }
 
+// A key that is absent and a key holding the wrong type end up in the same
+// place below, but they are not the same thing: the second is something the
+// user wrote, and readFTLconf() rewrites pihole.toml with the compiled-in
+// default afterwards, so their edit disappears from the file with nothing said.
+// The environment and CLI paths both warn about this, so this one does too
+static void log_absent_or_wrong_type(const toml_datum_t val, const struct conf_item *conf_item,
+                                     const char *expected)
+{
+	if(val.type == TOML_UNKNOWN)
+	{
+		log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST", conf_item->k);
+	}
+	else
+	{
+		log_warn("Ignoring %s in pihole.toml: not a valid %s", conf_item->k, expected);
+	}
+}
+
 // Read a TOML value from a table depending on its type
 void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t toml, struct config *newconf)
 {
@@ -462,7 +504,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_BOOLEAN)
 				conf_item->v.b = val.u.boolean;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid bool", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "bool");
 			break;
 		}
 		case CONF_ALL_DEBUG_BOOL:
@@ -471,7 +513,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_BOOLEAN)
 				set_all_debug(newconf, val.u.boolean);
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid bool", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "bool");
 			break;
 		}
 		case CONF_INT:
@@ -480,7 +522,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_INT64)
 				conf_item->v.i = val.u.int64;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid integer", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "integer");
 			break;
 		}
 		case CONF_UINT:
@@ -489,7 +531,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_INT64 && val.u.int64 >= 0 && val.u.int64 <= UINT_MAX)
 				conf_item->v.ui = val.u.int64;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid unsigned integer", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "unsigned integer");
 			break;
 		}
 		case CONF_UINT16:
@@ -498,7 +540,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_INT64 && val.u.int64 >= 0 && val.u.int64 <= UINT16_MAX)
 				conf_item->v.u16 = val.u.int64;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid unsigned integer (16 bit)", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "unsigned integer (16 bit)");
 			break;
 		}
 		case CONF_LONG:
@@ -507,7 +549,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_INT64 && val.u.int64 <= LONG_MAX)
 				conf_item->v.l = val.u.int64;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid long integer", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "long integer");
 			break;
 		}
 		case CONF_DOUBLE:
@@ -516,7 +558,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 			if(val.type == TOML_FP64)
 				conf_item->v.d = val.u.fp64;
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid double", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "double");
 			break;
 		}
 		case CONF_STRING:
@@ -535,7 +577,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 				}
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_PTR_TYPE:
@@ -550,7 +592,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_BUSY_TYPE:
@@ -565,7 +607,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_BLOCKING_MODE:
@@ -580,7 +622,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a validstring", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_REFRESH_HOSTNAMES:
@@ -595,7 +637,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_LISTENING_MODE:
@@ -610,7 +652,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_WEB_THEME:
@@ -625,7 +667,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_TEMP_UNIT:
@@ -640,7 +682,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_BLOCKING_EDNS_MODE:
@@ -655,7 +697,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 					log_warn("Config setting %s is invalid, allowed options are: %s", conf_item->k, conf_item->h);
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid string", conf_item->k);
+				log_absent_or_wrong_type(val, conf_item, "string");
 			break;
 		}
 		case CONF_ENUM_PRIVACY_LEVEL:
@@ -735,7 +777,7 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 				}
 			}
 			else
-				log_debug(DEBUG_CONFIG, "%s DOES NOT EXIST or is not a valid array", conf_item->k);
+				log_absent_or_wrong_type(array, conf_item, "array");
 			break;
 		}
 		case CONF_PASSWORD:

--- a/src/config/toml_helper.h
+++ b/src/config/toml_helper.h
@@ -18,7 +18,7 @@
 
 void indentTOML(FILE *fp, const unsigned int indent);
 FILE *openFTLtoml(const char *mode, const unsigned int version, bool *locked) __attribute((malloc)) __attribute((nonnull(1)));
-void closeFTLtoml(FILE *fp, const bool locked);
+bool closeFTLtoml(FILE *fp, const bool locked);
 void print_comment(FILE *fp, const char *str, const char *intro, const unsigned int width, const unsigned int indent);
 void print_toml_allowed_values(const cJSON *allowed_values, FILE *fp, const unsigned int indent);
 void writeTOMLvalue(FILE * fp, const int indent, const enum conf_type t, union conf_value *v);

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -186,7 +186,19 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 	// file pointer in which case we assume that the caller takes care of
 	// this
 	if(opened)
-		closeFTLtoml(fp, locked);
+	{
+		if(!closeFTLtoml(fp, locked))
+		{
+			// The temporary file is short or was never written.
+			// Rotating the good config away and renaming this over
+			// it would leave FTL starting from a file cut off
+			// mid-value next time
+			log_err("Not replacing "GLOBALTOMLPATH", the new config could not be written");
+			if(unlink(GLOBALTOMLPATH".tmp") != 0)
+				log_warn("Cannot remove temporary config file: %s", strerror(errno));
+			return false;
+		}
+	}
 	else
 		return true;
 

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -2494,9 +2494,9 @@ void FTL_dnsmasq_reload(void)
 	// - Flush FTL's DNS cache
 	set_event(RELOAD_GRAVITY);
 
-	// Print current set of capabilities if requested via debug flag
-	if(config.debug.caps.v.b)
-		check_capabilities();
+	// Re-check capabilities: what FTL needs depends on the configuration,
+	// which may have changed since the last check
+	check_capabilities();
 
 	// Re-read pihole.toml (incl. rewriting) on every but the first reload
 	// (which is happening right after the start of dnsmasq)

--- a/src/dotdoh/dot_server.c
+++ b/src/dotdoh/dot_server.c
@@ -54,7 +54,6 @@
 #include <sys/prctl.h>
 #include <time.h>
 
-#define DOT_PORT 853
 // Cap concurrent DoT connections so a flood cannot exhaust memory. Each slot
 // holds a small state record plus ~192 KiB of I/O buffers, allocated once and
 // then pooled across connections (freed only at thread shutdown), so the cap

--- a/src/dotdoh/server.h
+++ b/src/dotdoh/server.h
@@ -68,6 +68,9 @@ ssize_t dotdoh_server_resolve(const char *client, const char *dest,
                               const uint8_t *query, size_t qlen,
                               uint8_t *answer, size_t answer_sz);
 
+// Port the inbound DoT listener binds
+#define DOT_PORT 853
+
 // FTL worker thread entry for the inbound DoT (DNS-over-TLS) listener on port
 // 853. Runs only when dns.dot is enabled. Terminates TLS itself (DoT is not
 // HTTP, so it needs its own raw-TLS listener) and resolves via

--- a/src/main.c
+++ b/src/main.c
@@ -117,9 +117,12 @@ int main (int argc, char *argv[])
 	// Initialize overTime datastructure
 	initOverTime();
 
-	// Check for availability of capabilities in debug mode
-	if(config.debug.caps.v.b)
-		check_capabilities();
+	// Check for availability of capabilities. The per-capability table this
+	// prints is behind DEBUG_CAPS, but the warnings about the ones FTL needs
+	// and does not have are not, and they are the reason to run this at all:
+	// hiding them behind a debug flag means nobody sees them until they
+	// already suspect the problem
+	check_capabilities();
 
 	// Initialize pseudo-random number generator
 	srand(time(NULL) + getpid());


### PR DESCRIPTION
# What does this implement/fix?

three places where ftl knows more about the configuration than it says

a pihole.toml value of the wrong type is dropped exactly like a missing one, with a DEBUG_CONFIG line nobody has enabled, and readFTLconf() then rewrites the file with the compiled-in default: the edit disappears from the file and nothing is said. the two cases are told apart now, absent stays a debug line, present-but-wrong-type is a warning naming the key and the type expected, which is what the environment and cli paths already do

closeFTLtoml() was void. a short write sets the error indicator on the stream and fprintf() carries on, so on a full filesystem the temporary file was truncated, files_different() reported it as different, the good config was rotated away and the truncated one renamed over it. it returns a status now, from fflush(), ferror(), fsync() and fclose(), and writeFTLtoml() leaves the live file alone when the new one could not be written

check_capabilities() ran only when debug.caps was set, which also hid the warnings about capabilities ftl needs and does not have. the call is unconditional now, but warning about all of them always would be worse than silence: a container started without --cap-add would report capabilities its owner deliberately withheld, every boot. each warning is gated on the configuration that uses it - CAP_NET_ADMIN and CAP_NET_RAW on dhcp.active, CAP_NET_BIND_SERVICE on a privileged dns.port, CAP_SYS_NICE on a negative misc.nice, CAP_SYS_TIME on ntp.sync.active - with CAP_CHOWN unconditional. the second call site in dnsmasq_interface.c no longer hides behind debug.caps either, so the two agree

one thing worth stating about the write check: nine of writeFTLtoml()'s ten callers ignore its return, so what a user sees is the log_err, not a caller reacting. the value of the change is that the live pihole.toml survives a failed write, not that anything downstream handles it

mixed impact. the config write is the serious one, it destroys a working pihole.toml on a full disk, though that takes a full disk to reach. the rest is diagnostics: things that are already known and simply not said

## How to test the change during review

wrong type: put dns.port = "not a number" in pihole.toml and start ftl, the warning names the key and the type instead of nothing. full disk: fill the filesystem and set a config value, pihole.toml is left intact and the temporary file removed, where before it was replaced with a truncated one. capabilities: drop CAP_NET_RAW and start, the warning appears without debug.caps. full suite is 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
