### PR TITLE
copy client data under the lock, and stop the server before freeing the api

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -442,13 +442,16 @@ void cleanup(const int ret)
 	log_debug(DEBUG_ANY, "Terminating: Freeing regex filter memory");
 	free_regex();
 
+	// Terminate HTTP server (if running) before the API it serves. The other
+	// way round, free_api() backed up, zeroed and freed the session table
+	// while civetweb worker threads were still handling requests against it,
+	// since mg_stop() only runs inside http_terminate()
+	log_debug(DEBUG_ANY, "Terminating: Stopping HTTP server");
+	http_terminate();
+
 	// Terminate API
 	log_debug(DEBUG_ANY, "Terminating: Stopping API");
 	free_api();
-
-	// Terminate HTTP server (if running)
-	log_debug(DEBUG_ANY, "Terminating: Stopping HTTP server");
-	http_terminate();
 
 	// Close memory database
 	log_debug(DEBUG_ANY, "Terminating: Closing memory database");

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -1194,6 +1194,16 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 		size_t ippos = client->ippos;
 		size_t oldnamepos = client->namepos;
 
+		// Copy, do not keep pointing. Everything below runs with the
+		// lock released, and a concurrent mremap(MREMAP_MAYMOVE) of the
+		// strings region or of the clients array leaves both the shm
+		// string pointer and the clientsData pointer aimed at memory
+		// that is no longer mapped. resolveAndAddHostname() copies for
+		// the same reason
+		char ipaddr_copy[INET6_ADDRSTRLEN + 1] = { 0 };
+		strncpy(ipaddr_copy, getstr(ippos), sizeof(ipaddr_copy) - 1);
+		const double firstSeen = client->firstSeen;
+
 		// Only try to resolve host names of clients which were recently active if we are re-resolving
 		// Limit for a "recently active" client is two hours ago
 		if(!force_refreshing && !onlynew && client->lastQuery < now - 2*60*60)
@@ -1218,8 +1228,8 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 			continue;
 		}
 
-		// Get IP address of client
-		const char *ipaddr = getstr(ippos);
+		// Get IP address of client, from the copy taken under the lock
+		const char *ipaddr = ipaddr_copy;
 		unlock_shm();
 
 		// Check if we want to resolve an IPv6 address
@@ -1232,10 +1242,10 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 		// slightly to ensure the network table has had time to possibly
 		// correlate the IPv6 address via a related other address (e.g.,
 		// IPv4 address) though an identical MAC address.
-		if(onlynew && newflag && IPv6 && client->firstSeen + DELAY_V6_RESOLUTION > now)
+		if(onlynew && newflag && IPv6 && firstSeen + DELAY_V6_RESOLUTION > now)
 		{
 			log_debug(DEBUG_RESOLVER, "Postponing resolution of new client %s (IPv6) for at least %.0f more seconds",
-			          getstr(ippos), now - client->firstSeen + DELAY_V6_RESOLUTION);
+			          ipaddr, now - firstSeen + DELAY_V6_RESOLUTION);
 
 			skipped++;
 			continue;
@@ -1251,7 +1261,7 @@ static void resolveClients(const bool onlynew, const bool force_refreshing)
 		// - still new,
 		// - IPv6, and
 		// - need to be resolved
-		const bool new_ipv6_needs_resolve = newflag && IPv6 && client->firstSeen + DELAY_V6_RESOLUTION <= now;
+		const bool new_ipv6_needs_resolve = newflag && IPv6 && firstSeen + DELAY_V6_RESOLUTION <= now;
 
 		if(onlynew == false && !new_ipv6_needs_resolve &&
 		   (config.resolver.refreshNames.v.refresh_hostnames == REFRESH_NONE ||


### PR DESCRIPTION
# What does this implement/fix?

copy client data under the lock, and stop the server before freeing the api

resolveClients() reads client->ippos while holding the shared memory lock, keeps
both the resulting string pointer and the clientsData pointer, then releases the
lock and goes on using them - the IPv6 postponement check, the firstSeen
comparison and two debug lines. a concurrent mremap(MREMAP_MAYMOVE) of the
strings region or of the clients array while the resolver thread is unlocked
leaves both aimed at memory that is no longer mapped. resolveAndAddHostname() in
the same file already copies for exactly this reason

cleanup() called free_api() before http_terminate(), and mg_stop() runs inside
the latter, so the session table was backed up, zeroed and freed while civetweb
workers could still be serving requests against it

## How to test the change during review

restart FTL under load with a few API sessions open

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
