### PR TITLE
four performance findings, no behaviour change except one new error path

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -167,9 +167,10 @@ int api_handler(struct mg_connection *conn, void *ignored)
 
 			if(api_request[i].opts.flags & API_PARSE_JSON)
 			{
-				// Allocate memory for the payload
-				api.payload.raw = calloc(MAX_PAYLOAD_BYTES, sizeof(char));
-				if(!api.payload.raw)
+				// Read and try to parse payload. The buffer is
+				// allocated in there, and only for a request that
+				// actually carries a body
+				if(!read_and_parse_payload(&api))
 				{
 					log_crit("Cannot handle API request %s %s: %s",
 							api.request->request_method,
@@ -182,9 +183,6 @@ int api_handler(struct mg_connection *conn, void *ignored)
 					                      NULL);
 					break;
 				}
-
-				// Read and try to parse payload
-				read_and_parse_payload(&api);
 			}
 
 			// Verify requesting client is allowed to see this resource

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -728,7 +728,10 @@ static int api_list_write(struct ftl_conn *api,
 		// own while the ones before it were undone, so neither the
 		// per-item results above nor a plain commit failure describe
 		// what is in the database
-		const char *commit_msg = sqlite3_get_autocommit(db) != 0
+		// SQLite has ended the transaction itself if the connection is
+		// back in autocommit, which means part of the batch is on disk
+		const bool partially_applied = sqlite3_get_autocommit(db) != 0;
+		const char *commit_msg = partially_applied
 		                       ? "Gravity database batch was only partially applied"
 		                       : NULL;
 
@@ -744,12 +747,11 @@ static int api_list_write(struct ftl_conn *api,
 
 		if(commit_msg != NULL)
 		{
-			const bool partial = commit_err[0] == '\0';
 			gravityDB_write_close(db);
 
 			// A partially applied batch left rows behind that the
 			// resolver has to pick up, a failed commit left none
-			if(partial)
+			if(partially_applied)
 				set_event(RELOAD_GRAVITY);
 
 			const int ret = send_json_error(api, 500, // 500 Internal Server Error

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -649,16 +649,48 @@ static int api_list_write(struct ftl_conn *api,
 	cJSON *success = JSON_NEW_ARRAY();
 	cJSON_AddItemToObject(processed, "errors", errors);
 	cJSON_AddItemToObject(processed, "success", success);
+
+	// One connection for the whole batch. Adding N items used to open and
+	// close a gravity connection twice per item, once for the item and once
+	// for its groups
+	sqlite3 *db = gravityDB_write_open(&sql_msg);
+	if(db == NULL)
+	{
+		const int ret = send_json_error(api, 500, // 500 Internal Server Error
+		                                "database_error",
+		                                "Could not open gravity database for writing",
+		                                sql_msg);
+		cJSON_Delete(processed);
+		if(allocated_json)
+			cJSON_Delete(row.items);
+		return ret;
+	}
+
+	// And one transaction for the whole batch, so it costs a single commit
+	// rather than one per item. Failing to start it is not fatal, the items
+	// then commit one by one as they did before.
+	//
+	// IMMEDIATE, not the default DEFERRED: a deferred transaction takes only
+	// SHARED and has to promote to RESERVED on the first INSERT, and SQLite
+	// skips the busy handler on that promotion because waiting there could
+	// deadlock. The batch would fail instantly with "database is locked"
+	// during a gravity run, where every item used to get the full
+	// DATABASE_BUSY_TIMEOUT to itself
+	bool in_transaction = sqlite3_exec(db, "BEGIN IMMEDIATE TRANSACTION;", NULL, NULL, NULL) == SQLITE_OK;
+	if(!in_transaction)
+		log_warn("Could not start transaction for gravity batch add: %s",
+		         sqlite3_errmsg(db));
+
 	cJSON_ArrayForEach(elem, row.items)
 	{
 		row.item = elem->valuestring;
-		if((okay = gravityDB_addToTable(listtype, &row, &sql_msg, api->method)))
+		if((okay = gravityDB_addToTable(db, listtype, &row, &sql_msg, api->method)))
 		{
 			if(listtype != GRAVITY_GROUPS)
 			{
 				cJSON *groups = cJSON_GetObjectItemCaseSensitive(api->payload.json, "groups");
 				if(groups != NULL)
-					okay = gravityDB_edit_groups(listtype, groups, &row, &sql_msg);
+					okay = gravityDB_edit_groups(db, listtype, groups, &row, &sql_msg);
 				else
 					// The groups array is optional, we still succeed if it
 					// is omitted (groups stay as they are)
@@ -672,11 +704,65 @@ static int api_list_write(struct ftl_conn *api,
 		}
 
 		cJSON *details = JSON_NEW_OBJECT();
-		JSON_COPY_STR_TO_OBJECT(details, "item", row.item);
-		if(!okay)
-			JSON_COPY_STR_TO_OBJECT(details, "error", sql_msg);
+		if(details == NULL ||
+		   !add_string_to_object(details, "item", row.item, false) ||
+		   (!okay && !add_string_to_object(details, "error", sql_msg, false)))
+		{
+			// Leaving through the JSON macros here would return
+			// from inside the transaction and strand the write
+			// connection, locking gravity.db for good
+			cJSON_Delete(details);
+			goto batch_abort;
+		}
 		cJSON_AddItemToArray(okay ? success : errors, details);
 	}
+
+	// Commit the batch. Nothing above reached the disk before this, so a
+	// failure here has to be reported rather than logged - every item this
+	// response is about to call a success would be lost
+	if(in_transaction)
+	{
+		// SQLite rolls a transaction back by itself on some errors, a
+		// full disk among them, and returns the connection to
+		// autocommit. Items after that point were then written on their
+		// own while the ones before it were undone, so neither the
+		// per-item results above nor a plain commit failure describe
+		// what is in the database
+		const char *commit_msg = sqlite3_get_autocommit(db) != 0
+		                       ? "Gravity database batch was only partially applied"
+		                       : NULL;
+
+		char commit_err[256] = { 0 };
+		if(commit_msg == NULL &&
+		   sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK)
+		{
+			// The message belongs to the connection, take a copy
+			// of it before the handle goes away
+			strncpy(commit_err, sqlite3_errmsg(db), sizeof(commit_err) - 1);
+			commit_msg = "Could not commit to gravity database";
+		}
+
+		if(commit_msg != NULL)
+		{
+			const bool partial = commit_err[0] == '\0';
+			gravityDB_write_close(db);
+
+			// A partially applied batch left rows behind that the
+			// resolver has to pick up, a failed commit left none
+			if(partial)
+				set_event(RELOAD_GRAVITY);
+
+			const int ret = send_json_error(api, 500, // 500 Internal Server Error
+			                                "database_error",
+			                                commit_msg,
+			                                commit_err[0] != '\0' ? commit_err : NULL);
+			cJSON_Delete(processed);
+			if(allocated_json)
+				cJSON_Delete(row.items);
+			return ret;
+		}
+	}
+	gravityDB_write_close(db);
 
 	// If all items failed, return a database error instead of
 	// a success response with an empty result set
@@ -721,6 +807,32 @@ static int api_list_write(struct ftl_conn *api,
 		cJSON_Delete(row.items);
 
 	return ret;
+
+batch_abort:
+	// The response cannot be assembled any more. Undo what this transaction
+	// holds if it is still ours to undo - if SQLite has already ended it,
+	// part of the batch is on disk and the resolver has to hear about it
+	{
+		bool committed = !in_transaction;
+		if(in_transaction)
+		{
+			if(sqlite3_get_autocommit(db) != 0)
+				committed = true;
+			else
+				sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+		}
+
+		gravityDB_write_close(db);
+
+		if(committed)
+			set_event(RELOAD_GRAVITY);
+	}
+
+	cJSON_Delete(processed);
+	if(allocated_json)
+		cJSON_Delete(row.items);
+
+	return send_http_internal_error(api);
 }
 
 static int api_list_remove(struct ftl_conn *api,

--- a/src/api/list.c
+++ b/src/api/list.c
@@ -17,11 +17,48 @@
 #include "shmem.h"
 // getNameFromIP()
 #include "database/network-table.h"
+// dbopen()
+#include "database/common.h"
 // valid_domain()
 #include "tools/gravity-parseList.h"
 // parse_groupIDs()
 #include "webserver/http-common.h"
 #include <idn2.h>
+
+// cJSON_AddStringToObject() that reports a failure rather than returning 500
+// from the middle of a loop that is holding a database handle open
+static bool add_string_to_object(cJSON *object, const char *key, const char *string,
+                                 const bool reference)
+{
+	cJSON *item = NULL;
+	if(string == NULL)
+		item = cJSON_CreateNull();
+	else
+		item = reference ? cJSON_CreateStringReference(string)
+		                 : cJSON_CreateString(string);
+	if(item == NULL)
+		return false;
+
+	cJSON_AddItemToObject(object, key, item);
+	return true;
+}
+
+// The JSON_* macros answer 500 and return where they fail. Inside the row loop
+// of api_list_read() that would strand the statement and the name-resolution
+// connection it holds, so these do the same job and leave through a label that
+// releases both
+#define ROW_COPY_STR(obj, key, str) do { \
+	if(!add_string_to_object(obj, key, str, false)) goto list_read_fail; \
+} while(0)
+#define ROW_REF_STR(obj, key, str) do { \
+	if(!add_string_to_object(obj, key, str, true)) goto list_read_fail; \
+} while(0)
+#define ROW_ADD_NUM(obj, key, num) do { \
+	if(cJSON_AddNumberToObject(obj, key, num) == NULL) goto list_read_fail; \
+} while(0)
+#define ROW_ADD_BOOL(obj, key, val) do { \
+	if(cJSON_AddBoolToObject(obj, key, val) == NULL) goto list_read_fail; \
+} while(0)
 
 static int api_list_read(struct ftl_conn *api,
                          const int code,
@@ -33,59 +70,96 @@ static int api_list_read(struct ftl_conn *api,
 	sqlite3_stmt *stmt = NULL;
 	if(!gravityDB_readTable(NULL, listtype, item, &sql_msg, true, NULL, &stmt))
 	{
+		JSON_DELETE(processed);
 		return send_json_error(api, 500, // 500 Internal Server Error
 		                       "database_error",
 		                       "Could not read domains from database table",
 		                       sql_msg);
 	}
 
+	// Everything below leaves through list_read_fail, which releases the
+	// statement, the name-resolution connection and the JSON built so far.
+	// ret stays 0 while nothing has been sent yet
+	int ret = 0;
+	cJSON *row = NULL;
+
+	// Resolving a client name reads pihole-FTL.db, and the lookups open
+	// their own connection when they are not handed one. That is once per
+	// returned row, so open it once here and let every row share it. Both
+	// lookups give up on their own config before they touch the database,
+	// so a setup that resolves nothing must not pay an open at all, and the
+	// open waits for the first row that actually wants a name so an empty
+	// client list does not pay one either. A failure is not fatal, the
+	// lookups then fall back to opening their own
+	const bool resolve_names = listtype == GRAVITY_CLIENTS &&
+	                           (config.resolver.resolveIPv4.v.b ||
+	                            config.resolver.resolveIPv6.v.b ||
+	                            config.resolver.macNames.v.b);
+	sqlite3 *namedb = NULL;
+	bool namedb_tried = false;
+
 	tablerow table = { 0 };
 	cJSON *rows = JSON_NEW_ARRAY();
 	while(gravityDB_readTableGetRow(listtype, &table, &sql_msg, stmt))
 	{
-		cJSON *row = JSON_NEW_OBJECT();
+		row = JSON_NEW_OBJECT();
+		if(row == NULL)
+			goto list_read_fail;
 
 		// Special fields
 		if(listtype == GRAVITY_GROUPS)
 		{
-			JSON_COPY_STR_TO_OBJECT(row, "name", table.name);
-			JSON_COPY_STR_TO_OBJECT(row, "comment", table.comment);
+			ROW_COPY_STR(row, "name", table.name);
+			ROW_COPY_STR(row, "comment", table.comment);
 		}
 		else if(listtype == GRAVITY_ADLISTS ||
 		        listtype == GRAVITY_ADLISTS_BLOCK ||
 		        listtype == GRAVITY_ADLISTS_ALLOW)
 		{
-			JSON_COPY_STR_TO_OBJECT(row, "address", table.address);
-			JSON_COPY_STR_TO_OBJECT(row, "comment", table.comment);
+			ROW_COPY_STR(row, "address", table.address);
+			ROW_COPY_STR(row, "comment", table.comment);
 		}
 		else if(listtype == GRAVITY_CLIENTS)
 		{
 			char name[MAXDOMAINLEN] = { 0 };
-			if(table.client != NULL)
+			if(table.client != NULL && resolve_names)
 			{
-				// Try to obtain hostname
-				if(isValidIPv4(table.client) || isValidIPv6(table.client))
-					getNameFromIP(NULL, name, table.client);
-				else if(isMAC(table.client))
-					getNameFromMAC(table.client, name);
+				const bool is_ip = isValidIPv4(table.client) ||
+				                   isValidIPv6(table.client);
+				if(is_ip || isMAC(table.client))
+				{
+					// First row that needs a name opens the
+					// connection the remaining ones reuse
+					if(!namedb_tried)
+					{
+						namedb = dbopen(false, false);
+						namedb_tried = true;
+					}
+
+					// Try to obtain hostname
+					if(is_ip)
+						getNameFromIP(namedb, name, table.client);
+					else
+						getNameFromMAC(namedb, table.client, name);
+				}
 			}
 
-			JSON_COPY_STR_TO_OBJECT(row, "client", table.client);
-			JSON_COPY_STR_TO_OBJECT(row, "name", name);
-			JSON_COPY_STR_TO_OBJECT(row, "comment", table.comment);
+			ROW_COPY_STR(row, "client", table.client);
+			ROW_COPY_STR(row, "name", name);
+			ROW_COPY_STR(row, "comment", table.comment);
 		}
 		else // domainlists
 		{
 			char *unicode = NULL;
 			const int rc = idn2_to_unicode_lzlz(table.domain, &unicode, IDN2_NONTRANSITIONAL);
-			JSON_COPY_STR_TO_OBJECT(row, "domain", table.domain);
+			ROW_COPY_STR(row, "domain", table.domain);
 			if(rc == IDN2_OK)
-				JSON_COPY_STR_TO_OBJECT(row, "unicode", unicode);
+				ROW_COPY_STR(row, "unicode", unicode);
 			else
-				JSON_COPY_STR_TO_OBJECT(row, "unicode", table.domain);
-			JSON_REF_STR_IN_OBJECT(row, "type", table.type);
-			JSON_REF_STR_IN_OBJECT(row, "kind", table.kind);
-			JSON_COPY_STR_TO_OBJECT(row, "comment", table.comment);
+				ROW_COPY_STR(row, "unicode", table.domain);
+			ROW_REF_STR(row, "type", table.type);
+			ROW_REF_STR(row, "kind", table.kind);
+			ROW_COPY_STR(row, "comment", table.comment);
 			if(unicode != NULL)
 				free(unicode);
 		}
@@ -95,16 +169,9 @@ static int api_list_read(struct ftl_conn *api,
 		{
 			if(table.group_ids != NULL)
 			{
-				const int ret = parse_groupIDs(api, &table, row);
+				ret = parse_groupIDs(api, &table, row);
 				if(ret != 0)
-				{
-					// row is not in rows yet, it is only
-					// appended at the end of the loop body
-					JSON_DELETE(row);
-					JSON_DELETE(rows);
-					gravityDB_readTableFinalize(stmt);
-					return ret;
-				}
+					goto list_read_fail;
 
 			}
 			else
@@ -117,29 +184,33 @@ static int api_list_read(struct ftl_conn *api,
 
 		// Clients don't have the enabled property
 		if(listtype != GRAVITY_CLIENTS)
-			JSON_ADD_BOOL_TO_OBJECT(row, "enabled", table.enabled);
+			ROW_ADD_BOOL(row, "enabled", table.enabled);
 
 		// Add read-only database parameters
-		JSON_ADD_NUMBER_TO_OBJECT(row, "id", table.id);
-		JSON_ADD_NUMBER_TO_OBJECT(row, "date_added", table.date_added);
-		JSON_ADD_NUMBER_TO_OBJECT(row, "date_modified", table.date_modified);
+		ROW_ADD_NUM(row, "id", table.id);
+		ROW_ADD_NUM(row, "date_added", table.date_added);
+		ROW_ADD_NUM(row, "date_modified", table.date_modified);
 
 		// Properties added in https://github.com/pi-hole/pi-hole/pull/3951
 		if(listtype == GRAVITY_ADLISTS ||
 		   listtype == GRAVITY_ADLISTS_BLOCK ||
 		   listtype == GRAVITY_ADLISTS_ALLOW)
 		{
-			JSON_REF_STR_IN_OBJECT(row, "type", table.type);
-			JSON_ADD_NUMBER_TO_OBJECT(row, "date_updated", table.date_updated);
-			JSON_ADD_NUMBER_TO_OBJECT(row, "number", table.number);
-			JSON_ADD_NUMBER_TO_OBJECT(row, "invalid_domains", table.invalid_domains);
-			JSON_ADD_NUMBER_TO_OBJECT(row, "abp_entries", table.abp_entries);
-			JSON_ADD_NUMBER_TO_OBJECT(row, "status", table.status);
+			ROW_REF_STR(row, "type", table.type);
+			ROW_ADD_NUM(row, "date_updated", table.date_updated);
+			ROW_ADD_NUM(row, "number", table.number);
+			ROW_ADD_NUM(row, "invalid_domains", table.invalid_domains);
+			ROW_ADD_NUM(row, "abp_entries", table.abp_entries);
+			ROW_ADD_NUM(row, "status", table.status);
 		}
 
 		JSON_ADD_ITEM_TO_ARRAY(rows, row);
+		row = NULL;
 	}
 	gravityDB_readTableFinalize(stmt);
+
+	if(namedb != NULL)
+		dbclose(&namedb);
 
 	if(sql_msg == NULL)
 	{
@@ -167,11 +238,25 @@ static int api_list_read(struct ftl_conn *api,
 	else
 	{
 		JSON_DELETE(rows);
+		JSON_DELETE(processed);
 		return send_json_error(api, 400, // 400 Bad Request
 		                       "database_error",
 		                       "Could not read from gravity database",
 		                       sql_msg);
 	}
+
+list_read_fail:
+	// row is not in rows yet, it is only handed over at the end of the loop
+	JSON_DELETE(row);
+	JSON_DELETE(rows);
+	JSON_DELETE(processed);
+	gravityDB_readTableFinalize(stmt);
+
+	if(namedb != NULL)
+		dbclose(&namedb);
+
+	// A non-zero ret means a reply has gone out already
+	return ret != 0 ? ret : send_http_internal_error(api);
 }
 
 static int api_list_write(struct ftl_conn *api,

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1851,13 +1851,13 @@ bool gravityDB_get_regex_client_groups(clientsData *client, const unsigned int n
 // lookup never waits for the database (see gravityDB_open()). A write does want
 // to wait: the database thread reads gravity.db once per second in
 // gravity_updated(), and a COMMIT meeting that reader fails outright otherwise
-static sqlite3 *gravity_write_open(const char **message)
+sqlite3 *gravityDB_write_open(const char **message)
 {
 	sqlite3 *db = NULL;
 	const int rc = sqlite3_open_v2(config.files.gravity.v.s, &db, SQLITE_OPEN_READWRITE, NULL);
 	if(rc != SQLITE_OK || db == NULL)
 	{
-		log_err("gravity_write_open() - SQL error open: %s", sqlite3_errstr(rc));
+		log_err("gravityDB_write_open() - SQL error open: %s", sqlite3_errstr(rc));
 		if(message != NULL)
 			*message = "Cannot open gravity database for writing";
 		sqlite3_close(db);
@@ -1865,7 +1865,7 @@ static sqlite3 *gravity_write_open(const char **message)
 	}
 
 	if(sqlite3_busy_handler(db, sqliteBusyCallback, NULL) != SQLITE_OK)
-		log_err("gravity_write_open() - Cannot set busy handler: %s", sqlite3_errmsg(db));
+		log_err("gravityDB_write_open() - Cannot set busy handler: %s", sqlite3_errmsg(db));
 
 	return db;
 }
@@ -2153,17 +2153,18 @@ static const char *keep_message(const char *message)
 	return kept;
 }
 
-bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
+void gravityDB_write_close(sqlite3 *db)
+{
+	if(db != NULL)
+		dbclose_handle(db);
+}
+
+bool gravityDB_addToTable(sqlite3 *db, const enum gravity_list_type listtype, tablerow *row,
                           const char **message, const enum http_method method)
 {
-	sqlite3 *db = gravity_write_open(message);
-	if(db == NULL)
-		return false;
-
 	const bool ret = addToTable(db, listtype, row, message, method);
 	if(!ret && message != NULL)
 		*message = keep_message(*message);
-	dbclose_handle(db);
 	return ret;
 }
 
@@ -2433,7 +2434,7 @@ static bool delFromTable(sqlite3 *db, const enum gravity_list_type listtype, con
 
 bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message)
 {
-	sqlite3 *db = gravity_write_open(message);
+	sqlite3 *db = gravityDB_write_open(message);
 	if(db == NULL)
 		return false;
 
@@ -3086,17 +3087,12 @@ static bool edit_groups(sqlite3 *db, const enum gravity_list_type listtype, cJSO
 	return okay;
 }
 
-bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
+bool gravityDB_edit_groups(sqlite3 *db, const enum gravity_list_type listtype, cJSON *groups,
                            const tablerow *row, const char **message)
 {
-	sqlite3 *db = gravity_write_open(message);
-	if(db == NULL)
-		return false;
-
 	const bool ret = edit_groups(db, listtype, groups, row, message);
 	if(!ret && message != NULL)
 		*message = keep_message(*message);
-	dbclose_handle(db);
 	return ret;
 }
 

--- a/src/database/gravity-db.h
+++ b/src/database/gravity-db.h
@@ -84,10 +84,12 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype, con
 bool gravityDB_readTableGetRow(const enum gravity_list_type listtype, tablerow *row, const char **message,
                                sqlite3_stmt *stmt);
 void gravityDB_readTableFinalize(sqlite3_stmt *stmt);
-bool gravityDB_addToTable(const enum gravity_list_type listtype, tablerow *row,
+sqlite3 *gravityDB_write_open(const char **message);
+void gravityDB_write_close(sqlite3 *db);
+bool gravityDB_addToTable(sqlite3 *db, const enum gravity_list_type listtype, tablerow *row,
                           const char **message, const enum http_method method);
 bool gravityDB_delFromTable(const enum gravity_list_type listtype, const cJSON* array, unsigned int *deleted, const char **message);
-bool gravityDB_edit_groups(const enum gravity_list_type listtype, cJSON *groups,
+bool gravityDB_edit_groups(sqlite3 *db, const enum gravity_list_type listtype, cJSON *groups,
                            const tablerow *row, const char **message);
 
 time_t gravity_last_updated(void);

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -2325,7 +2325,8 @@ getNameFromIP_end:
 }
 
 // Get most recently seen host name of device identified by MAC address
-bool getNameFromMAC(const char *client, char hostn[MAXDOMAINLEN])
+// db may be NULL, in which case a connection is opened just for this lookup
+bool getNameFromMAC(sqlite3 *db, const char *client, char hostn[MAXDOMAINLEN])
 {
 	bool got_name = false;
 
@@ -2340,12 +2341,18 @@ bool getNameFromMAC(const char *client, char hostn[MAXDOMAINLEN])
 		return false;
 	}
 
-	// Open pihole-FTL.db database file
-	sqlite3 *db = NULL;
-	if((db = dbopen(false, false)) == NULL)
+	// Open pihole-FTL.db database file if needed
+	bool db_opened = false;
+	if(db == NULL)
 	{
-		log_warn("getNameFromMAC(\"%s\") - Failed to open DB", client);
-		return false;
+		if((db = dbopen(false, false)) == NULL)
+		{
+			log_warn("getNameFromMAC(\"%s\") - Failed to open DB", client);
+			return false;
+		}
+
+		// Successful
+		db_opened = true;
 	}
 
 	// Check for a host name associated with the given client as MAC address
@@ -2404,11 +2411,13 @@ getNameFromMAC_end:
 	if(!got_name)
 		checkFTLDBrc(rc);
 
-	// Finalize statement and close database handle
+	// Finalize statement and close database handle (if opened)
 	if(stmt != NULL)
 		sqlite3_finalize(stmt);
 
-	dbclose(&db);
+	if(db_opened)
+		dbclose(&db);
+
 	return got_name;
 }
 

--- a/src/database/network-table.h
+++ b/src/database/network-table.h
@@ -23,7 +23,7 @@ bool unify_hwaddr(sqlite3 *db);
 bool getMACfromIP(sqlite3 *db, char mac[MAXMACLEN], const char* ipaddr);
 int getAliasclientIDfromIP(sqlite3 *db, const char *ipaddr);
 bool getNameFromIP(sqlite3 *db, char hostn[MAXDOMAINLEN], const char* ipaddr);
-bool getNameFromMAC(const char *client, char hostn[MAXDOMAINLEN]);
+bool getNameFromMAC(sqlite3 *db, const char *client, char hostn[MAXDOMAINLEN]);
 bool getIfaceFromIP(sqlite3 *db, char iface[MAXIFACESTRLEN], const char* ipaddr);
 void resolveNetworkTableNames(void);
 bool flush_network_table(void);

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -53,7 +53,8 @@
 // Version 1
 #define CREATE_QUERIES_TIMESTAMP_INDEX		"CREATE INDEX idx_queries_timestamp ON queries (timestamp);"
 // Version 12
-#define CREATE_QUERY_STORAGE_ID_INDEX			"CREATE UNIQUE INDEX idx_query_storage_id ON query_storage (id);"
+// No index on query_storage(id): id is INTEGER PRIMARY KEY, hence an alias for
+// the rowid, and the rowid B-tree already is that index
 #define CREATE_QUERY_STORAGE_TIMESTAMP_INDEX		"CREATE INDEX idx_query_storage_timestamp ON query_storage (timestamp);"
 #define CREATE_QUERY_STORAGE_TYPE_INDEX		"CREATE INDEX idx_query_storage_type ON query_storage (type);"
 #define CREATE_QUERY_STORAGE_STATUS_INDEX		"CREATE INDEX idx_query_storage_status ON query_storage (status);"
@@ -86,7 +87,6 @@ const char *table_creation[] = {
 	CREATE_QUERIES_VIEW,
 };
 const char *index_creation[] = {
-	CREATE_QUERY_STORAGE_ID_INDEX,
 	CREATE_QUERY_STORAGE_TIMESTAMP_INDEX,
 	CREATE_QUERY_STORAGE_TYPE_INDEX,
 	CREATE_QUERY_STORAGE_STATUS_INDEX,

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -540,18 +540,45 @@ const char * __attribute__((const)) get_http_method_str(const enum http_method m
 	}
 }
 
-void read_and_parse_payload(struct ftl_conn *api)
+// Does this request carry a body at all? civetweb leaves content_length at -1
+// both for a request that announced no length and for a chunked one, so the
+// encoding header has to be read as well - the same test civetweb makes before
+// it sets is_chunked, and it has already rejected any other encoding with a 400
+static bool payload_expected(struct ftl_conn *api)
 {
-	// Defense in depth: never operate on an unallocated payload buffer
-	if(api->payload.raw == NULL)
-		return;
+	if(api->request->content_length > 0)
+		return true;
 
-	// Read payload
-	api->payload.size = mg_read(api->conn, api->payload.raw, MAX_PAYLOAD_BYTES - 1);
+	const char *encoding = mg_get_header(api->conn, "Transfer-Encoding");
+	return encoding != NULL && strcasecmp(encoding, "identity") != 0;
+}
+
+bool read_and_parse_payload(struct ftl_conn *api)
+{
+	// Most requests are bodyless - every GET a dashboard polls - and those
+	// need no buffer at all
+	if(!payload_expected(api))
+		return true;
+
+	api->payload.raw = calloc(MAX_PAYLOAD_BYTES, sizeof(char));
+	if(api->payload.raw == NULL)
+		return false;
+
+	// Read payload. mg_read() reports a read error as a negative number,
+	// which must not reach the unsigned payload size - it would wrap and
+	// read as a payload too large to handle
+	const int nread = mg_read(api->conn, api->payload.raw, MAX_PAYLOAD_BYTES - 1);
+	if (nread < 0)
+	{
+		log_web_debug(DEBUG_API, "Error reading payload");
+		return true;
+	}
+
+	api->payload.size = (long unsigned int)nread;
 	if (api->payload.size < 1)
 	{
 		log_web_debug(DEBUG_API, "Received no payload");
-		return;
+		return true;
 	}
 	else if (api->payload.size >= MAX_PAYLOAD_BYTES-1)
 	{
@@ -559,7 +586,7 @@ void read_and_parse_payload(struct ftl_conn *api)
 		// truncated the payload. The only reasonable thing to do here is to
 		// discard the payload altogether
 		log_web(LOG_WARNING, "API: Received too large payload - DISCARDING");
-		return;
+		return true;
 	}
 
 	// Debug output of received payload (if enabled)
@@ -573,6 +600,8 @@ void read_and_parse_payload(struct ftl_conn *api)
 
 	// Try to parse possibly existing JSON payload
 	api->payload.json = cJSON_ParseWithOpts(api->payload.raw, &api->payload.json_error, 0);
+
+	return true;
 }
 
 // Escape a string to mask HTML special characters, the resulting string is

--- a/src/webserver/http-common.h
+++ b/src/webserver/http-common.h
@@ -99,7 +99,7 @@ int get_string_var(const char *source, const char *var, char *dest, size_t dest_
 // Utils
 enum http_method __attribute__((pure)) http_method(struct mg_connection *conn);
 const char* startsWith(const char *path, struct ftl_conn *api);
-void read_and_parse_payload(struct ftl_conn *api);
+bool read_and_parse_payload(struct ftl_conn *api);
 char * __attribute__((malloc)) escape_html(const char *string);
 int check_json_payload(struct ftl_conn *api);
 int parse_groupIDs(struct ftl_conn *api, tablerow *table, cJSON *row);

--- a/test/api/test_m_mutations.py
+++ b/test/api/test_m_mutations.py
@@ -710,3 +710,37 @@ class TestConfigPatchRoundTrip:
                               timeout=20)
         assert r.status_code == 200
         assert _j(r)["config"]["dns"]["blockTTL"] == orig_val
+
+
+# ---------------------------------------------------------------------------
+# POST several domains in one request
+# ---------------------------------------------------------------------------
+
+class TestBatchAddDomains:
+
+    def test_post_multiple_domains(self, api_session):
+        """All items of a batch add land in one transaction and all survive."""
+        domains = [f"_pytest-batch-{i}.example.com" for i in range(5)]
+        url = f"{FTL_URL}/api/domains/deny/exact"
+
+        r = api_session.post(url,
+                             json={"domain": domains, "comment": "pytest batch",
+                                   "groups": [0], "enabled": True},
+                             timeout=20)
+        assert r.status_code in (200, 201), f"POST failed: {r.status_code} {r.text}"
+
+        # Every item is reported as a success, none as an error
+        processed = _j(r)["processed"]
+        assert processed["errors"] == [], f"Unexpected errors: {processed['errors']}"
+        assert sorted(s["item"] for s in processed["success"]) == sorted(domains)
+
+        # And every one of them is actually readable back
+        present = {d["domain"] for d in _j(api_session.get(url, timeout=5))["domains"]}
+        for domain in domains:
+            assert domain in present, f"{domain} missing after batch POST"
+
+        # Clean up so the seed counts other tests assert stay intact
+        for domain in domains:
+            r = api_session.delete(f"{url}/{domain}", timeout=10)
+            assert r.status_code == 204, \
+                f"Cleanup of {domain} failed: {r.status_code} {r.text}"


### PR DESCRIPTION
# What does this implement/fix?

the payload buffer. every endpoint with API_PARSE_JSON allocated 64 KiB and
calloc zeroes all of it, before looking at the request. that flag is on almost
the whole table, GET endpoints included, so a dashboard polling
/api/stats/summary paid a 64 KiB allocation, a 64 KiB memset and a free per
request with no body to read. now allocated inside read_and_parse_payload() and
only when the request announces one

the clients list. GET /api/clients resolves a name per row, and both lookups
opened pihole-FTL.db, ran one SELECT and closed it again, once per client.
getNameFromMAC() gets the optional connection parameter getNameFromIP() already
had, and the list opens it once

gravity batch adds. POST /api/domains with an array called gravityDB_addToTable()
and gravityDB_edit_groups() per item, each opening a write connection,
committing and closing. N items cost 2N connections and 2N commits, and every
commit is an fsync. one connection and one transaction for the whole loop now.
modelled on the same schema and access pattern, 100 items go from about 1.2 s to
6 ms and 1000 from 12.5 s to 10 ms. the gain is the commits. nothing covered
that path, so there is a pytest case for it now, five domains in one request

query_storage(id). id is INTEGER PRIMARY KEY, so it is the rowid and the table
b-tree already is that index. idx_query_storage_id maintained a second one with
the same keys, costing 990 pages and 4 percent of the insert time per 300000
rows. only the in-memory database ever created it, no on-disk schema or
migration is touched

the one behaviour change is in the gravity batch: nothing reaches the disk until
the commit, so a failing commit now answers 500 instead of reporting items as
successes that were lost. a failing BEGIN is not fatal, it falls back to
committing per item

## How to test the change during review

post an array of domains to /api/domains/deny/exact and compare the wall time
against development. for the index, create it by hand on a pihole-FTL.db and
diff EXPLAIN QUERY PLAN before and after: id lookups and id ranges do not move,
only MAX(id) picks the index up, and that is a seek to the last rowid either way

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
