### PR TITLE
add --config -t to check a value without applying it

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -911,7 +911,7 @@ static int api_config_patch(struct ftl_conn *api)
 		if(dnsmasq_changed)
 		{
 			char errbuf[ERRBUF_SIZE] = { 0 };
-			if(write_dnsmasq_config(&newconf, true, errbuf))
+			if(write_dnsmasq_config(&newconf, DNSMASQ_TEST_INSTALL, errbuf))
 			{
 				api->ftl.restart_reason = "dnsmasq config changed";
 				api->ftl.restart = restart;
@@ -1133,7 +1133,7 @@ static int api_config_put_delete(struct ftl_conn *api)
 	{
 		char errbuf[ERRBUF_SIZE] = { 0 };
 		// Request restart of FTL
-		if(write_dnsmasq_config(&newconf, true, errbuf))
+		if(write_dnsmasq_config(&newconf, DNSMASQ_TEST_INSTALL, errbuf))
 		{
 			api->ftl.restart_reason = "dnsmasq config changed";
 			// Only restart if the user didn't request otherwise

--- a/src/args.c
+++ b/src/args.c
@@ -432,17 +432,25 @@ void parse_args(int argc, char *argv[])
 				                "         The value shown below may not reflect the current configuration.\n",
 				        GLOBALTOMLPATH);
 		}
-		if(argc == 2)
+		if(argc > 2 && strcmp(argv[2], "-t") == 0)
+		{
+			if(argc == 5)
+				exit(set_config_from_CLI(argv[3], argv[4], true));
+		}
+		else if(argc == 2)
 			exit(get_config_from_CLI(NULL, false));
 		else if(argc == 3)
 			exit(get_config_from_CLI(argv[2], false));
 		else if(argc == 4 && strcmp(argv[2], "-q") == 0)
 			exit(get_config_from_CLI(argv[3], true));
 		else if(argc == 4)
-			exit(set_config_from_CLI(argv[2], argv[3]));
-		else
+			exit(set_config_from_CLI(argv[2], argv[3], false));
+
+		// Anything else, including `--config -t key` with the value
+		// forgotten, falls through to the usage text
 		{
 			printf("Usage: %s --config [<config item key>] [<value>]\n", argv[0]);
+			printf("       %s --config -t <config item key> <value>\n", argv[0]);
 			printf("Example: %s --config dns.CNAMEdeepInspect true\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
@@ -1347,7 +1355,11 @@ void parse_args(int argc, char *argv[])
 			printf("\t%s--config %skey%s        Get current value of config item %skey%s\n", green, blue, normal, blue, normal);
 			printf("\t                    Config items with non-default values may\n");
 			printf("\t                    be colored in %sred%s\n", red, normal);
-			printf("\t%s--config %skey %svalue%s  Set new %svalue%s of config item %skey%s\n\n", green, blue, cyan, normal, cyan, normal, blue, normal);
+			printf("\t%s--config %skey %svalue%s  Set new %svalue%s of config item %skey%s\n", green, blue, cyan, normal, cyan, normal, blue, normal);
+			printf("\t%s--config -t %skey %svalue%s\n", green, blue, cyan, normal);
+			printf("\t                    Check whether %svalue%s would be accepted for\n", cyan, normal);
+			printf("\t                    %skey%s, without applying it or writing the\n", blue, normal);
+			printf("\t                    config file\n\n");
 
 			printf("%sEmbedded GZIP un-/compressor:%s\n", yellow, normal);
 			printf("    A simple but fast in-memory gzip compressor\n\n");

--- a/src/config/cli.c
+++ b/src/config/cli.c
@@ -380,7 +380,7 @@ static bool readStringValue(struct conf_item *conf_item, const char *value, stru
 	return true;
 }
 
-int set_config_from_CLI(const char *key, const char *value)
+int set_config_from_CLI(const char *key, const char *value, const bool test_only)
 {
 	// Check if we are either
 	// - root, or
@@ -494,7 +494,7 @@ int set_config_from_CLI(const char *key, const char *value)
 		if(conf_item->f & FLAG_RESTART_FTL)
 		{
 			char errbuf[ERRBUF_SIZE] = { 0 };
-			if(!write_dnsmasq_config(&newconf, true, errbuf))
+			if(!write_dnsmasq_config(&newconf, test_only ? DNSMASQ_TEST_ONLY : DNSMASQ_TEST_INSTALL, errbuf))
 			{
 				// Test failed
 				log_debug(DEBUG_CONFIG, "Config item %s: dnsmasq config test failed", conf_item->k);
@@ -502,11 +502,20 @@ int set_config_from_CLI(const char *key, const char *value)
 				return DNSMASQ_TEST_FAILED;
 			}
 		}
-		else if(conf_item == &config.dns.hosts)
+		else if(conf_item == &config.dns.hosts && !test_only)
 		{
 			// We need to rewrite the custom.list file but do not
 			// need to restart dnsmasq
 			write_custom_list();
+		}
+
+		// Test mode stops here: nothing is installed, nothing is written
+		if(test_only)
+		{
+			writeTOMLvalue(stdout, -1, new_item->t, &new_item->v);
+			putchar('\n');
+			free_config(&newconf, false);
+			return OKAY;
 		}
 
 		// Install new configuration
@@ -523,6 +532,12 @@ int set_config_from_CLI(const char *key, const char *value)
 
 		// Print value
 		writeTOMLvalue(stdout, -1, conf_item->t, &conf_item->v);
+
+		if(test_only)
+		{
+			putchar('\n');
+			return OKAY;
+		}
 	}
 
 	putchar('\n');

--- a/src/config/cli.h
+++ b/src/config/cli.h
@@ -10,7 +10,7 @@
 #ifndef CONFIG_CLI_H
 #define CONFIG_CLI_H
 
-int set_config_from_CLI(const char *key, const char *value);
+int set_config_from_CLI(const char *key, const char *value, const bool test_only);
 int get_config_from_CLI(const char *key, const bool quiet);
 
 #endif //CONFIG_CLI_H

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1904,7 +1904,7 @@ bool migrate_config_v6(void)
 	// Initialize the TOML config file
 	writeFTLtoml(true, NULL);
 	char errbuf[ERRBUF_SIZE] = { 0 };
-	write_dnsmasq_config(&config, false, errbuf);
+	write_dnsmasq_config(&config, DNSMASQ_INSTALL, errbuf);
 	write_custom_list();
 
 	return true;
@@ -1934,7 +1934,7 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 			{
 				writeFTLtoml(true, NULL);
 				char errbuf[ERRBUF_SIZE] = { 0 };
-				write_dnsmasq_config(conf, false, errbuf);
+				write_dnsmasq_config(conf, DNSMASQ_INSTALL, errbuf);
 				write_custom_list();
 			}
 			return true;
@@ -1967,7 +1967,7 @@ bool readFTLconf(struct config *conf, const bool rewrite)
 	// Initialize the TOML config file
 	writeFTLtoml(true, NULL);
 	char errbuf[ERRBUF_SIZE] = { 0 };
-	write_dnsmasq_config(conf, false, errbuf);
+	write_dnsmasq_config(conf, DNSMASQ_INSTALL, errbuf);
 	write_custom_list();
 
 	return false;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -294,7 +294,7 @@ static const char *invalid_host_address(const struct in_addr addr, const uint32_
 	return NULL;
 }
 
-bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE])
+bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enum dnsmasq_write_mode mode, char errbuf[ERRBUF_SIZE])
 {
 	// Early config checks
 	if(conf->dhcp.active.v.b)
@@ -434,7 +434,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 				}
 				// Settle on a tuple that actually binds (redrawing on a collision) so
 				// dnsmasq is pointed at the one the proxy will bind; skip for validation.
-				if(!test_config)
+				if(mode == DNSMASQ_INSTALL)
 					dotdoh_tuple_ensure_bindable(enc);
 				char ip[INET_ADDRSTRLEN];
 				dotdoh_tuple_ip(enc, ip, sizeof(ip));
@@ -976,7 +976,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		chown_pihole(DNSMASQ_TEMP_CONF, NULL);
 
 	log_debug(DEBUG_CONFIG, "Testing "DNSMASQ_TEMP_CONF);
-	if(test_config && !test_dnsmasq_config(errbuf))
+	if(mode != DNSMASQ_INSTALL && !test_dnsmasq_config(errbuf))
 	{
 		log_warn("New dnsmasq configuration is not valid (%s), config remains unchanged", errbuf);
 
@@ -994,6 +994,19 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, boo
 		}
 
 		return false;
+	}
+
+	// The caller only wanted to know whether the config is valid, so the
+	// file it was tested from goes away again rather than being installed
+	if(mode == DNSMASQ_TEST_ONLY)
+	{
+		if(remove(DNSMASQ_TEMP_CONF) != 0)
+		{
+			log_err("Cannot remove temporary dnsmasq config file: %s", strerror(errno));
+			return false;
+		}
+
+		return true;
 	}
 
 	// Check if the new config file is different from the old one

