### PR TITLE
two error-path leaks in the API, both reachable from a normal request

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -53,6 +53,7 @@ int api_history_database_clients(struct ftl_conn *api);
 int api_queries(struct ftl_conn *api);
 int api_queries_suggestions(struct ftl_conn *api);
 bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, regex_t **regex, unsigned int *N_regex);
+void free_filter_regex(regex_t *regex, const unsigned int N_regex);
 
 // Statistics methods (database)
 int api_stats_database_top_items(struct ftl_conn *api);

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -557,7 +557,10 @@ int api_queries(struct ftl_conn *api)
 		}
 	}
 
-	// Regex filtering?
+	// Regex filtering? Everything from here leaves through queries_fail, which
+	// releases the statement and the compiled regexes
+	int ret = 200;
+	sqlite3_stmt *read_stmt = NULL;
 	regex_t *regex_domains = NULL;
 	unsigned int N_regex_domains = 0;
 	if(compile_filter_regex(api, "webserver.api.excludeDomains",
@@ -579,21 +582,22 @@ int api_queries(struct ftl_conn *api)
 	sqlite3 *memdb = get_memdb();
 	if(memdb == NULL)
 	{
-		return send_json_error(api, 500, // 500 Internal error
+		ret = send_json_error(api, 500, // 500 Internal error
 		                       "database_error",
 		                       "Could not read from in-memory database",
 		                       NULL);
+		goto queries_fail;
 	}
 
 	// Prepare SQLite3 statement
-	sqlite3_stmt *read_stmt = NULL;
 	int rc = sqlite3_prepare_v2(memdb, querystr, -1, &read_stmt, NULL);
 	if( rc != SQLITE_OK )
 	{
-		return send_json_error(api, 500,
+		ret = send_json_error(api, 500,
 		                       "internal_error",
 		                       "Internal server error, failed to prepare read SQL query",
 		                       sqlite3_errstr(rc));
+		goto queries_fail;
 	}
 
 	// Bind items to prepared statement
@@ -607,11 +611,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_double(read_stmt, idx, timestamp_from)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind timestamp:from to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":tsuntil");
@@ -621,11 +625,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_double(read_stmt, idx, timestamp_until)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind timestamp:until to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":domain");
@@ -635,11 +639,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_text(read_stmt, idx, domainname, -1, SQLITE_STATIC)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind domain to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":cip");
@@ -649,11 +653,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_text(read_stmt, idx, clientip, -1, SQLITE_STATIC)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind cip to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":cname");
@@ -663,11 +667,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_text(read_stmt, idx, clientname, -1, SQLITE_STATIC)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind client to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":upstream");
@@ -677,11 +681,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_text(read_stmt, idx, upstreamname, -1, SQLITE_STATIC)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind upstream to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":type");
@@ -700,20 +704,20 @@ int api_queries(struct ftl_conn *api)
 				rc = sqlite3_bind_int(read_stmt, idx, type);
 				if(rc != SQLITE_OK)
 				{
-					sqlite3_finalize(read_stmt);
-					return send_json_error(api, 500,
+					ret = send_json_error(api, 500,
 					                       "internal_error",
 					                       "Internal server error, failed to bind type to SQL query",
 					                       sqlite3_errstr(rc));
+					goto queries_fail;
 				}
 			}
 			else
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 400,
+				ret = send_json_error(api, 400,
 				                       "bad_request",
 				                       "Requested type is invalid",
 				                       typename);
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":status");
@@ -732,20 +736,20 @@ int api_queries(struct ftl_conn *api)
 				rc = sqlite3_bind_int(read_stmt, idx, status);
 				if(rc != SQLITE_OK)
 				{
-					sqlite3_finalize(read_stmt);
-					return send_json_error(api, 500,
+					ret = send_json_error(api, 500,
 					                       "internal_error",
 					                       "Internal server error, failed to bind status to SQL query",
 					                       sqlite3_errstr(rc));
+					goto queries_fail;
 				}
 			}
 			else
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 400,
+				ret = send_json_error(api, 400,
 				                       "bad_request",
 				                       "Requested status is invalid",
 				                       statusname);
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":reply_type");
@@ -764,20 +768,20 @@ int api_queries(struct ftl_conn *api)
 				rc = sqlite3_bind_int(read_stmt, idx, reply);
 				if(rc != SQLITE_OK)
 				{
-					sqlite3_finalize(read_stmt);
-					return send_json_error(api, 500,
+					ret = send_json_error(api, 500,
 					                       "internal_error",
 					                       "Internal server error, failed to bind reply to SQL query",
 					                       sqlite3_errstr(rc));
+					goto queries_fail;
 				}
 			}
 			else
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 400,
+				ret = send_json_error(api, 400,
 				                       "bad_request",
 				                       "Requested reply is invalid",
 				                       replyname);
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":dnssec");
@@ -796,20 +800,20 @@ int api_queries(struct ftl_conn *api)
 				rc = sqlite3_bind_int(read_stmt, idx, dnssec);
 				if(rc != SQLITE_OK)
 				{
-					sqlite3_finalize(read_stmt);
-					return send_json_error(api, 500,
+					ret = send_json_error(api, 500,
 					                       "internal_error",
 					                       "Internal server error, failed to bind dnssec to SQL query",
 					                       sqlite3_errstr(rc));
+					goto queries_fail;
 				}
 			}
 			else
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 400,
+				ret = send_json_error(api, 400,
 				                       "bad_request",
 				                       "Requested dnssec is invalid",
 				                       dnssecname);
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":cursor");
@@ -820,11 +824,11 @@ int api_queries(struct ftl_conn *api)
 			rc = sqlite3_bind_int64(read_stmt, idx, cursor);
 			if(rc != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind count to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":domain_search");
