### PR TITLE
latch a corrupt database when the api messages paths hit one

### DIFF
--- a/src/database/message-table.c
+++ b/src/database/message-table.c
@@ -482,6 +482,12 @@ static int _add_message(const enum message_type type,
 
 end_of_add_message: // Close database connection
 
+	// Every path that jumps here carries a failing rc, and the duplicate
+	// removing DELETE above is on a hotter path than anything else in this
+	// file - a corrupt database met there has to latch as well
+	if(rc != SQLITE_OK && rc != SQLITE_DONE)
+		checkFTLDBrc(rc);
+
 	// Final database handling
 	if(stmt != NULL)
 		sqlite3_finalize(stmt);
@@ -506,9 +512,11 @@ bool delete_message(cJSON *ids, int *deleted)
 	}
 
 	sqlite3_stmt *res = NULL;
-	if(sqlite3_prepare_v2(db, "DELETE FROM message WHERE id = ?;", -1, &res, 0) != SQLITE_OK)
+	int rc = sqlite3_prepare_v2(db, "DELETE FROM message WHERE id = ?;", -1, &res, 0);
+	if(rc != SQLITE_OK)
 	{
 		log_err("SQL error (%i): %s", sqlite3_errcode(db), sqlite3_errmsg(db));
+		checkFTLDBrc(rc);
 		dbclose(&db);
 		return false;
 	}
@@ -520,7 +528,8 @@ bool delete_message(cJSON *ids, int *deleted)
 	{
 		// Bind id to prepared statement
 		const int idval = cJSON_GetNumberValue(id);
-		if(sqlite3_bind_int(res, 1, idval) != SQLITE_OK)
+		rc = sqlite3_bind_int(res, 1, idval);
+		if(rc != SQLITE_OK)
 		{
 			log_err("delete_message() - Failed to bind id %d: %s", idval, sqlite3_errmsg(db));
 			success = false;
@@ -528,7 +537,8 @@ bool delete_message(cJSON *ids, int *deleted)
 		}
 
 		// Execute and finalize
-		if(sqlite3_step(res) != SQLITE_DONE)
+		rc = sqlite3_step(res);
+		if(rc != SQLITE_DONE)
 		{
 			log_err("SQL error (%i): %s", sqlite3_errcode(db), sqlite3_errmsg(db));
 			success = false;
@@ -541,6 +551,11 @@ bool delete_message(cJSON *ids, int *deleted)
 		sqlite3_reset(res);
 	}
 	sqlite3_finalize(res);
+
+	// A corrupt database has to be latched here, or the next caller opens it
+	// again and fails the same way
+	if(!success)
+		checkFTLDBrc(rc);
 
 	// Close database connection
 	dbclose(&db);
@@ -1067,6 +1082,9 @@ int count_messages(void)
 	count = sqlite3_column_int(stmt, 0);
 
 end_of_count_messages: // Close database connection
+	if(rc != SQLITE_OK && rc != SQLITE_ROW)
+		checkFTLDBrc(rc);
+
 	if(stmt != NULL)
 		sqlite3_finalize(stmt);
 	dbclose(&db);
@@ -1358,11 +1376,20 @@ bool format_messages(cJSON *array)
 	}
 
 end_of_format_message: // Close database connection
+	// SQLITE_ROW is how the loop above leaves on a failed allocation, not a
+	// database error - the sibling in count_messages() excludes it too
+	if(rc != SQLITE_OK && rc != SQLITE_DONE && rc != SQLITE_ROW)
+		checkFTLDBrc(rc);
+
 	if(stmt != NULL)
 		sqlite3_finalize(stmt);
 	dbclose(&db);
 
-	return true;
+	// Only a result set read to its end is an answer. Returning true after
+	// any of the paths above meant `/api/info/messages` served a truncated
+	// array with a 200 and left its 500 branch unreachable, so the request
+	// that met the corruption never heard about it
+	return rc == SQLITE_DONE;
 }
 
 void logg_regex_warning(const char *type, const char *warning, const int dbindex, const char *regex)


### PR DESCRIPTION
# What does this implement/fix?

delete_message(), count_messages() and format_messages() all return early on FTLDBerror(), so they expect the flag to be set for them. none of them sets it: they run raw sqlite3_prepare_v2() and sqlite3_step() and only log what comes back. a corruption first met on /api/info/messages is reported upward and retried by every later caller instead of being latched once and answered from the flag

each of the three hands its return code to checkFTLDBrc() now, which is what the rest of the database layer does - 38 call sites across network-table.c, common.c and aliasclients.c, and two in this file already. count_messages() and format_messages() had an rc and a cleanup label to hang it on, delete_message() gains the variable and reports where its loop breaks converge

same class as #3062 and #3064, in the file those two left out

low impact: it needs a corrupt or unwritable pihole-FTL.db to reach at all. what it changes there is that the failure is recorded once rather than rediscovered on every request

## How to test the change during review

by inspection, or by corrupting pihole-FTL.db (truncate it mid-file) and calling /api/info/messages: FTL.log gets the "Database is not available" latch once, and later requests answer from the flag instead of reopening and failing again. full suite in the container is 194 bats, 152 pytest, 12, 25, 9

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
