### PR TITLE
stop database failure sentinels reaching arithmetic

### DIFF
--- a/src/api/network.c
+++ b/src/api/network.c
@@ -363,6 +363,18 @@ int api_client_suggestions(struct ftl_conn *api)
 
 	// Open pihole-FTL.db database file connection
 	sqlite3 *db = dbopen(true, false);
+	if(db == NULL)
+	{
+		// The two sibling handlers in this file check this. Without it
+		// the attach below fails on a NULL handle and answers with that
+		// instead of naming the real problem, and dbclose() takes a
+		// decrement for a connection that was never opened
+		log_err("Failed to open database in api_client_suggestions()");
+		return send_json_error(api, 500,
+		                       "database_error",
+		                       "Could not open long-term database",
+		                       NULL);
+	}
 
 	// Attach gravity database
 	const char *message = "";

--- a/src/api/stats_database.c
+++ b/src/api/stats_database.c
@@ -763,12 +763,27 @@ int api_stats_database_upstreams(struct ftl_conn *api)
 	           "WHERE timestamp >= :from AND timestamp <= :until "
 	           "AND status = 3";
 	int cached_queries = db_query_int_from_until(db, querystr, from, until);
-	sum_queries += cached_queries;
 
 	querystr = "SELECT COUNT(*) FROM query_storage "
 	           "WHERE timestamp >= :from AND timestamp <= :until "
 		   "AND status != 0 AND status != 2 AND status != 3";
 	int blocked_queries = db_query_int_from_until(db, querystr, from, until);
+
+	// A failed query reports a negative sentinel, and sum_queries is
+	// unsigned - adding it in would wrap into an enormous total and be
+	// served as fact. api_stats_database_summary() checks the same way
+	if(cached_queries < 0 || blocked_queries < 0)
+	{
+		// Close (= unlock) database connection
+		dbclose(&db);
+
+		return send_json_error(api, 500,
+		                       "internal_error",
+		                       "Internal server error",
+		                       NULL);
+	}
+
+	sum_queries += cached_queries;
 	sum_queries += blocked_queries;
 
 	querystr = "SELECT forward,COUNT(*) FROM query_storage "

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1017,8 +1017,12 @@ void initConfig(struct config *conf)
 	conf->database.maxDBdays.k = "database.maxDBdays";
 	conf->database.maxDBdays.h = "How long should queries be stored in the database [days]?";
 	conf->database.maxDBdays.a = cJSON_CreateStringReference("A positive integer value in days, or 0 to disable the database");
-	conf->database.maxDBdays.t = CONF_INT;
-	conf->database.maxDBdays.d.i = (365/4);
+	// Unsigned: every reader takes .v.ui - database-thread.c, query-table.c
+	// and common.c - and the help text above promises a positive value. As
+	// CONF_INT the two disagreed, and a -1 stored through .v.i came back out
+	// of .v.ui as 4294967295
+	conf->database.maxDBdays.t = CONF_UINT;
+	conf->database.maxDBdays.d.ui = (365/4);
 	conf->database.maxDBdays.c = validate_stub; // Only type-based checking
 
 	conf->database.DBinterval.k = "database.DBinterval";

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -108,13 +108,16 @@ void _dbclose(sqlite3 **db, const char *func, const int line, const char *file)
 		const int rc = _dbclose_handle(*db, func, line, file);
 		if(rc != SQLITE_OK)
 			checkFTLDBrc(rc);
+
+		// Inside the guard: dbopen() only counted up when it handed out
+		// a connection, so closing a handle that is already NULL used to
+		// take a decrement with no increment behind it and drift the
+		// counter down, eventually below zero
+		atomic_fetch_sub_explicit(&dbopen_cnt, 1, memory_order_relaxed);
 	}
 
 	// Always set database pointer to NULL, even when closing failed
 	if(db) *db = NULL;
