### PR TITLE
close two memory-safety holes on error and signal paths

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2134,6 +2134,25 @@ static bool addToTable(sqlite3 *db, const enum gravity_list_type listtype, table
 	return okay;
 }
 
+// sqlite3_errmsg() hands back a string owned by the connection, and the
+// wrappers below close that connection before their caller ever reads the
+// message. Copy it somewhere that outlives the handle. Thread-local because
+// the API answers several requests at once, and only called on failure: a
+// success leaves *message as an earlier iteration set it, which would make
+// this copy a string onto itself
+static const char *keep_message(const char *message)
+{
+	static _Thread_local char kept[256];
+
+	if(message == NULL)
+		return NULL;
+
+	strncpy(kept, message, sizeof(kept) - 1);
+	kept[sizeof(kept) - 1] = '\0';
+
+	return kept;
+}
+
 bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
                           const char **message, const enum http_method method)
 {
@@ -2142,6 +2161,8 @@ bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
 		return false;
 
 	const bool ret = addToTable(db, listtype, row, message, method);
+	if(!ret && message != NULL)
+		*message = keep_message(*message);
 	dbclose_handle(db);
 	return ret;
 }
@@ -2417,6 +2438,8 @@ bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* 
 		return false;
 
 	const bool ret = delFromTable(db, listtype, array, deleted, message);
+	if(!ret && message != NULL)
+		*message = keep_message(*message);
 	dbclose_handle(db);
 	return ret;
 }
@@ -3071,6 +3094,8 @@ bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
 		return false;
 
 	const bool ret = edit_groups(db, listtype, groups, row, message);
+	if(!ret && message != NULL)
+		*message = keep_message(*message);
 	dbclose_handle(db);
 	return ret;
 }

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -3934,6 +3934,20 @@ void FTL_forwarding_retried(struct frec *forward, const int newID, const bool dn
 volatile atomic_flag worker_already_terminating = ATOMIC_FLAG_INIT;
 void FTL_TCP_worker_terminating(bool finished)
 {
+	if(!finished)
+	{
+		// Both callers passing false are inside dnsmasq's sig_handler()
+		// (dnsmasq.c, the SIGALRM arms), and both _exit(0) right after.
+		// Nothing below this point may run there: log_debug() allocates,
+		// lock_shm() takes a process-shared mutex the interrupted code
+		// may be holding mid-update, and gravityDB_close() finalizes
+		// statements that code may still be stepping. None of it is
+		// async-signal-safe, and none of it is needed - the worker's
+		// connections go with the process, and the SHM mutex is robust,
+		// so the parent recovers it through EOWNERDEAD
+		return;
+	}
+
 	if(get_dnsmasq_debug())
 	{
 		// Nothing to be done here, forking does not happen in debug mode


### PR DESCRIPTION
# What does this implement/fix?

two memory-safety fixes on error and signal paths, unrelated to each other beyond that

the three gravity write wrappers call dbclose_handle(db) and then return the worker's *message, which every failure path sets to sqlite3_errmsg(db). that string belongs to the connection just closed, so a failing write on /api/domains, /api/lists, /api/groups or /api/clients copies freed heap into the json error body. it is a use-after-free, though the reader is an already authenticated admin, so nothing crosses a privilege boundary. keep_message() snapshots the string before the handle dies, thread-local because the api answers several requests at once, and the roughly thirty *message = sqlite3_errmsg(db) assignments in the workers are left alone

FTL_TCP_worker_terminating(false) is reached only from dnsmasq's sig_handler(), both SIGALRM arms, each of which _exit(0)s straight after. what ran there was log_debug(), lock_shm() on a process-shared mutex, gravityDB_close() and unlock_shm(), none of it async-signal-safe. the case that hurts is an alarm landing while the worker holds the shm lock mid-update: is_our_lock() is true, so the handler skips the lock, finalizes sqlite statements the interrupted code was stepping, unlocks and exits, publishing a half-written query record to the parent. none of that work is needed on the way out, the worker's connections go with the process and the shm mutex is robust, so the parent takes it back through EOWNERDEAD

low impact for the first, an authenticated admin sees a garbled error message or a crash on a path that is already failing. medium for the second, it needs a tcp client holding a connection past the timeout and an alarm landing inside a narrow window, but what it corrupts is shared memory the parent goes on using

## How to test the change during review

the first by inspection, or under asan: make a gravity write fail and read the json error. the second the same way, the signal path is not reachable on demand. full suite in the container is 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