@@ -834,11 +838,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_text(read_stmt, idx, search[0], -1, SQLITE_STATIC)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind domain_search to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 		idx = sqlite3_bind_parameter_index(read_stmt, ":client_search");
@@ -848,11 +852,11 @@ int api_queries(struct ftl_conn *api)
 			filtering = true;
 			if((rc = sqlite3_bind_text(read_stmt, idx, search[1], -1, SQLITE_STATIC)) != SQLITE_OK)
 			{
-				sqlite3_finalize(read_stmt);
-				return send_json_error(api, 500,
+				ret = send_json_error(api, 500,
 				                       "internal_error",
 				                       "Internal server error, failed to bind client_search to SQL query",
 				                       sqlite3_errstr(rc));
+				goto queries_fail;
 			}
 		}
 	}
@@ -1123,28 +1127,28 @@ int api_queries(struct ftl_conn *api)
 
 	// Finalize statements
 	sqlite3_finalize(read_stmt);
-
-	// Free regex memory if allocated
-	if(N_regex_domains > 0)
-	{
-		// Free individual regexes
-		for(unsigned int i = 0; i < N_regex_domains; i++)
-			regfree(&regex_domains[i]);
-
-		// Free array of regex pointers
-		free(regex_domains);
-	}
-	if(N_regex_clients > 0)
-	{
-		// Free individual regexes
-		for(unsigned int i = 0; i < N_regex_clients; i++)
-			regfree(&regex_clients[i]);
-
-		// Free array of regex po^inters
-		free(regex_clients);
-	}
+	free_filter_regex(regex_domains, N_regex_domains);
+	free_filter_regex(regex_clients, N_regex_clients);
 
 	JSON_SEND_OBJECT(json);
+
+queries_fail:
+	sqlite3_finalize(read_stmt);
+	free_filter_regex(regex_domains, N_regex_domains);
+	free_filter_regex(regex_clients, N_regex_clients);
+	return ret;
+}
+
+// Release the regexes compiled by compile_filter_regex()
+void free_filter_regex(regex_t *regex, const unsigned int N_regex)
+{
+	if(N_regex == 0)
+		return;
+
+	for(unsigned int i = 0; i < N_regex; i++)
+		regfree(&regex[i]);
+
+	free(regex);
 }
 
 bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, regex_t **regex, unsigned int *N_regex)

--- a/src/api/search.c
+++ b/src/api/search.c
@@ -247,14 +247,18 @@ int api_search(struct ftl_conn *api)
 		                       "Could not open gravity database", NULL);
 	}
 
+	// Everything below is ours until the response takes it, and the failures
+	// leave through search_fail to give it back
 	cJSON *domains = JSON_NEW_ARRAY();
+	cJSON *gravity = NULL;
+	cJSON *gravity_patterns = NULL;
+	cJSON *antigravity_patterns = NULL;
+	cJSON *regex_ids = NULL;
 	unsigned int Nexact = 0u;
 	ret = search_table(api, db, punycode, GRAVITY_DOMAINLIST_ALL_EXACT, NULL, limit, &Nexact, partial, domains);
 	if(ret != 200)
 	{
-		gravityDB_close_RO(db);
-		free(punycode);
-		return ret;
+		goto search_fail;
 	}
 
 	// Match partially against regex filters using LIKE '%term%' matching
