### PR TITLE
wait properly for the test resolver, and say so when it does not come

### DIFF
--- a/test/pdns/setup.sh
+++ b/test/pdns/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "************ Installing PowerDNS configuration ************"
 
@@ -156,7 +157,7 @@ pdnsutil zone secure dnssec
 #   dnssec. IN DS 42206 8 2 6d2007e292483fa061db37011676d9592649d1600e5b2ece1326f792ebedd412 ; ( SHA256 digest )
 # --->
 #   trust-anchor=dnssec.,42206,8,2,6d2007e292483fa061db37011676d9592649d1600e5b2ece1326f792ebedd412
-pdnsutil zone export-ds dnssec. | head -n1 | awk '{FS=" "; OFS=""; print "trust-anchor=",$1,",",$4,",",$5,",",$6,",",$7}' > /etc/dnsmasq.d/02-trust-anchor.conf
+pdnsutil zone export-ds dnssec. | awk 'NR==1{FS=" "; OFS=""; print "trust-anchor=",$1,",",$4,",",$5,",",$6,",",$7}' > /etc/dnsmasq.d/02-trust-anchor.conf
 
 # Create a locally-signed root zone so DNSSEC validation never leaves the test
 # environment. FTL ships the real ICANN root trust anchors, so without a local
@@ -164,7 +165,7 @@ pdnsutil zone export-ds dnssec. | head -n1 | awk '{FS=" "; OFS=""; print "trust-
 # rollovers). Serving a signed root here and trusting its key keeps it hermetic.
 pdnsutil zone create . ns1.
 pdnsutil zone secure .
-pdnsutil zone export-ds . | head -n1 | awk '{FS=" "; OFS=""; print "trust-anchor=",$1,",",$4,",",$5,",",$6,",",$7}' >> /etc/dnsmasq.d/02-trust-anchor.conf
+pdnsutil zone export-ds . | awk 'NR==1{FS=" "; OFS=""; print "trust-anchor=",$1,",",$4,",",$5,",",$6,",",$7}' >> /etc/dnsmasq.d/02-trust-anchor.conf
 
 # Create intentionally broken DNSSEC (BOGUS) zone
 # The only difference to above is that this zone is signed with a key that is
@@ -179,8 +180,8 @@ pdnsutil zone secure bogus
 # keytag/algorithm/digest-type as the real key, but a corrupted digest). This
 # makes bogus validation fail as BOGUS *locally* instead of dnsmasq walking up
 # to the real ICANN root to learn the zone has no secure delegation.
-pdnsutil zone export-ds bogus. | head -n1 | \
-  awk '{OFS=""; d=$7; d=substr(d, 1, length(d) - 8) "deadbeef"; print "trust-anchor=", $1, ",", $4, ",", $5, ",", $6, ",", d}' \
+pdnsutil zone export-ds bogus. | \
+  awk 'NR==1{OFS=""; d=$7; d=substr(d, 1, length(d) - 8) "deadbeef"; print "trust-anchor=", $1, ",", $4, ",", $5, ",", $6, ",", d}' \
   >> /etc/dnsmasq.d/02-trust-anchor.conf
 
 # Create reverse lookup zone
@@ -230,17 +231,31 @@ done
 mkdir -p /var/run/pdns-recursor
 rm -f /var/run/pdns-recursor/*
 
+# Wait until a pdns process answers on its port, for up to thirty seconds: a
+# slow or emulated runner takes noticeably longer than a local one, and the
+# tests below are meaningless against a resolver that is not up. Failing here
+# says which process did not start, rather than leaving it to be inferred
+wait_for_pdns() {
+  local port="${1}" name="${2}" i
+  for i in $(seq 1 60); do
+    if dig @127.0.0.1 -p "${port}" ftl. SOA +tries=1 +time=1 +short > /dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "ERROR: ${name} did not answer on port ${port} within 30 s" >&2
+  return 1
+}
+
 # Start authoritative pdns_server and wait for it to accept queries on
 # its configured port (5554) before continuing.
 pdns_server --daemon
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  dig @127.0.0.1 -p 5554 ftl. SOA +tries=1 +time=1 +short > /dev/null 2>&1 && break
-  sleep 0.5
-done
+if ! wait_for_pdns 5554 "pdns_server"; then
+  exit 1
+fi
 
 # Start pdns_recursor and wait for it to accept queries on port 5555.
 pdns_recursor --daemon
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  dig @127.0.0.1 -p 5555 ftl. SOA +tries=1 +time=1 +short > /dev/null 2>&1 && break
-  sleep 0.5
-done
+if ! wait_for_pdns 5555 "pdns_recursor"; then
+  exit 1
+fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -68,7 +68,10 @@ cp test/broken_lua.lp /var/www/html/broken_lua.lp
 cp test/broken_lua_2.lp /var/www/html/broken_lua_2.lp
 
 # Prepare local powerDNS resolver
-bash test/pdns/setup.sh
+if ! bash test/pdns/setup.sh; then
+  echo "Local PowerDNS setup failed, the DNS tests below cannot pass"
+  exit 1
+fi
 
 # Start the DoT/DoH encrypted-upstream test shim (terminates TLS with the repo
 # test certificate and forwards to the local recursor). See test/dotdoh.bats.


### PR DESCRIPTION
# What does this implement/fix?

test/pdns/setup.sh starts pdns_server and pdns_recursor and polls each for five seconds, then carries on whether or not they answered:

```sh
pdns_server --daemon
for _ in 1 2 3 4 5 6 7 8 9 10; do
  dig @127.0.0.1 -p 5554 ftl. SOA +tries=1 +time=1 +short > /dev/null 2>&1 && break
  sleep 0.5
done
```

on a slow or emulated runner that is not always enough, and if the resolver is not up the tests query something that is not there. what follows is a wall of dns failures with nothing saying why, which is a poor way to learn that a daemon did not start

this makes no claim on the intermittent unique_domains failure. that has a confirmed cause in #3073, the dhcp.netmask write tripping the config watcher, and a dead resolver does not fit it

both loops become one wait_for_pdns() that waits thirty seconds and returns failure naming the process and the port, and run.sh stops there rather than running a dns test suite against nothing

low impact and no behaviour change when the resolver comes up, which is the normal case. what it buys is that the other case says what happened

## How to test the change during review

break it on purpose: point pdns at a port already in use, or chmod -x the binary, and the run stops with "ERROR: pdns_server did not answer on port 5554 within 30 s" instead of continuing into a wall of dns failures. setup.sh also runs under set -euo pipefail now, and the suite is unchanged at 194 bats, 151 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
