### PR TITLE
Change CSP for img-src to allow inline Base64 encoded data URIs

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -881,7 +881,7 @@ components:
             threads: 0
             headers:
               - "X-DNS-Prefetch-Control: off"
-              - "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'"
+              - "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'"
               - "X-Frame-Options: DENY"
               - "X-XSS-Protection: 0"
               - "X-Content-Type-Options: nosniff"

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1108,7 +1108,7 @@ void initConfig(struct config *conf)
 	conf->webserver.headers.f = FLAG_RESTART_FTL;
 	conf->webserver.headers.d.json = cJSON_CreateArray();
 	cJSON_AddItemToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("X-DNS-Prefetch-Control: off"));
-	cJSON_AddItemToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'"));
+	cJSON_AddItemToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'"));
 	cJSON_AddItemToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("X-Frame-Options: DENY"));
 	cJSON_AddItemToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("X-XSS-Protection: 0"));
 	cJSON_AddItemToArray(conf->webserver.headers.d.json, cJSON_CreateStringReference("X-Content-Type-Options: nosniff"));

--- a/src/config/toml_reader.c
+++ b/src/config/toml_reader.c
@@ -130,6 +130,35 @@ static bool migrate_dns_domain(toml_datum_t toml, struct config *newconf)
 }
 
 
+// The default Content-Security-Policy before img-src was allowed to load
+// data: URIs
+#define CSP_HEADER_OLD "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'"
+#define CSP_HEADER_NEW "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'"
+
+static bool migrate_webserver_csp(struct config *newconf)
+{
+	cJSON *header = NULL;
+	int idx = 0;
+
+	// Only replace the policy if it is 1:1 the old default - anyone who
+	// wrote their own Content-Security-Policy keeps it
+	cJSON_ArrayForEach(header, newconf->webserver.headers.v.json)
+	{
+		if(cJSON_IsString(header) && strcmp(header->valuestring, CSP_HEADER_OLD) == 0)
+		{
+			log_debug(DEBUG_CONFIG, "Config setting webserver.headers MIGRATED to CSP img-src 'self' data:");
+			cJSON_ReplaceItemInArray(newconf->webserver.headers.v.json, idx,
+			                         cJSON_CreateString(CSP_HEADER_NEW));
+			return true;
+		}
+		idx++;
+	}
+
+	log_debug(DEBUG_CONFIG, "webserver.headers does not carry the old CSP default - nothing to migrate");
+
+	return false;
+}
+
 // Migrate config from old to new, returns true if a restart is required to
 // apply the changes
 static bool migrate_config(toml_datum_t toml, struct config *newconf)
@@ -140,6 +169,8 @@ static bool migrate_config(toml_datum_t toml, struct config *newconf)
 	restart |= migrate_dns_revServer(toml, newconf);
 	// Migrate dns.domain -> dns.domain.name
 	restart |= migrate_dns_domain(toml, newconf);
+	// Migrate the old Content-Security-Policy default to allow data: images
+	restart |= migrate_webserver_csp(newconf);
 
 	return restart;
 }

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -989,7 +989,7 @@
   #     An array of HTTP headers
   headers = [
     "X-DNS-Prefetch-Control: off",
-    "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'",
+    "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'",
     "X-Frame-Options: DENY",
     "X-XSS-Protection: 0",
     "X-Content-Type-Options: nosniff",

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1903,7 +1903,7 @@ setup() {
   assert_success
   run bash -c 'grep -F "Webserver option 6/13: authentication_domain=pi.hole" /var/log/pihole/webserver.log'
   assert_success
-  run bash -c 'grep -F "Webserver option 7/13: additional_header=X-DNS-Prefetch-Control: off\r\nContent-Security-Policy: default-src '"'none'"'; connect-src '"'self'"'; font-src '"'self'"'; frame-ancestors '"'none'"'; img-src '"'self'"'; manifest-src '"'self'"'; script-src '"'self'"'; style-src '"'self'"' '"'unsafe-inline'"'; form-action '"'self'"'\r\nX-Frame-Options: DENY\r\nX-XSS-Protection: 0\r\nX-Content-Type-Options: nosniff\r\nReferrer-Policy: strict-origin-when-cross-origin\r\n" /var/log/pihole/webserver.log'
+  run bash -c 'grep -F "Webserver option 7/13: additional_header=X-DNS-Prefetch-Control: off\r\nContent-Security-Policy: default-src '"'none'"'; connect-src '"'self'"'; font-src '"'self'"'; frame-ancestors '"'none'"'; img-src '"'self'"' data:; manifest-src '"'self'"'; script-src '"'self'"'; style-src '"'self'"' '"'unsafe-inline'"'; form-action '"'self'"'\r\nX-Frame-Options: DENY\r\nX-XSS-Protection: 0\r\nX-Content-Type-Options: nosniff\r\nReferrer-Policy: strict-origin-when-cross-origin\r\n" /var/log/pihole/webserver.log'
   assert_success
   run bash -c 'grep -F "Webserver option 8/13: index_files=index.html,index.htm,index.lp" /var/log/pihole/webserver.log'
   assert_success


### PR DESCRIPTION
### What does this PR aim to accomplish?

Allow the web interface to load Base64 encoded images from Bootstrap 5 CSS files.

### How does this PR accomplish the above?

Adding `data:` to the `img-src` Content Security Policy.

**NOTE:**
This will change the default value for new installations, but it won't change the current `webserver.headers` value from previous installations.

--- 

**CSP evaluation:**
<img width="1121" height="1040" alt="image" src="https://github.com/user-attachments/assets/22fa3a1c-51ce-4f4e-8126-14cd285f36b3" />


### Link documentation PRs if any are needed to support this PR:

None

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
