### PR TITLE
dot: fix compilation without TLS and warn if a thread is created with no TLS support

### DIFF
--- a/src/dotdoh/dot_server.c
+++ b/src/dotdoh/dot_server.c
@@ -843,6 +843,9 @@ void *dotdoh_dot_thread(void *val)
 void *dotdoh_dot_thread(void *val)
 {
 	(void)val;
+	// The log also gives the stub a side effect, so it is not mistaken for a
+	// candidate for __attribute__((const)) under -Wsuggest-attribute=const.
+	log_warn("FTL was compiled without TLS support, DoT is not available");
 	return NULL;
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Currently `./build.sh -DUSE_TLS=OFF` fails with:
```log
src/dotdoh/dot_server.c: In function ‘dotdoh_dot_thread’:
src/dotdoh/dot_server.c:843:7: error: function might be candidate for attribute ‘const’ [-Werror=suggest-attribute=const]
  843 | void *dotdoh_dot_thread(void *val)
      |       ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [src/dotdoh/CMakeFiles/dotdoh.dir/build.make:205: src/dotdoh/CMakeFiles/dotdoh.dir/dot_server.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1250: src/dotdoh/CMakeFiles/dotdoh.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```

I chose to add a side effect by logging a waring if DoT is enabled, but FTL was built without OpenSSL, this also informs the user why DoT is not available.

**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
