### PR TITLE
endpoints that answer twice, or answer with the wrong numbers

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -52,7 +52,8 @@ int api_history_database_clients(struct ftl_conn *api);
 // Query methods
 int api_queries(struct ftl_conn *api);
 int api_queries_suggestions(struct ftl_conn *api);
-bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, regex_t **regex, unsigned int *N_regex);
+bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json,
+                          regex_t **regex, unsigned int *N_regex, int *ret);
 void free_filter_regex(regex_t *regex, const unsigned int N_regex);
 
 // Statistics methods (database)

--- a/src/api/history.c
+++ b/src/api/history.c
@@ -159,6 +159,10 @@ int api_history_clients(struct ftl_conn *api)
 
 	// Main return loop
 	int others_total = 0;
+	// Whether any client was actually folded into the "others" series. The
+	// label below has to follow this and not a separate count, or a client
+	// disappears into an unlabelled bucket
+	bool folded_others = false;
 
 	// The JSON_* macros cannot be used below while we hold the lock, as
 	// their early return would leave it taken for good. Everything that
@@ -206,9 +210,13 @@ int api_history_clients(struct ftl_conn *api)
 			// -1 because of the special "other" client we add below
 			// This is disabled when Nc is 0, which means we want to return
 			// all clients
-			if(arrayID >= Nc - 1)
+			// Fold only when there are more clients than fit. Folding
+			// on arrayID alone also swallowed the lowest-ranked client
+			// when every client fits, which is the normal case
+			if(num_clients > Nc && arrayID >= Nc - 1)
 			{
 				others += client->overTime[slot];
+				folded_others = true;
 				continue;
 			}
 
@@ -243,7 +251,8 @@ int api_history_clients(struct ftl_conn *api)
 		// - N is 0, which means we want to return all clients, or
 		// - when we are NOT in global-max mode as we need to return all
 		//   clients in that case
-		if(config.webserver.api.client_history_global_max.v.b && arrayID >= Nc - 1)
+		if(config.webserver.api.client_history_global_max.v.b &&
+		   num_clients > Nc && arrayID >= Nc - 1)
 			break;
 
 		// Get client name and IP address
@@ -273,9 +282,9 @@ int api_history_clients(struct ftl_conn *api)
 	// can occur if the strings SHM segment is remapped by another thread.
 	unlock_shm();
 
-	// Add "others" client only if there are more clients than we return
-	// and if we are not returning all clients
-	if(num_clients > Nc)
+	// Add the "others" client exactly when the loop above folded something
+	// into that series
+	if(folded_others)
 	{
 		item = JSON_NEW_OBJECT();
 		cJSON *name = cJSON_CreateStringReference("other clients");

--- a/src/api/info.c
+++ b/src/api/info.c
@@ -427,11 +427,15 @@ static int get_hwmon_sensors(struct ftl_conn *api, cJSON *sensors)
 				// Remove newline if present
 				char *p = strchr(name, '\n');
 				if (p != NULL) *p = '\0';
-				fclose(f_name);
 			}
+
+			// Closed either way - a failed read left it open before
+			fclose(f_name);
 		}
-		else
-			break;
+		// No readable name file: fall through and report the sensor under
+		// the directory name copied into name above, which is what that
+		// fallback is for. Breaking out here instead dropped this sensor
+		// and every one after it
 
 		// Create sensor array item
 		cJSON *hwmon = JSON_NEW_OBJECT();
@@ -791,10 +795,22 @@ int get_version_obj(struct ftl_conn *api, cJSON *version)
 
 	FILE *fp = fopen(VERSIONS_FILE, "r");
 	if(!fp)
+	{
+		// The seven objects above are ours until they are attached to
+		// the version object at the end of this function
+		JSON_DELETE(core_local);
+		JSON_DELETE(web_local);
+		JSON_DELETE(ftl_local);
+		JSON_DELETE(core_remote);
+		JSON_DELETE(web_remote);
+		JSON_DELETE(ftl_remote);
+		JSON_DELETE(docker);
+
 		return send_json_error(api, 500,
 		                       "internal_error",
 		                       "Failed to read " VERSIONS_FILE,
 		                       NULL);
+	}
 
 	// Loop over KEY=VALUE parts in the versions file
 	while((read = getline(&line, &len, fp)) != -1)
