### PR TITLE
405 with an Allow header instead of 404 for a wrong method

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -109,6 +109,58 @@ static struct {
 	{ "/api/docs",                              "",                           api_docs,                              { API_PARSE_JSON, 0                         }, false, HTTP_GET },
 };
 
+// Does the URI carry as many path components as this table row expects? Several
+// rows share a URI and are told apart only by their parameters, which
+// startsWith() does not look at - /api/domains has four of them. Answering a
+// 405 with the union of all four advertises a DELETE that /api/domains without
+// arguments would refuse with a 400, so count the components and keep the rows
+// that would really have taken this URI
+static bool __attribute__((pure)) parameters_match(const char *parameters, const char *item)
+{
+	unsigned int expected = 0;
+	for(const char *p = parameters; *p != '\0'; p++)
+		if(*p == '{')
+			expected++;
+
+	// A trailing slash does not open another component: /api/domains/deny/
+	// addresses the same one-parameter row as /api/domains/deny
+	size_t len = strlen(item);
+	if(len > 0 && item[len - 1] == '/')
+		len--;
+
+	unsigned int found = 0;
+	if(len > 0)
+	{
+		found = 1;
+		for(size_t i = 0; i < len; i++)
+			if(item[i] == '/')
+				found++;
+	}
+
+	return expected == found;
+}
+
+// Format the methods an endpoint accepts as an Allow header value, e.g.
+// "GET, POST, OPTIONS". OPTIONS is answered for every endpoint by the handler
+// itself, so it belongs in a header a client is meant to act on
+static void format_allowed_methods(char *buffer, const size_t size, const enum http_method allowed)
+{
+	size_t len = 0;
+	buffer[0] = '\0';
+	for(enum http_method j = HTTP_GET; j <= HTTP_OPTIONS; j <<= 1)
+	{
+		if(!(allowed & j))
+			continue;
+
+		const int n = snprintf(buffer + len, size - len, "%s%s",
+		                       len > 0 ? ", " : "", get_http_method_str(j));
+		if(n < 0 || (size_t)n >= size - len)
+			break;
+
+		len += n;
+	}
+}
+
 int api_handler(struct mg_connection *conn, void *ignored)
 {
 	// Unused, but required by CivetWeb
@@ -143,27 +195,30 @@ int api_handler(struct mg_connection *conn, void *ignored)
 
 	// Loop over all API endpoints and check if the requested URI matches
 	bool unauthorized = false;
+	bool handler_ran = false;
 	enum http_method allowed_methods = 0;
 	for(unsigned int i = 0; i < ArraySize(api_request); i++)
 	{
-		// Check if the requested method is allowed
-		if(!(api_request[i].methods & api.method) && api.method != HTTP_OPTIONS)
-			continue;
-
 		// Check if the requested URI starts with the API endpoint
 		if((api.item = startsWith(api_request[i].uri, &api)) != NULL)
 		{
+			// The URI exists. Remember every method it accepts,
+			// both to answer OPTIONS below and to tell a request
+			// that came with the wrong one which would have worked
+			if(parameters_match(api_request[i].parameters, api.item))
+				allowed_methods |= api_request[i].methods | HTTP_OPTIONS;
+
+			// If this is an OPTIONS request, collecting the
+			// methods is all there is to do here
+			if(api.method == HTTP_OPTIONS)
+				continue;
+
+			// Check if the requested method is allowed
+			if(!(api_request[i].methods & api.method))
+				continue;
 
 			// Copy options to API struct
 			memcpy(&api.opts, &api_request[i].opts, sizeof(api.opts));
-
-			// If this is an OPTIONS request, we add the supported
-			// options of this endpoint and continue
-			if(api.method == HTTP_OPTIONS)
-			{
-				allowed_methods |= api_request[i].methods;
-				continue;
-			}
 
 			if(api_request[i].opts.flags & API_PARSE_JSON)
 			{
@@ -199,6 +254,7 @@ int api_handler(struct mg_connection *conn, void *ignored)
 			          api.request->request_method,
 			          api.request->local_uri_raw,
 			          api_request[i].uri);
+			handler_ran = true;
 			ret = api_request[i].func(&api);
 			log_web_debug(DEBUG_API, "Done");
 			break;
@@ -241,34 +297,45 @@ int api_handler(struct mg_connection *conn, void *ignored)
 	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
 	if(api.method == HTTP_OPTIONS)
 	{
-		// Send Allow header
+		char allow[128];
+		format_allowed_methods(allow, sizeof(allow), allowed_methods);
+
+		// Send Allow header and an empty body
 		mg_printf(conn, "HTTP/1.1 204 No Content\r\n"
-		                "Allow: ");
-
-		// Loop over all possible methods
-		unsigned int m = 0;
-		for(enum http_method j = HTTP_GET; j < HTTP_OPTIONS; j <<= 1)
-		{
-			// Check if this method is allowed for this endpoint
-			if(allowed_methods & j)
-				mg_printf(conn, "%s%s", m++ > 0 ? ", " : "", get_http_method_str(j));
-		}
-
-		// Finish header and send empty body
-		mg_printf(conn, "\r\n"
+		                "Allow: %s\r\n"
 		                "Content-Length: 0\r\n"
-		                "Connection: close\r\n\r\n");
+		                "Connection: close\r\n\r\n", allow);
 		return 204;
 	}
 
-	// Check if we need to return with not found payload
 	if(ret == 0)
 	{
-		// not found or invalid request
-		ret = send_json_error(&api, 404,
-		                      "not_found",
-		                      "Not found",
-		                      api.request->local_uri_raw);
+		// A handler that ran and returned 0 is asking for a 404 of its
+		// own - api_docs() does that for a file it does not have - and
+		// must not be turned into a 405 refusing the method it just
+		// served
+		if(allowed_methods != 0 && !handler_ran)
+		{
+			// The URI exists, the method does not. RFC 9110 section
+			// 15.5.6 requires a 405 to name the methods that do
+			char allow[128];
+			format_allowed_methods(allow, sizeof(allow), allowed_methods);
+			snprintf(pi_hole_extra_headers, sizeof(pi_hole_extra_headers),
+			         "Allow: %s", allow);
+
+			ret = send_json_error(&api, 405,
+			                      "method_not_allowed",
+			                      "Method Not Allowed",
+			                      api.request->request_method);
+		}
+		else
+		{
+			// not found or invalid request
+			ret = send_json_error(&api, 404,
+			                      "not_found",
+			                      "Not found",
+			                      api.request->local_uri_raw);
+		}
 	}
 
 	// Restart FTL if requested

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -849,6 +849,87 @@ class TestEndpoints:
 
 
 # ---------------------------------------------------------------------------
+# Wrong method on an existing endpoint
+# ---------------------------------------------------------------------------
+
+class TestMethodNotAllowed:
+
+    @staticmethod
+    def _allow(response):
+        return sorted(m.strip() for m in response.headers["Allow"].split(","))
+
+    def test_wrong_method_returns_405_with_allow(self, api_session):
+        """DELETE on a GET-only endpoint is a 405 naming the methods that work."""
+        r = api_session.delete(f"{FTL_URL}/api/stats/summary", timeout=5)
+        assert r.status_code == 405, \
+            f"Expected 405, got {r.status_code} {r.text}"
+
+        assert r.headers.get("Allow") is not None, \
+            f"No Allow header, got {dict(r.headers)}"
+        assert self._allow(r) == ["GET", "OPTIONS"]
+
+        assert _j(r)["error"]["key"] == "method_not_allowed"
+
+    def test_allow_lists_every_accepted_method(self, api_session):
+        """An endpoint reached by several methods names all of them."""
+        r = api_session.patch(f"{FTL_URL}/api/dns/blocking", json={}, timeout=5)
+        assert r.status_code == 405, \
+            f"Expected 405, got {r.status_code} {r.text}"
+        assert self._allow(r) == ["GET", "OPTIONS", "POST"]
+
+    def test_allow_only_names_methods_this_uri_shape_takes(self, api_session):
+        """Rows sharing a URI are told apart by their parameters, not just the URI.
+
+        /api/domains has four table rows. Without arguments only the GET one
+        applies, so DELETE - which needs /{type}/{kind}/{domain} - must not be
+        advertised, and with two arguments POST must be.
+        """
+        r = api_session.patch(f"{FTL_URL}/api/domains", json={}, timeout=5)
+        assert r.status_code == 405, \
+            f"Expected 405, got {r.status_code} {r.text}"
+        assert self._allow(r) == ["GET", "OPTIONS"]
+
+        r = api_session.patch(f"{FTL_URL}/api/domains/deny/exact", json={}, timeout=5)
+        assert r.status_code == 405, \
+            f"Expected 405, got {r.status_code} {r.text}"
+        assert self._allow(r) == ["GET", "OPTIONS", "POST"]
+
+    def test_trailing_slash_does_not_shift_the_path(self, api_session):
+        """A trailing slash must not count as another path component.
+
+        /api/domains/deny/ addresses the same row as /api/domains/deny, so it
+        has to advertise the same methods rather than those of the row one
+        level deeper.
+        """
+        plain = api_session.patch(f"{FTL_URL}/api/domains/deny", json={}, timeout=5)
+        slash = api_session.patch(f"{FTL_URL}/api/domains/deny/", json={}, timeout=5)
+        assert plain.status_code == 405, \
+            f"Expected 405, got {plain.status_code} {plain.text}"
+        assert slash.status_code == 405, \
+            f"Expected 405, got {slash.status_code} {slash.text}"
+        assert self._allow(slash) == self._allow(plain), \
+            f"{self._allow(slash)} != {self._allow(plain)}"
+
+    def test_handler_asking_for_404_still_gets_one(self, api_session):
+        """api_docs() returns 0 for a file it does not have, which is a 404.
+
+        It must not be mistaken for "no method matched" and answered 405 with
+        an Allow header naming the very method that was used.
+        """
+        r = api_session.get(f"{FTL_URL}/api/docs/_pytest_no_such_file.html",
+                            timeout=5)
+        assert r.status_code == 404, \
+            f"Expected 404, got {r.status_code} {r.text}"
+
+    def test_unknown_uri_is_still_404(self, api_session):
+        """A URI that does not exist keeps its 404, no Allow header."""
+        r = api_session.delete(f"{FTL_URL}/api/_pytest_no_such_endpoint", timeout=5)
+        assert r.status_code == 404, \
+            f"Expected 404, got {r.status_code} {r.text}"
+        assert "Allow" not in r.headers
+
+
+# ---------------------------------------------------------------------------
 # Info endpoints
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# What does this implement/fix?

a request to an endpoint that exists with a method it does not accept falls
through the whole table and comes back as 404 Not found. DELETE
/api/stats/summary is the easy example. RFC 9110 15.5.6 wants a 405 that names
the methods that would have worked, and the handler was already collecting
exactly that set to answer OPTIONS, it just threw it away

so the change is small: check the URI first and the method second, let every
URI match contribute its methods to allowed_methods, and answer 405 with an
Allow header when nothing matched by method but something did by URI. a URI that
does not exist at all is still a 404 with no Allow header

## on the header route, since it came up

i had this filed as blocked on there being no way to attach a header to an error
response, since my_send_http_error_headers() emits the whole block. that turns
out to be wrong. it calls send_additional_header(), which appends
pi_hole_extra_headers, so an error response has always been able to carry a
header, and that is the route the Location header of a list add and the session
cookie already take. i used the same one here

asked whether a real parameter on send_json_error() would be preferred to the
thread-local and the answer was no: send_additional_header() emits and clears
pi_hole_extra_headers in the same place, so it cannot reach the next response,
and a parameter would mean touching civetweb.c and mirroring that in
patch/civetweb/. so the thread-local stays

two smaller ones while you are looking

OPTIONS is in the Allow list. an earlier version of this description said it was
left out - that was wrong, allowed_methods ors in HTTP_OPTIONS and the formatter
runs j <= HTTP_OPTIONS, so it is advertised by both the new 405 and the existing
204. that also means the OPTIONS answer itself changed: it used to leave itself
out of the list it returned

and the openapi spec is untouched. a 405 belongs to the path, not to an
operation, and the method being refused has no operation object to hang a
response on, so i did not see a clean place for it. tell me if you want it
somewhere anyway

one behaviour note: this tells an unauthenticated caller which methods a URI
takes. /api/docs is public and documents that already, so i do not think
anything new leaks, but it is a change worth naming

## How to test the change during review

curl -i -X DELETE /api/stats/summary and look at the status line and the Allow
header, then the same against a URI that does not exist

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.


