### PR TITLE
check fork, terminate the sender name, and do not count a thread that failed

### DIFF
--- a/src/api/action.c
+++ b/src/api/action.c
@@ -39,6 +39,20 @@ static int run_and_stream_command(struct ftl_conn *api, const char *path, const 
 	pid_t cpid = fork();
 	int code = -1;
 	bool crashed = false;
+	if(cpid == -1)
+	{
+		// Neither branch below tests for this, and the parent one ends in
+		// waitpid(-1, ...): it would reap an unrelated child of ours - a
+		// dnsmasq TCP helper, say, whose tcp_pids slot then leaks - and
+		// report that child's exit status as the result of this command.
+		// test_dnsmasq_config() has the same fork and is fixed alongside
+		// the config write path
+		log_err("Cannot fork to run command: %s", strerror(errno));
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return false;
+	}
+
 	if (cpid == 0)
 	{
 		/*** CHILD ***/

--- a/src/signals.c
+++ b/src/signals.c
@@ -1278,11 +1278,17 @@ void log_sigterm_info(void)
 	if(fp != NULL)
 	{
 		size_t read = 0;
-		if((read = fread(kill_name, sizeof(char), sizeof(kill_name), fp)) > 0)
+		// One byte short of the buffer, and terminated below: every NUL
+		// separator in cmdline is turned into a space further down, so a
+		// read that filled the buffer completely would leave the string
+		// with no terminator at all for the log line to stop at
+		if((read = fread(kill_name, sizeof(char), sizeof(kill_name) - 1, fp)) > 0)
 		{
+			kill_name[read] = '\0';
+
 			// cmdline contains null-separated arguments - replace
 			// null bytes with spaces for display
-			for(unsigned int i = 0; i < min((size_t)read, sizeof(kill_name)); i++)
+			for(size_t i = 0; i < read; i++)
 			{
 				if(kill_name[i] == '\0')
 					kill_name[i] = ' ';

--- a/src/tools/arp-scan.c
+++ b/src/tools/arp-scan.c
@@ -679,14 +679,17 @@ int run_arp_scan(const bool scan_all, const bool extreme_mode)
 			if(thread_data[tid].src_addr.sin_addr.s_addr != htonl(INADDR_LOOPBACK))
 			{
 				// Create thread
+				// Count the thread only once it exists. A slot
+				// that was never started stays at
+				// STATUS_INITIALIZING, and the progress loop
+				// below waits for every counted slot to reach a
+				// finished state, so counting it hangs
+				// pihole-FTL arp-scan for good
 				if(pthread_create(&scanthread[tid], &attr, arp_scan_iface, &thread_data[tid] ) != 0)
-				{
 					printf("Unable to launch thread for interface %s, skipping...\n",
 						tmp->ifa_name);
-				}
-
-				// Increase thread ID
-				tid++;
+				else
+					tid++;
 			}
 		}
 


### PR DESCRIPTION
# What does this implement/fix?

check fork, terminate the sender name, and do not count a thread that failed

run_and_stream_command() tested only cpid == 0, so a failed fork fell into the
parent branch and reached waitpid(-1, &status, 0). that reaps any child of ours
- a dnsmasq TCP helper, whose tcp_pids slot then leaks - and reports its exit
status as the result of a command that was never run. the identical fork in
test_dnsmasq_config() is fixed in the config write PR, that file belongs there

log_sigterm_info() read up to all 256 bytes of kill_name and then replaced every
NUL separator in the cmdline with a space. a read that filled the buffer left no
terminator anywhere in it, and the trailing-space trim only writes one when the
last byte happens to be a space, so log_info() and the snprintf after it ran off
the end

run_arp_scan() increased tid even when pthread_create() had just failed, leaving
that slot at STATUS_INITIALIZING. the progress loop waits for every counted slot
to reach a finished state, so one failed thread hung pihole-FTL arp-scan for good

## How to test the change during review

send SIGTERM from a process with a long cmdline and look at the log line

## Additional information

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. My change does not modify `src/dnsmasq/`. That tree is a verbatim copy of upstream dnsmasq and we do not carry anything in it that deviates from upstream. Fixes have to go through the [`dnsmasq-discuss` mailing list](https://lists.thekelleys.org.uk/cgi-bin/mailman/listinfo/dnsmasq-discuss) first, we merge them once they are in dnsmasq master.

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repository's `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
