### PR TITLE
feat: support stdin for --config values via - marker

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -443,6 +443,32 @@ void parse_args(int argc, char *argv[])
 			exit(get_config_from_CLI(argv[2], false));
 		else if(argc == 4 && strcmp(argv[2], "-q") == 0)
 			exit(get_config_from_CLI(argv[3], true));
+		else if(argc == 4 && strcmp(argv[3], "-") == 0)
+		{
+			// Read the value from stdin. Used to keep secrets out of argv
+			// (visible via /proc/<pid>/cmdline and `ps -eo args=`).
+			char buf[4096];
+			if(fgets(buf, sizeof(buf), stdin) == NULL)
+			{
+				fprintf(stderr, "Error: Failed to read value from stdin\n");
+				exit(EXIT_FAILURE);
+			}
+			// Strip trailing CR/LF
+			size_t len = strlen(buf);
+			while(len > 0 && (buf[len-1] == '\n' || buf[len-1] == '\r'))
+				buf[--len] = '\0';
+			// Reject values that did not fit in the buffer. fgets reads
+			// at most sizeof(buf)-1 characters; if it filled the buffer
+			// without encountering a newline, either the input was
+			// truncated (more data follows) or the user sent an
+			// unterminated value. Both are errors.
+			if(len == sizeof(buf) - 1)
+			{
+				fprintf(stderr, "Error: Stdin value too long (max %zu bytes)\n", sizeof(buf) - 1);
+				exit(EXIT_FAILURE);
+			}
+			exit(set_config_from_CLI(argv[2], buf, false));
+		}
 		else if(argc == 4)
 			exit(set_config_from_CLI(argv[2], argv[3], false));
 
@@ -452,6 +478,7 @@ void parse_args(int argc, char *argv[])
 			printf("Usage: %s --config [<config item key>] [<value>]\n", argv[0]);
 			printf("       %s --config -t <config item key> <value>\n", argv[0]);
 			printf("Example: %s --config dns.CNAMEdeepInspect true\n", argv[0]);
+			printf("         echo 'secret' | %s --config webserver.api.password -\n", argv[0]);
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -1356,6 +1383,7 @@ void parse_args(int argc, char *argv[])
 			printf("\t                    Config items with non-default values may\n");
 			printf("\t                    be colored in %sred%s\n", red, normal);
 			printf("\t%s--config %skey %svalue%s  Set new %svalue%s of config item %skey%s\n", green, blue, cyan, normal, cyan, normal, blue, normal);
+			printf("\t%s--config %skey -%s      Set new value of config item %skey%s by reading from stdin\n", green, blue, normal, blue, normal);
 			printf("\t%s--config -t %skey %svalue%s\n", green, blue, cyan, normal);
 			printf("\t                    Check whether %svalue%s would be accepted for\n", cyan, normal);
 			printf("\t                    %skey%s, without applying it or writing the\n", blue, normal);

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1740,6 +1740,82 @@ setup() {
   assert_line --partial --index 0 '"no password set"'
 }
 
