### PR TITLE
Fix timestamp losing ms accuracy for rolling-over seconds

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -80,10 +80,13 @@ double double_time(void)
 }
 
 // Get a human-readable time string
-void get_timestr(char timestring[TIMESTR_SIZE], const time_t timein, const bool millis, const bool uri_compatible)
+// timein is a double epoch-seconds timestamp as produced by double_time() so
+// that the millisecond fraction comes from the timestamp itself
+void get_timestr(char timestring[TIMESTR_SIZE], const double timein, const bool millis, const bool uri_compatible)
 {
+	const time_t seconds = (time_t)timein;
 	struct tm tm;
-	localtime_r(&timein, &tm);
+	localtime_r(&seconds, &tm);
 	char space = ' ';
 	char colon = ':';
 	if(uri_compatible)
@@ -94,9 +97,7 @@ void get_timestr(char timestring[TIMESTR_SIZE], const time_t timein, const bool 
 
 	if(millis)
 	{
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		const int millisec = tv.tv_usec/1000;
+		const int millisec = (int)((timein - seconds) * 1000.0);
 
 		snprintf(timestring, TIMESTR_SIZE, "%d-%02d-%02d%c%02d%c%02d%c%02d.%03i%c%s",
 		        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, space,
@@ -264,7 +265,7 @@ void __attribute__ ((format (printf, 3, 4))) _FTL_log(const int priority, const 
 		return;
 
 	// Get human-readable time
-	get_timestr(timestring, time(NULL), true, false);
+	get_timestr(timestring, double_time(), true, false);
 
 	// Get and log PID of current process to avoid ambiguities when more than one
 	// pihole-FTL instance is logging into the same file
@@ -342,7 +343,7 @@ void __attribute__ ((format (printf, 3, 4))) _log_web(const int priority, const 
 		return;
 
 	char timestring[TIMESTR_SIZE];
-	const time_t now = time(NULL);
+	const double now = double_time();
 	va_list args;
 
 	// Get human-readable time

--- a/src/log.h
+++ b/src/log.h
@@ -51,7 +51,7 @@ unsigned int get_year(const time_t timein);
 const char *get_FTL_version(void);
 void log_FTL_version(bool crashreport);
 double double_time(void);
-void get_timestr(char timestring[TIMESTR_SIZE], const time_t timein, const bool millis, const bool uri_compatible);
+void get_timestr(char timestring[TIMESTR_SIZE], const double timein, const bool millis, const bool uri_compatible);
 const char *priostr(const int priority, const enum debug_flag flag)  __attribute__((const));
 const char *debugstr(const enum debug_flag flag) __attribute__((const));
 const char *get_ordinal_suffix(unsigned int number) __attribute__ ((const));

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -1943,7 +1943,7 @@ void dump_strings(void)
 	if(str_dumpfile != NULL)
 	{
 		char timestring[TIMESTR_SIZE] = { 0 };
-		get_timestr(timestring, time(NULL), true, false);
+		get_timestr(timestring, double_time(), true, false);
 		fprintf(str_dumpfile, "String dump starting at %s\n", timestring);
 		log_info("String dump to "STRING_DUMPFILE);
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Make `get_timestr()` take a `double` instead of `time_t` per **DL6ER**'s request in https://github.com/pi-hole/FTL/pull/3079#issuecomment-5580756721.
This avoids re-sampling the time via `gettimeofday()` if millies are requested, which may result in a different second losing millisecond accuracy.

We use `double` because it is an already established pattern across the codebase via functions like `double_time()`. Precision is not an issue, as it will remain accurate to at least a microsecond for over 100a

~~Make `get_timestr()` take a `struct timespec` instead of `time_t`.
This avoids re-sampling the time via `gettimeofday()` if millies are requested, which may result in a different second losing millisecond accuracy.~~

~~Why `struct timespec` and not `struct timeval`?
`timeval` may seem more fitting because we never use the nanosecond representation provided by `timespec`. I still prefer it because `timespec` is explicitly preferred by POSIX and recommended for new APIs. In fact, gettimeofday() got marked as obsolete in The Open Group Specification Issue 7 (POSIX.1-2008) and officially removed in The Open Group Specification Issue 8 (POSIX.1-2024). This shows that `timeval` is effectively obsolete and shouldn't be relied upon in new code.~~


This PR is not simply about fixing the bug, but also about modernization of the API, as it will be beneficial to my further logging changes and also for https://github.com/pi-hole/FTL/pull/3005.

**How does this PR accomplish the above?:**

~~Change the parameter of `get_timestr()`.
Convert all existing calls to use `clock_gettime()` if ms are wanted or the `(struct timespec){ .tv_sec = now, .tv_nsec = 0 }` pattern if ms are not required to easily convert an existing `time_t` to `struct timespec`.~~


**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*