### PR TITLE
free the teleporter archive, and end the reader on a rejected import

### DIFF
--- a/src/api/teleporter.c
+++ b/src/api/teleporter.c
@@ -64,8 +64,12 @@ static int api_teleporter_GET(struct ftl_conn *api)
 	// Send raw (binary) ZIP content
 	mg_write(api->conn, ptr, size);
 
-	// Free allocated ZIP memory
+	// Free allocated ZIP memory. mz_zip_writer_finalize_heap_archive() has
+	// handed the buffer over to us and cleared it out of the writer's state,
+	// so mz_zip_writer_end() inside free_teleporter_zip() releases the
+	// writer but not the archive itself - that is ours now
 	free_teleporter_zip(&zip);
+	free(ptr);
 
 	return 200;
 }
@@ -153,6 +157,15 @@ static int field_get(const char *key, const char *value, size_t valuelen, void *
 	}
 	else if(data->field.sid)
 	{
+		// A field can arrive in more than one chunk, and a client is free
+		// to send the same field twice. Either way this runs again, and
+		// overwriting the pointer would drop what was allocated before
+		if(data->sid != NULL)
+		{
+			log_web(LOG_WARNING, "Ignoring repeated SID field in teleporter upload");
+			return MG_FORM_FIELD_HANDLE_GET;
+		}
+
 		// Allocate memory for the SID
 		data->sid = calloc(valuelen + 1, sizeof(char));
 		if(data->sid == NULL)
@@ -168,6 +181,13 @@ static int field_get(const char *key, const char *value, size_t valuelen, void *
 	}
 	else if(data->field.import)
 	{
+		// As above: do not leak an already parsed object by replacing it
+		if(data->import != NULL)
+		{
+			log_web(LOG_WARNING, "Ignoring repeated import field in teleporter upload");
+			return MG_FORM_FIELD_HANDLE_GET;
+		}
+
 		// Try to parse the JSON data
 		const char *json_error = NULL;
 		cJSON *json = cJSON_ParseWithLengthOpts(value, valuelen, &json_error, false);

--- a/src/zip/teleporter.c
+++ b/src/zip/teleporter.c
@@ -648,6 +648,7 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 			if(err != NULL)
 			{
 				free(ptr);
+				mz_zip_reader_end(&zip);
 				return err;
 			}
 			log_debug(DEBUG_CONFIG, "Imported Pi-hole configuration: %s", file_stat.m_filename);
@@ -669,6 +670,7 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 			if(err != NULL)
 			{
 				free(ptr);
+				mz_zip_reader_end(&zip);
 				return err;
 			}
 			log_debug(DEBUG_CONFIG, "Imported DHCP leases: %s", file_stat.m_filename);
@@ -720,6 +722,7 @@ const char *read_teleporter_zip(uint8_t *buffer, const size_t buflen, char * con
 			if(err != NULL)
 			{
 				free(ptr);
+				mz_zip_reader_end(&zip);
 				return err;
 			}
 			log_debug(DEBUG_CONFIG, "Imported database: %s", file_stat.m_filename);
@@ -799,19 +802,23 @@ bool write_teleporter_zip_to_disk(void)
 	{
 		log_err("Failed to open %s for writing: %s", filename, strerror(errno));
 		free_teleporter_zip(&zip);
+		free(ptr);
 		return false;
 	}
 	if(fwrite(ptr, 1, size, fp) != size)
 	{
 		log_err("Failed to write %zu bytes to %s: %s", size, filename, strerror(errno));
 		free_teleporter_zip(&zip);
+		free(ptr);
 		fclose(fp);
 		return false;
 	}
 	fclose(fp);
 
-	// Free allocated ZIP memory
+	// Free allocated ZIP memory, including the archive buffer that
+	// mz_zip_writer_finalize_heap_archive() handed over to us
 	free_teleporter_zip(&zip);
+	free(ptr);
 
 	/* Output filename on successful creation */
 	log_info("%s", filename);


### PR DESCRIPTION
# What does this implement/fix?

free the teleporter archive, and end the reader on a rejected import

mz_zip_writer_finalize_heap_archive() hands the archive buffer to its caller and
clears m_pMem out of the writer state, so the mz_zip_writer_end() inside
free_teleporter_zip() releases the writer and nothing else. both callers treated
it as if it freed everything, so every authenticated GET /api/teleporter leaked
an entire ZIP of the config, the gravity database and the leases, and
pihole-FTL --teleporter leaked the same on its way out

on the import side the three error returns for pihole.toml, the leases and
gravity.db return straight out of the loop, past the only mz_zip_reader_end() at
the end, so a rejected import leaked the reader state and its copy of the
central directory

field_get() overwrote data->sid and data->import instead of keeping what was
already there. civetweb calls it again for each chunk of a field larger than its
buffer, and a client can just send the same field twice, so both were one POST
away from dropping an allocation

## How to test the change during review

watch RSS across a few GET /api/teleporter, then POST an import that gets
rejected

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
