### PR TITLE
generate dnsmasq.conf from the candidate, notice failed writes, and do not race

### DIFF
--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -53,6 +53,19 @@ static bool test_dnsmasq_config(char errbuf[ERRBUF_SIZE])
 	pid_t cpid = fork();
 	int code = -1;
 	bool crashed = false;
+	if(cpid == -1)
+	{
+		// Without this the parent branch below would waitpid(-1, ...)
+		// and reap some unrelated child of ours - a dnsmasq TCP helper -
+		// then report its exit status as the result of the config test
+		log_err("Cannot fork to test new dnsmasq config: %s", strerror(errno));
+		close(pipefd[0]);
+		close(pipefd[1]);
+		strncpy(errbuf, strerror(errno), ERRBUF_SIZE - 1);
+		errbuf[ERRBUF_SIZE - 1] = '\0';
+		return false;
+	}
+
 	if (cpid == 0)
 	{
 		/*** CHILD ***/

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -628,8 +628,8 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 			fprintf(pihole_conf, "server=/%s/%s\n", domain, target);
 
 			// Check if the configured domain is the same as the main domain
-			if(strlen(config.dns.domain.name.v.s) > 0 &&
-			   strcasecmp(domain, config.dns.domain.name.v.s) == 0)
+			if(strlen(conf->dns.domain.name.v.s) > 0 &&
+			   strcasecmp(domain, conf->dns.domain.name.v.s) == 0)
 				revServer_domain = true;
 
 			// Flag if configured a server for queries for "home.arpa" TLD
@@ -676,7 +676,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 		fputs("# All queries for this domain will be forwarded to this\n", pihole_conf);
 		fputs("# upstream server\n\n", pihole_conf);
 	}
-	else if(domain_homearpa && !config.dns.domain.local.v.b)
+	else if(domain_homearpa && !conf->dns.domain.local.v.b)
 	{
 		fputs("# The configured DNS domain is \"home.arpa\" and is explicitly\n", pihole_conf);
 		fputs("# marked non-local. Pi-hole will be forwarding queries for this\n", pihole_conf);
@@ -703,7 +703,7 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 		fputs("# All queries for this domain will be forwarded to this\n", pihole_conf);
 		fputs("# upstream server\n\n", pihole_conf);
 	}