+@test "CLI: Setting password via stdin (--config <key> -) leaves no net change" {
+  # Set password via stdin (value is piped, not in argv)
+  logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
+  run bash -c "echo 'STDIN_PW' | ./pihole-FTL --config webserver.api.password -"
+  assert_success
+
+  # Wait for the running FTL instance to pick up the config file change
+  run bash -c "./pihole-FTL wait-for 'pihole.toml unchanged' /var/log/pihole/FTL.log 5 $logsize_before"
+  assert_success
+
+  # Verify login is required
+  run bash -c 'curl -s 127.0.0.1/api/auth'
+  assert_line --partial --index 0 '"valid":false'
+
+  # Verify the stdin-supplied password works
+  run bash -c 'curl -s -X POST 127.0.0.1/api/auth -d "{\"password\":\"STDIN_PW\"}" | jq .session.valid'
+  assert_line --index 0 "true"
+
+  # Verify the password was never present in the long-running FTL
+  # daemon's argv. The daemon was started without --config so its
+  # cmdline should not contain the password.
+  for pid in $(pidof pihole-FTL 2>/dev/null); do
+    if [ -r "/proc/$pid/cmdline" ]; then
+      ! tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q "STDIN_PW"
+    fi
+  done
+
+  # Remove password via stdin (empty value)
+  logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
+  run bash -c "echo '' | ./pihole-FTL --config webserver.api.password -"
+  assert_success
+
+  # Wait for the running FTL instance to pick up the config file change
+  run bash -c "./pihole-FTL wait-for 'pihole.toml unchanged' /var/log/pihole/FTL.log 5 $logsize_before"
+  assert_success
+
+  # Verify no login is required again
+  run bash -c 'curl -s 127.0.0.1/api/auth'
+  assert_line --partial --index 0 '"valid":true'
+  assert_line --partial --index 0 '"no password set"'
+}
+
+@test "CLI: Stdin --config rejects values longer than 4095 bytes" {
+  # Generate a value that is exactly 4096 bytes (no newline within the
+  # 4096-byte buffer means the value did not fit and would be silently
+  # truncated). The CLI must refuse this with a non-zero exit code.
+  run bash -c "python3 -c 'import sys; sys.stdout.write(\"a\"*4096)' | ./pihole-FTL --config webserver.api.password -"
+  assert_failure
+  assert_output --partial "too long"
+}
+
+@test "CLI: Stdin --config reads only the first line for multi-line input" {
+  # For multi-line input, only the first line is consumed. The second
+  # line ("SECOND_LINE") is dropped. We verify by piping "MULTI\nSECOND"
+  # and confirming only "MULTI" was set.
+  logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
+  run bash -c "printf 'MULTI\nSECOND_LINE\n' | ./pihole-FTL --config webserver.api.password -"
+  assert_success
+
+  # Wait for the running FTL instance to pick up the config file change
+  run bash -c "./pihole-FTL wait-for 'pihole.toml unchanged' /var/log/pihole/FTL.log 5 $logsize_before"
+  assert_success
+
+  # Only the first line was used as the password
+  run bash -c 'curl -s -X POST 127.0.0.1/api/auth -d "{\"password\":\"MULTI\"}" | jq .session.valid'
+  assert_line --index 0 "true"
+
+  # The second line was NOT used
+  run bash -c 'curl -s -X POST 127.0.0.1/api/auth -d "{\"password\":\"SECOND_LINE\"}" | jq .session.valid'
+  refute_line --index 0 "true"
+
+  # Cleanup: remove the password
+  run bash -c "./pihole-FTL --config webserver.api.password \"\""
+  assert_success
+}
+
 @test "Test TLS/SSL server using self-signed certificate" {
   # -s: silent
   # -I: HEAD request

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1758,15 +1758,6 @@ setup() {
   run bash -c 'curl -s -X POST 127.0.0.1/api/auth -d "{\"password\":\"STDIN_PW\"}" | jq .session.valid'
   assert_line --index 0 "true"
 
-  # Verify the password was never present in the long-running FTL
-  # daemon's argv. The daemon was started without --config so its
-  # cmdline should not contain the password.
-  for pid in $(pidof pihole-FTL 2>/dev/null); do
-    if [ -r "/proc/$pid/cmdline" ]; then
-      ! tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q "STDIN_PW"
-    fi
-  done
-
   # Remove password via stdin (empty value)
   logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
   run bash -c "echo '' | ./pihole-FTL --config webserver.api.password -"
@@ -1777,6 +1768,68 @@ setup() {
   assert_success
 
   # Verify no login is required again
+  run bash -c 'curl -s 127.0.0.1/api/auth'
+  assert_line --partial --index 0 '"valid":true'
+  assert_line --partial --index 0 '"no password set"'
+}
+
+@test "CLI: Password set via stdin is never visible in the process argv" {
+  # The value must never enter the process command line: argv is visible to
+  # other unprivileged users via /proc/<pid>/cmdline and `ps -eo args=`.
+  # Start the CLI with stdin connected to an empty FIFO so it blocks inside
+  # fgets() while we inspect its /proc/<pid>/cmdline, holding only the "-"
+  # marker. FD 9 keeps the FIFO's writer side open: fgets() blocks instead
+  # of seeing EOF. FD 3 belongs to BATS (TAP protocol) and must not be
+  # touched here. If the CLI never starts, kill it so the suite is
+  # not left with a stuck process.
+  tmp="$(mktemp -d)"
+  fifo="${tmp}/pw"
+  mkfifo "${fifo}"
+  ./pihole-FTL --config webserver.api.password - < "${fifo}" > /dev/null 2>&1 &
+  cli_pid=$!
+  exec 9>"${fifo}"
+
+  # Wait until the real binary is running: before execve, /proc/<pid>/cmdline
+  # still holds the fork's argv and would let this test pass vacuously
+  ready=0
+  for _ in $(seq 1 100); do
+    if tr '\0' ' ' < "/proc/${cli_pid}/cmdline" 2>/dev/null | grep -q 'pihole-FTL'; then
+      ready=1
+      break
+    fi
+    sleep 0.05
+  done
+  if [ "${ready}" -ne 1 ]; then
+    kill "${cli_pid}" 2>/dev/null
+    wait "${cli_pid}" 2>/dev/null
+    exec 9>&-
+    rm -rf "${tmp}"
+    fail "CLI process never started"
+  fi
+
+  # argv holds only the "-" marker, never the password itself
+  run bash -c "tr '\\0' ' ' < /proc/${cli_pid}/cmdline"
+  assert_success
+  assert_output --partial "pihole-FTL --config webserver.api.password -"
+  refute_output --partial "FIFO_PW"
+
+  # Release the blocked reader and let the CLI finish setting the password
+  echo 'FIFO_PW' >&9
+  exec 9>&-
+  wait "${cli_pid}"
+
+  rm -rf "${tmp}"
+
+  # Verify the password set this way actually works ...
+  run bash -c 'curl -s -X POST 127.0.0.1/api/auth -d "{\"password\":\"FIFO_PW\"}" | jq .session.valid'
+  assert_line --index 0 "true"
+
+  # ... and clean up so later tests see no password set
+  logsize_before=$(stat -c%s /var/log/pihole/FTL.log)
+  run bash -c "echo '' | ./pihole-FTL --config webserver.api.password -"
+  assert_success
+  run bash -c "./pihole-FTL wait-for 'pihole.toml unchanged' /var/log/pihole/FTL.log 5 $logsize_before"
+  assert_success
   run bash -c 'curl -s 127.0.0.1/api/auth'
   assert_line --partial --index 0 '"valid":true'
   assert_line --partial --index 0 '"no password set"'


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

`pihole-FTL --config <key> <value>` puts the value in argv, which is visible via `/proc/<pid>/cmdline` and `ps -eo args=`. For secret values (notably the web password) this leaks to other unprivileged users for the lifetime of the child process.

**How does this PR accomplish the above?:**

Allow reading the value from stdin by passing `-` in place of the value: `echo secret | pihole-FTL --config webserver.api.password -`. fgets reads up to 4095 bytes into a stack buffer, trailing CR/LF is stripped, and the existing set_config_from_CLI validation pipeline is reused unchanged.

Buffer is bounded at 4096 bytes; values that fill the buffer without a terminating newline are rejected with a clear error rather than silently truncated.

**Link documentation PRs if any are needed to support this PR:**

TBD

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