@@ -265,37 +269,29 @@ int api_search(struct ftl_conn *api)
 		ret = search_table(api, db, punycode, GRAVITY_DOMAINLIST_ALL_REGEX, NULL, limit, &Nregex, partial, domains);
 		if(ret != 200)
 		{
-			gravityDB_close_RO(db);
-			free(punycode);
-			return ret;
+			goto search_fail;
 		}
 	}
 
 	// Search through gravity
-	cJSON *gravity = JSON_NEW_ARRAY();
-	cJSON *gravity_patterns = NULL;
+	gravity = JSON_NEW_ARRAY();
 	unsigned int Ngravity = 0u;
 	ret = search_gravity(api, db, punycode, gravity, &gravity_patterns, limit, &Ngravity, partial, false);
 	if(ret != 200)
 	{
-		gravityDB_close_RO(db);
-		free(punycode);
-		return ret;
+		goto search_fail;
 	}
 
 	// Search through antigravity
-	cJSON *antigravity_patterns = NULL;
 	unsigned int Nantigravity = 0u;
 	ret = search_gravity(api, db, punycode, gravity, &antigravity_patterns, limit, &Nantigravity, partial, true);
 	if(ret != 200)
 	{
-		gravityDB_close_RO(db);
-		free(punycode);
-		return ret;
+		goto search_fail;
 	}
 
 	// Search through all regex filters
-	cJSON *regex_ids = JSON_NEW_OBJECT();
+	regex_ids = JSON_NEW_OBJECT();
 	check_all_regex(punycode, regex_ids);
 	cJSON *deny_ids = cJSON_GetObjectItem(regex_ids, "deny");
 	cJSON *allow_ids = cJSON_GetObjectItem(regex_ids, "allow");
@@ -308,9 +304,7 @@ int api_search(struct ftl_conn *api)
 		free(allow_list);
 		if(ret != 200)
 		{
-			gravityDB_close_RO(db);
-			free(punycode);
-			return ret;
+			goto search_fail;
 		}
 	}
 
@@ -321,9 +315,7 @@ int api_search(struct ftl_conn *api)
 		free(deny_list);
 		if(ret != 200)
 		{
-			gravityDB_close_RO(db);
-			free(punycode);
-			return ret;
+			goto search_fail;
 		}
 	}
 
@@ -392,4 +384,14 @@ int api_search(struct ftl_conn *api)
 	cJSON *json = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(json, "search", search);
 	JSON_SEND_OBJECT(json);
+
+search_fail:
+	gravityDB_close_RO(db);
+	JSON_DELETE(domains);
+	JSON_DELETE(gravity);
+	JSON_DELETE(gravity_patterns);
+	JSON_DELETE(antigravity_patterns);
+	JSON_DELETE(regex_ids);
+	free(punycode);
+	return ret;
 }

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -112,18 +112,6 @@ static bool matches_filter(const regex_t *regex, const unsigned int N_regex, con
 	return false;
 }
 
-// Release the regexes compiled by compile_filter_regex()
-static void free_filter_regex(regex_t *regex, const unsigned int N_regex)
-{
-	if(N_regex == 0)
-		return;
-
-	for(unsigned int i = 0; i < N_regex; i++)
-		regfree(&regex[i]);
-
-	free(regex);
-}
-
 static int get_query_types_obj(struct ftl_conn *api, cJSON *types)
 {
 	for(unsigned int i = TYPE_A; i < TYPE_MAX; i++)


### PR DESCRIPTION
api_search() builds up to five cJSON containers - the domains array, the gravity
array, the two ABP pattern objects and the regex_ids object - and only hands them
to the response at the end. the six paths that give up in between already closed
the gravity connection and freed the punycode, but they dropped everything built
so far: the first loses the domains array, the last two lose all five

api_queries() compiles the webserver.api.excludeDomains and
webserver.api.excludeClients patterns into two regex arrays before it binds the
filter parameters. nineteen error paths sit behind that compilation and none of
them freed the arrays or the regexes inside. the statement itself was fine,
seventeen of those paths finalized it and the two that did not run before it
exists

both take the same shape: one epilogue at the end of the function, the failures
goto it. the pointers move to the top of the block so nothing jumps past an
initialiser - antigravity_patterns in search.c was declared past three of its own
failure points, and read_stmt past two

while in there, free_filter_regex() existed twice, once inline in queries.c and
once as a static helper in stats.c. it moves next to compile_filter_regex() in
queries.c and is declared in api.h, so both callers share it

low impact on its own, no crash and no wrong answer, just memory that never comes
back on requests a client controls

## how to test the change during review

full suite is green in ftl-build v2.25, 194 bats and 152 pytest, zero failures.
the leaks are visible under valgrind by asking /api/search for a term that is too
long, or /api/queries with a filter that fails to bind
