### PR TITLE
upstream accounting, a stale query index, and three smaller things in the bridge

### DIFF
--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -1717,6 +1717,7 @@ void DB_read_queries(void)
 					{
 						upstream->lastQuery = queryTimeStamp;
 						upstream->count++;
+						query->flags.upstream_counted = true;
 					}
 				}
 				break;

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -64,10 +64,6 @@ typedef struct {
 	} flags;
 } queriesData;
 
-// The layout above is deliberately packed to 64 bytes and lives in shared
-// memory, so a change that grows it needs a SHARED_MEMORY_VERSION bump
-_Static_assert(sizeof(queriesData) == 64, "queriesData must stay 64 bytes");
-
 typedef struct {
 	// Contains size_t and double fields -> size differs by architecture
 	// (64-bit: 64 bytes with 4 bytes internal padding before ippos; 32-bit:

--- a/src/datastructure.h
+++ b/src/datastructure.h
@@ -53,12 +53,20 @@ typedef struct {
 		bool complete :1;
 		bool blocked :1;
 		bool response_calculated :1;
+		// Set while this query holds a count on upstreamID, so the count
+		// is returned exactly once - either by query_blocked() when the
+		// query stops being a forwarded one, or by the GC when it expires
+		bool upstream_counted :1;
 		struct database_flags {
 			bool changed :1;
 			bool imported :1;
 		} database;
 	} flags;
 } queriesData;
+
+// The layout above is deliberately packed to 64 bytes and lives in shared
+// memory, so a change that grows it needs a SHARED_MEMORY_VERSION bump
+_Static_assert(sizeof(queriesData) == 64, "queriesData must stay 64 bytes");
 
 typedef struct {
 	// Contains size_t and double fields -> size differs by architecture

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1389,12 +1389,6 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 		                            "    --> NO MATCH <--");
 	}
 
-	// Interface resolved by the last call, used to skip the address
-	// collection below when the same one is seen again. The pointer is
-	// stable within dnsmasq's daemon->interfaces list and is invalidated on
-	// SIGHUP/restart.
-	static struct irec *cached_recviface = NULL;
-
 	// Return early when there is no interface available at this point
 	// This means we didn't get one passed + we didn't find one above
 	if(!recviface)
@@ -1406,21 +1400,15 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 		next_iface.haveIPv4 = next_iface.haveIPv6 = false;
 		next_iface.name[0] = '-';
 		next_iface.name[1] = '\0';
-		// Drop the cache too, so the next query on that interface
-		// collects its addresses again
-		cached_recviface = NULL;
 		return;
 	}
 
-	// Skip the expensive second loop (which iterates all interfaces to
-	// collect IPv4 and IPv6 addresses) when the interface is unchanged
-	if(recviface == cached_recviface)
-	{
-		log_debug(DEBUG_NETWORKING, "Interface unchanged, using cached result");
-		return;
-	}
-
-	// Interface changed — invalidate and recompute
+	// Recomputed on every call. dnsmasq keeps one irec per address, so the
+	// irec pointer says nothing about whether the addresses behind it have
+	// changed, and establishing that they have not costs at least as much as
+	// collecting them again: the loop below stops as soon as it has an IPv4
+	// and a ULA IPv6 address, while any check covering every address cannot
+	// stop early. What it would save is debug-gated anyway
 	memset(&next_iface.addr4, 0, sizeof(next_iface.addr4));
 	memset(&next_iface.addr6, 0, sizeof(next_iface.addr6));
 	next_iface.haveIPv4 = next_iface.haveIPv6 = false;
@@ -1524,7 +1512,6 @@ void _FTL_iface(struct irec *recviface, const union all_addr *addr, const sa_fam
 	}
 
 	// Update cache so subsequent queries on the same interface skip the loops
-	cached_recviface = recviface;
 }
 
 static void check_pihole_PTR(char *domain)