-	else if(domain_internal && !config.dns.domain.local.v.b)
+	else if(domain_internal && !conf->dns.domain.local.v.b)
 	{
 		fputs("# The configured DNS domain is \"internal\" and is explicitly\n", pihole_conf);
 		fputs("# marked non-local. Pi-hole will be forwarding queries for this\n", pihole_conf);
@@ -720,14 +720,14 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 	if(strlen(conf->dns.domain.name.v.s) > 0)
 	{
 		fputs("# DNS domain for both the DNS and DHCP server\n", pihole_conf);
-		if(revServer_domain || !config.dns.domain.local.v.b)
+		if(revServer_domain || !conf->dns.domain.local.v.b)
 		{
 			if(revServer_domain)
 			{
 				fputs("# This DNS domain is also used for reverse lookups\n", pihole_conf);
 				fputs("# It is forwarded to the upstream servers configured above\n", pihole_conf);
 			}
-			else // !config.dns.domain.local.v.b
+			else // !conf->dns.domain.local.v.b
 			{
 				fputs("# This domain is explicitly configured to *not* be local. Ensure\n", pihole_conf);
 				fputs("# that you have configured at least one upstream server for this\n", pihole_conf);
@@ -948,8 +948,15 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 		fputs("#### Additional user configuration - END ####\n\n", pihole_conf);
 	}
 
-	// Flush config file to disk
-	fflush(pihole_conf);
+	// Flush config file to disk and make sure all of it got there. Every
+	// directive above is written without checking, and fclose() reports
+	// success after a short write, so without this a disk that filled up
+	// part-way through would be renamed over the live dnsmasq config as a
+	// truncated file that dnsmasq would happily start from
+	const bool write_failed = fflush(pihole_conf) != 0 || ferror(pihole_conf) != 0 ||
+	                          fsync(fileno(pihole_conf)) != 0;
+	if(write_failed)
+		log_err("Cannot write dnsmasq config file: %s", strerror(errno));
 
 	// Unlock file
 	if(locked)
@@ -959,6 +966,15 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 	if(fclose(pihole_conf) != 0)
 	{
 		log_err("Cannot close dnsmasq config file: %s", strerror(errno));
+		return false;
+	}
+
+	// Leave the half-written temporary file behind rather than installing it
+	if(write_failed)
+	{
+		if(remove(DNSMASQ_TEMP_CONF) != 0)
+			log_err("Cannot remove incomplete dnsmasq config file: %s", strerror(errno));
+
 		return false;
 	}
 
@@ -1276,6 +1292,14 @@ bool write_custom_list(void)
 	else if(N == 0)
 		fputs("\n# There are currently no entries in this file\n", custom_list);
 
+	// Make sure everything written above actually reached the disk, for the
+	// same reason as in write_dnsmasq_config(): none of the writes is
+	// checked and fclose() succeeds after a short one
+	const bool write_failed = fflush(custom_list) != 0 || ferror(custom_list) != 0 ||
+	                          fsync(fileno(custom_list)) != 0;
+	if(write_failed)
+		log_err("Cannot write custom.list: %s", strerror(errno));
+
 	// Unlock file
 	if(locked)
 		unlock_file(custom_list, DNSMASQ_CUSTOM_LIST_LEGACY".tmp");
@@ -1284,6 +1308,15 @@ bool write_custom_list(void)
 	if(fclose(custom_list) != 0)
 	{
 		log_err("Cannot close custom.list: %s", strerror(errno));
+		return false;
+	}
+
+	// Leave the half-written temporary file behind rather than installing it
+	if(write_failed)
+	{
+		if(remove(DNSMASQ_CUSTOM_LIST_LEGACY".tmp") != 0)
+			log_err("Cannot remove incomplete custom.list: %s", strerror(errno));
+
 		return false;
 	}
 

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -55,8 +55,25 @@ FILE * __attribute((malloc)) __attribute((nonnull(1))) openFTLtoml(const char *m
 		snprintf(filename, sizeof(filename), BACKUP_DIR"/pihole.toml.%u", version);
 	}
 
-	// Try to open config file
-	FILE *fp = fopen(filename, mode);
+	// Try to open config file. For writing this deliberately does not go
+	// through fopen(..., "w"): that truncates at open time, before the lock
+	// below is taken, so a second writer arriving mid-write would empty the
+	// temporary file the first one is still filling. Open without
+	// truncating, take the lock, and only then cut the file back to zero
+	const bool writing = mode[0] == 'w';
+	FILE *fp = NULL;
+	if(writing)
+	{
+		const int fd = open(filename, O_RDWR | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP);
+		if(fd >= 0)
+		{
+			fp = fdopen(fd, "r+");
+			if(fp == NULL)
+				close(fd);
+		}
+	}
+	else
+		fp = fopen(filename, mode);
 
 	// Return early if opening failed
 	if(!fp)
@@ -68,6 +85,16 @@ FILE * __attribute((malloc)) __attribute((nonnull(1))) openFTLtoml(const char *m
 
 	// Lock file, may block if the file is currently opened
 	*locked = lock_file(fp, filename);
+
+	// Now that the file is ours, discard whatever an earlier write left in it
+	if(writing && ftruncate(fileno(fp), 0) != 0)
+	{
+		log_err("Cannot truncate %s: %s", filename, strerror(errno));
+		if(*locked)
+			unlock_file(fp, filename);
+		fclose(fp);
+		return NULL;
+	}
 
 	// Log if we are using a backup file
 	if(version > 0)

--- a/src/config/toml_helper.c
+++ b/src/config/toml_helper.c
@@ -546,7 +546,11 @@ void readTOMLvalue(struct conf_item *conf_item, const char* key, toml_datum_t to
 		case CONF_INT:
 		{
 			const toml_datum_t val = toml_table_find(toml, key);
-			if(val.type == TOML_INT64)
+			// Range-checked like the unsigned cases below: v.i is a
+			// 32-bit int and TOML integers are 64-bit, so without this
+			// an out-of-range value in pihole.toml is silently
+			// truncated into something else entirely
+			if(val.type == TOML_INT64 && val.u.int64 >= INT_MIN && val.u.int64 <= INT_MAX)
 				conf_item->v.i = val.u.int64;
 			else
 				log_absent_or_wrong_type(val, conf_item, "integer");

--- a/src/config/toml_writer.c
+++ b/src/config/toml_writer.c
@@ -14,6 +14,10 @@
 #include "log.h"
 #include "tomlc17/tomlc17.h"
 #include "toml_writer.h"
+// open(), O_RDWR
+#include <fcntl.h>
+// flock()
+#include <sys/file.h>
 #include "toml_helper.h"
 // get_blocking_mode_str()
 #include "datastructure.h"
@@ -28,6 +32,17 @@
 
 // defined in config/config.c
 extern uint8_t last_checksum[SHA256_DIGEST_SIZE];
+
+// Release the lock that serialises writing and installing pihole.toml
+static void release_install_lock(int *fd)
+{
+	if(*fd < 0)
+		return;
+
+	// Closing the descriptor releases the flock
+	close(*fd);
+	*fd = -1;
+}
 
 bool writeFTLtoml(const bool verbose, FILE *fp)
 {
@@ -44,16 +59,41 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 		return true;
 	}
 
+	// Serialise the whole write-and-install against another writer. The lock
+	// has to sit on a path nothing ever renames: locking the temporary file
+	// or pihole.toml itself would leave the next writer holding a lock on a
+	// different inode the moment one of them renames, which serialises
+	// nothing. Held until this function returns
+	int install_lock = -1;
+	const bool opened = fp == NULL;
+	if(opened)
+	{
+		install_lock = open(GLOBALTOMLPATH".lock", O_RDWR | O_CREAT | O_CLOEXEC,
+		                    S_IRUSR | S_IWUSR | S_IRGRP);
+		if(install_lock < 0)
+			log_warn("Cannot open %s (%s), writing the config unserialised",
+			         GLOBALTOMLPATH".lock", strerror(errno));
+		else if(flock(install_lock, LOCK_EX) != 0)
+		{
+			log_warn("Cannot lock %s (%s), writing the config unserialised",
+			         GLOBALTOMLPATH".lock", strerror(errno));
+			close(install_lock);
+			install_lock = -1;
+		}
+	}
+
 	// open temporary config file for writing *unless* we are provided with
 	// a file pointer to an already opened file
 	bool locked = false;
-	const bool opened = fp == NULL;
 	if(fp == NULL)
 	{
 		// Try to open a temporary config file for writing
 		fp = openFTLtoml("w", 0, &locked);
 		if(fp == NULL)
+		{
+			release_install_lock(&install_lock);
 			return false;
+		}
 	}
 
 	// Write header
@@ -196,6 +236,7 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 			log_err("Not replacing "GLOBALTOMLPATH", the new config could not be written");
 			if(unlink(GLOBALTOMLPATH".tmp") != 0)
 				log_warn("Cannot remove temporary config file: %s", strerror(errno));
+			release_install_lock(&install_lock);
 			return false;
 		}
 	}
@@ -219,6 +260,7 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 			log_warn("Cannot move temporary config file to final location (%s), content not updated", strerror(errno));
 			// Restart watching for changes in the config file
 			watch_config(true);
+			release_install_lock(&install_lock);
 			return false;
 		}
 
@@ -236,6 +278,7 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 		if(unlink(GLOBALTOMLPATH".tmp") != 0)
 		{
 			log_warn("Cannot remove temporary config file (%s), content not updated", strerror(errno));
+			release_install_lock(&install_lock);
 			return false;
 		}
 
@@ -246,5 +289,6 @@ bool writeFTLtoml(const bool verbose, FILE *fp)
 	if(!sha256sum(GLOBALTOMLPATH, last_checksum, false))
 		log_err("Unable to create checksum of %s", GLOBALTOMLPATH);
 
+	release_install_lock(&install_lock);
 	return true;
 }


### PR DESCRIPTION
# What does this implement/fix?

generate dnsmasq.conf from the candidate, notice failed writes, and do not race

write_dnsmasq_config() takes the config to render as conf, but six reads of
dns.domain.local and dns.domain.name went to the global config instead - the one
that is still live and has not had the change applied. changing either setting
generated the file from the old values and the next SIGHUP applied them

nothing noticed a failed write either. every directive is fputs/fprintf with the
result discarded, the fflush return was thrown away, and fclose reports success
after a short write, so a disk filling up part-way produced a truncated file
that was renamed over /etc/pihole/dnsmasq.conf and handed to dnsmasq.
write_custom_list() had the same hole

openFTLtoml("w") opened the temp file with fopen(..., "w"), which truncates
before the lock on the next line, so a second writer empties the file the first
is still filling. and the install was unserialised: closeFTLtoml() drops the
lock and only then does writeFTLtoml() compare, rotate and rename. the lock for
that has to sit on a path nothing renames, otherwise the next writer locks a
different inode and it serialises nothing, so it is a lock file of its own

plus two small ones: CONF_INT assigned a TOML int64 into a 32-bit int with no
range check, unlike CONF_UINT and CONF_UINT16 right below it, and
test_dnsmasq_config() never checked its fork so a failure fell through to
waitpid(-1, ...) and reported an unrelated child's exit status as the verdict on
the config. the identical fork in run_and_stream_command() is fixed in the
process handling PR, that file belongs with the action endpoints

## How to test the change during review

change dns.domain.local and look at the generated dnsmasq.conf, then fill the
disk part-way through a write and check nothing is installed

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