-
-	// Decrement the number of open database connections
-	atomic_fetch_sub_explicit(&dbopen_cnt, 1, memory_order_relaxed);
 }
 
 /**

--- a/src/database/database-thread.c
+++ b/src/database/database-thread.c
@@ -258,7 +258,11 @@ void *DB_thread(void *val)
 		{
 			// Update lastDBdelete timer to avoid multiple deletions
 			lastDBdelete = now;
-			const double mintime = now - (double)(config.database.maxDBdays.v.ui * 86400);
+			// Widen before multiplying: maxDBdays is an unsigned int, so
+			// the product was computed in 32-bit arithmetic and wrapped
+			// for large values, turning a long retention into a cutoff
+			// that deletes almost everything
+			const double mintime = now - (double)config.database.maxDBdays.v.ui * 86400.0;
 			DBOPEN_OR_AGAIN();
 			TIMED_DB_OP(delete_old_queries_from_db(false, mintime));
 			DBCLOSE_OR_BREAK();

--- a/src/database/network-table.c
+++ b/src/database/network-table.c
@@ -297,7 +297,12 @@ static int find_recent_device_by_mock_hwaddr(sqlite3 *db, const char *ipaddr)
 
 	const char *querystr = "SELECT id FROM network WHERE "
 	                       "hwaddr = concat('ip-',?1) AND "
-	                       "firstSeen > (cast(strftime('%%s', 'now') as int)-3600)";
+	                       // Single %, this string goes to SQLite as it is
+	                       // and is never run through a formatter. As %%s
+	                       // it reached strftime() literally, which answers
+	                       // NULL, so the cast produced 0 and the one-hour
+	                       // window was never applied
+	                       "firstSeen > (cast(strftime('%s', 'now') as int)-3600)";
 
 	// Perform SQL query
 	return db_query_int_str(db, querystr, ipaddr);

--- a/src/database/query-table.c
+++ b/src/database/query-table.c
@@ -752,6 +752,20 @@ static bool count_queries_on_disk(sqlite3 *memdb)
 	log_debug(DEBUG_DATABASE, "count_queries_on_disk(): Going to import %i queries from disk database",
 	          counted_queries);
 
+	// A failed query reports DB_FAILED, which is negative. counters->queries
+	// is unsigned and init_queries_shm_sz() sizes the queries object from it,
+	// so letting that through asks for an allocation of nearly the whole
+	// address space and takes the startup down
+	if(counted_queries < 0)
+	{
+		log_err("count_queries_on_disk(): Cannot count queries on disk");
+
+		// Zero rather than leave the sentinel in this static: the import
+		// compares its own progress against it further down
+		counted_queries = 0;
+		return false;
+	}
+
 	// Lock shared memory
 	lock_shm();
 	// Set query counter high enough so that the subsequent lock_shm() call


### PR DESCRIPTION
# What does this implement/fix?

stop database failure sentinels reaching arithmetic

db_query_int_from_until() and friends report a failure as a negative value and
three places used the result without asking

count_queries_on_disk() stored it straight into counters->queries, which is
unsigned, and init_queries_shm_sz() then sized the shared queries object from it
- an allocation of very nearly the whole address space, during startup

api_stats_database_upstreams() added two unchecked results into an unsigned
sum_queries, so a failed count wrapped the total into an enormous number and
served it as fact. api_stats_database_summary() already checks the same values
the same way

_dbclose() decremented dbopen_cnt outside the db != NULL && *db != NULL guard
while dbopen() only counts up once it has a connection, so closing an
already-NULL handle drifted the counter down. and api_client_suggestions()
skipped the dbopen() NULL check both its siblings in that file perform

two arithmetic ones in the same area. maxDBdays * 86400 was evaluated in 32-bit
unsigned arithmetic and only widened to double afterwards, so a large retention
wrapped into a cutoff that deletes nearly everything. and
find_recent_device_by_mock_hwaddr() wrote strftime('%%s','now') in a string that
never passes through a formatter, so SQLite got a literal %%s, strftime()
answered NULL, the cast gave 0 and the one-hour window never applied

## How to test the change during review

set database.maxDBdays to 50000 and check what the cleanup would delete

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