@@ -1827,7 +1814,13 @@ static bool special_domain(const queriesData *query, const char *domain)
 	if(config.dns.specialDomains.designatedResolver.v.b)
 	{
 		const size_t len = strlen(domain);
-		if(len > 13 && strcmp(&domain[len - 13], "resolver.arpa") == 0)
+		const size_t zonelen = sizeof("resolver.arpa") - 1;
+		// >= rather than >, so the zone apex resolver.arpa itself is
+		// answered instead of being forwarded, and a label boundary,
+		// so notresolver.arpa is not mistaken for part of the zone
+		if(len >= zonelen &&
+		   strcmp(&domain[len - zonelen], "resolver.arpa") == 0 &&
+		   (len == zonelen || domain[len - zonelen - 1] == '.'))
 		{
 			blockingreason = "Designated Resolver domain";
 			force_next_DNS_reply = REPLY_NODATA;
@@ -2310,11 +2303,24 @@ bool FTL_CNAME(const char *dst, const char *src, const int id)
 		if(child_domain_data != NULL)
 			child_domain_data->cname_refcount++;
 
-		// Store CNAME domain ID in DNS cache
+		// Store CNAME domain ID in DNS cache. A cache entry holds at most
+		// one reference and gives it back once, when runGC() recycles it,
+		// so taking one unconditionally here leaks: this path runs again
+		// for an entry whose blocking status a gravity reload has reset,
+		// and the entry is then counted twice against the same domain.
+		// Take a reference only when the entry is not already holding one
+		// for this domain, and hand back the old one when it moves
 		const int parent_cacheID = query->cacheID > -1 ? query->cacheID : findCacheID(parent_domainID, clientID, query->type, false);
 		DNSCacheData *parent_cache = parent_cacheID < 0 ? NULL : getDNSCache(parent_cacheID, true);
-		if(parent_cache != NULL)
+		if(parent_cache != NULL && parent_cache->CNAME_domainID != (unsigned int)child_domainID)
 		{
+			if(parent_cache->CNAME_domainID != (unsigned int)-1)
+			{
+				domainsData *old_cname = getDomain(parent_cache->CNAME_domainID, true);
+				if(old_cname != NULL)
+					old_cname->cname_refcount--;
+			}
+
 			parent_cache->CNAME_domainID = child_domainID;
 			if(child_domain_data != NULL)
 				child_domain_data->cname_refcount++;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1238,6 +1238,10 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 		// (iface_enumerate) to refresh the ARP table on a cache miss.
 		// Release the SHM lock so this potentially slow I/O doesn't
 		// block all other threads (API, database, GC, TCP workers).
+		// Remember where the query array starts: the logical query index
+		// we are holding is relative to queries_offset, which the GC
+		// advances when it drops queries off the front
+		const unsigned int queries_offset_before = counters->queries_offset;
 		unlock_shm();
 
 		unsigned char hwaddr[16] = {0};
@@ -1259,8 +1263,21 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 			client->hwlen = hwlen;
 		}
 
-		// Re-fetch all SHM pointers as SHM may have been remapped
-		query = getQuery(queryID, true);
+		// Re-fetch all SHM pointers as SHM may have been remapped.
+		// If queries_offset moved while we were unlocked then every
+		// logical query index shifted with it, and ours now resolves to
+		// a different query that is very much alive - magic byte and
+		// all - so re-fetching it would quietly update someone else's.
+		// There is no way to rebase it from here, so drop it instead.
+		// Domains and clients are not offset-indexed and are fine
+		if(counters->queries_offset != queries_offset_before)
+		{
+			log_debug(DEBUG_GC, "Query indices moved while resolving the MAC address, "
+			          "dropping query %d", queryID);
+			query = NULL;
+		}
+		else
+			query = getQuery(queryID, true);
 		domain = getDomain(domainID, true);
 		dns_cache_entry = query != NULL && query->cacheID > -1
 		                ? getDNSCache(query->cacheID, true) : NULL;

--- a/src/dnsmasq_interface.c
+++ b/src/dnsmasq_interface.c
@@ -1134,6 +1134,7 @@ bool _FTL_new_query(const unsigned int flags, const char *name,
 	query->flags.database.imported = false;
 	query->flags.database.changed = true;
 	query->flags.complete = false;
+	query->flags.upstream_counted = false;
 	query->response = querytimestamp;
 	query->flags.response_calculated = false;
 	// Initialize reply type
@@ -2423,6 +2424,7 @@ static void FTL_forwarded(const unsigned int flags, const char *name, const unio
 	if(upstream != NULL)
 	{
 		upstream->count++;
+		query->flags.upstream_counted = true;
 		upstream->lastQuery = now;
 	}
 
@@ -2585,6 +2587,25 @@ static void update_upstream(queriesData *query, const int id)
 				log_debug(DEBUG_QUERIES, "Query ID %d: Associated upstream changed (was %s#%d) as %s#%d replied earlier",
 				          id, oldaddr, oldport, ip, port);
 			}
+		}
+
+		// Move the count along with the attribution. FTL_forwarded()
+		// counted this query against the upstream it first picked and
+		// returns early for every further server of the same forward
+		// round, so the server that actually answered was never counted
+		// and whoever decrements later - query_blocked() or the GC -
+		// would take it off the wrong one
+		if(query->flags.upstream_counted)
+		{
+			upstreamsData *old_upstream = getUpstream(query->upstreamID, true);
+			if(old_upstream != NULL)
+				old_upstream->count--;
+
+			upstreamsData *new_upstream = upstreamID > -1 ? getUpstream(upstreamID, true) : NULL;
+			if(new_upstream != NULL)
+				new_upstream->count++;
+			else
+				query->flags.upstream_counted = false;
 		}
 
 		// Update upstream server ID
@@ -3069,13 +3090,18 @@ static enum query_status detect_blocked_IP(const unsigned short flags, const uni
 
 static void query_blocked(queriesData *query, domainsData *domain, clientsData *client, const enum query_status new_status)
 {
-	// Adjust counters if we recorded a non-blocking status
-	if(query->status == QUERY_FORWARDED && query->upstreamID > -1)
+	// Adjust counters if we recorded a non-blocking status. Clear the flag
+	// with it: the query keeps pointing at the upstream for the reply and
+	// for the database, but the count has been handed back and the GC must
+	// not hand it back a second time when the query expires
+	if(query->status == QUERY_FORWARDED && query->flags.upstream_counted)
 	{
 		// Get forward pointer
 		upstreamsData *upstream = getUpstream(query->upstreamID, true);
 		if(upstream != NULL)
 			upstream->count--;
+
+		query->flags.upstream_counted = false;
 	}
 	else if(is_blocked(query->status))
 	{

--- a/src/gc.c
+++ b/src/gc.c
@@ -468,12 +468,17 @@ void runGC(const time_t now, time_t *lastGCrun, const bool flush)
 		}
 
 		// Adjust upstream counter (no overTime information)
-		if(query->upstreamID > -1)
+		// Only if this query still holds a count. query_blocked() hands
+		// it back when a forwarded query turns out to be blocked, and
+		// the query keeps its upstreamID after that
+		if(query->flags.upstream_counted && query->upstreamID > -1)
 		{
 			upstreamsData *upstream = getUpstream(query->upstreamID, true);
 			if(upstream != NULL)
 				// Adjust upstream counter
 				upstream->count--;
+
+			query->flags.upstream_counted = false;
 		}
 
 		// Adjust cache refcount

--- a/src/shmem.c
+++ b/src/shmem.c
@@ -38,6 +38,43 @@
 /// The version of shared memory used
 #define SHARED_MEMORY_VERSION 17
 
+// Every struct below is stored in shared memory, so a change to any of their
+// layouts makes a segment written by an older build unreadable and needs the
+// version above bumped. These assertions hold the sizes to what they are today
+// so that cannot happen unnoticed.
+//
+// The sizes are not the same everywhere. size_t members make them follow the
+// word size, and a 32-bit target aligns double to either 8 (ARM EABI) or 4
+// (i386), which moves the members after it again - clientsData is 688 bytes on
+// 64-bit, 672 on armhf and 664 on i386. All three are pinned rather than only
+// the one this happens to be compiled for. sizeof and _Alignof are constant
+// expressions, so this needs no per-architecture #ifdef
+#define SHM_STRUCT_SIZE(w64, arm32, x86_32) \
+	(sizeof(size_t) == 8 ? (w64) : (_Alignof(double) == 8 ? (arm32) : (x86_32)))
+
+#define ASSERT_SHM_SIZE(type, w64, arm32, x86_32) \
+	_Static_assert(sizeof(type) == SHM_STRUCT_SIZE(w64, arm32, x86_32), \
+	               #type " changed size - bump SHARED_MEMORY_VERSION")
+
+ASSERT_SHM_SIZE(queriesData,            64,     64,     64);
+ASSERT_SHM_SIZE(domainsData,            48,     40,     40);
+ASSERT_SHM_SIZE(clientsData,           688,    672,    664);
+ASSERT_SHM_SIZE(upstreamsData,          64,     56,     52);
+ASSERT_SHM_SIZE(DNSCacheData,           40,     40,     40);
+// overTimeData is the one of these that ends in a time_t, whose alignment is 8
+// on 64-bit and on ARM EABI but 4 on i386, which moves the timestamp and with
+// it the total: 32, 32 and 28. Derive it from the layout rather than write
+// three numbers, so it stays right on a target none of us measured
+#define ROUND_UP_TO(n, a) ((((n) + (a) - 1u) / (a)) * (a))
+_Static_assert(sizeof(overTimeData) ==
+               ROUND_UP_TO(ROUND_UP_TO(sizeof(unsigned char), _Alignof(int)) + 4u * sizeof(int),
+                           _Alignof(time_t)) + sizeof(time_t),
+               "overTimeData changed size - bump SHARED_MEMORY_VERSION");
+ASSERT_SHM_SIZE(struct lookup_table,     8,      8,      8);
+ASSERT_SHM_SIZE(fifologData,        568576, 560352, 560336);
+ASSERT_SHM_SIZE(ShmSettings,           152,    140,    140);
+ASSERT_SHM_SIZE(countersStruct,        356,    356,    356);
+
 /// The name of the shared memory. Use this when connecting to the shared memory.
 #define SHMEM_PATH "/dev/shm"
 #define SHARED_LOCK_NAME "lock"


### PR DESCRIPTION
# What does this implement/fix?

upstream accounting, a stale query index, and three smaller things in the bridge

FTL_forwarded() counts a query against the upstream it first picks and returns
early for every further server of the same forward round, so a forwardall probe
counts only the first. update_upstream() then repoints query->upstreamID at
whichever server answered without moving the count, so the counted server keeps
a +1 nobody takes back and the answering one is decremented by the GC although
it was never counted - upstream->count is a signed int and goes negative.
query_blocked() has the opposite problem, handing the count back and leaving
upstreamID set so the GC hands it back again

there was no record of whether a query holds a count, which is the root of both.
flags.upstream_counted is that record. it fits in the existing bitfield and
queriesData stays 64 bytes, so SHARED_MEMORY_VERSION is unchanged - and since
nothing was checking that, the last commit pins the size of all ten structs that
live in shared memory. those sizes differ per target, clientsData is 688 bytes
on 64-bit, 672 on armhf and 664 on i386, so all three cases are held rather than
just the one this is built on

_FTL_new_query() drops the SHM lock around find_mac() and re-fetches its
pointers, which handles a remap but not the GC. a query index is logical,
_getQuery() resolves it as queryID + queries_offset, and runGC() advances that
offset - so after a GC run in that window the re-fetch returns a different query
that is very much alive, and the blocking decision lands on someone else's.
there is no way to rebase the index from there, so it gives up on the query
instead

three smaller ones: a DNS cache entry took a CNAME domain reference every time
the path ran but gives it back once when recycled, so a gravity reload leaks one
and the domain never leaves the table. _FTL_iface() cached its addresses against
the irec pointer alone, which does not move when another address on the same
interface changes, so the cached addr4/addr6 go stale with nothing to signal it
- the comment claiming the pointer is invalidated on SIGHUP had the wrong
invariant, an address change needs no SIGHUP. that cache is deleted rather than
taught to notice: any check covering the addresses has to visit all of them,
while the collection loop it guarded stops as soon as it has an IPv4 and a ULA
IPv6, and the expensive part of that loop is behind debug.networking anyway, so
the check costs at least what it saves. recomputing every time is correct and
smaller, three hunks of deletions. and the RFC 9462 test asked for len > 13 against a
13-character zone, so resolver.arpa itself was forwarded instead of answered,
with no label boundary either, so notresolver.arpa matched

## How to test the change during review

two upstreams with dnsmasq probing both, then watch /api/stats/upstreams over a
few GC cycles. dig resolver.arpa and dig notresolver.arpa

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.