--- a/src/config/dnsmasq_config.h
+++ b/src/config/dnsmasq_config.h
@@ -14,7 +14,14 @@
 
 #define ERRBUF_SIZE 1024
 
-bool write_dnsmasq_config(struct config *conf, bool test_config, char errbuf[ERRBUF_SIZE]) __attribute__((nonnull(1,3)));
+// What write_dnsmasq_config() should do with the file it builds
+enum dnsmasq_write_mode {
+	DNSMASQ_INSTALL,      // install it, no syntax test
+	DNSMASQ_TEST_INSTALL, // test it, install it if the test passes
+	DNSMASQ_TEST_ONLY,    // test it and remove it again
+};
+
+bool write_dnsmasq_config(struct config *conf, enum dnsmasq_write_mode mode, char errbuf[ERRBUF_SIZE]) __attribute__((nonnull(1,3)));
 int get_lineno_from_string(const char *string);
 char *get_dnsmasq_line(const unsigned int lineno);
 bool read_legacy_dhcp_static_config(void);

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -334,7 +334,7 @@ static const char *test_and_import_pihole_toml(void *ptr, size_t size, char * co
 
 	// Test dnsmasq config in the imported configuration
 	// The dnsmasq configuration will be overwritten if the test succeeds
-	if(!write_dnsmasq_config(&teleporter_config, true, hint))
+	if(!write_dnsmasq_config(&teleporter_config, DNSMASQ_TEST_INSTALL, hint))
 	{
 		free_config(&teleporter_config, false);
 		toml_free(toml);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1653,19 +1653,24 @@ setup() {
   assert_line --index 0 'Invalid value: webserver.api.excludeClients[2]: not a valid regex ("[[["): Missing '\'']'\'''
   assert_failure 3
 
-  run bash -c './pihole-FTL --config dhcp.netmask 255.254.255.0'
+  # dhcp.netmask carries FLAG_RESTART_FTL, so check it with -t: writing one and
+  # putting it back lets the config watcher restart FTL mid-suite
+  run bash -c './pihole-FTL --config -t dhcp.netmask 255.254.255.0'
   assert_line --index 0 'Invalid value: dhcp.netmask: not a valid netmask ("255.254.255.0"), the one-bits are not contiguous'
   assert_failure 3
 
-  run bash -c './pihole-FTL --config dhcp.netmask 255.255.254.0'
-  assert_success
-
-  run bash -c './pihole-FTL --config dhcp.netmask'
+  run bash -c './pihole-FTL --config -t dhcp.netmask 255.255.254.0'
   assert_line --index 0 '255.255.254.0'
   assert_success
 
-  # An empty netmask is valid, it is then taken from the interface
-  run bash -c './pihole-FTL --config dhcp.netmask ""'
+  # Nothing was applied, so the netmask is still the empty default
+  run bash -c './pihole-FTL --config dhcp.netmask'
+  assert_output ''
+  assert_success
+
+  # An empty netmask is valid, it is then taken from the interface. This equals
+  # the current value, so it takes the unchanged branch and no validator runs
+  run bash -c './pihole-FTL --config -t dhcp.netmask ""'
   assert_success
 }
 


### PR DESCRIPTION
# What does this implement/fix?

the api tests fail intermittently on two assertions, `unique_domains == 77` and `top_blocked == "gravity.ftl"`, roughly one arm/v6 job in ten. #3071 tried to relax them and was rightly closed: this is the cause

`--config key value` is the only way to ask the cli whether a value is acceptable, and it answers by installing it. for an item carrying FLAG_RESTART_FTL the write that follows restarts a running ftl, so a caller who only wants an answer has to change the configuration and put it back, and lives with whatever the daemon did in between

that is what the netmask test does: it writes a valid netmask, then writes an empty one to restore it. between those two cli calls the config file holds a changed value, and ftl's watcher restarts the daemon if it reads the file in that window, which depends on nothing but how long the two invocations take. a restart rebuilds the domain table from the query database, which has no record of domains no query references, so seven cname targets and pi.hole do not come back and their blocking credits go with them: 70 domains instead of 77, and gravity.ftl level with denied.ftl on 4, which then wins top_blocked on table order

`--config -t key value` runs the parse, the validator and the dnsmasq config test, then stops. nothing is installed, pihole.toml is untouched, and the value that would have been stored is printed. exit codes are the setter's own, so an invalid value stays distinguishable from an unknown key or a failed dnsmasq test. the netmask cases use it, and a following read asserts nothing was applied

no assertion is weakened: unique_domains stays 77 and top_blocked stays gravity.ftl, exactly as before

## How to test the change during review

```
pihole-FTL --config -t dhcp.netmask 255.255.254.0   # prints the value, exit 0
pihole-FTL --config dhcp.netmask                    # still unset
pihole-FTL --config -t dhcp.netmask 255.254.255.0   # "not a valid netmask", exit 3
```

the flake reproduces under emulated linux/arm/v6, two runs in twelve before the change: `Restarting FTL due to change of dhcp.netmask` mid-suite in FTL.log, then the two assertions failing in pytest. with the change, twelve iterations under the same emulation and no restart from that write. x86 suite: 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
