### PR TITLE
Add dns.fastRetry to retransmit unanswered upstream queries

### DIFF
--- a/src/api/docs/content/specs/config.yaml
+++ b/src/api/docs/content/specs/config.yaml
@@ -227,6 +227,8 @@ components:
                   type: array
                   items:
                     type: string
+                fastRetry:
+                  type: integer
                 CNAMEdeepInspect:
                   type: boolean
                 EDNS0ECS:
@@ -770,6 +772,7 @@ components:
         config:
           dns:
             upstreams: [ "127.0.0.1#5353", "8.8.8.8" ]
+            fastRetry: 1000
             upstreamCA: ""
             doh: true
             dot: true

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -420,6 +420,14 @@ void initConfig(struct config *conf)
 	conf->dns.upstreams.f = FLAG_RESTART_FTL;
 	conf->dns.upstreams.c = validate_upstreams;
 
+	conf->dns.fastRetry.k = "dns.fastRetry";
+	conf->dns.fastRetry.h = "Retransmission interval (in milliseconds) for unanswered upstream queries.\n\n Pi-hole forwards a query and then waits for the reply. If either the query or the reply is lost on the way, nothing happens until the client gives up and asks again. Repetitions of a query that is still in flight are attached to the running query instead of being forwarded again, so a client cannot recover such a loss on its own either - only Pi-hole can, by asking upstream once more.\n\n The first retransmission is sent after the configured number of milliseconds, the interval doubles for every further attempt, and retransmissions stop as soon as the query is answered or has timed out. Setting this to 0 disables retransmission. Note that DNSSEC validation enables it independently of this setting because an unanswered query would otherwise stall the whole validation chain.";
+	conf->dns.fastRetry.a = cJSON_CreateStringReference("An integer value between 50 and 10000 (milliseconds), or 0 to disable retransmission");
+	conf->dns.fastRetry.t = CONF_UINT;
+	conf->dns.fastRetry.f = FLAG_RESTART_FTL;
+	conf->dns.fastRetry.d.ui = 1000u;
+	conf->dns.fastRetry.c = validate_dns_fastRetry;
+
 	conf->dns.CNAMEdeepInspect.k = "dns.CNAMEdeepInspect";
 	conf->dns.CNAMEdeepInspect.h = "Use this option to control deep CNAME inspection. Disabling it might be beneficial for very low-end devices";
 	conf->dns.CNAMEdeepInspect.t = CONF_BOOL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -135,6 +135,7 @@ struct enum_options {
 struct config {
 	struct {
 		struct conf_item upstreams;
+		struct conf_item fastRetry;
 		struct conf_item CNAMEdeepInspect;
 		struct conf_item EDNS0ECS;
 		struct conf_item ignoreLocalhost;

--- a/src/config/dnsmasq_config.c
+++ b/src/config/dnsmasq_config.c
@@ -549,6 +549,14 @@ bool __attribute__((nonnull(1,3))) write_dnsmasq_config(struct config *conf, enu
 		fputs("\n", pihole_conf);
 	}
 
+	if(conf->dns.fastRetry.v.ui > 0)
+	{
+		fputs("# Retransmit an unanswered upstream query after this many milliseconds,\n", pihole_conf);
+		fputs("# doubling the interval for every further attempt\n", pihole_conf);
+		fprintf(pihole_conf, "fast-dns-retry=%u\n", conf->dns.fastRetry.v.ui);
+		fputs("\n", pihole_conf);
+	}
+
 	// Check if an explicit interface is configured
 	char interface[MAXIFACESTRLEN];
 	strncpy(interface, conf->dns.interface.v.s, sizeof(interface) - 1);

--- a/src/config/validator.c
+++ b/src/config/validator.c
@@ -637,6 +637,19 @@ bool validate_dns_revServers(union conf_value *val, const char *key, char err[VA
 	return true;
 }
 
+bool validate_dns_fastRetry(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
+{
+	// dnsmasq rejects intervals below 50 ms outright, and an interval
+	// beyond the forwarding timeout would never fire a retransmission
+	if(val->ui != 0 && (val->ui < 50 || val->ui > 10000))
+	{
+		snprintf(err, VALIDATOR_ERRBUF_LEN, "%s: must be 0 (disabled) or between 50 and 10000", key);
+		return false;
+	}
+
+	return true;
+}
+
 bool validate_ui_min_7_or_0(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN])
 {
 	if(val->ui < 7 && val->ui != 0)

--- a/src/config/validator.h
+++ b/src/config/validator.h
@@ -27,6 +27,7 @@ bool validate_filepath_empty(union conf_value *val, const char *key, char err[VA
 bool validate_webserver_logfile(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_regex_array(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_dns_revServers(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
+bool validate_dns_fastRetry(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 bool validate_ui_min_7_or_0(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);
 void sanitize_dns_hosts(union conf_value *val);
 bool validate_dns_domain_or_ip(union conf_value *val, const char *key, char err[VALIDATOR_ERRBUF_LEN]);

--- a/test/pihole.toml
+++ b/test/pihole.toml
@@ -15,6 +15,25 @@
     "127.0.0.1#5555"
   ] ### CHANGED, default = []
 
+  # Retransmission interval (in milliseconds) for unanswered upstream queries.
+  #
+  # Pi-hole forwards a query and then waits for the reply. If either the query or the
+  # reply is lost on the way, nothing happens until the client gives up and asks again.
+  # Repetitions of a query that is still in flight are attached to the running query
+  # instead of being forwarded again, so a client cannot recover such a loss on its own
+  # either - only Pi-hole can, by asking upstream once more.
+  #
+  # The first retransmission is sent after the configured number of milliseconds, the
+  # interval doubles for every further attempt, and retransmissions stop as soon as the
+  # query is answered or has timed out. Setting this to 0 disables retransmission. Note
+  # that DNSSEC validation enables it independently of this setting because an
+  # unanswered query would otherwise stall the whole validation chain.
+  #
+  # Allowed values are:
+  #     An integer value between 50 and 10000 (milliseconds), or 0 to disable
+  #     retransmission
+  fastRetry = 1000
+
   # Use this option to control deep CNAME inspection. Disabling it might be beneficial
   # for very low-end devices
   #
@@ -1761,7 +1780,7 @@
   all = true ### CHANGED, default = false
 
 # Configuration statistics:
-# 170 total entries out of which 114 entries are default
+# 171 total entries out of which 115 entries are default
 # --> 56 entries are modified
 # 3 entries are forced through environment:
 #   - misc.nice

--- a/test/test_suite.bats
+++ b/test/test_suite.bats
@@ -1649,6 +1649,14 @@ setup() {
   assert_line --regexp --index 0 'New dnsmasq configuration is not valid \(.+resolve at line [[:digit:]]+ of /etc/pihole/dnsmasq.conf.temp: "rev-server=1.1.1.1,def"\), config remains unchanged'
   assert_failure 3
 
+  run bash -c './pihole-FTL --config dns.fastRetry 10'
+  assert_line --index 0 'Invalid value: dns.fastRetry: must be 0 (disabled) or between 50 and 10000'
+  assert_failure 3
+
+  run bash -c './pihole-FTL --config dns.fastRetry 10001'
+  assert_line --index 0 'Invalid value: dns.fastRetry: must be 0 (disabled) or between 50 and 10000'
+  assert_failure 3
+
   run bash -c './pihole-FTL --config webserver.api.excludeClients "[\".*\",\"$$$\",\"[[[\"]"'
   assert_line --index 0 'Invalid value: webserver.api.excludeClients[2]: not a valid regex ("[[["): Missing '\'']'\'''
   assert_failure 3
@@ -1672,6 +1680,11 @@ setup() {
   # the current value, so it takes the unchanged branch and no validator runs
   run bash -c './pihole-FTL --config -t dhcp.netmask ""'
   assert_success
+}
+
+@test "Fast retry interval is passed on to dnsmasq" {
+  run bash -c 'grep "^fast-dns-retry=" /etc/pihole/dnsmasq.conf'
+  assert_line --index 0 'fast-dns-retry=1000'
 }
 
 @test "DNS hosts sanitization: Whitespace is normalized when saving" {


### PR DESCRIPTION
Despite LLM wrote most of it under my guidance, I reviewed, edited and tested the changes to the best of my ability before opening the PR.

**What does this PR aim to accomplish?:**

This is a partial solution to https://github.com/pi-hole/pi-hole/issues/6667, while the more fundamental fix probably belongs to the dnsmasq itself.

This change exposes dnsmasq's `fast-dns-retry` as a new config option `dns.fastRetry`, so that Pi-hole retransmits an upstream query that has not been answered instead of waiting for the client to notice.

Today it never does. `fast-dns-retry` defaults to off, and the only thing that turns it on is DNSSEC validation:

```c
/* Default fast retry on when doing DNSSEC */
if (option_bool(OPT_DNSSEC_VALID) && daemon->fast_retry_time == 0)
```

With the default `dns.dnssec = false`, `daemon->fast_retry_time` stays 0 and `fast_retry()` is a no-op, so a single lost packet on the way to or from an upstream server leaves the query hanging until the frec times out.

A repeated query does not necessarily rescue it either. `forward_query()` matches a new query against the in-flight one on the question alone - name, class and type (`lookup_frec(..., id = -1, ...)`) - but only treats it as a retry of that query when source address, source port *and* query ID all match as well. Anything else is attached to the stuck query and nothing is sent upstream for the first two seconds:

```c
/* closely spaced identical queries cannot be a try and a retry, so
   it's safe to wait for the reply from the first without
   forwarding the second. */
if (difftime(now, forward->time) < 2)
```

That assumption holds for stub resolvers that retry at multi-second intervals, but not for a caching resolver forwarding to Pi-hole - which is a common way to run it, e.g. pfSense/OPNsense with unbound in front. unbound retries an unanswered server after [376 ms](https://github.com/NLnetLabs/unbound/blob/5ccee67af22022f93dfc2b6723146b399955a4a4/util/config_file.c#L322) by default and derives later timeouts from measured RTT with a [50 ms](https://github.com/NLnetLabs/unbound/blob/5ccee67af22022f93dfc2b6723146b399955a4a4/util/rtt.c#L47) floor, so its retransmissions arrive comfortably inside the two-second window. They also cannot take the retry path: every unbound UDP send goes through `randomize_and_send_udp()`, which picks a fresh query ID via `select_id()` and a fresh source port via `select_ifport()`, so no retransmission ever matches the source-address/port/ID triple dnsmasq requires.

The practical result is that during the window where a lost packet needs covering, Pi-hole neither retries itself nor passes on the retries of the resolver in front of it. The query eventually fails upwards, the client falls back to its search domain, and the user sees NXDOMAIN for a domain that resolves perfectly well a second later.

## Measured effect

I extracted stats from two 24 h windows on the same installation, ~128k queries each, before and after adding `fast-dns-retry=250` via `/etc/dnsmasq.d`:

| metric | before | after |
|---|---|---|
| queries > 1 s | 1433 | 206 |
| queries > 5 s | 119 | 21 |
| `RETRIED` (status 12) | 274 | 54 |
| queries 0.5–1 s | 125 | 567 |

The growth in the 0.5–1 s bucket is the mechanism working: queries that used to hang for seconds now get an answer after a retransmission. Above 1 s, where clients start failing over, everything dropped by roughly 7x, and subjectively I stopped seeing them.

**How does this PR accomplish the above?:**

New `dns.fastRetry` is added, emitted as `fast-dns-retry=<ms>` in `dnsmasq.conf` when non-zero.
The default value is 1000 ms - the same `DEFAULT_FAST_RETRY` dnsmasq itself applies when it enables the feature for DNSSEC.

I realize a default that retransmits has an upstream-load cost, and that dnsmasq's conservative default made sense for its original role: a LAN resolver one hop from the ISP's resolver, in front of clients that retried at 5 s.

At least my Pi-hole's deployment is a different shape: it forwards across the internet to public resolvers, in front of unbound that has little patience.
Let me know if you prefer the default value to remain `0`/disabled so that previous behavior it retained (though in that case there is not as much benefit from this change since `fast-dns-retry=250` can already be customized with config file).

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