@@ -911,7 +927,16 @@ int api_info_version(struct ftl_conn *api)
 {
 	// Send reply
 	cJSON *version = JSON_NEW_OBJECT();
-	get_version_obj(api, version);
+
+	// A non-zero return means get_version_obj() has answered the request
+	// itself. Carrying on would append a second body to that response
+	const int ret = get_version_obj(api, version);
+	if(ret != 0)
+	{
+		JSON_DELETE(version);
+		return ret;
+	}
+
 	cJSON *json = JSON_NEW_OBJECT();
 	JSON_ADD_ITEM_TO_OBJECT(json, "version", version);
 	JSON_SEND_OBJECT(json);

--- a/src/api/padd.c
+++ b/src/api/padd.c
@@ -298,7 +298,14 @@ int api_padd(struct ftl_conn *api)
 
 		// info/version
 		cJSON *version = JSON_NEW_OBJECT();
-		get_version_obj(api, version);
+		const int ret = get_version_obj(api, version);
+		if(ret != 0)
+		{
+			// get_version_obj() has answered already
+			JSON_DELETE(version);
+			JSON_DELETE(json);
+			return ret;
+		}
 		JSON_ADD_ITEM_TO_OBJECT(json, "version", version);
 	}
 

--- a/src/api/queries.c
+++ b/src/api/queries.c
@@ -561,19 +561,34 @@ int api_queries(struct ftl_conn *api)
 	// releases the statement and the compiled regexes
 	int ret = 200;
 	sqlite3_stmt *read_stmt = NULL;
+	// Both regex arrays are declared before the first goto below: the
+	// epilogue frees them, and jumping past their declarations would leave
+	// it reading indeterminate values
 	regex_t *regex_domains = NULL;
 	unsigned int N_regex_domains = 0;
-	if(compile_filter_regex(api, "webserver.api.excludeDomains",
-	                        config.webserver.api.excludeDomains.v.json,
-	                        &regex_domains, &N_regex_domains))
-		filtering = true;
-
 	regex_t *regex_clients = NULL;
 	unsigned int N_regex_clients = 0;
+	int regex_ret = 0;
+
+	if(compile_filter_regex(api, "webserver.api.excludeDomains",
+	                        config.webserver.api.excludeDomains.v.json,
+	                        &regex_domains, &N_regex_domains, &regex_ret))
+		filtering = true;
+	if(regex_ret != 0)
+	{
+		ret = regex_ret;
+		goto queries_fail;
+	}
+
 	if(compile_filter_regex(api, "webserver.api.excludeClients",
 	                        config.webserver.api.excludeClients.v.json,
-	                        &regex_clients, &N_regex_clients))
+	                        &regex_clients, &N_regex_clients, &regex_ret))
 		filtering = true;
+	if(regex_ret != 0)
+	{
+		ret = regex_ret;
+		goto queries_fail;
+	}
 
 	// Finish preparing query string
 	querystr_finish(querystr, sort_col, sort_dir);
@@ -1151,8 +1166,19 @@ void free_filter_regex(regex_t *regex, const unsigned int N_regex)
 	free(regex);
 }
 
-bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, regex_t **regex, unsigned int *N_regex)
+// Returns whether any regex was compiled, i.e. whether filtering is in effect.
+//
+// A caller that can carry an HTTP status passes ret, and a failure then answers
+// the request and reports the code it sent through it. Answering without that
+// is not allowed: a caller which cannot propagate the code - get_top_domains()
+// and get_top_clients() return a cJSON object, not a status - would go on to
+// send a second body on the same connection. Those pass NULL, and a failure is
+// logged and treated as "no filtering" instead.
+bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json,
+                          regex_t **regex, unsigned int *N_regex, int *ret)
 {
+	if(ret != NULL)
+		*ret = 0;
 
 	const int N = cJSON_GetArraySize(json);
 	if(N < 1)
@@ -1164,10 +1190,15 @@ bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, r
 	*regex = calloc(N, sizeof(regex_t));
 	if(*regex == NULL)
 	{
-		return send_json_error(api, 500,
-		                       "internal_error",
-		                       "Internal server error, failed to allocate memory for regex array",
-		                       NULL);
+		if(ret != NULL)
+			*ret = send_json_error(api, 500,
+			                       "internal_error",
+			                       "Internal server error, failed to allocate memory for regex array",
+			                       NULL);
+		else
+			log_web(LOG_ERR, "Cannot allocate regex array for %s", path);
+
+		return false;
 	}
 
 	// Compile regexes
@@ -1200,10 +1231,13 @@ bool compile_filter_regex(struct ftl_conn *api, const char *path, cJSON *json, r
 			*regex = NULL;
 			*N_regex = 0;
 
-			return send_json_error(api, 400,
-			                       "bad_request",
-			                       "Failed to compile regex",
-			                       filter->valuestring);
+			if(ret != NULL)
+				*ret = send_json_error(api, 400,
+				                       "bad_request",
+				                       "Failed to compile regex",
+				                       filter->valuestring);
+
+			return false;
 		}
 
 		i++;

--- a/src/api/stats.c
+++ b/src/api/stats.c
@@ -234,9 +234,12 @@ cJSON *get_top_domains(struct ftl_conn *api, const int count,
 	// Get domains which the user doesn't want to see
 	regex_t *regex_domains = NULL;
 	unsigned int N_regex_domains = 0;
+	// NULL: this function returns a cJSON object and cannot carry an HTTP
+	// status, so compile_filter_regex() logs a bad regex rather than
+	// answering the request behind our back
 	compile_filter_regex(api, "webserver.api.excludeDomains",
 	                     config.webserver.api.excludeDomains.v.json,
-	                     &regex_domains, &N_regex_domains);
+	                     &regex_domains, &N_regex_domains, NULL);
 
 	// Lock shared memory
 	lock_shm();
@@ -424,9 +427,10 @@ cJSON *get_top_clients(struct ftl_conn *api, const int count,
 	// Get clients which the user doesn't want to see
 	regex_t *regex_clients = NULL;
 	unsigned int N_regex_clients = 0;
+	// NULL for the same reason as in get_top_domains() above
 	compile_filter_regex(api, "webserver.api.excludeClients",
 	                     config.webserver.api.excludeClients.v.json,
-	                     &regex_clients, &N_regex_clients);
+	                     &regex_clients, &N_regex_clients, NULL);
 
 	// Lock shared memory
 	lock_shm();

--- a/src/webserver/http-common.c
+++ b/src/webserver/http-common.c
@@ -422,15 +422,26 @@ int get_string_var(const char *source, const char *var, char *dest, size_t dest_
 		return -1;
 	}
 
-	// Extract value of the particular variable
+	// Extract value of the particular variable. mg_get_var() already
+	// URL-decodes what it returns, so this must not decode it a second time:
+	// a value that legitimately contains a percent sign, or a space that
+	// arrived as '+', comes back from the second pass as -1 and the caller
+	// silently drops the filter
 	int len = mg_get_var(source, strlen(source), var, tempbuf, dest_len);
 
-	// Decode the URI component if needed
 	if(len > 0)
-		len = mg_url_decode(tempbuf, len, dest, dest_len, 0);
+	{
+		// Copy rather than decode. The temporary buffer is still needed:
+		// mg_get_var() wants a buffer of its own and dest may be shorter
+		// than dest_len suggests to it
+		if((size_t)len >= dest_len)
+			len = (int)dest_len - 1;
 
-	// Free the temporary buffer, if anything was decoded it's now stored in
-	// dest
+		memcpy(dest, tempbuf, len);
+		dest[len] = '\0';
+	}
+
+	// Free the temporary buffer, the value is now stored in dest
 	free(tempbuf);
 
 	// Return the length of the decoded string


### PR DESCRIPTION
# What does this implement/fix?

endpoints that answer twice, or answer with the wrong numbers

get_version_obj() returns a status code when it cannot read the versions file
and both callers discarded it, so after the 500 had gone out they carried on and
appended a whole second body to it. the same function also allocates seven cJSON
objects before opening that file and returned without freeing any of them

get_hwmon_sensors() broke out of the entire readdir loop when a hwmonX had no
readable name file, throwing away the directory-name fallback it had just
prepared and every sensor after that one, and left the stream open when the read
itself failed

compile_filter_regex() answered the request on a bad regex but reported it as a
plain bool, which every call site read as "filtering is on" before sending its
own response. it reports the code through an out-parameter now.
get_top_domains() and get_top_clients() return a cJSON object and have no status
to carry, so they pass NULL and a bad regex is logged rather than answered
behind their caller's back

get_string_var() ran mg_url_decode() over a value mg_get_var() had already
decoded, so any value with a percent sign, or a space that arrived as +, came
back as -1 from the second pass and the filter was silently dropped

api_history_clients() folded the lowest-ranked client into the unlabelled others
series whenever arrayID >= Nc - 1, while the clients map only gained an others
entry when there were more clients than fit. at the usual num_clients == Nc a
client's data vanished into a series with no name

## How to test the change during review

GET /api/queries?domain=a b with a space in it, and compare /api/history/clients
against the number of clients you actually have

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
