### PR TITLE
two defects in the gravity database reader, one of them a double free

### DIFF
--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -2554,7 +2554,12 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
 		*message = "Failed to allocate memory for query string";
 		return false;
 	}
+	// like_name is the caller's item until we build a LIKE pattern of our own.
+	// The free() calls below have to follow the allocation, not just !exact:
+	// an empty non-exact item skips the allocation and would otherwise make
+	// this function free a string it never owned
 	char *like_name = (char*)item;
+	bool like_name_allocated = false;
 	if(!exact && item != NULL && item[0] != '\0')
 	{
 		// Build LIKE string (% + item + %)
@@ -2570,6 +2575,7 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
 			return false;
 		}
 		snprintf(like_name, maxlen, "%%%s%%", item);
+		like_name_allocated = true;
 	}
 	const char *filter = "";
 	if(listtype == GRAVITY_GROUPS)
@@ -2662,7 +2668,7 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
 		*message = sqlite3_errmsg(db);
 		log_err("gravityDB_readTable(%d => (%s)) - SQL error prepare (%i): %s => %s",
 		        listtype, type, rc, querystr, *message);
-		if(!exact)
+		if(like_name_allocated)
 			free(like_name);
 		free(querystr);
 		return false;
@@ -2677,7 +2683,7 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
 		        listtype, type, like_name, rc, *message);
 		sqlite3_finalize(*read_stmt_p);
 		*read_stmt_p = NULL;
-		if(!exact)
+		if(like_name_allocated)
 			free(like_name);
 		free(querystr);
 		return false;
@@ -2692,7 +2698,7 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
 		        listtype, type, like_name, rc, *message);
 		sqlite3_finalize(*read_stmt_p);
 		*read_stmt_p = NULL;
-		if(!exact)
+		if(like_name_allocated)
 			free(like_name);
 		free(querystr);
 		return false;
@@ -2708,7 +2714,7 @@ bool gravityDB_readTable(sqlite3 *db, const enum gravity_list_type listtype,
 
 	// Free memory
 	free(querystr);
-	if(!exact)
+	if(like_name_allocated)
 		free(like_name);
 
 	return true;

--- a/src/database/gravity-db.c
+++ b/src/database/gravity-db.c
@@ -1809,12 +1809,23 @@ bool gravityDB_get_regex_client_groups(clientsData *client, const unsigned int n
 		return false;
 	}
 
-	// Bind client's group_id array via carray (parameter ?1)
+	// Bind client's group_id array via carray (parameter ?1). A client in no
+	// group at all must not reach the step below: the statement is shared
+	// between all clients and sqlite3_reset() keeps bindings, so skipping the
+	// bind would leave the previously processed client's array in place and
+	// hand this client that client's regexes. The gravity, allowlist and
+	// denylist lookups return early here for the same reason
 	int group_count = 0;
 	const int32_t *group_ids = getintarray(client->groupspos, &group_count);
-	if(group_ids != NULL && group_count > 0)
-		sqlite3_carray_bind(query_stmt, 1, (void*)group_ids, group_count,
-		                    SQLITE_CARRAY_INT32, SQLITE_STATIC);
+	if(group_ids == NULL || group_count <= 0)
+	{
+		log_debug(DEBUG_REGEX, "Regex %s: Client %s is in no group, no regex applies",
+		          regextype[type], getstr(client->ippos));
+		return true;
+	}
+
+	sqlite3_carray_bind(query_stmt, 1, (void*)group_ids, group_count,
+	                    SQLITE_CARRAY_INT32, SQLITE_STATIC);
 
 	// Perform query
 	log_debug(DEBUG_REGEX, "Regex %s: Querying associated regexes for client %s (groups: %s)",


### PR DESCRIPTION
# What does this implement/fix?

two defects in the gravity database reader, one of them a double free

gravityDB_readTable() builds a LIKE pattern only when the item is non-empty, but
all four free() calls guard on !exact alone. so an item that is present but
empty makes the function free a string it never allocated

api_search() reaches that: it passes exact = !partial, and idn2_to_ascii_lz()
answers IDN2_OK with an empty heap string for input that IDNA maps away
entirely - a soft hyphen does it. GET /api/search/%C2%AD?partial=true frees
punycode, uses it in the five searches that follow and frees it again at the
end. whether the conversion gives an empty string rather than an error depends
on LC_CTYPE, which daemon.c inherits from the service environment, so this is
real wherever LANG is a UTF-8 one

second one, unrelated failure but the same file: the regex group statement is
shared between all clients and sqlite3_reset() does not clear bindings.
gravityDB_get_regex_client_groups() skips the carray bind when a client has no
groups and steps anyway, so that client is given the previously processed
client's deny or allow regexes. the gravity, allowlist and denylist lookups all
return early in that case, this one was the outlier

## How to test the change during review

GET /api/search/%C2%AD?partial=true under a UTF-8 locale, before and after. for
the second one, put a client in no group at all and reload gravity with another
client that has regex rules

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
